### PR TITLE
[rocjitsu] Replace decoder exceptions with results

### DIFF
--- a/emulation/rocjitsu/CONTRIBUTING.md
+++ b/emulation/rocjitsu/CONTRIBUTING.md
@@ -49,8 +49,11 @@ Before writing new infrastructure, check these existing libraries:
 - **Intrusive list** — `util/intrusive_list.h` for linked data structures
   that need O(1) insert/erase without heap allocation per node.
 - **Arena allocator** — `util/arena_alloc.h` for fixed-size block pools.
-- **Exceptions** — `util/except.h` for `InvalidInst`, `UnimplementedInst`,
-  `ConfigError`.
+- **Expected failures** — Return `Result` or `FailureOr<T>` and accept a
+  `DiagnosticEmitter` when the caller needs a reason. Its sink is non-owning
+  and must not outlive its callable.
+- **Exceptions** — `util/except.h` for unrecoverable initialization,
+  configuration, and execution failures.
 - **Register sets** — `isa/register_set.h` for ISA-independent register
   file modeling (SGPR/VGPR/AccVGPR bitsets).
 - **Spill manager** — `code/patch/spill_manager.h` for scratch layout
@@ -88,16 +91,13 @@ Before writing new infrastructure, check these existing libraries:
   `stderr` — it runs inside another runtime's `OnLoad`, its messages must
   survive a log-groups-OFF build, and its signal-backtrace path must stay
   async-signal-safe (`rj_hsa_dbt_hooks.cpp` uses raw `::write`).
-- **Exceptions.** Exceptions are used only for unrecoverable errors
-  during initialization and configuration (`ConfigError`) or when
-  encountering invalid/unimplemented instructions during code object
-  parsing (`InvalidInst`, `UnimplementedInst`). All exception types
-  live in `util/except.h`. Do not throw exceptions in simulation hot
-  paths (event handlers, instruction execution, cache lookups). Do not
-  add `try`/`catch` blocks unless you are at a boundary that must
-  translate an error (e.g., the C API layer). There is no general
-  exception safety guarantee — assume code is not exception-safe
-  unless explicitly documented.
+- **Errors.** Expected failures such as a rejected instruction encoding return
+  `Result` or `FailureOr<T>` and optionally emit a diagnostic. Exceptions are
+  reserved for unrecoverable initialization, configuration, or execution
+  failures. Do not throw exceptions in simulation hot paths (event handlers,
+  instruction execution, cache lookups). Do not add `try`/`catch` blocks unless
+  you are at a boundary that must translate an error (e.g., the C API layer).
+  There is no general exception safety guarantee unless explicitly documented.
 
 ## ISA codegen workflow
 

--- a/emulation/rocjitsu/docs/style.md
+++ b/emulation/rocjitsu/docs/style.md
@@ -148,10 +148,11 @@ Foo foo = static_cast<Foo>(bar); // OK but could use auto instead to avoid repet
 
 ## Error Handling
 
-- Exceptions are only for unrecoverable errors: initialization/configuration
-  failures (`ConfigError`) and invalid or unimplemented instructions during
-  code-object parsing (`InvalidInst`, `UnimplementedInst`). All exception types
-  live in `util/except.h`.
+- Expected failures such as a rejected instruction encoding return `Result` or
+  `FailureOr<T>`. Accept a `DiagnosticEmitter` when the caller needs the reason;
+  its sink is non-owning and must not outlive its callable.
+- Exceptions are only for unrecoverable initialization, configuration, or
+  execution failures. Exception types live in `util/except.h`.
 - Do not throw in simulation hot paths (event handlers, instruction execution,
   cache lookups).
 - Do not add `try`/`catch` except at a boundary that must translate an error

--- a/emulation/rocjitsu/fuzz/decode/README.md
+++ b/emulation/rocjitsu/fuzz/decode/README.md
@@ -77,7 +77,7 @@ ninja -C build-decode-afl rj_decode_fuzz
   build-decode-afl/fuzz/decode/rj_decode_fuzz --afl --target gfx1250
 ```
 
-`InvalidInst` is an ordinary rejection. Other exceptions, signals, sanitizer
+Decoder failure is an ordinary rejection. Exceptions from unrelated failures, signals, sanitizer
 findings, and decoder invariant failures remain crashes for AFL++ to retain.
 
 ## Offline LLVM comparison

--- a/emulation/rocjitsu/fuzz/decode/decode_fuzz_core.cpp
+++ b/emulation/rocjitsu/fuzz/decode/decode_fuzz_core.cpp
@@ -8,7 +8,6 @@
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/isa/operand.h"
 #include "rocjitsu/isa/target_registry.h"
-#include "util/except.h"
 
 #include <array>
 #include <cstdlib>
@@ -91,17 +90,14 @@ DecodeRecord decode_window(Decoder &decoder, std::span<const uint8_t> bytes) {
       words[word] |= static_cast<uint32_t>(bytes[word * sizeof(uint32_t) + byte]) << (byte * 8);
   }
 
-  std::unique_ptr<Instruction> inst;
-  try {
-    inst.reset(decoder.decode(words.data()));
-  } catch (const util::InvalidInst &error) {
+  util::StringDiagnostic rejection;
+  DecodeResult decoded = decoder.decode(words.data(), rejection.emitter());
+  if (decoded.failed()) {
     DecodeRecord record;
-    record.rejection = error.what();
+    record.rejection = rejection.message();
     return record;
   }
-
-  if (!inst)
-    fail_invariant("a successful decode returned null");
+  std::unique_ptr<Instruction> inst = std::move(decoded).value();
 
   const int size = inst->size();
   if (size != 4 && size != 8 && size != 12 && size != 16)

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -1942,6 +1942,7 @@ class CodeGenerator:
         vopd3_execute_slot_cases = ''
         vopd3_constructor_branch = ''
         vopd3_constructor_close = ''
+        vopd3_validation_branch = ''
         vopd3_init_operands_prefix = ''
         vopd3_init_operands_suffix = ''
         vopdxy_bits_decl = cpp_block('''
@@ -2038,14 +2039,8 @@ class CodeGenerator:
                 word2_ = words[2];
                 opx_ = static_cast<uint16_t>((word0_ >> 18) & 0x3F);
                 opy_ = static_cast<uint16_t>((word0_ >> 12) & 0x3F);
-                if (!is_valid_opcode(opx_, kVopd3XOpcodeMask))
-                  throw util::InvalidInst("invalid VOPD3 X opcode", "");
-                if (!is_valid_opcode(opy_, kVopd3YOpcodeMask))
-                  throw util::InvalidInst("invalid VOPD3 Y opcode", "");
                 uint16_t srcx0 = static_cast<uint16_t>(word0_ & 0x1FF);
                 uint16_t srcy0 = static_cast<uint16_t>(word1_ & 0x1FF);
-                if (srcx0 == 254 || srcx0 == 255 || srcy0 == 254 || srcy0 == 255)
-                  throw util::InvalidInst("VOPD3 does not support literal selectors", "");
                 negx_ = static_cast<uint8_t>((word1_ >> 9) & 0x7);
                 negy_ = static_cast<uint8_t>((word1_ >> 12) & 0x7);
                 uint16_t vsrcx1 = static_cast<uint16_t>((word1_ >> 16) & 0xFF);
@@ -2057,10 +2052,6 @@ class CodeGenerator:
 
                 uint32_t x_bits = is_float64_op(opx_) ? 64 : 32;
                 uint32_t y_bits = is_float64_op(opy_) ? 64 : 32;
-                const uint32_t x_end = vdstx + x_bits / 32;
-                const uint32_t y_end = vdsty + y_bits / 32;
-                if (vdstx < y_end && vdsty < x_end)
-                  throw util::InvalidInst("VOPD3 destination ranges overlap", "");
                 dstx_ = Operand(x_bits, OperandType::OPR_VGPR, vdstx);
                 dsty_ = Operand(y_bits, OperandType::OPR_VGPR, vdsty);
                 srcx0_ = make_src0(x_bits, true, false, 0, srcx0);
@@ -2074,6 +2065,31 @@ class CodeGenerator:
               } else {
             ''')
             vopd3_constructor_branch = vopd3_constructor_branch.replace(
+                '@VOPD3_PREFIX_SHIFT@', str(32 - vopd3_prefix.prefix_bits)
+            ).replace('@VOPD3_PREFIX@', f'0x{vopd3_prefix.prefix:X}')
+            vopd3_validation_branch = cpp_block('''
+              if ((word0 >> @VOPD3_PREFIX_SHIFT@) == @VOPD3_PREFIX@) {
+                const uint16_t opx = static_cast<uint16_t>((word0 >> 18) & 0x3F);
+                const uint16_t opy = static_cast<uint16_t>((word0 >> 12) & 0x3F);
+                if (!is_valid_opcode(opx, kVopd3XOpcodeMask)) [[unlikely]]
+                  return emit_error.emit() << "invalid VOPD3 X opcode";
+                if (!is_valid_opcode(opy, kVopd3YOpcodeMask)) [[unlikely]]
+                  return emit_error.emit() << "invalid VOPD3 Y opcode";
+                const uint16_t srcx0 = static_cast<uint16_t>(word0 & 0x1FF);
+                const uint16_t srcy0 = static_cast<uint16_t>(word1 & 0x1FF);
+                if (srcx0 == 254 || srcx0 == 255 || srcy0 == 254 || srcy0 == 255) [[unlikely]]
+                  return emit_error.emit() << "VOPD3 does not support literal selectors";
+                const uint32_t word2 = words[2];
+                const uint16_t vdstx = static_cast<uint16_t>(word2 & 0xFF);
+                const uint16_t vdsty = static_cast<uint16_t>((word2 >> 24) & 0xFF);
+                const uint32_t x_end = vdstx + (is_float64_op(opx) ? 2 : 1);
+                const uint32_t y_end = vdsty + (is_float64_op(opy) ? 2 : 1);
+                if (vdstx < y_end && vdsty < x_end) [[unlikely]]
+                  return emit_error.emit() << "VOPD3 destination ranges overlap";
+                return Result::success();
+              }
+            ''')
+            vopd3_validation_branch = vopd3_validation_branch.replace(
                 '@VOPD3_PREFIX_SHIFT@', str(32 - vopd3_prefix.prefix_bits)
             ).replace('@VOPD3_PREFIX@', f'0x{vopd3_prefix.prefix:X}')
             vopd3_constructor_close = '              }'
@@ -2165,6 +2181,7 @@ class CodeGenerator:
 
             #include "@GENERATED_ARCH@/encodings.h"
             #include "@GENERATED_ARCH@/operand.h"
+            #include "rocjitsu/isa/decode_result.h"
             #include <cstdint>
             #include <string>
 
@@ -2175,6 +2192,8 @@ class CodeGenerator:
             {
               public:
               explicit Vopd(const MachineInst *inst);
+              static Result validate_encoding(const MachineInst *inst,
+                                              const util::DiagnosticEmitter &emit_error);
               void execute_impl(amdgpu::Wavefront &wf);
 
               private:
@@ -2345,6 +2364,26 @@ class CodeGenerator:
 
             @INLINE_EXECUTION_HELPERS@
 
+            Result
+            Vopd::validate_encoding(const MachineInst *inst,
+                                    const util::DiagnosticEmitter &emit_error) {
+              const auto *words = reinterpret_cast<const uint32_t *>(inst);
+              const uint32_t word0 = words[0];
+              const uint32_t word1 = words[1];
+            @VOPD3_VALIDATION_BRANCH@
+              const uint16_t opx = static_cast<uint16_t>((word0 >> 22) & 0xF);
+              const uint16_t opy = static_cast<uint16_t>((word0 >> 17) & 0x1F);
+              if (!is_valid_opcode(opx, kVopdXOpcodeMask)) [[unlikely]]
+                return emit_error.emit() << "invalid VOPD X opcode";
+              if (!is_valid_opcode(opy, kVopdYOpcodeMask)) [[unlikely]]
+                return emit_error.emit() << "invalid VOPD Y opcode";
+              const uint16_t srcx0 = static_cast<uint16_t>(word0 & 0x1FF);
+              const uint16_t srcy0 = static_cast<uint16_t>(word1 & 0x1FF);
+              if (srcx0 == 254 || srcy0 == 254) [[unlikely]]
+                return emit_error.emit() << "VOPD does not support 64-bit literals";
+              return Result::success();
+            }
+
             Vopd::Vopd(const MachineInst *inst)
                 : IsaInstruction<Isa>("vopd", @VOPD_EXEC_FN@),
                   dstx_(32, OperandType::OPR_VGPR, 0),
@@ -2365,16 +2404,10 @@ class CodeGenerator:
                 encoding_id_ = @VOPD_PREFIX@;
                 opx_ = static_cast<uint16_t>((word0_ >> 22) & 0xF);
                 opy_ = static_cast<uint16_t>((word0_ >> 17) & 0x1F);
-                if (!is_valid_opcode(opx_, kVopdXOpcodeMask))
-                  throw util::InvalidInst("invalid VOPD X opcode", "");
-                if (!is_valid_opcode(opy_, kVopdYOpcodeMask))
-                  throw util::InvalidInst("invalid VOPD Y opcode", "");
                 uint16_t srcx0 = static_cast<uint16_t>(word0_ & 0x1FF);
                 uint16_t vsrcx1 = static_cast<uint16_t>((word0_ >> 9) & 0xFF);
                 uint16_t srcy0 = static_cast<uint16_t>(word1_ & 0x1FF);
                 uint16_t vsrcy1 = static_cast<uint16_t>((word1_ >> 9) & 0xFF);
-                if (srcx0 == 254 || srcy0 == 254)
-                  throw util::InvalidInst("VOPD does not support 64-bit literals", "");
                 uint16_t vdstx = static_cast<uint16_t>((word1_ >> 24) & 0xFF);
                 uint16_t vdsty_hi = static_cast<uint16_t>((word1_ >> 17) & 0x7F);
                 uint16_t vdsty = static_cast<uint16_t>((vdsty_hi << 1) | ((~vdstx) & 1u));
@@ -2503,6 +2536,7 @@ class CodeGenerator:
             .replace('@VOPD3_UNUSED_ATTR@', vopd3_unused_attr)
             .replace('@VOPD_OP_NAME_CASES@', vopd_op_name_cases)
             .replace('@VOPD3_MODEL_HELPERS@', vopd3_model_helpers)
+            .replace('@VOPD3_VALIDATION_BRANCH@', vopd3_validation_branch)
             .replace('@VOPD3_CONSTRUCTOR_BRANCH@', vopd3_constructor_branch)
             .replace('@VOPD3_CONSTRUCTOR_CLOSE@', vopd3_constructor_close)
             .replace('@VOPD_PREFIX@', f'0x{vopd_prefix.prefix:X}')
@@ -2680,7 +2714,6 @@ class CodeGenerator:
         enc_classes = []
         class_func_impls = []
         cond_emitted: set[str] = set()
-        needs_invalid_inst_include = False
         for inst_enc in self.isa_spec.inst_encodings:
             if not inst_enc.insts:
                 continue
@@ -2696,8 +2729,6 @@ class CodeGenerator:
                 self._supports_simm64_literal_operands()
                 and bool(encoded_literal_fields)
             )
-            if uses_instruction_literal_policy:
-                needs_invalid_inst_include = True
             unsupported_literal64_fields = self._unsupported_literal64_selector_fields(
                 inst_enc
             )
@@ -2730,21 +2761,6 @@ class CodeGenerator:
                 ),
                 cgen.Value('ExecuteFn', 'exec_fn'),
             ]
-            if uses_instruction_literal_policy:
-                constructor_args.extend(
-                    [
-                        cgen.Value(
-                            'LiteralSupport',
-                            'literal_support = LiteralSupport::Both',
-                        ),
-                        cgen.Value(
-                            'int',
-                            'num_encoded_sources = ' f'{len(encoded_literal_fields)}',
-                        ),
-                    ]
-                )
-            elif unsupported_literal64_fields:
-                constructor_args.append(cgen.Value('int', 'num_encoded_sources = 3'))
             if supports_fixed_size_embedding:
                 constructor_args.append(
                     cgen.Value(
@@ -2763,6 +2779,25 @@ class CodeGenerator:
                     constructor_args,
                 )
             )
+            validation_args = [
+                '[[maybe_unused]] std::string_view mnemonic',
+                f'const {inst_enc.fmt_enc_name}MachineInst *inst',
+                'const util::DiagnosticEmitter &emit_error',
+            ]
+            if uses_instruction_literal_policy:
+                validation_args.extend(
+                    [
+                        'LiteralSupport literal_support = LiteralSupport::Both',
+                        f'int num_encoded_sources = {len(encoded_literal_fields)}',
+                    ]
+                )
+            elif unsupported_literal64_fields:
+                validation_args.append('int num_encoded_sources = 3')
+            if supports_fixed_size_embedding:
+                validation_args.append(
+                    'ExtensionDecodePolicy extension_policy = '
+                    'ExtensionDecodePolicy::Decode'
+                )
             # Determine whether the constructor needs a runtime size
             # check for an extension DWORD beyond the base encoding.
             #
@@ -2836,6 +2871,8 @@ class CodeGenerator:
                 '  raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);\n'
                 '  encoding_id_ = raw_encoding_[0] >> 23;'
             )
+            validation_body = ' const auto &inst_ = *inst;'
+            has_encoding_validation = False
             if has_op:
                 size_line += '\n  opcode_ = inst_.op;'
             literal64_conds = self._literal64_condition_names(inst_enc)
@@ -2882,6 +2919,9 @@ class CodeGenerator:
             literal32_condition = ' || '.join(f'{name}()' for name in literal32_conds)
             if supports_fixed_size_embedding:
                 size_line += ' if (extension_policy == ExtensionDecodePolicy::Decode) {'
+                validation_body += (
+                    ' if (extension_policy == ExtensionDecodePolicy::Decode) {'
+                )
             # Some profiles expose SRC_LITERAL64 in their global operand
             # selector table even when a particular encoding has no 64-bit
             # literal extension form.  Derive the affected source fields from
@@ -2891,38 +2931,41 @@ class CodeGenerator:
             # constructor reads two extension DWORDs that the encoding does
             # not own.
             if unsupported_literal64_fields:
+                has_encoding_validation = True
                 reject_condition = ' || '.join(
                     f'(num_encoded_sources > {source_idx} && inst_.{field} == 254)'
                     for source_idx, field in enumerate(unsupported_literal64_fields)
                 )
-                size_line += (
+                validation_body += (
                     f'\n  if ({reject_condition})'
-                    f' throw util::InvalidInst("{inst_enc.fmt_enc_name} does not support '
-                    'Literal64", "");'
+                    f' [[unlikely]] return emit_error.emit() << "{inst_enc.fmt_enc_name} does not support '
+                    'Literal64";'
                 )
             if uses_instruction_literal_policy:
+                has_encoding_validation = True
                 for width, selector in ((32, 255), (64, 254)):
                     reject_condition = ' || '.join(
                         f'(num_encoded_sources > {source_idx} && '
                         f'inst_.{field} == {selector})'
                         for source_idx, field in enumerate(encoded_literal_fields)
                     )
-                    size_line += (
+                    validation_body += (
                         f'\n  if (!supports_literal(literal_support, '
                         f'LiteralSupport::Literal{width}) && ({reject_condition}))'
-                        ' throw util::InvalidInst('
-                        f'std::string(mnemonic) + " does not support {width}-bit literals", "");'
+                        f' [[unlikely]] return emit_error.emit() << mnemonic << " does not support {width}-bit literals";'
                     )
             if needs_explicit_dpp_size and encoded_literal_fields:
+                has_encoding_validation = True
                 dpp_extension_condition = ' || '.join(dpp_extension_conditions)
-                literal_selector_condition = literal32_condition or 'false'
-                size_line += (
+                literal_selector_condition = ' || '.join(
+                    f'inst_.{field} == 255' for field in encoded_literal_fields
+                )
+                validation_body += (
                     f' if (({dpp_extension_condition}) && '
                     f'({literal_selector_condition}))'
-                    ' throw util::InvalidInst('
-                    '"DPP and literal operands cannot be combined", "");'
+                    ' [[unlikely]] return emit_error.emit() << '
+                    '"DPP and literal operands cannot be combined";'
                 )
-                needs_invalid_inst_include = True
             # Size owned storage from this encoding's declared extension forms,
             # not the architecture-wide operand selector table. For example,
             # gfx1250 defines selector 254 for 64-bit literals, but the 64-bit
@@ -3026,13 +3069,17 @@ class CodeGenerator:
                 )
             if supports_fixed_size_embedding:
                 size_line += ' }'
-            constructor_extra_params = ''
-            if uses_instruction_literal_policy:
-                constructor_extra_params += (
-                    ', LiteralSupport literal_support, int num_encoded_sources'
+                validation_body += ' }'
+            validation_body += ' return Result::success();'
+            if has_encoding_validation:
+                public_members.append(
+                    cgen.Line(
+                        'static Result validate_encoding('
+                        + ', '.join(validation_args)
+                        + f') {{{validation_body}}}'
+                    )
                 )
-            elif unsupported_literal64_fields:
-                constructor_extra_params += ', int num_encoded_sources'
+            constructor_extra_params = ''
             if supports_fixed_size_embedding:
                 constructor_extra_params += ', ExtensionDecodePolicy extension_policy'
             if rule.use_flat_mnemonic:
@@ -3056,7 +3103,6 @@ class CodeGenerator:
                     f'{{{size_line}}}'
                 )
             class_func_impls.append(cgen.Line(class_ctor_impl))
-
             # Generate build_modifiers() override for encoding bases
             # that have modifier flags (memory instructions). This is
             # called lazily by disassemble() instead of eagerly in the
@@ -3402,6 +3448,7 @@ class CodeGenerator:
                     False,
                 ),
                 ('rocjitsu/isa/instruction.h', False),
+                ('rocjitsu/isa/decode_result.h', False),
                 (encoding_helper_header, False),
                 ('array', True),
                 ('cstdint', True),
@@ -3448,14 +3495,6 @@ class CodeGenerator:
             _enc_cpp_includes.insert(
                 1, ('rocjitsu/isa/arch/amdgpu/shared/dpp_sdwa_ops.h', False)
             )
-        if needs_invalid_inst_include or (
-            self._supports_simm64_literal_operands()
-            and any(
-                self._rejects_unencoded_vop3p_literal64(enc)
-                for enc in self.isa_spec.inst_encodings
-            )
-        ):
-            _enc_cpp_includes.insert(1, ('util/except.h', False))
         class_impl_file = CppFile(
             'encodings',
             self.out_path,
@@ -4250,8 +4289,7 @@ class CodeGenerator:
         model = textwrap.dedent('''\
             VWmmaScaleF32Vop3px2::VWmmaScaleF32Vop3px2(const MachineInst *inst)
                 : Vop3p(gfx1250_scaled_wmma_mnemonic(inst), reinterpret_cast<const OpEncoding *>(inst + 2),
-                        @EXEC_FN@, LiteralSupport::Both, 3,
-                        Vop3p::ExtensionDecodePolicy::Skip),
+                        @EXEC_FN@, Vop3p::ExtensionDecodePolicy::Skip),
                   vdst(gfx1250_scaled_wmma_dst_size_bits(inst), OperandType::OPR_VGPR,
                        reinterpret_cast<const OpEncoding *>(inst + 2)->vdst),
                   src0(gfx1250_scaled_wmma_src0_size_bits(inst), OperandType::OPR_SRC_VGPR,
@@ -8266,7 +8304,7 @@ class CodeGenerator:
                     init_list_parts = [
                         f'{inst.fmt_true_enc_name}({mnemonic_expr}, '
                         f'reinterpret_cast<const OpEncoding*>(inst), '
-                        f'{exec_fn_expr}{literal_policy_args})'
+                        f'{exec_fn_expr})'
                     ] + opnd_ctor_init
                     init_list = ', '.join(init_list_parts)
                     # Check if this is a memory instruction to set MEMORY_OP flag
@@ -8308,6 +8346,8 @@ class CodeGenerator:
                     )
                     ctor_body_parts = list(opnd_body)
                     fieldless_caps_guards: dict[str, str] = {}
+                    factory_validation_parts: list[str] = []
+                    factory_op_encoding = f'{inst.fmt_true_enc_name}::OpEncoding'
                     # Guard fieldless def/use operands (pushed positionally) from
                     # silently writing past the fixed-size operand arrays. The
                     # capacities mirror instruction.h (see the class constants).
@@ -8335,16 +8375,17 @@ class CodeGenerator:
                             opnd.operand_type
                         )
                         raw_value = (
-                            f'reinterpret_cast<const OpEncoding*>(inst)->{opnd.name}'
+                            f'reinterpret_cast<const {factory_op_encoding}*>(inst)'
+                            f'->{opnd.name}'
                         )
                         valid_expr = ' || '.join(
                             f'({raw_value} >= {lo} && {raw_value} <= {hi})'
                             for lo, hi in intervals
                         )
-                        ctor_body_parts.append(
+                        factory_validation_parts.append(
                             f'if (!({valid_expr})) '
-                            f'throw util::InvalidInst("{inst.name} has an invalid '
-                            'accumulator selector", "");'
+                            f'[[unlikely]] return emit_error.emit() << "{inst.name} has an invalid '
+                            'accumulator selector";'
                         )
 
                     # LLVM models pseudo-scalar V_S_* destinations as
@@ -8358,11 +8399,11 @@ class CodeGenerator:
                         inst_sem is not None
                         and inst_sem.semantic_class == 'pseudo_scalar_unary'
                     ):
-                        ctor_body_parts.append(
-                            'if (reinterpret_cast<const OpEncoding*>(inst)->vdst >= '
+                        factory_validation_parts.append(
+                            f'if (reinterpret_cast<const {factory_op_encoding}*>(inst)->vdst >= '
                             'OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) '
-                            f'throw util::InvalidInst("{inst.name} has an invalid '
-                            'SReg_32_XEXEC destination", "");'
+                            f'[[unlikely]] return emit_error.emit() << "{inst.name} has an invalid '
+                            'SReg_32_XEXEC destination";'
                         )
 
                     # Flat segment-aware operands: adjust addr width and add
@@ -8437,20 +8478,20 @@ class CodeGenerator:
                             and len(_encoded_literal_fields) > 1
                         ):
                             literal32_selector = ' || '.join(
-                                'reinterpret_cast<const OpEncoding*>(inst)->'
+                                f'reinterpret_cast<const {factory_op_encoding}*>(inst)->'
                                 f'{field} == 255'
                                 for field in _encoded_literal_fields
                             )
                             literal64_selector = ' || '.join(
-                                'reinterpret_cast<const OpEncoding*>(inst)->'
+                                f'reinterpret_cast<const {factory_op_encoding}*>(inst)->'
                                 f'{field} == 254'
                                 for field in _encoded_literal_fields
                             )
-                            ctor_body_parts.append(
+                            factory_validation_parts.append(
                                 f'if (({literal32_selector}) && '
                                 f'({literal64_selector})) '
-                                f'throw util::InvalidInst("{inst.name} may not mix '
-                                '32-bit and 64-bit literals", "");'
+                                f'[[unlikely]] return emit_error.emit() << "{inst.name} may not mix '
+                                '32-bit and 64-bit literals";'
                             )
                         for opnd in inst.operands:
                             # The only fieldless operand that needs a fixup
@@ -8676,10 +8717,16 @@ class CodeGenerator:
                                         if len(unsupported_dpp_markers) == 1
                                         else 'DPP'
                                     )
-                                    ctor_body_parts.append(
-                                        f'if ({" || ".join(marker for marker, _ in unsupported_dpp_markers)}) '
-                                        f'throw util::InvalidInst("{inst.name} does not support '
-                                        f'{unsupported_dpp_label}", "");'
+                                    qualified_dpp_markers = [
+                                        marker.replace(
+                                            'OpEncoding', factory_op_encoding
+                                        )
+                                        for marker, _ in unsupported_dpp_markers
+                                    ]
+                                    factory_validation_parts.append(
+                                        f'if ({" || ".join(qualified_dpp_markers)}) '
+                                        f'[[unlikely]] return emit_error.emit() << "{inst.name} does not support '
+                                        f'{unsupported_dpp_label}";'
                                     )
                                 # SDWA (src0 == amdgpu::SRC_SDWA): CDNA and RDNA1/2 only.
                                 _has_sdwa = any(
@@ -8798,10 +8845,10 @@ class CodeGenerator:
                                     'ENC_VOP2',
                                     'ENC_VOPC',
                                 ):
-                                    ctor_body_parts.append(
-                                        'if (reinterpret_cast<const OpEncoding*>(inst)->src0 == '
+                                    factory_validation_parts.append(
+                                        f'if (reinterpret_cast<const {factory_op_encoding}*>(inst)->src0 == '
                                         'amdgpu::SRC_SDWA) '
-                                        f'throw util::InvalidInst("{inst.name} does not support SDWA", "");'
+                                        f'[[unlikely]] return emit_error.emit() << "{inst.name} does not support SDWA";'
                                     )
 
                     # Apply the fieldless-operand capability policy once, after
@@ -9424,11 +9471,31 @@ class CodeGenerator:
                     inst_impls = [class_ctor_impl]
                     decoder_factory = decoder_factories.get(inst.fmt_name)
                     if decoder_factory is not None:
+                        factory_mnemonic_expr = mnemonic_expr.replace(
+                            'OpEncoding', factory_op_encoding
+                        )
+                        factory_validation_body = ''.join(
+                            f'  {line}\n' for line in factory_validation_parts
+                        )
+                        factory_inst_decl = (
+                            '  const auto *inst = opcode;\n'
+                            if factory_validation_parts
+                            or '(inst)' in factory_mnemonic_expr
+                            else ''
+                        )
                         inst_impls.append(
                             cgen.Line(
                                 'namespace detail {\n'
-                                f'std::unique_ptr<Instruction> {decoder_factory}'
-                                '(const MachineInst *opcode) {\n'
+                                f'DecodeResult {decoder_factory}'
+                                '(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {\n'
+                                f'{factory_inst_decl}'
+                                f'  Result validation = {inst.fmt_true_enc_name}::validate_encoding('
+                                f'{factory_mnemonic_expr}, '
+                                f'reinterpret_cast<const {factory_op_encoding}*>(opcode), '
+                                f'emit_error{literal_policy_args});\n'
+                                '  if (validation.failed()) [[unlikely]]\n'
+                                '    return Result::failure();\n'
+                                f'{factory_validation_body}'
                                 f'  return std::make_unique<{inst.fmt_name}>(opcode);\n'
                                 '}\n'
                                 '} // namespace detail'
@@ -9935,7 +10002,6 @@ class CodeGenerator:
                             ),
                             False,
                         ),
-                        ('util/except.h', False),
                     ]
                     if is_mem_enc:
                         model_cpp_includes.extend(
@@ -12471,7 +12537,6 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                         False,
                     ),
                     ('rocjitsu/isa/arch/amdgpu/shared/scalar_static_resolve.h', False),
-                    ('util/except.h', False),
                     ('format', True),
                     ('optional', True),
                     ('stdexcept', True),
@@ -12576,8 +12641,11 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                         f'static constexpr std::size_t kMaxInstructionWords = {self._max_instruction_word_count()}'
                     ),
                     cgen.FunctionDeclaration(
-                        cgen.Value('static std::unique_ptr<Instruction>', 'decode'),
-                        [cgen.Value('const MachineInst *', 'opcode')],
+                        cgen.Value('static DecodeResult', 'decode'),
+                        [
+                            cgen.Value('const MachineInst *', 'opcode'),
+                            cgen.Value('const DecodeErrorEmitter &', 'emit_error'),
+                        ],
                     ),
                 ],
             )
@@ -12586,16 +12654,23 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
         class_members = [
             cgen.Line('public:'),
             cgen.FunctionDeclaration(
-                cgen.Value('static std::unique_ptr<Instruction>', 'decode'),
-                [cgen.Value('const MachineInst *', 'opcode')],
+                cgen.Value('static DecodeResult', 'decode'),
+                [
+                    cgen.Value('const MachineInst *', 'opcode'),
+                    cgen.Value('const DecodeErrorEmitter &', 'emit_error'),
+                ],
             ),
             cgen.Line('private:'),
             cgen.Statement(
-                'using DecodeFunc = std::unique_ptr<Instruction>(*)(const MachineInst *)'
+                'using DecodeFunc = DecodeResult(*)(const MachineInst *, '
+                'const DecodeErrorEmitter &)'
             ),
             cgen.FunctionDeclaration(
-                cgen.Value('static std::unique_ptr<Instruction>', 'decodeInvalid'),
-                [cgen.Value('const MachineInst *', 'opcode')],
+                cgen.Value('static DecodeResult', 'decodeInvalid'),
+                [
+                    cgen.Value('const MachineInst *', 'opcode'),
+                    cgen.Value('const DecodeErrorEmitter &', 'emit_error'),
+                ],
             ),
         ]
         decode_body = []
@@ -12608,31 +12683,39 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                 cgen.Statement(
                     'Sop1MachineInst op = std::bit_cast<decltype(op)>(*opcode)'
                 ),
-                cgen.Statement('return primary_decode_table[op.encoding](opcode)'),
+                cgen.Statement(
+                    'return primary_decode_table[op.encoding](opcode, emit_error)'
+                ),
             ]
         )
         decode_table_funcs = [
             cgen.FunctionBody(
                 cgen.FunctionDeclaration(
-                    cgen.Value('std::unique_ptr<Instruction>', 'DecoderImpl::decode'),
-                    [cgen.Value('const MachineInst *', 'opcode')],
+                    cgen.Value('DecodeResult', 'DecoderImpl::decode'),
+                    [
+                        cgen.Value('const MachineInst *', 'opcode'),
+                        cgen.Value('const DecodeErrorEmitter &', 'emit_error'),
+                    ],
                 ),
                 cgen.Block(decode_body),
             ),
             cgen.FunctionBody(
                 cgen.FunctionDeclaration(
                     cgen.Value(
-                        'std::unique_ptr<Instruction>',
+                        'DecodeResult',
                         'DecoderImpl::decodeInvalid',
                     ),
-                    [cgen.Value('const MachineInst *', 'opcode')],
+                    [
+                        cgen.Value('const MachineInst *', 'opcode'),
+                        cgen.Value('const DecodeErrorEmitter &', 'emit_error'),
+                    ],
                 ),
                 cgen.Block(
                     [
                         cgen.Statement(
-                            'throw util::InvalidInst(std::format("{:X}", *opcode))'
+                            'return emit_error.emit() << "Invalid instruction opcode: " '
+                            '<< std::format("{:X}", *opcode)'
                         ),
-                        cgen.Statement('return nullptr'),
                     ]
                 ),
             ),
@@ -12675,7 +12758,14 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
             for _prefix in self.isa_spec.profile.vopd_encoding_prefixes:
                 _reserve_primary_prefix(_prefix.prefix, _prefix.prefix_bits, _vopd_fn)
             _custom_primary_decode_bodies[_vopd_fn] = cgen.Block(
-                [cgen.Statement('return std::make_unique<Vopd>(opcode)')]
+                [
+                    cgen.Line(
+                        '  Result validation = Vopd::validate_encoding(opcode, emit_error);\n'
+                        '  if (validation.failed()) [[unlikely]]\n'
+                        '    return Result::failure();\n'
+                    ),
+                    cgen.Statement('return std::make_unique<Vopd>(opcode)'),
+                ]
             )
 
         if self._supports_gfx1250_scaled_wmma_vop3px2():
@@ -12702,7 +12792,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                             cgen.Line(
                                 '  if (!isVop3pOp(opcode[2], 0x33) && '
                                 '!isVop3pOp(opcode[2], 0x88))\n'
-                                '    return decodeInvalid(opcode);\n'
+                                '    return decodeInvalid(opcode, emit_error);\n'
                             ),
                             cgen.Statement(
                                 'return std::make_unique<VWmmaScaleF32Vop3px2>(opcode)'
@@ -12755,7 +12845,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                                         'kVMfmaF3216x16x128F8f6f4Vop3pMfma &&\n'
                                         '       suffix_opcode != '
                                         'kVMfmaF3232x32x64F8f6f4Vop3pMfma))\n'
-                                        '    return decodeInvalid(opcode);\n'
+                                        '    return decodeInvalid(opcode, emit_error);\n'
                                         '  if (suffix_opcode == '
                                         'kVMfmaF3216x16x128F8f6f4Vop3pMfma)\n'
                                         '    return std::make_unique<VMfmaF3216x16x128F8f6f4Vop3pMfma>(opcode + 2, true);\n'
@@ -12770,24 +12860,28 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                                         f'auto op = *reinterpret_cast<const {_dte.enc.fmt_enc_name}::OpEncoding *>(opcode + 2)'
                                     ),
                                     cgen.Statement(
-                                        f'return {_dte.sub_decode_table}[op.op](opcode + 2)'
+                                        f'return {_dte.sub_decode_table}[op.op](opcode + 2, emit_error)'
                                     ),
                                 ]
                             )
                         break
         for _fn, _body in _custom_primary_decode_bodies.items():
             _decl = cgen.FunctionDeclaration(
-                cgen.Value('static std::unique_ptr<Instruction>', _fn),
-                [cgen.Value('const MachineInst *', 'opcode')],
+                cgen.Value('static DecodeResult', _fn),
+                [
+                    cgen.Value('const MachineInst *', 'opcode'),
+                    cgen.Value('const DecodeErrorEmitter &', 'emit_error'),
+                ],
             )
             class_members.append(_decl)
             decode_table_funcs.append(
                 cgen.FunctionBody(
                     cgen.FunctionDeclaration(
-                        cgen.Value(
-                            'std::unique_ptr<Instruction>', f'DecoderImpl::{_fn}'
-                        ),
-                        [cgen.Value('const MachineInst *', 'opcode')],
+                        cgen.Value('DecodeResult', f'DecoderImpl::{_fn}'),
+                        [
+                            cgen.Value('const MachineInst *', 'opcode'),
+                            cgen.Value('const DecodeErrorEmitter &', 'emit_error'),
+                        ],
                     ),
                     _body,
                 )
@@ -12811,10 +12905,13 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                     decode_funcs_found.add(dte.decode_func)
                     func_decl = cgen.FunctionDeclaration(
                         cgen.Value(
-                            'std::unique_ptr<Instruction>',
+                            'DecodeResult',
                             f'DecoderImpl::{dte.decode_func}',
                         ),
-                        [cgen.Value('const MachineInst *', 'opcode')],
+                        [
+                            cgen.Value('const MachineInst *', 'opcode'),
+                            cgen.Value('const DecodeErrorEmitter &', 'emit_error'),
+                        ],
                     )
                     sub_decode_func_decls = []
                     if primary_factory_is_distributed:
@@ -12843,7 +12940,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                                             'op = *reinterpret_cast<const decltype(op) *>(opcode)',
                                         ),
                                         cgen.Statement(
-                                            f'return {dte.sub_decode_table}[op.op](opcode)'
+                                            f'return {dte.sub_decode_table}[op.op](opcode, emit_error)'
                                         ),
                                     ]
                                 ),
@@ -12876,14 +12973,18 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                                     sub_decode_func_decls.append(
                                         cgen.FunctionDeclaration(
                                             cgen.Value(
-                                                'static std::unique_ptr<Instruction>',
+                                                'static DecodeResult',
                                                 fn,
                                             ),
                                             [
                                                 cgen.Value(
                                                     'const MachineInst *',
                                                     'opcode',
-                                                )
+                                                ),
+                                                cgen.Value(
+                                                    'const DecodeErrorEmitter &',
+                                                    'emit_error',
+                                                ),
                                             ],
                                         )
                                     )
@@ -12902,14 +13003,18 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                                         cgen.FunctionBody(
                                             cgen.FunctionDeclaration(
                                                 cgen.Value(
-                                                    'std::unique_ptr<Instruction>',
+                                                    'DecodeResult',
                                                     f'DecoderImpl::{fn}',
                                                 ),
                                                 [
                                                     cgen.Value(
                                                         'const MachineInst *',
                                                         'opcode',
-                                                    )
+                                                    ),
+                                                    cgen.Value(
+                                                        'const DecodeErrorEmitter &',
+                                                        'emit_error',
+                                                    ),
                                                 ],
                                             ),
                                             _fn_body,
@@ -12929,10 +13034,15 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                         class_members.append(
                             cgen.FunctionDeclaration(
                                 cgen.Value(
-                                    'static std::unique_ptr<Instruction>',
+                                    'static DecodeResult',
                                     f'{dte.decode_func}',
                                 ),
-                                [cgen.Value('const MachineInst *', 'opcode')],
+                                [
+                                    cgen.Value('const MachineInst *', 'opcode'),
+                                    cgen.Value(
+                                        'const DecodeErrorEmitter &', 'emit_error'
+                                    ),
+                                ],
                             )
                         )
                     class_members.extend(sub_decode_func_decls)
@@ -12941,8 +13051,8 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
         decode_table_entries = ''.join(decode_table_entries)
         class_members.extend(decode_tables)
         detail_decls = '\n'.join(
-            f'std::unique_ptr<Instruction> {factory_name}'
-            '(const MachineInst *opcode);'
+            f'DecodeResult {factory_name}'
+            '(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);'
             for factory_name in sorted(distributed_factory_names)
         )
         class_impl[0:0] = [
@@ -12955,10 +13065,15 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
             0,
             cgen.FunctionBody(
                 cgen.FunctionDeclaration(
-                    cgen.Value('std::unique_ptr<Instruction>', 'Decoder::decode'),
-                    [cgen.Value('const MachineInst *', 'opcode')],
+                    cgen.Value('DecodeResult', 'Decoder::decode'),
+                    [
+                        cgen.Value('const MachineInst *', 'opcode'),
+                        cgen.Value('const DecodeErrorEmitter &', 'emit_error'),
+                    ],
                 ),
-                cgen.Block([cgen.Statement('return DecoderImpl::decode(opcode)')]),
+                cgen.Block(
+                    [cgen.Statement('return DecoderImpl::decode(opcode, emit_error)')]
+                ),
             ),
         )
         class_impl.extend(decode_table_funcs)
@@ -12981,6 +13096,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                     ),
                     False,
                 ),
+                ('rocjitsu/isa/decode_result.h', False),
                 ('array', True),
                 ('cstddef', True),
                 ('memory', True),
@@ -12996,7 +13112,6 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                 self.config.generated_include(self.generated_dir_name, 'decoder.h'),
                 False,
             ),
-            ('util/except.h', False),
             (
                 self.config.generated_include(
                     self.generated_dir_name,

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -255,6 +255,12 @@ def _generated_bool_method_body(cpp: str, class_name: str, method: str) -> str:
     return cpp[start:end]
 
 
+def _generated_decode_body(cpp: str, class_name: str) -> str:
+    start = cpp.index(f'DecodeResult decode{class_name}(')
+    end = cpp.index('\n}\n} // namespace detail', start)
+    return cpp[start : end + 2]
+
+
 def _execution_source_path(path: Path, profile) -> Path:
     """Return the source containing execution bodies for a generated file."""
     if not profile.split_execution_sources:
@@ -1937,15 +1943,15 @@ def test_generated_pseudo_scalar_vop3_paths_ignore_exec_and_f16_opsel(
             'VSSqrtF16Vop3',
         ]
         for class_name in pseudo_scalar_constructors:
-            constructor = _generated_constructor_body(constructor_source, class_name)
-            assert '>= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO' in constructor
-            assert 'has an invalid SReg_32_XEXEC destination' in constructor
-            assert 'may not use VCC as a destination' not in constructor
-            assert constructor.index(
+            decode_body = _generated_decode_body(constructor_source, class_name)
+            assert 'OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO' in decode_body
+            assert 'has an invalid SReg_32_XEXEC destination' in decode_body
+            assert 'may not use VCC as a destination' not in decode_body
+            assert decode_body.index(
                 'has an invalid SReg_32_XEXEC destination'
-            ) < constructor.index('does not support DPP')
-            assert '->opsel' not in constructor
-            assert 'vop3_opsel' not in constructor
+            ) < decode_body.index('does not support DPP')
+            assert '->opsel' not in decode_body
+            assert 'vop3_opsel' not in decode_body
         assert constructor_source.count(
             'has an invalid SReg_32_XEXEC destination'
         ) == len(pseudo_scalar_constructors)
@@ -2298,7 +2304,10 @@ def test_generated_restricted_operands_do_not_apply_literal_fixups(
     assert 'src2 == 255' not in wmma
     assert 'src2 == 254' not in wmma
     assert 'OperandType::OPR_SRC' in generic_accumulator_wmma
-    assert 'has an invalid accumulator selector' in generic_accumulator_wmma
+    generic_accumulator_decode = _generated_decode_body(
+        vop3p, 'VWmmaF3216x16x128Fp8Fp8Vop3p'
+    )
+    assert 'has an invalid accumulator selector' in generic_accumulator_decode
     assert 'src2 == 255' not in generic_accumulator_wmma
     assert 'src2 == 254' not in generic_accumulator_wmma
     assert 'OperandType::OPR_SIMM32' not in generic_accumulator_wmma
@@ -2314,7 +2323,7 @@ def test_gfx1250_generated_operand_validates_lane_selectors(
     operand = (gfx1250_generated_root / 'operand.cpp').read_text()
 
     assert 'OPR_SSRC_LANESEL_POS_INT_MAX = 191' in operand_types
-    assert '#include "util/except.h"' in operand
+    assert '#include "util/except.h"' not in operand
     assert 'opr_type == OperandType::OPR_SSRC_LANESEL' in operand
     assert 'EncodingError::InvalidLaneSelector' in operand
 
@@ -2323,7 +2332,7 @@ def test_gfx1250_generated_operand_rejects_invalid_exec_selector(
     gfx1250_generated_root: Path,
 ):
     operand = (gfx1250_generated_root / 'operand.cpp').read_text()
-    assert '#include "util/except.h"' in operand
+    assert '#include "util/except.h"' not in operand
     assert 'opr_type == OperandType::OPR_EXEC' in operand
     assert '(encoding_value >= 126 && encoding_value <= 126)' in operand
     assert 'EncodingError::InvalidExecSelector' in operand
@@ -2348,15 +2357,18 @@ def test_gfx1250_generated_vop3_add_f16_applies_dpp(
     assert 'std::array<uint32_t, 3> raw_words_{};' in vop3_base
 
     vop3_encoding_ctor = _generated_constructor_body(encodings_cpp, 'Vop3')
+    vop3_validation = vop3_base
     assert 'inst_.src0 == amdgpu::SRC_DPP' in vop3_encoding_ctor
     assert 'amdgpu::dpp::is_src_dpp8(inst_.src0)' in vop3_encoding_ctor
-    assert 'DPP and literal operands cannot be combined' in vop3_encoding_ctor
-    assert vop3_encoding_ctor.index('DPP and literal operands cannot be combined') < (
-        vop3_encoding_ctor.index('std::memcpy(raw_words_.data(), inst, size_);')
-    )
+    assert 'DPP and literal operands cannot be combined' in vop3_validation
     assert 'size_ += sizeof(MachineInst);' in vop3_encoding_ctor
     assert 'std::memcpy(raw_words_.data(), inst, size_);' in vop3_encoding_ctor
     assert 'raw_encoding_ = raw_words_.data();' in vop3_encoding_ctor
+
+    decode = _generated_decode_body(vop3_alu, 'VAddF16Vop3')
+    assert 'Result validation = Vop3::validate_encoding(' in decode
+    assert decode.index('validate_encoding(') < decode.index('validation.failed()')
+    assert decode.index('validation.failed()') < decode.index('std::make_unique')
 
     ctor = _generated_constructor_body(vop3_alu, 'VAddF16Vop3')
     assert 'Vop3VopDpp16MachineInst' in ctor
@@ -2370,6 +2382,18 @@ def test_gfx1250_generated_vop3_add_f16_applies_dpp(
     assert 'ScopedOperandDelegate dpp_src0_binding_(src0, dpp_src0_.get());' in body
     assert 'src0.set_delegate(' not in body
     assert 'src0.clear_delegate();' not in body
+
+
+def test_noop_format_validation_is_inherited(amdgpu_generated_root: Path):
+    encodings_h = (amdgpu_generated_root / 'rdna4' / 'encodings.h').read_text()
+
+    sopp_start = encodings_h.index('class Sopp ')
+    sopp = encodings_h[sopp_start : encodings_h.index('\n};', sopp_start)]
+    assert 'validate_encoding' not in sopp
+
+    vop3_start = encodings_h.index('class Vop3 ')
+    vop3 = encodings_h[vop3_start : encodings_h.index('\n};', vop3_start)]
+    assert 'validate_encoding' in vop3
 
 
 def test_generated_dpp8_disassembly_uses_encoding_state(
@@ -2411,12 +2435,14 @@ def test_gfx1250_generated_vop3_rejects_literal64_selectors(
     assert 'src0 == 254' in vop1_ctor
     assert 'OperandType::OPR_SIMM64' in vop1_ctor
 
+    vop3_decode = _generated_decode_body(vop3_alu, 'VSqrtF16Vop3')
+    assert 'LiteralSupport::Literal32, 1' in vop3_decode
     vop3_ctor = _generated_constructor_body(vop3_alu, 'VSqrtF16Vop3')
-    assert 'LiteralSupport::Literal32, 1' in vop3_ctor
     assert 'OperandType::OPR_SIMM64' not in vop3_ctor
 
+    vop3p_decode = _generated_decode_body(vop3p, 'VFmaMixF32Vop3p')
+    assert 'LiteralSupport::Literal32' in vop3p_decode
     vop3p_ctor = _generated_constructor_body(vop3p, 'VFmaMixF32Vop3p')
-    assert 'LiteralSupport::Literal32' in vop3p_ctor
     assert 'OperandType::OPR_SIMM64' not in vop3p_ctor
 
 
@@ -2434,13 +2460,14 @@ def test_gfx1250_generated_literal_validation(gfx1250_generated_root: Path):
     assert 'case 76:' not in sop1_literal_helper
     assert 'case 77:' not in sop1_literal_helper
 
+    barrier_decode = _generated_decode_body(sop1, 'SBarrierSignalSop1')
+    assert 'LiteralSupport::None' in barrier_decode
     barrier_ctor = _generated_constructor_body(sop1, 'SBarrierSignalSop1')
-    assert 'LiteralSupport::None' in barrier_ctor
     assert 'OperandType::OPR_SIMM32' not in barrier_ctor
     assert 'OperandType::OPR_SIMM64' not in barrier_ctor
 
-    sop2_ctor = _generated_constructor_body(sop2, 'SAddCoU32Sop2')
-    assert 'may not mix 32-bit and 64-bit literals' in sop2_ctor
+    sop2_decode = _generated_decode_body(sop2, 'SAddCoU32Sop2')
+    assert 'may not mix 32-bit and 64-bit literals' in sop2_decode
     assert vopd.count('VOPD does not support 64-bit literals') == 1
     assert 'srcx0 == 254 || srcx0 == 255 || srcy0 == 254 || srcy0 == 255' in vopd
     assert 'VOPD3 does not support literal selectors' in vopd
@@ -2468,14 +2495,14 @@ def test_generated_sendmsg_return_selectors_are_not_literals(
         assert 'OperandType::OPR_SIMM32' not in sendmsg_ctor
         assert 'OperandType::OPR_SIMM64' not in sendmsg_ctor
         if arch == 'gfx1250':
-            assert 'LiteralSupport::None, 0' in sendmsg_ctor
+            sendmsg_decode = _generated_decode_body(sop1, class_name)
+            assert 'LiteralSupport::None, 0' in sendmsg_decode
 
 
 def test_gfx1250_compact_literal_policy_precedes_extension_sizing(
     gfx1250_generated_root: Path,
 ):
     encodings_h = (gfx1250_generated_root / 'encodings.h').read_text()
-    encodings_cpp = (gfx1250_generated_root / 'encodings.cpp').read_text()
     vop1 = (gfx1250_generated_root / 'vop1.cpp').read_text()
     vop2 = (gfx1250_generated_root / 'vop2.cpp').read_text()
 
@@ -2483,17 +2510,28 @@ def test_gfx1250_compact_literal_policy_precedes_extension_sizing(
     assert 'LiteralSupport::Both' in encodings_h
 
     for class_name in ('Vop1', 'Vop2', 'Vopc'):
-        body = _generated_constructor_body(encodings_cpp, class_name)
+        start = encodings_h.index(f'class {class_name} ')
+        body = encodings_h[start : encodings_h.index('\n};', start)]
         assert 'supports_literal(literal_support, LiteralSupport::Literal32)' in body
         assert 'supports_literal(literal_support, LiteralSupport::Literal64)' in body
-        assert body.index('supports_literal(') < body.index('has_encoded_literal64()')
+        assert 'static Result validate_encoding' in body
 
-    readfirstlane = _generated_constructor_body(vop1, 'VReadfirstlaneB32Vop1')
+    readfirstlane = _generated_decode_body(vop1, 'VReadfirstlaneB32Vop1')
     assert 'LiteralSupport::None' in readfirstlane
+    assert readfirstlane.index('validate_encoding(') < readfirstlane.index(
+        'validation.failed()'
+    )
+    assert readfirstlane.index('validation.failed()') < readfirstlane.index(
+        'std::make_unique'
+    )
 
-    fmamk_f64 = _generated_constructor_body(vop2, 'VFmamkF64Vop2')
+    fmamk_f64 = _generated_decode_body(vop2, 'VFmamkF64Vop2')
     assert 'LiteralSupport::Literal64' in fmamk_f64
-    fmamk_f32 = _generated_constructor_body(vop2, 'VFmamkF32Vop2')
+    assert fmamk_f64.index('validate_encoding(') < fmamk_f64.index(
+        'validation.failed()'
+    )
+    assert fmamk_f64.index('validation.failed()') < fmamk_f64.index('std::make_unique')
+    fmamk_f32 = _generated_decode_body(vop2, 'VFmamkF32Vop2')
     assert 'LiteralSupport::Literal32' in fmamk_f32
 
 
@@ -2777,7 +2815,7 @@ def test_cdna4_generated_vop1_sdwa_availability_is_instruction_specific(
     encodings_h = (amdgpu_generated_root / 'cdna4' / 'encodings.h').read_text()
 
     supported = _generated_constructor_body(vop1, 'VMovB32Vop1')
-    unsupported = _generated_constructor_body(vop1, 'VCvtF64I32Vop1')
+    unsupported = _generated_decode_body(vop1, 'VCvtF64I32Vop1')
 
     assert 'reinterpret_cast<const Vop1VopSdwaMachineInst *>' in supported
     assert 'sdwa_mnemonic' not in vop1
@@ -2786,10 +2824,7 @@ def test_cdna4_generated_vop1_sdwa_availability_is_instruction_specific(
     assert vop1_class is not None
     assert 'owned_mnemonic_' not in vop1_class.group()
     assert 'V_MOV_B32 does not support SDWA' not in supported
-    assert (
-        'throw util::InvalidInst("V_CVT_F64_I32 does not support SDWA", "");'
-        in unsupported
-    )
+    assert 'emit_error.emit() << "V_CVT_F64_I32 does not support SDWA"' in unsupported
 
 
 def test_gfx1250_generated_vop1_dpp8_availability_is_instruction_specific(
@@ -2797,13 +2832,11 @@ def test_gfx1250_generated_vop1_dpp8_availability_is_instruction_specific(
 ):
     vop1 = (gfx1250_generated_root / 'vop1.cpp').read_text()
     constructor = _generated_constructor_body(vop1, 'VCvtF64I32Vop1')
+    decode_body = _generated_decode_body(vop1, 'VCvtF64I32Vop1')
 
     assert 'reinterpret_cast<const Vop1VopDpp16MachineInst *>' in constructor
     assert 'reinterpret_cast<const Vop1VopDpp8MachineInst *>' not in constructor
-    assert (
-        'throw util::InvalidInst("V_CVT_F64_I32 does not support DPP8", "");'
-        in constructor
-    )
+    assert 'emit_error.emit() << "V_CVT_F64_I32 does not support DPP8"' in decode_body
 
 
 def test_rdna4_generated_vop3_dpp_availability_is_instruction_specific(
@@ -2813,19 +2846,15 @@ def test_rdna4_generated_vop3_dpp_availability_is_instruction_specific(
     vop3p = (rdna4_generated_root / 'vop3p.cpp').read_text()
 
     supported = _generated_constructor_body(vop3, 'VAddF32Vop3')
-    unsupported_vop3 = _generated_constructor_body(vop3, 'VAddF64Vop3')
-    unsupported_vop3p = _generated_constructor_body(vop3p, 'VPkAddF16Vop3p')
+    unsupported_vop3 = _generated_decode_body(vop3, 'VAddF64Vop3')
+    unsupported_vop3p = _generated_decode_body(vop3p, 'VPkAddF16Vop3p')
 
     assert 'reinterpret_cast<const Vop3VopDpp16MachineInst *>' in supported
     assert 'reinterpret_cast<const Vop3VopDpp8MachineInst *>' in supported
     assert 'V_ADD_F32 does not support DPP' not in supported
+    assert 'emit_error.emit() << "V_ADD_F64 does not support DPP"' in unsupported_vop3
     assert (
-        'throw util::InvalidInst("V_ADD_F64 does not support DPP", "");'
-        in unsupported_vop3
-    )
-    assert (
-        'throw util::InvalidInst("V_PK_ADD_F16 does not support DPP", "");'
-        in unsupported_vop3p
+        'emit_error.emit() << "V_PK_ADD_F16 does not support DPP"' in unsupported_vop3p
     )
 
 
@@ -2852,18 +2881,15 @@ def test_gfx1250_packed_f32_execute_uses_local_simd_probe(
 def test_gfx1250_vop3p_rejects_unencoded_literal64_selectors(
     gfx1250_generated_root: Path,
 ):
-    encodings = (gfx1250_generated_root / 'encodings.cpp').read_text()
+    encodings_h = (gfx1250_generated_root / 'encodings.h').read_text()
     vop3p = (gfx1250_generated_root / 'vop3p.cpp').read_text()
-    ctor_start = encodings.index('Vop3p::Vop3p(')
-    ctor_end = encodings.index('void Vop3p::implicit_uses', ctor_start)
-    vop3p_ctor = encodings[ctor_start:ctor_end]
+    class_start = encodings_h.index('class Vop3p ')
+    validation = encodings_h[class_start : encodings_h.index('\n};', class_start)]
 
-    assert 'num_encoded_sources > 0 && inst_.src0 == 254' in vop3p_ctor
-    assert 'num_encoded_sources > 1 && inst_.src1 == 254' in vop3p_ctor
-    assert 'num_encoded_sources > 2 && inst_.src2 == 254' in vop3p_ctor
-    assert (
-        'throw util::InvalidInst("Vop3p does not support Literal64", "")' in vop3p_ctor
-    )
+    assert 'num_encoded_sources > 0 && inst_.src0 == 254' in validation
+    assert 'num_encoded_sources > 1 && inst_.src1 == 254' in validation
+    assert 'num_encoded_sources > 2 && inst_.src2 == 254' in validation
+    assert 'emit_error.emit() << "Vop3p does not support Literal64"' in validation
 
     for class_name in ('VPkAddF32Vop3p', 'VPkMulF32Vop3p', 'VPkFmaF32Vop3p'):
         body = _generated_constructor_body(vop3p, class_name)
@@ -2871,16 +2897,11 @@ def test_gfx1250_vop3p_rejects_unencoded_literal64_selectors(
         assert 'literal_word + 1' not in body
 
     for class_name in ('VPkAddF32Vop3p', 'VPkMulF32Vop3p'):
-        body = _generated_constructor_body(vop3p, class_name)
-        assert (
-            f'selected_exec_fn(InstructionExecutionId::{class_name}), '
-            'LiteralSupport::Literal32, 2)' in body
-        )
-    fma_body = _generated_constructor_body(vop3p, 'VPkFmaF32Vop3p')
-    assert (
-        'selected_exec_fn(InstructionExecutionId::VPkFmaF32Vop3p), '
-        'LiteralSupport::Literal32)' in fma_body
-    )
+        body = _generated_decode_body(vop3p, class_name)
+        assert 'LiteralSupport::Literal32,' in body
+        assert '2);' in body
+    fma_body = _generated_decode_body(vop3p, 'VPkFmaF32Vop3p')
+    assert 'LiteralSupport::Literal32);' in fma_body
 
 
 def test_split_execution_ids_name_and_match_callbacks(
@@ -3025,14 +3046,9 @@ def test_rdna1_2_generated_vopc_dpp_is_explicitly_unsupported(
         assert 'amdgpu::dpp::apply_dpp' not in vopc_exec, arch
         assert 'dpp_write_mask' not in vopc_exec, arch
 
-        ctor = _generated_constructor_body(vopc_model, 'VCmpEqU32Vopc')
-        assert (
-            'throw util::InvalidInst("V_CMP_EQ_U32 does not support DPP", "");' in ctor
-        ), arch
-        assert (
-            'amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)'
-            in ctor
-        ), arch
+        ctor = _generated_decode_body(vopc_model, 'VCmpEqU32Vopc')
+        assert 'emit_error.emit() << "V_CMP_EQ_U32 does not support DPP"' in ctor, arch
+        assert 'amdgpu::dpp::is_src_dpp8(' in ctor, arch
         assert 'reinterpret_cast<const Vop1VopDpp16MachineInst *>' not in ctor, arch
 
         body = _generated_method_body(vopc_exec, 'VCmpEqU32Vopc', 'VCmpLeU32Vopc')
@@ -3386,7 +3402,6 @@ def test_gfx1250_helper_blocks_emit_scaled_wmma_table_decoder(
     assert (
         'reinterpret_cast<const OpEncoding *>(inst + 2), '
         'selected_exec_fn(InstructionExecutionId::VWmmaScaleF32Vop3px2), '
-        'LiteralSupport::Both, 3, '
         'Vop3p::ExtensionDecodePolicy::Skip),'
     ) in model_impl
 
@@ -3396,8 +3411,9 @@ def test_gfx1250_helper_blocks_emit_scaled_wmma_table_decoder(
 
     decoder = (gfx1250_generated_root / 'decoder.cpp').read_text()
     decode_body = decoder.split(
-        'std::unique_ptr<Instruction> DecoderImpl::decode(const MachineInst *opcode) {'
-    )[1].split('std::unique_ptr<Instruction> DecoderImpl::decodeInvalid', 1)[0]
+        'DecodeResult DecoderImpl::decode(const MachineInst *opcode, '
+        'const DecodeErrorEmitter &emit_error) {'
+    )[1].split('DecodeResult DecoderImpl::decodeInvalid', 1)[0]
     assert 'isWmmaScaleF32Vop3px2' not in decode_body
     assert decoder.count('&DecoderImpl::decodeVWmmaScaleF32Vop3px2,') == 2
     assert 'if (!isVop3pOp(opcode[2], 0x33)' in decoder
@@ -3531,14 +3547,15 @@ def test_instruction_lookahead_derivation_covers_each_width_source() -> None:
 def test_cdna4_vop3px2_prefix_decoder_validates_suffix(cdna4_generated_root: Path):
     decoder = (cdna4_generated_root / 'decoder.cpp').read_text()
     decode_body = decoder.split(
-        'std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {'
-    )[1].split('std::unique_ptr<Instruction> Decoder::decodeInvalid', 1)[0]
+        'DecodeResult DecoderImpl::decode(const MachineInst *opcode, '
+        'const DecodeErrorEmitter &emit_error) {'
+    )[1].split('DecodeResult DecoderImpl::decodeInvalid', 1)[0]
 
     assert 'isMfmaScaleF8f6f4Vop3px2' not in decode_body
     assert 'suffix_encoding != encoding::kVop3pMfma' in decoder
     assert 'kVMfmaF3216x16x128F8f6f4Vop3pMfma' in decoder
     assert 'kVMfmaF3232x32x64F8f6f4Vop3pMfma' in decoder
-    assert 'return decodeInvalid(opcode);' in decoder
+    assert 'return decodeInvalid(opcode, emit_error);' in decoder
     assert 'VMfmaF3216x16x128F8f6f4Vop3pMfma>(opcode + 2, true)' in decoder
     assert 'VMfmaF3232x32x64F8f6f4Vop3pMfma>(opcode + 2, true)' in decoder
     assert '#include "rocjitsu/isa/arch/amdgpu/generated/cdna4/opcodes.h"' in decoder
@@ -3561,8 +3578,9 @@ def test_vopd_dispatch_uses_primary_decode_table(
     arch_root = amdgpu_generated_root / _generated_dir_name(arch_name)
     decoder = (arch_root / 'decoder.cpp').read_text()
     decode_body = decoder.split(
-        'std::unique_ptr<Instruction> DecoderImpl::decode(const MachineInst *opcode) {'
-    )[1].split('std::unique_ptr<Instruction> DecoderImpl::decodeInvalid', 1)[0]
+        'DecodeResult DecoderImpl::decode(const MachineInst *opcode, '
+        'const DecodeErrorEmitter &emit_error) {'
+    )[1].split('DecodeResult DecoderImpl::decodeInvalid', 1)[0]
 
     assert 'Vopd::is_vopd' not in decode_body
     primary_table = decoder.split('DecoderImpl::primary_decode_table = {', 1)[1].split(
@@ -3578,7 +3596,12 @@ def test_vopd_dispatch_uses_primary_decode_table(
         if entry == '&DecoderImpl::decodeVopd'
     }
     assert actual_vopd_indices == expected_vopd_indices
-    assert 'DecoderImpl::decodeVopd(const MachineInst *opcode)' in decoder
+    assert re.search(
+        r'DecoderImpl::decodeVopd\(const MachineInst \*opcode,\s+'
+        r'const DecodeErrorEmitter &emit_error\)',
+        decoder,
+    )
+    assert 'Result validation = Vopd::validate_encoding(opcode, emit_error);' in decoder
     assert 'is_vopd' not in (arch_root / 'vopd.h').read_text()
     assert 'is_vopd' not in (arch_root / 'vopd.cpp').read_text()
 
@@ -3603,7 +3626,7 @@ def test_decoder_header_keeps_dispatch_details_private(
         assert 'DecodeFunc' not in decoder_header
         assert 'decodeInvalid' not in decoder_header
         assert 'primary_decode_table' not in decoder_header
-        assert decoder_header.count('static std::unique_ptr<Instruction> decode(') == 1
+        assert decoder_header.count('static DecodeResult decode(') == 1
 
 
 def test_gfx1250_scaled_wmma_skips_vop3p_extension_decode(
@@ -3626,7 +3649,6 @@ def test_gfx1250_scaled_wmma_skips_vop3p_extension_decode(
     guarded_body, constructor_suffix = guarded_suffix.rsplit('\n  }\n}', 1)
     assert not constructor_suffix.strip()
     for extension_step in (
-        'throw util::InvalidInst("Vop3p does not support Literal64", "")',
         'has_encoded_literal32()',
         'inst_.src0 == amdgpu::SRC_DPP',
         'amdgpu::dpp::is_src_dpp8(inst_.src0)',
@@ -3635,9 +3657,14 @@ def test_gfx1250_scaled_wmma_skips_vop3p_extension_decode(
     ):
         assert extension_step in guarded_body
 
+    validation_start = encodings_h.index('class Vop3p ')
+    validation = encodings_h[
+        validation_start : encodings_h.index('\n};', validation_start)
+    ]
+    assert 'emit_error.emit() << "Vop3p does not support Literal64"' in validation
+
     assert (
         'selected_exec_fn(InstructionExecutionId::VWmmaScaleF32Vop3px2), '
-        'LiteralSupport::Both, 3, '
         'Vop3p::ExtensionDecodePolicy::Skip)'
     ) in vop3p_cpp
 
@@ -3802,10 +3829,12 @@ def test_gfx1250_vopd_template_uses_dx9_zero_and_fma(tmp_path):
     assert 'make_src0(y_bits, true, false, 0, srcy0)' in cpp
     assert 'make_src0(x_bits, false, has_literal_, literal_, srcx0)' in cpp
     assert 'make_src0(y_bits, false, has_literal_, literal_, srcy0)' in cpp
-    assert 'if (!is_valid_opcode(opx_, kVopdXOpcodeMask))' in cpp
-    assert 'if (!is_valid_opcode(opy_, kVopdYOpcodeMask))' in cpp
-    assert 'if (!is_valid_opcode(opx_, kVopd3XOpcodeMask))' in cpp
-    assert 'if (!is_valid_opcode(opy_, kVopd3YOpcodeMask))' in cpp
+    assert 'if (!is_valid_opcode(opx, kVopdXOpcodeMask))' in cpp
+    assert 'if (!is_valid_opcode(opy, kVopdYOpcodeMask))' in cpp
+    assert 'if (!is_valid_opcode(opx, kVopd3XOpcodeMask))' in cpp
+    assert 'if (!is_valid_opcode(opy, kVopd3YOpcodeMask))' in cpp
+    assert 'return emit_error.emit() << "invalid VOPD X opcode";' in cpp
+    assert 'throw util::InvalidInst' not in cpp
     assert 'if (vdstx < y_end && vdsty < x_end)' in cpp
     assert 'case 3:\n              case 7:' not in cpp
     assert 'if (lhs == 0.0f || rhs == 0.0f)' in exec_cpp
@@ -4288,7 +4317,7 @@ def test_cdna4_mfma_f8f6f4_accepts_standalone_and_prefixed_encodings(
     source = (amdgpu_generated_root / 'cdna4' / 'vop3p.cpp').read_text()
 
     assert 'VMfmaF3216x16x128F8f6f4Vop3pMfma>(opcode + 2, true)' in decoder
-    assert 'decodeVMfmaF3216x16x128F8f6f4Vop3pMfma(const MachineInst *opcode)' in source
+    assert 'decodeVMfmaF3216x16x128F8f6f4Vop3pMfma(const MachineInst *opcode,' in source
     assert 'decodeVMfmaF3216x16x128F8f6f4Vop3pMfma' in decoder
     assert 'bool has_vop3px2_prefix = false' in header
     assert 'if (has_vop3px2_prefix)' in source

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
@@ -145,10 +145,10 @@ void BasicBlock::add_static_pc_address_builder(PcAddressBuilder builder) {
   static_pc_address_builders_.push_back(builder);
 }
 
-std::vector<std::unique_ptr<BasicBlock>>
+FailureOr<std::vector<std::unique_ptr<BasicBlock>>>
 BasicBlock::build(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
-                  std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy,
-                  std::span<const uint64_t> extra_split_points) {
+                  DecodeErrorEmitter emit_error, std::span<const uint64_t> extra_leaders,
+                  ExternalEntryPolicy entry_policy, std::span<const uint64_t> extra_split_points) {
   std::vector<std::unique_ptr<BasicBlock>> blocks;
 
   for (const auto *sec : co.text_sections()) {
@@ -169,14 +169,15 @@ BasicBlock::build(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
         continue;
       }
 
-      Instruction *raw_inst = nullptr;
-      try {
-        raw_inst = decoder.decode(&inst_data[pc], byte_offset);
-      } catch (const util::InvalidInst &error) {
-        throw util::InvalidInst(
-            std::string(error.what()) + " at .text byte offset " + std::to_string(byte_offset), "");
-      }
-      std::unique_ptr<Instruction> inst(raw_inst);
+      auto emit_at_offset = [&](std::string_view message) {
+        emit_error.emit() << message << " at .text byte offset " << byte_offset;
+      };
+      const DecodeErrorEmitter decode_error =
+          emit_error.ignores_messages() ? DecodeErrorEmitter{} : DecodeErrorEmitter(emit_at_offset);
+      DecodeResult decode_result = decoder.decode(&inst_data[pc], byte_offset, decode_error);
+      if (decode_result.failed())
+        return Result::failure();
+      std::unique_ptr<Instruction> inst = std::move(decode_result).value();
       uint32_t inst_size_bytes = static_cast<uint32_t>(inst->size());
       uint32_t inst_words = inst_size_bytes / sizeof(uint32_t);
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.h
@@ -10,6 +10,7 @@
 #include "rocjitsu/analysis/indirect_branch_discovery.h"
 #include "rocjitsu/code/instruction_list.h"
 #include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/decode_result.h"
 #include "util/intrusive_list.h"
 
 #include <cstdint>
@@ -153,6 +154,8 @@ public:
   /// @param[in] co Code object to analyze.
   /// @param[in] decoder Decoder for the target ISA.
   /// @param[in] arch ISA architecture used to match static PC builders.
+  /// @param[in] emit_error Destination for a decode diagnostic, including the
+  /// source `.text` byte offset.
   /// @param[in] extra_leaders Byte offsets that must start a basic block AND are entered from
   /// outside the decoded graph. Under ExplicitOnly these become the external-entry set, so an
   /// offset listed here has no incoming caller facts.
@@ -163,10 +166,10 @@ public:
   /// entries. Function-entry symbols and stored-pointer targets belong here: they are genuine
   /// boundaries, yet most are ordinary helpers whose callers reach them by a decoded edge, and
   /// calling them external would throw those caller facts away.
-  /// @returns Ordered list of basic blocks with their decoded instructions.
-  static std::vector<std::unique_ptr<BasicBlock>>
+  /// @returns Ordered basic blocks with their decoded instructions, or failure.
+  static FailureOr<std::vector<std::unique_ptr<BasicBlock>>>
   build(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
-        std::span<const uint64_t> extra_leaders = {},
+        DecodeErrorEmitter emit_error = {}, std::span<const uint64_t> extra_leaders = {},
         ExternalEntryPolicy entry_policy = ExternalEntryPolicy::InferPredecessorless,
         std::span<const uint64_t> extra_split_points = {});
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -35,7 +35,6 @@
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/isa/isa_traits.h"
-#include "util/except.h"
 
 #include <algorithm>
 #include <cassert>
@@ -354,15 +353,13 @@ generated_branch_island_pool_offsets(std::span<const uint8_t> text, rj_code_arch
       // A malformed slot can select an extension-bearing format. Pad the
       // speculative decode so pool recognition never reads beyond its input.
       const std::array<uint32_t, 3> slot_words = {text_word_at(text, slot_offset), 0, 0};
-      try {
-        std::unique_ptr<Instruction> slot_inst(decoder->decode(slot_words.data()));
-        if (slot_inst && slot_inst->size() == static_cast<int>(sizeof(uint32_t)) &&
+      DecodeResult decoded = decoder->decode(slot_words.data());
+      if (decoded.succeeded()) {
+        const std::unique_ptr<Instruction> &slot_inst = decoded.value();
+        if (slot_inst->size() == static_cast<int>(sizeof(uint32_t)) &&
             slot_inst->mnemonic() == "s_branch" && slot_inst->branch_offset_bytes()) {
           continue;
         }
-      } catch (const util::InvalidInst &) {
-        // A marker-shaped region containing an invalid instruction is not a
-        // generated pool. Normal block decoding will report the instruction.
       }
       has_canonical_slots = false;
       break;
@@ -1938,10 +1935,9 @@ namespace internal {
 RewriteDischargeInstructionDecoder::RewriteDischargeInstructionDecoder(Decoder &decoder)
     : decoder_(decoder), lookahead_words_(decoder.max_instruction_words()) {}
 
-RewriteDischargeDecodeStatus
-RewriteDischargeInstructionDecoder::decode(std::span<const uint8_t> remaining_bytes,
-                                           uint64_t source_offset,
-                                           std::unique_ptr<Instruction> &instruction) {
+RewriteDischargeDecodeStatus RewriteDischargeInstructionDecoder::decode(
+    std::span<const uint8_t> remaining_bytes, uint64_t source_offset,
+    std::unique_ptr<Instruction> &instruction, const DecodeErrorEmitter &emit_error) {
   instruction.reset();
   if (lookahead_words_.empty())
     return RewriteDischargeDecodeStatus::InvalidLookaheadBound;
@@ -1950,7 +1946,10 @@ RewriteDischargeInstructionDecoder::decode(std::span<const uint8_t> remaining_by
   const size_t remaining_words = remaining_bytes.size() / sizeof(uint32_t);
   const size_t copied_words = std::min(remaining_words, lookahead_words_.size());
   std::memcpy(lookahead_words_.data(), remaining_bytes.data(), copied_words * sizeof(uint32_t));
-  instruction.reset(decoder_.decode(lookahead_words_.data(), source_offset));
+  DecodeResult decoded = decoder_.decode(lookahead_words_.data(), source_offset, emit_error);
+  if (decoded.failed())
+    return RewriteDischargeDecodeStatus::InvalidEncoding;
+  instruction = std::move(decoded).value();
   if (instruction == nullptr || instruction->size() <= 0 ||
       instruction->size() % static_cast<int>(sizeof(uint32_t)) != 0) {
     return RewriteDischargeDecodeStatus::InvalidInstructionSize;
@@ -2191,12 +2190,21 @@ void BinaryTranslator::verify_rewrite_discharge(TranslatedCodeObject &result) co
       }
 
       std::unique_ptr<Instruction> inst;
-      const auto decode_status = instruction_decoder.decode(text_bytes.subspan(instruction_offset),
-                                                            instruction_offset, inst);
+      util::StringDiagnostic decode_error;
+      const auto decode_status = instruction_decoder.decode(
+          text_bytes.subspan(instruction_offset), instruction_offset, inst, decode_error.emitter());
       if (decode_status == internal::RewriteDischargeDecodeStatus::InvalidLookaheadBound) {
         append_rewrite_discharge_error(
             result.diagnostics,
             "rewrite-discharge verification decoder reported an invalid lookahead bound");
+        return;
+      }
+      if (decode_status == internal::RewriteDischargeDecodeStatus::InvalidEncoding) {
+        append_rewrite_discharge_error(
+            result.diagnostics,
+            "rewrite-discharge verification failed to decode final output: " +
+                decode_error.message(),
+            instruction_offset);
         return;
       }
       if (decode_status == internal::RewriteDischargeDecodeStatus::InvalidInstructionSize) {
@@ -2244,8 +2252,17 @@ void BinaryTranslator::verify_rewrite_discharge(TranslatedCodeObject &result) co
       return;
     }
 
-    const auto blocks = BasicBlock::build(output, *decoder, host_arch_, block_leaders,
-                                          ExternalEntryPolicy::ExplicitOnly);
+    util::StringDiagnostic decode_error;
+    FailureOr<std::vector<std::unique_ptr<BasicBlock>>> block_result =
+        BasicBlock::build(output, *decoder, host_arch_, decode_error.emitter(), block_leaders,
+                          ExternalEntryPolicy::ExplicitOnly);
+    if (block_result.failed()) {
+      append_rewrite_discharge_error(
+          result.diagnostics, "rewrite-discharge verification failed to decode final output: " +
+                                  decode_error.message());
+      return;
+    }
+    std::vector<std::unique_ptr<BasicBlock>> blocks = std::move(block_result).value();
     if (has_invalid_block_leader(blocks, block_leaders, text->size())) {
       append_rewrite_discharge_error(
           result.diagnostics,
@@ -2496,13 +2513,15 @@ TranslatedCodeObject BinaryTranslator::translate_impl(const AmdGpuCodeObject &ob
   // branch or call target can be resolved through the current kernel's placement
   // map without borrowing another kernel's return continuation.
   std::vector<std::unique_ptr<BasicBlock>> blocks;
-  try {
-    blocks = BasicBlock::build(obj, *decoder, guest_arch_, block_leaders,
-                               ExternalEntryPolicy::ExplicitOnly, block_split_points);
-  } catch (const util::InvalidInst &error) {
-    append_error(result.diagnostics, DiagnosticKind::Legalization, error.what());
+  util::StringDiagnostic decode_error;
+  auto block_result =
+      BasicBlock::build(obj, *decoder, guest_arch_, decode_error.emitter(), block_leaders,
+                        ExternalEntryPolicy::ExplicitOnly, block_split_points);
+  if (block_result.failed()) {
+    append_error(result.diagnostics, DiagnosticKind::Legalization, decode_error.message());
     return leave_unchanged();
   }
+  blocks = std::move(block_result).value();
   if (has_invalid_block_leader(blocks, block_leaders, text.size())) {
     append_error(result.diagnostics, DiagnosticKind::Legalization,
                  "translation found an invalid executable entry");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator_internal.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator_internal.h
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include "rocjitsu/isa/decode_result.h"
+
 #include <cstdint>
 #include <memory>
 #include <span>
@@ -29,6 +31,7 @@ namespace internal {
 enum class RewriteDischargeDecodeStatus : uint8_t {
   Success,
   InvalidLookaheadBound,
+  InvalidEncoding,
   InvalidInstructionSize,
   TruncatedInstruction,
 };
@@ -46,7 +49,8 @@ public:
 
   [[nodiscard]] RewriteDischargeDecodeStatus decode(std::span<const uint8_t> remaining_bytes,
                                                     uint64_t source_offset,
-                                                    std::unique_ptr<Instruction> &instruction);
+                                                    std::unique_ptr<Instruction> &instruction,
+                                                    const DecodeErrorEmitter &emit_error = {});
 
 private:
   Decoder &decoder_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -584,7 +584,13 @@ bool Instrumentor::ensure_blocks_built(std::string *error_out) {
     return false;
   }
   decoder_ = std::move(decoder);
-  blocks_ = BasicBlock::build(obj_, *decoder_, arch_);
+  util::StringDiagnostic decode_error;
+  auto blocks = BasicBlock::build(obj_, *decoder_, arch_, decode_error.emitter());
+  if (blocks.failed()) {
+    report(error_out, decode_error.message().c_str());
+    return false;
+  }
+  blocks_ = std::move(blocks).value();
   // BasicBlock::build returns blocks in .text order. Keep clause state across
   // block boundaries because a branch target may split the linear instruction
   // stream in the middle of a clause.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_callable.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_callable.cpp
@@ -15,6 +15,8 @@
 #include <cstring>
 #include <memory>
 #include <span>
+#include <string>
+#include <string_view>
 
 namespace rocjitsu {
 
@@ -172,11 +174,15 @@ std::optional<ProbeCallable> build_probe_callable(const AmdGpuCodeObject &probe_
   bool last_has_src0 = false;
   size_t w = 0;
   while (w < num_words) {
-    std::unique_ptr<Instruction> inst(decoder->decode(&words[w]));
-    if (inst == nullptr) {
-      report(error_out, "probe body failed to decode");
+    util::StringDiagnostic decode_error;
+    DecodeResult decoded = decoder->decode(&words[w], decode_error.emitter());
+    if (decoded.failed()) {
+      const std::string message = "probe body failed to decode at word " + std::to_string(w) +
+                                  ": " + decode_error.message();
+      report(error_out, message.c_str());
       return std::nullopt;
     }
+    std::unique_ptr<Instruction> inst = std::move(decoded).value();
     const int size = inst->size();
     if (size != 4 && size != 8) {
       report(error_out, "probe body has an unsupported instruction size");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_clobber.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_clobber.cpp
@@ -138,11 +138,15 @@ std::optional<ProbeClobberSummary> build_probe_clobber_summary(const ProbeCallab
 
   size_t w = 0;
   while (w < num_words) {
-    std::unique_ptr<Instruction> inst(decoder->decode(&words[w]));
-    if (!inst) {
-      report(error_out, "failed to decode probe body while summarizing clobbers");
+    util::StringDiagnostic decode_error;
+    DecodeResult decoded = decoder->decode(&words[w], decode_error.emitter());
+    if (decoded.failed()) {
+      const std::string message = "failed to decode probe body at word " + std::to_string(w) +
+                                  " while summarizing clobbers: " + decode_error.message();
+      report(error_out, message.c_str());
       return std::nullopt;
     }
+    std::unique_ptr<Instruction> inst = std::move(decoded).value();
     const int size = inst->size();
     if (size != 4 && size != 8) {
       report(error_out, "probe body instruction has an unexpected size");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp
@@ -5,9 +5,9 @@
 
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/target_registry.h"
-#include "util/except.h"
 
 #include <cstring>
+#include <new>
 #include <unordered_map>
 
 using namespace rocjitsu;
@@ -136,8 +136,10 @@ rj_status_t rj_code_inst_list_create(rj_code_object_t *obj, rj_code_target_id_t 
       // at word zero for each section.
       std::size_t word_index = 0;
       while (word_index < inst_data_size) {
-        auto *raw_inst = decoder->decode(&inst_data[word_index]);
-        std::unique_ptr<Instruction> inst(raw_inst);
+        DecodeResult decoded = decoder->decode(&inst_data[word_index]);
+        if (decoded.failed())
+          return ROCJITSU_STATUS_ERROR;
+        std::unique_ptr<Instruction> inst = std::move(decoded).value();
         owned->list.push_back(*inst);
         word_index += static_cast<std::size_t>(inst->size()) / sizeof(uint32_t);
         owned->storage.push_back(std::move(inst));
@@ -145,7 +147,9 @@ rj_status_t rj_code_inst_list_create(rj_code_object_t *obj, rj_code_target_id_t 
     }
 
     *inst_list = owned.release();
-  } catch (const util::InvalidInst &) {
+  } catch (const std::bad_alloc &) {
+    return ROCJITSU_STATUS_OUT_OF_RESOURCES;
+  } catch (...) {
     return ROCJITSU_STATUS_ERROR;
   }
   return ROCJITSU_STATUS_SUCCESS;
@@ -191,12 +195,17 @@ rj_status_t rj_code_basic_block_list_create(rj_code_object_t *obj, rj_code_targe
   try {
     Instruction::ScopedHeapAllocation heap_allocation;
     auto owned = std::make_unique<rj_code_basic_block_list_t>();
-    owned->blocks = BasicBlock::build(*obj->co, *decoder, arch);
+    auto blocks = BasicBlock::build(*obj->co, *decoder, arch);
+    if (blocks.failed())
+      return ROCJITSU_STATUS_ERROR;
+    owned->blocks = std::move(blocks).value();
     *list = owned.release();
-  } catch (const util::InvalidInst &) {
+    return ROCJITSU_STATUS_SUCCESS;
+  } catch (const std::bad_alloc &) {
+    return ROCJITSU_STATUS_OUT_OF_RESOURCES;
+  } catch (...) {
     return ROCJITSU_STATUS_ERROR;
   }
-  return ROCJITSU_STATUS_SUCCESS;
 }
 
 void rj_code_basic_block_list_retain(rj_code_basic_block_list_t *list) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/decoder.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/decoder.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/vop3p.h"
-#include "util/except.h"
 #include <array>
 #include <bit>
 #include <format>
@@ -15,1475 +14,1985 @@ namespace rocjitsu {
 namespace cdna1 {
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicPkAddF16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSminMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUminMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSbyteMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadShortD16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSshortMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUbyteMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUshortMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreByteMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreLdsDwordMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreShortMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferWbinvl1Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferWbinvl1VolMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAppendDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsBpermuteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsConsumeDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsBarrierDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsInitDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaBrDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaPDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaVDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsNopDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrderedCountDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPermuteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2st64B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2st64B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadAddtidB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB128Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB96Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI8D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU16D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU16D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU8D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSwizzleB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrapRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2st64B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2st64B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteAddtidB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB128Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB16D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB96Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeExpExp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSminFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSminX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUminFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUminX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordx2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordx3Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordx4Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSbyteFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadShortD16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadShortD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSshortFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUbyteFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUshortFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreByteD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreByteFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordx2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordx3Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordx4Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreShortD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreShortFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicAddMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicAndMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicCmpswapMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicDecMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicIncMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicOrMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSmaxMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSminMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSubMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSwapMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicUmaxMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicUminMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicXorMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4BClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4BClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4BMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4BOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CBClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CBClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CBMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CBOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4COMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4ClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4ClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4OMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4hMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4hPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather8hPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGetLodMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGetResinfoMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipPckSgnMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadPckSgnMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStorePckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddcU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn1WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtcProbeBufferSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtcProbeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicAddSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicAddX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicAndSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicAndX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicCmpswapSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicCmpswapX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicDecSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicDecX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicIncSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicIncX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicOrSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicOrX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSmaxSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSmaxX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSminSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSminX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSubSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSubX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSwapSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSwapX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicUmaxSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicUmaxX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicUminSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicUminX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicXorSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicXorX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBarrierSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicAddSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicAddX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicAndSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicAndX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicCmpswapSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicCmpswapX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicDecSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicDecX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicIncSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicIncX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicOrSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicOrX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSmaxSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSmaxX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSminSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSminX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSubSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSubX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSwapSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSwapX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicUmaxSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicUmaxX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicUminSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicUminX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicXorSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicXorX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferStoreDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferStoreDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferStoreDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCallB64Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbguserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchGForkSop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchIForkSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchJoinSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkEqI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkEqU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGeI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGeU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGtI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGtU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLeI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLeU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLgI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLgU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLtI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLtU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheDiscardSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheDiscardX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheInvVolSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheWbSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheWbVolSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf0I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf0I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf1I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf1I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32I64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetpcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMemrealtimeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMemtimeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRfeB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRfeRestoreB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchLoadDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchStoreDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchStoreDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchStoreDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetGprIdxIdxSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetGprIdxModeSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetGprIdxOffSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetGprIdxOnSopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetkillSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetpcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetvskipSopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSStoreDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSStoreDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSStoreDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubbU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSwappcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAccvgprReadVop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAccvgprWriteVop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddcCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddcCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClrexcpVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClrexcpVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkaccumU8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormI16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormU16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupLegacyF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2F32F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2I32I16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2U32U16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cI32I16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cI32I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4I32I8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8I32I4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8cI32I4Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8cI32I4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhI32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhU32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfblB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfblB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaLegacyF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpMovF32Vintrp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpMovF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP1F32Vintrp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP1F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP1llF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP1lvF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2F32Vintrp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2LegacyF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMacF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMacF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMacF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadLegacyF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadLegacyF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadLegacyI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadLegacyU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadMixF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadMixhiF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadMixloF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadakF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadakF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadmkF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadmkF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x16f16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x1f32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x2bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x4f16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x4f32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x8bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x1f32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x2bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x2f32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x4bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x4f16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x8f16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF324x4x1f32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF324x4x2bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF324x4x4f16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI3216x16x16i8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI3216x16x4i8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI3232x32x4i8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI3232x32x8i8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI324x4x4i8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLegacyF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLegacyF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVScreenPartition4seB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVScreenPartition4seB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubbCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubbCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubbrevCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubbrevCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwapB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode);
+DecodeResult decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrMubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicPkAddF16Mubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXMubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadShortD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreByteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreLdsDwordMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreShortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferWbinvl1Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferWbinvl1VolMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAppendDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsBpermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsConsumeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsBarrierDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsInitDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaBrDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaPDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaVDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsNopDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrderedCountDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2st64B32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2st64B64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadAddtidB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI8D16HiDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU16D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU16D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU8D16HiDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSwizzleB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrapRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2st64B32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2st64B64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteAddtidB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB16D16HiDs(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB8D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchgRtnB32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchgRtnB64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeExpExp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapFlat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrX2Flat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordx2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordx3Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordx4Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadShortD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadShortD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreByteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreByteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordx2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordx3Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordx4Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreShortD16HiFlat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreShortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicAddMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicAndMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicCmpswapMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicDecMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicIncMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicOrMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSubMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSwapMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicUmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicUminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicXorMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4BClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4BClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4BMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4BOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CBClMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CBClOMimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CBMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CBOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLzMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLzOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4COMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4ClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4ClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4Mimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4OMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4hMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4hPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather8hPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGetLodMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGetResinfoMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipPckMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipPckSgnMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadPckMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadPckSgnMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdClMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdClOMimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleClMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleClOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLzMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLzOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleOMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStorePckMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddcU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn1WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtcProbeBufferSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtcProbeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicAddSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicAddX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicAndSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicAndX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicCmpswapSmem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicCmpswapX2Smem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicDecSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicDecX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicIncSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicIncX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicOrSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicOrX2Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSmaxSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSmaxX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSminSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSminX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSubSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSubX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSwapSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSwapX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicUmaxSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicUmaxX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicUminSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicUminX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicXorSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicXorX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBarrierSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicAddSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicAddX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicAndSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicAndX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicCmpswapSmem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicCmpswapX2Smem(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicDecSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicDecX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicIncSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicIncX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicOrSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicOrX2Smem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSmaxSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSmaxX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSminSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSminX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSubSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSubX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSwapSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSwapX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicUmaxSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicUmaxX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicUminSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicUminX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicXorSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicXorX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx16Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx4Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx8Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferStoreDwordSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferStoreDwordx2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferStoreDwordx4Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCallB64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysSopp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbguserSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchGForkSop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchIForkSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchJoinSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkEqI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkEqU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLgI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLgU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheDiscardSmem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheDiscardX2Smem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheInvVolSmem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheWbSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheWbVolSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf0I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf0I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf1I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf1I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32I64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx16Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx4Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx8Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMemrealtimeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMemtimeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRfeB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRfeRestoreB64Sop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchLoadDwordSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchLoadDwordx2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchLoadDwordx4Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchStoreDwordSmem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchStoreDwordx2Smem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchStoreDwordx4Smem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetGprIdxIdxSop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetGprIdxModeSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetGprIdxOffSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetGprIdxOnSopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetkillSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetvskipSopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSStoreDwordSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSStoreDwordx2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSStoreDwordx4Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubbU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSwappcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAccvgprReadVop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAccvgprWriteVop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddcCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddcCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClrexcpVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClrexcpVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFlrI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFlrI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkaccumU8F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtRpiI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtRpiI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupLegacyF16Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2F32F16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2I32I16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2U32U16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cF32F16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cF32F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cI32I16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cI32I16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4I32I8Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4cI32I8Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4cI32I8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8I32I4Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8cI32I4Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8cI32I4Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhU32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfblB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfblB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaLegacyF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpMovF32Vintrp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpMovF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP1F32Vintrp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP1F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP1llF16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP1lvF16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2F32Vintrp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2LegacyF16Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadLegacyF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadLegacyI16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadLegacyU16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadMixF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadmkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadmkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x16f16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x1f32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x2bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x4f16Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x4f32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x8bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x1f32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x2bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x2f32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x4bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x4f16Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x8f16Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF324x4x1f32Vop3pMfma(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF324x4x2bf16Vop3pMfma(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF324x4x4f16Vop3pMfma(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI3216x16x16i8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI3216x16x4i8Vop3pMfma(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI3232x32x4i8Vop3pMfma(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI3232x32x8i8Vop3pMfma(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI324x4x4i8Vop3pMfma(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLegacyF32Vop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVScreenPartition4seB32Vop1(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVScreenPartition4seB32Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubbCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubbCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubbrevCoU32Vop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubbrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwapB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 } // namespace detail
 
 struct DecoderImpl {
 public:
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 
 private:
-  using DecodeFunc = std::unique_ptr<Instruction> (*)(const MachineInst *);
-  static std::unique_ptr<Instruction> decodeInvalid(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopp(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSmem(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3p(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVintrp(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeDs(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeFlat(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMubuf(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMtbuf(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMimg(const MachineInst *opcode);
+  using DecodeFunc = DecodeResult (*)(const MachineInst *, const DecodeErrorEmitter &);
+  static DecodeResult decodeInvalid(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVintrp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMtbuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
   static const std::array<DecodeFunc, 512> primary_decode_table;
   static const std::array<DecodeFunc, 256> sub_decode_vopc;
   static const std::array<DecodeFunc, 256> sub_decode_vop1;
@@ -1501,88 +2010,102 @@ private:
   static const std::array<DecodeFunc, 256> sub_decode_mimg;
 };
 
-std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
-  return DecoderImpl::decode(opcode);
+DecodeResult Decoder::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  return DecoderImpl::decode(opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decode(const MachineInst *opcode) {
+DecodeResult DecoderImpl::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
   Sop1MachineInst op = std::bit_cast<decltype(op)>(*opcode);
-  return primary_decode_table[op.encoding](opcode);
+  return primary_decode_table[op.encoding](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decodeInvalid(const MachineInst *opcode) {
-  throw util::InvalidInst(std::format("{:X}", *opcode));
-  return nullptr;
+DecodeResult DecoderImpl::decodeInvalid(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  return emit_error.emit() << "Invalid instruction opcode: " << std::format("{:X}", *opcode);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vopc[op.op](opcode);
+  return sub_decode_vopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop1[op.op](opcode);
+  return sub_decode_vop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sop1[op.op](opcode);
+  return sub_decode_sop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopc[op.op](opcode);
+  return sub_decode_sopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopp(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopp::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopp[op.op](opcode);
+  return sub_decode_sopp[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSmem(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Smem::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_smem[op.op](opcode);
+  return sub_decode_smem[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop3::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3[op.op](opcode);
+  return sub_decode_vop3[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3p(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3p(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Vop3p::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3p[op.op](opcode);
+  return sub_decode_vop3p[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVintrp(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVintrp(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
   Vintrp::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vintrp[op.op](opcode);
+  return sub_decode_vintrp[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeDs(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeDs(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
   Ds::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_ds[op.op](opcode);
+  return sub_decode_ds[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeFlat(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeFlat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Flat::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_flat[op.op](opcode);
+  return sub_decode_flat[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMubuf(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Mubuf::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mubuf[op.op](opcode);
+  return sub_decode_mubuf[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMtbuf(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMtbuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Mtbuf::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mtbuf[op.op](opcode);
+  return sub_decode_mtbuf[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMimg(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Mimg::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mimg[op.op](opcode);
+  return sub_decode_mimg[op.op](opcode, emit_error);
 }
 
 const std::array<DecoderImpl::DecodeFunc, 512> DecoderImpl::primary_decode_table = {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/decoder.h
@@ -8,6 +8,7 @@
 #define ROCJITSU_ISA_ARCH_AMDGPU_CDNA1_DECODER_H_
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/machine_insts.h"
+#include "rocjitsu/isa/decode_result.h"
 #include <array>
 #include <cstddef>
 #include <memory>
@@ -21,7 +22,7 @@ namespace cdna1 {
 class Decoder {
 public:
   static constexpr std::size_t kMaxInstructionWords = 4;
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 };
 
 } // namespace cdna1

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/ds.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/ds.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/ds.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -31,7 +30,11 @@ DsAddU32Ds::DsAddU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU32Ds>(opcode);
 }
 } // namespace detail
@@ -54,7 +57,11 @@ DsSubU32Ds::DsSubU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU32Ds>(opcode);
 }
 } // namespace detail
@@ -77,7 +84,11 @@ DsRsubU32Ds::DsRsubU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU32Ds>(opcode);
 }
 } // namespace detail
@@ -100,7 +111,11 @@ DsIncU32Ds::DsIncU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU32Ds>(opcode);
 }
 } // namespace detail
@@ -123,7 +138,11 @@ DsDecU32Ds::DsDecU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU32Ds>(opcode);
 }
 } // namespace detail
@@ -146,7 +165,11 @@ DsMinI32Ds::DsMinI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI32Ds>(opcode);
 }
 } // namespace detail
@@ -169,7 +192,11 @@ DsMaxI32Ds::DsMaxI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI32Ds>(opcode);
 }
 } // namespace detail
@@ -192,7 +219,11 @@ DsMinU32Ds::DsMinU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU32Ds>(opcode);
 }
 } // namespace detail
@@ -215,7 +246,11 @@ DsMaxU32Ds::DsMaxU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU32Ds>(opcode);
 }
 } // namespace detail
@@ -238,7 +273,11 @@ DsAndB32Ds::DsAndB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB32Ds>(opcode);
 }
 } // namespace detail
@@ -261,7 +300,11 @@ DsOrB32Ds::DsOrB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB32Ds>(opcode);
 }
 } // namespace detail
@@ -284,7 +327,11 @@ DsXorB32Ds::DsXorB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB32Ds>(opcode);
 }
 } // namespace detail
@@ -309,7 +356,11 @@ DsMskorB32Ds::DsMskorB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB32Ds>(opcode);
 }
 } // namespace detail
@@ -330,7 +381,11 @@ DsWriteB32Ds::DsWriteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB32Ds>(opcode);
 }
 } // namespace detail
@@ -353,7 +408,11 @@ DsWrite2B32Ds::DsWrite2B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2B32Ds>(opcode);
 }
 } // namespace detail
@@ -376,7 +435,12 @@ DsWrite2st64B32Ds::DsWrite2st64B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2st64B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2st64B32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2st64_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2st64B32Ds>(opcode);
 }
 } // namespace detail
@@ -401,7 +465,11 @@ DsCmpstB32Ds::DsCmpstB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstB32Ds>(opcode);
 }
 } // namespace detail
@@ -426,7 +494,11 @@ DsCmpstF32Ds::DsCmpstF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstF32Ds>(opcode);
 }
 } // namespace detail
@@ -449,7 +521,11 @@ DsMinF32Ds::DsMinF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinF32Ds>(opcode);
 }
 } // namespace detail
@@ -472,7 +548,11 @@ DsMaxF32Ds::DsMaxF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxF32Ds>(opcode);
 }
 } // namespace detail
@@ -485,7 +565,11 @@ DsNopDs::DsNopDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsNopDs(const MachineInst *opcode) {
+DecodeResult decodeDsNopDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Ds::validate_encoding("ds_nop", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsNopDs>(opcode);
 }
 } // namespace detail
@@ -508,7 +592,11 @@ DsAddF32Ds::DsAddF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddF32Ds>(opcode);
 }
 } // namespace detail
@@ -529,7 +617,12 @@ DsWriteAddtidB32Ds::DsWriteAddtidB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteAddtidB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteAddtidB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_addtid_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteAddtidB32Ds>(opcode);
 }
 } // namespace detail
@@ -550,7 +643,11 @@ DsWriteB8Ds::DsWriteB8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB8Ds>(opcode);
 }
 } // namespace detail
@@ -571,7 +668,11 @@ DsWriteB16Ds::DsWriteB16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB16Ds>(opcode);
 }
 } // namespace detail
@@ -596,7 +697,11 @@ DsAddRtnU32Ds::DsAddRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -621,7 +726,11 @@ DsSubRtnU32Ds::DsSubRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -646,7 +755,11 @@ DsRsubRtnU32Ds::DsRsubRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -671,7 +784,11 @@ DsIncRtnU32Ds::DsIncRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -696,7 +813,11 @@ DsDecRtnU32Ds::DsDecRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -721,7 +842,11 @@ DsMinRtnI32Ds::DsMinRtnI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI32Ds>(opcode);
 }
 } // namespace detail
@@ -746,7 +871,11 @@ DsMaxRtnI32Ds::DsMaxRtnI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI32Ds>(opcode);
 }
 } // namespace detail
@@ -771,7 +900,11 @@ DsMinRtnU32Ds::DsMinRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -796,7 +929,11 @@ DsMaxRtnU32Ds::DsMaxRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -821,7 +958,11 @@ DsAndRtnB32Ds::DsAndRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -846,7 +987,11 @@ DsOrRtnB32Ds::DsOrRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -871,7 +1016,11 @@ DsXorRtnB32Ds::DsXorRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -898,7 +1047,12 @@ DsMskorRtnB32Ds::DsMskorRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -923,7 +1077,12 @@ DsWrxchgRtnB32Ds::DsWrxchgRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchgRtnB32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchgRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -950,7 +1109,12 @@ DsWrxchg2RtnB32Ds::DsWrxchg2RtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2RtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -977,7 +1141,12 @@ DsWrxchg2st64RtnB32Ds::DsWrxchg2st64RtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2st64_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2st64RtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1004,7 +1173,12 @@ DsCmpstRtnB32Ds::DsCmpstRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1031,7 +1205,12 @@ DsCmpstRtnF32Ds::DsCmpstRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnF32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1056,7 +1235,11 @@ DsMinRtnF32Ds::DsMinRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1081,7 +1264,11 @@ DsMaxRtnF32Ds::DsMaxRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1107,7 +1294,11 @@ DsWrapRtnB32Ds::DsWrapRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrapRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrapRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrap_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrapRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1132,7 +1323,11 @@ DsAddRtnF32Ds::DsAddRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1153,7 +1348,11 @@ DsReadB32Ds::DsReadB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB32Ds>(opcode);
 }
 } // namespace detail
@@ -1174,7 +1373,11 @@ DsRead2B32Ds::DsRead2B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2B32Ds>(opcode);
 }
 } // namespace detail
@@ -1195,7 +1398,12 @@ DsRead2st64B32Ds::DsRead2st64B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2st64B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2st64B32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2st64_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2st64B32Ds>(opcode);
 }
 } // namespace detail
@@ -1216,7 +1424,11 @@ DsReadI8Ds::DsReadI8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadI8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI8Ds>(opcode);
 }
 } // namespace detail
@@ -1237,7 +1449,11 @@ DsReadU8Ds::DsReadU8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU8Ds>(opcode);
 }
 } // namespace detail
@@ -1258,7 +1474,11 @@ DsReadI16Ds::DsReadI16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadI16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI16Ds>(opcode);
 }
 } // namespace detail
@@ -1279,7 +1499,11 @@ DsReadU16Ds::DsReadU16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU16Ds>(opcode);
 }
 } // namespace detail
@@ -1296,7 +1520,11 @@ DsSwizzleB32Ds::DsSwizzleB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSwizzleB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSwizzleB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_swizzle_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSwizzleB32Ds>(opcode);
 }
 } // namespace detail
@@ -1315,7 +1543,11 @@ DsPermuteB32Ds::DsPermuteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPermuteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsPermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_permute_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPermuteB32Ds>(opcode);
 }
 } // namespace detail
@@ -1334,7 +1566,12 @@ DsBpermuteB32Ds::DsBpermuteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsBpermuteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsBpermuteB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_bpermute_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsBpermuteB32Ds>(opcode);
 }
 } // namespace detail
@@ -1357,7 +1594,11 @@ DsAddU64Ds::DsAddU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU64Ds>(opcode);
 }
 } // namespace detail
@@ -1380,7 +1621,11 @@ DsSubU64Ds::DsSubU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU64Ds>(opcode);
 }
 } // namespace detail
@@ -1403,7 +1648,11 @@ DsRsubU64Ds::DsRsubU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU64Ds>(opcode);
 }
 } // namespace detail
@@ -1426,7 +1675,11 @@ DsIncU64Ds::DsIncU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU64Ds>(opcode);
 }
 } // namespace detail
@@ -1449,7 +1702,11 @@ DsDecU64Ds::DsDecU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU64Ds>(opcode);
 }
 } // namespace detail
@@ -1472,7 +1729,11 @@ DsMinI64Ds::DsMinI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI64Ds>(opcode);
 }
 } // namespace detail
@@ -1495,7 +1756,11 @@ DsMaxI64Ds::DsMaxI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI64Ds>(opcode);
 }
 } // namespace detail
@@ -1518,7 +1783,11 @@ DsMinU64Ds::DsMinU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU64Ds>(opcode);
 }
 } // namespace detail
@@ -1541,7 +1810,11 @@ DsMaxU64Ds::DsMaxU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU64Ds>(opcode);
 }
 } // namespace detail
@@ -1564,7 +1837,11 @@ DsAndB64Ds::DsAndB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB64Ds>(opcode);
 }
 } // namespace detail
@@ -1587,7 +1864,11 @@ DsOrB64Ds::DsOrB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB64Ds>(opcode);
 }
 } // namespace detail
@@ -1610,7 +1891,11 @@ DsXorB64Ds::DsXorB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB64Ds>(opcode);
 }
 } // namespace detail
@@ -1635,7 +1920,11 @@ DsMskorB64Ds::DsMskorB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB64Ds>(opcode);
 }
 } // namespace detail
@@ -1656,7 +1945,11 @@ DsWriteB64Ds::DsWriteB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB64Ds>(opcode);
 }
 } // namespace detail
@@ -1679,7 +1972,11 @@ DsWrite2B64Ds::DsWrite2B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2B64Ds>(opcode);
 }
 } // namespace detail
@@ -1702,7 +1999,12 @@ DsWrite2st64B64Ds::DsWrite2st64B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2st64B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2st64B64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2st64_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2st64B64Ds>(opcode);
 }
 } // namespace detail
@@ -1727,7 +2029,11 @@ DsCmpstB64Ds::DsCmpstB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstB64Ds>(opcode);
 }
 } // namespace detail
@@ -1752,7 +2058,11 @@ DsCmpstF64Ds::DsCmpstF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstF64Ds>(opcode);
 }
 } // namespace detail
@@ -1775,7 +2085,11 @@ DsMinF64Ds::DsMinF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinF64Ds>(opcode);
 }
 } // namespace detail
@@ -1798,7 +2112,11 @@ DsMaxF64Ds::DsMaxF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxF64Ds>(opcode);
 }
 } // namespace detail
@@ -1819,7 +2137,12 @@ DsWriteB8D16HiDs::DsWriteB8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB8D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -1840,7 +2163,12 @@ DsWriteB16D16HiDs::DsWriteB16D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB16D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB16D16HiDs(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b16_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB16D16HiDs>(opcode);
 }
 } // namespace detail
@@ -1861,7 +2189,11 @@ DsReadU8D16Ds::DsReadU8D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU8D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u8_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU8D16Ds>(opcode);
 }
 } // namespace detail
@@ -1888,7 +2220,12 @@ DsReadU8D16HiDs::DsReadU8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsReadU8D16HiDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -1915,7 +2252,11 @@ DsReadI8D16Ds::DsReadI8D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI8D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i8_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI8D16Ds>(opcode);
 }
 } // namespace detail
@@ -1942,7 +2283,12 @@ DsReadI8D16HiDs::DsReadI8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsReadI8D16HiDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -1969,7 +2315,11 @@ DsReadU16D16Ds::DsReadU16D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU16D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU16D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u16_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU16D16Ds>(opcode);
 }
 } // namespace detail
@@ -1996,7 +2346,12 @@ DsReadU16D16HiDs::DsReadU16D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU16D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsReadU16D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u16_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU16D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2027,7 +2382,11 @@ DsAddRtnU64Ds::DsAddRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2052,7 +2411,11 @@ DsSubRtnU64Ds::DsSubRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2077,7 +2440,11 @@ DsRsubRtnU64Ds::DsRsubRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2102,7 +2469,11 @@ DsIncRtnU64Ds::DsIncRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2127,7 +2498,11 @@ DsDecRtnU64Ds::DsDecRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2152,7 +2527,11 @@ DsMinRtnI64Ds::DsMinRtnI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI64Ds>(opcode);
 }
 } // namespace detail
@@ -2177,7 +2556,11 @@ DsMaxRtnI64Ds::DsMaxRtnI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI64Ds>(opcode);
 }
 } // namespace detail
@@ -2202,7 +2585,11 @@ DsMinRtnU64Ds::DsMinRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2227,7 +2614,11 @@ DsMaxRtnU64Ds::DsMaxRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2252,7 +2643,11 @@ DsAndRtnB64Ds::DsAndRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2277,7 +2672,11 @@ DsOrRtnB64Ds::DsOrRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2302,7 +2701,11 @@ DsXorRtnB64Ds::DsXorRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2329,7 +2732,12 @@ DsMskorRtnB64Ds::DsMskorRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2354,7 +2762,12 @@ DsWrxchgRtnB64Ds::DsWrxchgRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchgRtnB64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchgRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2381,7 +2794,12 @@ DsWrxchg2RtnB64Ds::DsWrxchg2RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2408,7 +2826,12 @@ DsWrxchg2st64RtnB64Ds::DsWrxchg2st64RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2st64_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2st64RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2435,7 +2858,12 @@ DsCmpstRtnB64Ds::DsCmpstRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnB64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2462,7 +2890,12 @@ DsCmpstRtnF64Ds::DsCmpstRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnF64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -2487,7 +2920,11 @@ DsMinRtnF64Ds::DsMinRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -2512,7 +2949,11 @@ DsMaxRtnF64Ds::DsMaxRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -2533,7 +2974,11 @@ DsReadB64Ds::DsReadB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB64Ds>(opcode);
 }
 } // namespace detail
@@ -2554,7 +2999,11 @@ DsRead2B64Ds::DsRead2B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2B64Ds>(opcode);
 }
 } // namespace detail
@@ -2575,7 +3024,12 @@ DsRead2st64B64Ds::DsRead2st64B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2st64B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2st64B64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2st64_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2st64B64Ds>(opcode);
 }
 } // namespace detail
@@ -2600,7 +3054,12 @@ DsCondxchg32RtnB64Ds::DsCondxchg32RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_condxchg32_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCondxchg32RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2613,7 +3072,12 @@ DsGwsSemaReleaseAllDs::DsGwsSemaReleaseAllDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_release_all", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaReleaseAllDs>(opcode);
 }
 } // namespace detail
@@ -2628,7 +3092,11 @@ DsGwsInitDs::DsGwsInitDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsInitDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsInitDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_init", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsInitDs>(opcode);
 }
 } // namespace detail
@@ -2641,7 +3109,11 @@ DsGwsSemaVDs::DsGwsSemaVDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaVDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaVDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_v", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaVDs>(opcode);
 }
 } // namespace detail
@@ -2656,7 +3128,11 @@ DsGwsSemaBrDs::DsGwsSemaBrDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaBrDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaBrDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_br", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaBrDs>(opcode);
 }
 } // namespace detail
@@ -2669,7 +3145,11 @@ DsGwsSemaPDs::DsGwsSemaPDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaPDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaPDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_p", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaPDs>(opcode);
 }
 } // namespace detail
@@ -2684,7 +3164,11 @@ DsGwsBarrierDs::DsGwsBarrierDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsBarrierDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsBarrierDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_barrier", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsBarrierDs>(opcode);
 }
 } // namespace detail
@@ -2705,7 +3189,12 @@ DsReadAddtidB32Ds::DsReadAddtidB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadAddtidB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadAddtidB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_addtid_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadAddtidB32Ds>(opcode);
 }
 } // namespace detail
@@ -2726,7 +3215,11 @@ DsConsumeDs::DsConsumeDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsConsumeDs(const MachineInst *opcode) {
+DecodeResult decodeDsConsumeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_consume", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsConsumeDs>(opcode);
 }
 } // namespace detail
@@ -2747,7 +3240,11 @@ DsAppendDs::DsAppendDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAppendDs(const MachineInst *opcode) {
+DecodeResult decodeDsAppendDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_append", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAppendDs>(opcode);
 }
 } // namespace detail
@@ -2767,7 +3264,12 @@ DsOrderedCountDs::DsOrderedCountDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrderedCountDs(const MachineInst *opcode) {
+DecodeResult decodeDsOrderedCountDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_ordered_count", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrderedCountDs>(opcode);
 }
 } // namespace detail
@@ -2788,7 +3290,11 @@ DsWriteB96Ds::DsWriteB96Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB96Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b96", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB96Ds>(opcode);
 }
 } // namespace detail
@@ -2809,7 +3315,11 @@ DsWriteB128Ds::DsWriteB128Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB128Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b128", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB128Ds>(opcode);
 }
 } // namespace detail
@@ -2830,7 +3340,11 @@ DsReadB96Ds::DsReadB96Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB96Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b96", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB96Ds>(opcode);
 }
 } // namespace detail
@@ -2851,7 +3365,11 @@ DsReadB128Ds::DsReadB128Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB128Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b128", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB128Ds>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/encodings.h
@@ -10,6 +10,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna1/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
+#include "rocjitsu/isa/decode_result.h"
 #include "rocjitsu/isa/instruction.h"
 #include <array>
 #include <cstdint>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/exp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/exp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/exp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -33,7 +32,11 @@ ExpExp::ExpExp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeExpExp(const MachineInst *opcode) {
+DecodeResult decodeExpExp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Exp::validate_encoding("exp", reinterpret_cast<const Exp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ExpExp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/flat.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/flat.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/flat.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -43,7 +42,12 @@ FlatLoadUbyteFlat::FlatLoadUbyteFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUbyteFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ubyte", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUbyteFlat>(opcode);
 }
 } // namespace detail
@@ -78,7 +82,12 @@ FlatLoadSbyteFlat::FlatLoadSbyteFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSbyteFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sbyte", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSbyteFlat>(opcode);
 }
 } // namespace detail
@@ -113,7 +122,12 @@ FlatLoadUshortFlat::FlatLoadUshortFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUshortFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ushort", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUshortFlat>(opcode);
 }
 } // namespace detail
@@ -148,7 +162,12 @@ FlatLoadSshortFlat::FlatLoadSshortFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSshortFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sshort", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSshortFlat>(opcode);
 }
 } // namespace detail
@@ -183,7 +202,12 @@ FlatLoadDwordFlat::FlatLoadDwordFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dword", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordFlat>(opcode);
 }
 } // namespace detail
@@ -218,7 +242,12 @@ FlatLoadDwordx2Flat::FlatLoadDwordx2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordx2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordx2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dwordx2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordx2Flat>(opcode);
 }
 } // namespace detail
@@ -253,7 +282,12 @@ FlatLoadDwordx3Flat::FlatLoadDwordx3Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordx3Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordx3Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dwordx3", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordx3Flat>(opcode);
 }
 } // namespace detail
@@ -288,7 +322,12 @@ FlatLoadDwordx4Flat::FlatLoadDwordx4Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordx4Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordx4Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dwordx4", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordx4Flat>(opcode);
 }
 } // namespace detail
@@ -323,7 +362,12 @@ FlatStoreByteFlat::FlatStoreByteFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreByteFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreByteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_byte", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreByteFlat>(opcode);
 }
 } // namespace detail
@@ -358,7 +402,12 @@ FlatStoreByteD16HiFlat::FlatStoreByteD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreByteD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreByteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_byte_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreByteD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -393,7 +442,12 @@ FlatStoreShortFlat::FlatStoreShortFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreShortFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreShortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_short", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreShortFlat>(opcode);
 }
 } // namespace detail
@@ -428,7 +482,12 @@ FlatStoreShortD16HiFlat::FlatStoreShortD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreShortD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreShortD16HiFlat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_short_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreShortD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -463,7 +522,12 @@ FlatStoreDwordFlat::FlatStoreDwordFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dword", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordFlat>(opcode);
 }
 } // namespace detail
@@ -498,7 +562,12 @@ FlatStoreDwordx2Flat::FlatStoreDwordx2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordx2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordx2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dwordx2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordx2Flat>(opcode);
 }
 } // namespace detail
@@ -533,7 +602,12 @@ FlatStoreDwordx3Flat::FlatStoreDwordx3Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordx3Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordx3Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dwordx3", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordx3Flat>(opcode);
 }
 } // namespace detail
@@ -568,7 +642,12 @@ FlatStoreDwordx4Flat::FlatStoreDwordx4Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordx4Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordx4Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dwordx4", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordx4Flat>(opcode);
 }
 } // namespace detail
@@ -603,7 +682,12 @@ FlatLoadUbyteD16Flat::FlatLoadUbyteD16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ubyte_d16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUbyteD16Flat>(opcode);
 }
 } // namespace detail
@@ -645,7 +729,12 @@ FlatLoadUbyteD16HiFlat::FlatLoadUbyteD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ubyte_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUbyteD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -687,7 +776,12 @@ FlatLoadSbyteD16Flat::FlatLoadSbyteD16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sbyte_d16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSbyteD16Flat>(opcode);
 }
 } // namespace detail
@@ -729,7 +823,12 @@ FlatLoadSbyteD16HiFlat::FlatLoadSbyteD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sbyte_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSbyteD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -771,7 +870,12 @@ FlatLoadShortD16Flat::FlatLoadShortD16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadShortD16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadShortD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_short_d16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadShortD16Flat>(opcode);
 }
 } // namespace detail
@@ -813,7 +917,12 @@ FlatLoadShortD16HiFlat::FlatLoadShortD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadShortD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadShortD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_short_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadShortD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -858,7 +967,12 @@ FlatAtomicSwapFlat::FlatAtomicSwapFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_swap", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapFlat>(opcode);
 }
 } // namespace detail
@@ -896,7 +1010,12 @@ FlatAtomicCmpswapFlat::FlatAtomicCmpswapFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapFlat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_cmpswap", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapFlat>(opcode);
 }
 } // namespace detail
@@ -934,7 +1053,12 @@ FlatAtomicAddFlat::FlatAtomicAddFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddFlat>(opcode);
 }
 } // namespace detail
@@ -972,7 +1096,12 @@ FlatAtomicSubFlat::FlatAtomicSubFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_sub", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubFlat>(opcode);
 }
 } // namespace detail
@@ -1010,7 +1139,12 @@ FlatAtomicSminFlat::FlatAtomicSminFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSminFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smin", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSminFlat>(opcode);
 }
 } // namespace detail
@@ -1048,7 +1182,12 @@ FlatAtomicUminFlat::FlatAtomicUminFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUminFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umin", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUminFlat>(opcode);
 }
 } // namespace detail
@@ -1086,7 +1225,12 @@ FlatAtomicSmaxFlat::FlatAtomicSmaxFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smax", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSmaxFlat>(opcode);
 }
 } // namespace detail
@@ -1124,7 +1268,12 @@ FlatAtomicUmaxFlat::FlatAtomicUmaxFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umax", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUmaxFlat>(opcode);
 }
 } // namespace detail
@@ -1162,7 +1311,12 @@ FlatAtomicAndFlat::FlatAtomicAndFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_and", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndFlat>(opcode);
 }
 } // namespace detail
@@ -1200,7 +1354,12 @@ FlatAtomicOrFlat::FlatAtomicOrFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_or", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrFlat>(opcode);
 }
 } // namespace detail
@@ -1238,7 +1397,12 @@ FlatAtomicXorFlat::FlatAtomicXorFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_xor", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorFlat>(opcode);
 }
 } // namespace detail
@@ -1276,7 +1440,12 @@ FlatAtomicIncFlat::FlatAtomicIncFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_inc", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncFlat>(opcode);
 }
 } // namespace detail
@@ -1314,7 +1483,12 @@ FlatAtomicDecFlat::FlatAtomicDecFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_dec", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecFlat>(opcode);
 }
 } // namespace detail
@@ -1352,7 +1526,12 @@ FlatAtomicSwapX2Flat::FlatAtomicSwapX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_swap_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapX2Flat>(opcode);
 }
 } // namespace detail
@@ -1390,7 +1569,12 @@ FlatAtomicCmpswapX2Flat::FlatAtomicCmpswapX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_cmpswap_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapX2Flat>(opcode);
 }
 } // namespace detail
@@ -1428,7 +1612,12 @@ FlatAtomicAddX2Flat::FlatAtomicAddX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddX2Flat>(opcode);
 }
 } // namespace detail
@@ -1466,7 +1655,12 @@ FlatAtomicSubX2Flat::FlatAtomicSubX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_sub_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubX2Flat>(opcode);
 }
 } // namespace detail
@@ -1504,7 +1698,12 @@ FlatAtomicSminX2Flat::FlatAtomicSminX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSminX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smin_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSminX2Flat>(opcode);
 }
 } // namespace detail
@@ -1542,7 +1741,12 @@ FlatAtomicUminX2Flat::FlatAtomicUminX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUminX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umin_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUminX2Flat>(opcode);
 }
 } // namespace detail
@@ -1580,7 +1784,12 @@ FlatAtomicSmaxX2Flat::FlatAtomicSmaxX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smax_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSmaxX2Flat>(opcode);
 }
 } // namespace detail
@@ -1618,7 +1827,12 @@ FlatAtomicUmaxX2Flat::FlatAtomicUmaxX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umax_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUmaxX2Flat>(opcode);
 }
 } // namespace detail
@@ -1656,7 +1870,12 @@ FlatAtomicAndX2Flat::FlatAtomicAndX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_and_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndX2Flat>(opcode);
 }
 } // namespace detail
@@ -1694,7 +1913,12 @@ FlatAtomicOrX2Flat::FlatAtomicOrX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrX2Flat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_or_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrX2Flat>(opcode);
 }
 } // namespace detail
@@ -1732,7 +1956,12 @@ FlatAtomicXorX2Flat::FlatAtomicXorX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_xor_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorX2Flat>(opcode);
 }
 } // namespace detail
@@ -1770,7 +1999,12 @@ FlatAtomicIncX2Flat::FlatAtomicIncX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_inc_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncX2Flat>(opcode);
 }
 } // namespace detail
@@ -1808,7 +2042,12 @@ FlatAtomicDecX2Flat::FlatAtomicDecX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_dec_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecX2Flat>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/mimg.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/mimg.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/mimg.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -26,7 +25,11 @@ ImageLoadMimg::ImageLoadMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMimg>(opcode);
 }
 } // namespace detail
@@ -45,7 +48,12 @@ ImageLoadMipMimg::ImageLoadMipMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipMimg>(opcode);
 }
 } // namespace detail
@@ -64,7 +72,12 @@ ImageLoadPckMimg::ImageLoadPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadPckMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadPckMimg>(opcode);
 }
 } // namespace detail
@@ -83,7 +96,12 @@ ImageLoadPckSgnMimg::ImageLoadPckSgnMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadPckSgnMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadPckSgnMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_pck_sgn", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadPckSgnMimg>(opcode);
 }
 } // namespace detail
@@ -102,7 +120,12 @@ ImageLoadMipPckMimg::ImageLoadMipPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipPckMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipPckMimg>(opcode);
 }
 } // namespace detail
@@ -121,7 +144,12 @@ ImageLoadMipPckSgnMimg::ImageLoadMipPckSgnMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipPckSgnMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipPckSgnMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_pck_sgn", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipPckSgnMimg>(opcode);
 }
 } // namespace detail
@@ -140,7 +168,11 @@ ImageStoreMimg::ImageStoreMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMimg>(opcode);
 }
 } // namespace detail
@@ -159,7 +191,12 @@ ImageStoreMipMimg::ImageStoreMipMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipMimg>(opcode);
 }
 } // namespace detail
@@ -178,7 +215,12 @@ ImageStorePckMimg::ImageStorePckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStorePckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStorePckMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStorePckMimg>(opcode);
 }
 } // namespace detail
@@ -197,7 +239,12 @@ ImageStoreMipPckMimg::ImageStoreMipPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipPckMimg>(opcode);
 }
 } // namespace detail
@@ -216,7 +263,12 @@ ImageGetResinfoMimg::ImageGetResinfoMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGetResinfoMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGetResinfoMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_get_resinfo", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGetResinfoMimg>(opcode);
 }
 } // namespace detail
@@ -236,7 +288,12 @@ ImageAtomicSwapMimg::ImageAtomicSwapMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSwapMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSwapMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_swap", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSwapMimg>(opcode);
 }
 } // namespace detail
@@ -256,7 +313,12 @@ ImageAtomicCmpswapMimg::ImageAtomicCmpswapMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicCmpswapMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicCmpswapMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_cmpswap", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicCmpswapMimg>(opcode);
 }
 } // namespace detail
@@ -276,7 +338,12 @@ ImageAtomicAddMimg::ImageAtomicAddMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicAddMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicAddMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_add", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicAddMimg>(opcode);
 }
 } // namespace detail
@@ -296,7 +363,12 @@ ImageAtomicSubMimg::ImageAtomicSubMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSubMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSubMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_sub", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSubMimg>(opcode);
 }
 } // namespace detail
@@ -316,7 +388,12 @@ ImageAtomicSminMimg::ImageAtomicSminMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSminMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_smin", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSminMimg>(opcode);
 }
 } // namespace detail
@@ -336,7 +413,12 @@ ImageAtomicUminMimg::ImageAtomicUminMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicUminMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicUminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_umin", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicUminMimg>(opcode);
 }
 } // namespace detail
@@ -356,7 +438,12 @@ ImageAtomicSmaxMimg::ImageAtomicSmaxMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSmaxMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_smax", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSmaxMimg>(opcode);
 }
 } // namespace detail
@@ -376,7 +463,12 @@ ImageAtomicUmaxMimg::ImageAtomicUmaxMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicUmaxMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicUmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_umax", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicUmaxMimg>(opcode);
 }
 } // namespace detail
@@ -396,7 +488,12 @@ ImageAtomicAndMimg::ImageAtomicAndMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicAndMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicAndMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_and", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicAndMimg>(opcode);
 }
 } // namespace detail
@@ -416,7 +513,12 @@ ImageAtomicOrMimg::ImageAtomicOrMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicOrMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicOrMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_or", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicOrMimg>(opcode);
 }
 } // namespace detail
@@ -436,7 +538,12 @@ ImageAtomicXorMimg::ImageAtomicXorMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicXorMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicXorMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_xor", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicXorMimg>(opcode);
 }
 } // namespace detail
@@ -456,7 +563,12 @@ ImageAtomicIncMimg::ImageAtomicIncMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicIncMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicIncMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_inc", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicIncMimg>(opcode);
 }
 } // namespace detail
@@ -476,7 +588,12 @@ ImageAtomicDecMimg::ImageAtomicDecMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicDecMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicDecMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_dec", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicDecMimg>(opcode);
 }
 } // namespace detail
@@ -497,7 +614,12 @@ ImageSampleMimg::ImageSampleMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleMimg(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleMimg>(opcode);
 }
 } // namespace detail
@@ -518,7 +640,12 @@ ImageSampleClMimg::ImageSampleClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleClMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleClMimg>(opcode);
 }
 } // namespace detail
@@ -539,7 +666,12 @@ ImageSampleDMimg::ImageSampleDMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDMimg>(opcode);
 }
 } // namespace detail
@@ -560,7 +692,12 @@ ImageSampleDClMimg::ImageSampleDClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClMimg>(opcode);
 }
 } // namespace detail
@@ -581,7 +718,12 @@ ImageSampleLMimg::ImageSampleLMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLMimg>(opcode);
 }
 } // namespace detail
@@ -602,7 +744,12 @@ ImageSampleBMimg::ImageSampleBMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBMimg>(opcode);
 }
 } // namespace detail
@@ -623,7 +770,12 @@ ImageSampleBClMimg::ImageSampleBClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBClMimg>(opcode);
 }
 } // namespace detail
@@ -644,7 +796,12 @@ ImageSampleLzMimg::ImageSampleLzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLzMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLzMimg>(opcode);
 }
 } // namespace detail
@@ -665,7 +822,12 @@ ImageSampleCMimg::ImageSampleCMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCMimg>(opcode);
 }
 } // namespace detail
@@ -686,7 +848,12 @@ ImageSampleCClMimg::ImageSampleCClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCClMimg>(opcode);
 }
 } // namespace detail
@@ -707,7 +874,12 @@ ImageSampleCDMimg::ImageSampleCDMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDMimg>(opcode);
 }
 } // namespace detail
@@ -728,7 +900,12 @@ ImageSampleCDClMimg::ImageSampleCDClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClMimg>(opcode);
 }
 } // namespace detail
@@ -749,7 +926,12 @@ ImageSampleCLMimg::ImageSampleCLMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLMimg>(opcode);
 }
 } // namespace detail
@@ -770,7 +952,12 @@ ImageSampleCBMimg::ImageSampleCBMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBMimg>(opcode);
 }
 } // namespace detail
@@ -791,7 +978,12 @@ ImageSampleCBClMimg::ImageSampleCBClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBClMimg>(opcode);
 }
 } // namespace detail
@@ -812,7 +1004,12 @@ ImageSampleCLzMimg::ImageSampleCLzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLzMimg>(opcode);
 }
 } // namespace detail
@@ -833,7 +1030,12 @@ ImageSampleOMimg::ImageSampleOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleOMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleOMimg>(opcode);
 }
 } // namespace detail
@@ -854,7 +1056,12 @@ ImageSampleClOMimg::ImageSampleClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleClOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleClOMimg>(opcode);
 }
 } // namespace detail
@@ -875,7 +1082,12 @@ ImageSampleDOMimg::ImageSampleDOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDOMimg>(opcode);
 }
 } // namespace detail
@@ -896,7 +1108,12 @@ ImageSampleDClOMimg::ImageSampleDClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClOMimg>(opcode);
 }
 } // namespace detail
@@ -917,7 +1134,12 @@ ImageSampleLOMimg::ImageSampleLOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_l_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLOMimg>(opcode);
 }
 } // namespace detail
@@ -938,7 +1160,12 @@ ImageSampleBOMimg::ImageSampleBOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBOMimg>(opcode);
 }
 } // namespace detail
@@ -959,7 +1186,12 @@ ImageSampleBClOMimg::ImageSampleBClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBClOMimg>(opcode);
 }
 } // namespace detail
@@ -980,7 +1212,12 @@ ImageSampleLzOMimg::ImageSampleLzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLzOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLzOMimg>(opcode);
 }
 } // namespace detail
@@ -1001,7 +1238,12 @@ ImageSampleCOMimg::ImageSampleCOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCOMimg>(opcode);
 }
 } // namespace detail
@@ -1022,7 +1264,12 @@ ImageSampleCClOMimg::ImageSampleCClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCClOMimg>(opcode);
 }
 } // namespace detail
@@ -1043,7 +1290,12 @@ ImageSampleCDOMimg::ImageSampleCDOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDOMimg>(opcode);
 }
 } // namespace detail
@@ -1064,7 +1316,12 @@ ImageSampleCDClOMimg::ImageSampleCDClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClOMimg>(opcode);
 }
 } // namespace detail
@@ -1085,7 +1342,12 @@ ImageSampleCLOMimg::ImageSampleCLOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_l_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLOMimg>(opcode);
 }
 } // namespace detail
@@ -1106,7 +1368,12 @@ ImageSampleCBOMimg::ImageSampleCBOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBOMimg>(opcode);
 }
 } // namespace detail
@@ -1127,7 +1394,12 @@ ImageSampleCBClOMimg::ImageSampleCBClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBClOMimg>(opcode);
 }
 } // namespace detail
@@ -1148,7 +1420,12 @@ ImageSampleCLzOMimg::ImageSampleCLzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLzOMimg>(opcode);
 }
 } // namespace detail
@@ -1169,7 +1446,12 @@ ImageGather4Mimg::ImageGather4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4Mimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4Mimg>(opcode);
 }
 } // namespace detail
@@ -1190,7 +1472,12 @@ ImageGather4ClMimg::ImageGather4ClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4ClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4ClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4ClMimg>(opcode);
 }
 } // namespace detail
@@ -1211,7 +1498,12 @@ ImageGather4hMimg::ImageGather4hMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4hMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4hMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4h", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4hMimg>(opcode);
 }
 } // namespace detail
@@ -1232,7 +1524,12 @@ ImageGather4LMimg::ImageGather4LMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LMimg>(opcode);
 }
 } // namespace detail
@@ -1253,7 +1550,12 @@ ImageGather4BMimg::ImageGather4BMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4BMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4BMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4BMimg>(opcode);
 }
 } // namespace detail
@@ -1274,7 +1576,12 @@ ImageGather4BClMimg::ImageGather4BClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4BClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4BClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4BClMimg>(opcode);
 }
 } // namespace detail
@@ -1295,7 +1602,12 @@ ImageGather4LzMimg::ImageGather4LzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LzMimg>(opcode);
 }
 } // namespace detail
@@ -1316,7 +1628,12 @@ ImageGather4CMimg::ImageGather4CMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CMimg>(opcode);
 }
 } // namespace detail
@@ -1337,7 +1654,12 @@ ImageGather4CClMimg::ImageGather4CClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CClMimg>(opcode);
 }
 } // namespace detail
@@ -1358,7 +1680,12 @@ ImageGather4hPckMimg::ImageGather4hPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4hPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4hPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4h_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4hPckMimg>(opcode);
 }
 } // namespace detail
@@ -1379,7 +1706,12 @@ ImageGather8hPckMimg::ImageGather8hPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather8hPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather8hPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather8h_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather8hPckMimg>(opcode);
 }
 } // namespace detail
@@ -1400,7 +1732,12 @@ ImageGather4CLMimg::ImageGather4CLMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLMimg>(opcode);
 }
 } // namespace detail
@@ -1421,7 +1758,12 @@ ImageGather4CBMimg::ImageGather4CBMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CBMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CBMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CBMimg>(opcode);
 }
 } // namespace detail
@@ -1442,7 +1784,12 @@ ImageGather4CBClMimg::ImageGather4CBClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CBClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CBClMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CBClMimg>(opcode);
 }
 } // namespace detail
@@ -1463,7 +1810,12 @@ ImageGather4CLzMimg::ImageGather4CLzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLzMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLzMimg>(opcode);
 }
 } // namespace detail
@@ -1484,7 +1836,12 @@ ImageGather4OMimg::ImageGather4OMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4OMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4OMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4OMimg>(opcode);
 }
 } // namespace detail
@@ -1505,7 +1862,12 @@ ImageGather4ClOMimg::ImageGather4ClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4ClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4ClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4ClOMimg>(opcode);
 }
 } // namespace detail
@@ -1526,7 +1888,12 @@ ImageGather4LOMimg::ImageGather4LOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_l_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LOMimg>(opcode);
 }
 } // namespace detail
@@ -1547,7 +1914,12 @@ ImageGather4BOMimg::ImageGather4BOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4BOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4BOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_b_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4BOMimg>(opcode);
 }
 } // namespace detail
@@ -1568,7 +1940,12 @@ ImageGather4BClOMimg::ImageGather4BClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4BClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4BClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_b_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4BClOMimg>(opcode);
 }
 } // namespace detail
@@ -1589,7 +1966,12 @@ ImageGather4LzOMimg::ImageGather4LzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LzOMimg>(opcode);
 }
 } // namespace detail
@@ -1610,7 +1992,12 @@ ImageGather4COMimg::ImageGather4COMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4COMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4COMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4COMimg>(opcode);
 }
 } // namespace detail
@@ -1631,7 +2018,12 @@ ImageGather4CClOMimg::ImageGather4CClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CClOMimg>(opcode);
 }
 } // namespace detail
@@ -1652,7 +2044,12 @@ ImageGather4CLOMimg::ImageGather4CLOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_l_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLOMimg>(opcode);
 }
 } // namespace detail
@@ -1673,7 +2070,12 @@ ImageGather4CBOMimg::ImageGather4CBOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CBOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CBOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_b_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CBOMimg>(opcode);
 }
 } // namespace detail
@@ -1694,7 +2096,12 @@ ImageGather4CBClOMimg::ImageGather4CBClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CBClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CBClOMimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_b_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CBClOMimg>(opcode);
 }
 } // namespace detail
@@ -1715,7 +2122,12 @@ ImageGather4CLzOMimg::ImageGather4CLzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLzOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLzOMimg>(opcode);
 }
 } // namespace detail
@@ -1736,7 +2148,12 @@ ImageGetLodMimg::ImageGetLodMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGetLodMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGetLodMimg(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_get_lod", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGetLodMimg>(opcode);
 }
 } // namespace detail
@@ -1757,7 +2174,12 @@ ImageSampleCdMimg::ImageSampleCdMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdMimg>(opcode);
 }
 } // namespace detail
@@ -1778,7 +2200,12 @@ ImageSampleCdClMimg::ImageSampleCdClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdClMimg>(opcode);
 }
 } // namespace detail
@@ -1799,7 +2226,12 @@ ImageSampleCCdMimg::ImageSampleCCdMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdMimg>(opcode);
 }
 } // namespace detail
@@ -1820,7 +2252,12 @@ ImageSampleCCdClMimg::ImageSampleCCdClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdClMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdClMimg>(opcode);
 }
 } // namespace detail
@@ -1841,7 +2278,12 @@ ImageSampleCdOMimg::ImageSampleCdOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdOMimg>(opcode);
 }
 } // namespace detail
@@ -1862,7 +2304,12 @@ ImageSampleCdClOMimg::ImageSampleCdClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdClOMimg>(opcode);
 }
 } // namespace detail
@@ -1883,7 +2330,12 @@ ImageSampleCCdOMimg::ImageSampleCCdOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdOMimg>(opcode);
 }
 } // namespace detail
@@ -1904,7 +2356,12 @@ ImageSampleCCdClOMimg::ImageSampleCCdClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdClOMimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdClOMimg>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/mtbuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/mtbuf.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/mtbuf.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -42,7 +41,12 @@ TbufferLoadFormatXMtbuf::TbufferLoadFormatXMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -66,7 +70,12 @@ TbufferLoadFormatXyMtbuf::TbufferLoadFormatXyMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xy", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -90,7 +99,12 @@ TbufferLoadFormatXyzMtbuf::TbufferLoadFormatXyzMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xyz", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -114,7 +128,12 @@ TbufferLoadFormatXyzwMtbuf::TbufferLoadFormatXyzwMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xyzw", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -138,7 +157,12 @@ TbufferStoreFormatXMtbuf::TbufferStoreFormatXMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -162,7 +186,12 @@ TbufferStoreFormatXyMtbuf::TbufferStoreFormatXyMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xy", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -186,7 +215,12 @@ TbufferStoreFormatXyzMtbuf::TbufferStoreFormatXyzMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xyz", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -210,7 +244,12 @@ TbufferStoreFormatXyzwMtbuf::TbufferStoreFormatXyzwMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xyzw", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -234,7 +273,12 @@ TbufferLoadFormatD16XMtbuf::TbufferLoadFormatD16XMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_d16_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XMtbuf>(opcode);
 }
 } // namespace detail
@@ -264,7 +308,13 @@ TbufferLoadFormatD16XyMtbuf::TbufferLoadFormatD16XyMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_format_d16_xy",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XyMtbuf>(opcode);
 }
 } // namespace detail
@@ -288,7 +338,13 @@ TbufferLoadFormatD16XyzMtbuf::TbufferLoadFormatD16XyzMtbuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_format_d16_xyz",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -318,7 +374,13 @@ TbufferLoadFormatD16XyzwMtbuf::TbufferLoadFormatD16XyzwMtbuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_format_d16_xyzw",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -342,7 +404,13 @@ TbufferStoreFormatD16XMtbuf::TbufferStoreFormatD16XMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_x",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XMtbuf>(opcode);
 }
 } // namespace detail
@@ -366,7 +434,13 @@ TbufferStoreFormatD16XyMtbuf::TbufferStoreFormatD16XyMtbuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_xy",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XyMtbuf>(opcode);
 }
 } // namespace detail
@@ -390,7 +464,13 @@ TbufferStoreFormatD16XyzMtbuf::TbufferStoreFormatD16XyzMtbuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_xyz",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -414,7 +494,13 @@ TbufferStoreFormatD16XyzwMtbuf::TbufferStoreFormatD16XyzwMtbuf(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_xyzw",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XyzwMtbuf>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/mubuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/mubuf.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/mubuf.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -42,7 +41,12 @@ BufferLoadFormatXMubuf::BufferLoadFormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXMubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -66,7 +70,12 @@ BufferLoadFormatXyMubuf::BufferLoadFormatXyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -90,7 +99,12 @@ BufferLoadFormatXyzMubuf::BufferLoadFormatXyzMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xyz", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -114,7 +128,12 @@ BufferLoadFormatXyzwMubuf::BufferLoadFormatXyzwMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xyzw", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -138,7 +157,12 @@ BufferStoreFormatXMubuf::BufferStoreFormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -162,7 +186,12 @@ BufferStoreFormatXyMubuf::BufferStoreFormatXyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -186,7 +215,12 @@ BufferStoreFormatXyzMubuf::BufferStoreFormatXyzMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xyz", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -210,7 +244,12 @@ BufferStoreFormatXyzwMubuf::BufferStoreFormatXyzwMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xyzw", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -234,7 +273,12 @@ BufferLoadFormatD16XMubuf::BufferLoadFormatD16XMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_d16_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XMubuf>(opcode);
 }
 } // namespace detail
@@ -265,7 +309,12 @@ BufferLoadFormatD16XyMubuf::BufferLoadFormatD16XyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_d16_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XyMubuf>(opcode);
 }
 } // namespace detail
@@ -289,7 +338,13 @@ BufferLoadFormatD16XyzMubuf::BufferLoadFormatD16XyzMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_format_d16_xyz",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XyzMubuf>(opcode);
 }
 } // namespace detail
@@ -320,7 +375,13 @@ BufferLoadFormatD16XyzwMubuf::BufferLoadFormatD16XyzwMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_format_d16_xyzw",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -344,7 +405,12 @@ BufferStoreFormatD16XMubuf::BufferStoreFormatD16XMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_d16_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XMubuf>(opcode);
 }
 } // namespace detail
@@ -368,7 +434,13 @@ BufferStoreFormatD16XyMubuf::BufferStoreFormatD16XyMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_xy",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XyMubuf>(opcode);
 }
 } // namespace detail
@@ -392,7 +464,13 @@ BufferStoreFormatD16XyzMubuf::BufferStoreFormatD16XyzMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_xyz",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XyzMubuf>(opcode);
 }
 } // namespace detail
@@ -416,7 +494,13 @@ BufferStoreFormatD16XyzwMubuf::BufferStoreFormatD16XyzwMubuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_xyzw",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -440,7 +524,12 @@ BufferLoadUbyteMubuf::BufferLoadUbyteMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUbyteMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ubyte", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUbyteMubuf>(opcode);
 }
 } // namespace detail
@@ -464,7 +553,12 @@ BufferLoadSbyteMubuf::BufferLoadSbyteMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSbyteMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sbyte", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSbyteMubuf>(opcode);
 }
 } // namespace detail
@@ -488,7 +582,12 @@ BufferLoadUshortMubuf::BufferLoadUshortMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUshortMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ushort", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUshortMubuf>(opcode);
 }
 } // namespace detail
@@ -512,7 +611,12 @@ BufferLoadSshortMubuf::BufferLoadSshortMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSshortMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sshort", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSshortMubuf>(opcode);
 }
 } // namespace detail
@@ -536,7 +640,12 @@ BufferLoadDwordMubuf::BufferLoadDwordMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dword", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordMubuf>(opcode);
 }
 } // namespace detail
@@ -560,7 +669,12 @@ BufferLoadDwordx2Mubuf::BufferLoadDwordx2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dwordx2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordx2Mubuf>(opcode);
 }
 } // namespace detail
@@ -584,7 +698,12 @@ BufferLoadDwordx3Mubuf::BufferLoadDwordx3Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dwordx3", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordx3Mubuf>(opcode);
 }
 } // namespace detail
@@ -608,7 +727,12 @@ BufferLoadDwordx4Mubuf::BufferLoadDwordx4Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dwordx4", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordx4Mubuf>(opcode);
 }
 } // namespace detail
@@ -632,7 +756,12 @@ BufferStoreByteMubuf::BufferStoreByteMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreByteMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreByteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_byte", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreByteMubuf>(opcode);
 }
 } // namespace detail
@@ -656,7 +785,12 @@ BufferStoreByteD16HiMubuf::BufferStoreByteD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_byte_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreByteD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -680,7 +814,12 @@ BufferStoreShortMubuf::BufferStoreShortMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreShortMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreShortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_short", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreShortMubuf>(opcode);
 }
 } // namespace detail
@@ -704,7 +843,12 @@ BufferStoreShortD16HiMubuf::BufferStoreShortD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_short_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreShortD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -728,7 +872,12 @@ BufferStoreDwordMubuf::BufferStoreDwordMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dword", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordMubuf>(opcode);
 }
 } // namespace detail
@@ -752,7 +901,12 @@ BufferStoreDwordx2Mubuf::BufferStoreDwordx2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dwordx2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordx2Mubuf>(opcode);
 }
 } // namespace detail
@@ -776,7 +930,12 @@ BufferStoreDwordx3Mubuf::BufferStoreDwordx3Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dwordx3", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordx3Mubuf>(opcode);
 }
 } // namespace detail
@@ -800,7 +959,12 @@ BufferStoreDwordx4Mubuf::BufferStoreDwordx4Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dwordx4", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordx4Mubuf>(opcode);
 }
 } // namespace detail
@@ -824,7 +988,12 @@ BufferLoadUbyteD16Mubuf::BufferLoadUbyteD16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ubyte_d16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUbyteD16Mubuf>(opcode);
 }
 } // namespace detail
@@ -855,7 +1024,12 @@ BufferLoadUbyteD16HiMubuf::BufferLoadUbyteD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ubyte_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUbyteD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -886,7 +1060,12 @@ BufferLoadSbyteD16Mubuf::BufferLoadSbyteD16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sbyte_d16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSbyteD16Mubuf>(opcode);
 }
 } // namespace detail
@@ -917,7 +1096,12 @@ BufferLoadSbyteD16HiMubuf::BufferLoadSbyteD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sbyte_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSbyteD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -948,7 +1132,12 @@ BufferLoadShortD16Mubuf::BufferLoadShortD16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadShortD16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadShortD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_short_d16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadShortD16Mubuf>(opcode);
 }
 } // namespace detail
@@ -979,7 +1168,12 @@ BufferLoadShortD16HiMubuf::BufferLoadShortD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_short_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadShortD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -1010,7 +1204,13 @@ BufferLoadFormatD16HiXMubuf::BufferLoadFormatD16HiXMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_format_d16_hi_x",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16HiXMubuf>(opcode);
 }
 } // namespace detail
@@ -1041,7 +1241,13 @@ BufferStoreFormatD16HiXMubuf::BufferStoreFormatD16HiXMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_hi_x",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16HiXMubuf>(opcode);
 }
 } // namespace detail
@@ -1059,7 +1265,12 @@ BufferStoreLdsDwordMubuf::BufferStoreLdsDwordMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreLdsDwordMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreLdsDwordMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_lds_dword", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreLdsDwordMubuf>(opcode);
 }
 } // namespace detail
@@ -1072,7 +1283,12 @@ BufferWbinvl1Mubuf::BufferWbinvl1Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferWbinvl1Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferWbinvl1Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_wbinvl1", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferWbinvl1Mubuf>(opcode);
 }
 } // namespace detail
@@ -1085,7 +1301,12 @@ BufferWbinvl1VolMubuf::BufferWbinvl1VolMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferWbinvl1VolMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferWbinvl1VolMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_wbinvl1_vol", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferWbinvl1VolMubuf>(opcode);
 }
 } // namespace detail
@@ -1111,7 +1332,12 @@ BufferAtomicSwapMubuf::BufferAtomicSwapMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_swap", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapMubuf>(opcode);
 }
 } // namespace detail
@@ -1138,7 +1364,12 @@ BufferAtomicCmpswapMubuf::BufferAtomicCmpswapMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_cmpswap", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapMubuf>(opcode);
 }
 } // namespace detail
@@ -1164,7 +1395,12 @@ BufferAtomicAddMubuf::BufferAtomicAddMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddMubuf>(opcode);
 }
 } // namespace detail
@@ -1190,7 +1426,12 @@ BufferAtomicSubMubuf::BufferAtomicSubMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_sub", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubMubuf>(opcode);
 }
 } // namespace detail
@@ -1216,7 +1457,12 @@ BufferAtomicSminMubuf::BufferAtomicSminMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSminMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smin", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSminMubuf>(opcode);
 }
 } // namespace detail
@@ -1242,7 +1488,12 @@ BufferAtomicUminMubuf::BufferAtomicUminMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUminMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umin", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUminMubuf>(opcode);
 }
 } // namespace detail
@@ -1268,7 +1519,12 @@ BufferAtomicSmaxMubuf::BufferAtomicSmaxMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smax", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSmaxMubuf>(opcode);
 }
 } // namespace detail
@@ -1294,7 +1550,12 @@ BufferAtomicUmaxMubuf::BufferAtomicUmaxMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umax", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUmaxMubuf>(opcode);
 }
 } // namespace detail
@@ -1320,7 +1581,12 @@ BufferAtomicAndMubuf::BufferAtomicAndMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_and", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndMubuf>(opcode);
 }
 } // namespace detail
@@ -1346,7 +1612,12 @@ BufferAtomicOrMubuf::BufferAtomicOrMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrMubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_or", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrMubuf>(opcode);
 }
 } // namespace detail
@@ -1372,7 +1643,12 @@ BufferAtomicXorMubuf::BufferAtomicXorMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_xor", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorMubuf>(opcode);
 }
 } // namespace detail
@@ -1398,7 +1674,12 @@ BufferAtomicIncMubuf::BufferAtomicIncMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_inc", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncMubuf>(opcode);
 }
 } // namespace detail
@@ -1424,7 +1705,12 @@ BufferAtomicDecMubuf::BufferAtomicDecMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_dec", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecMubuf>(opcode);
 }
 } // namespace detail
@@ -1450,7 +1736,12 @@ BufferAtomicAddF32Mubuf::BufferAtomicAddF32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_f32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddF32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1476,7 +1767,12 @@ BufferAtomicPkAddF16Mubuf::BufferAtomicPkAddF16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicPkAddF16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicPkAddF16Mubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_pk_add_f16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicPkAddF16Mubuf>(opcode);
 }
 } // namespace detail
@@ -1502,7 +1798,12 @@ BufferAtomicSwapX2Mubuf::BufferAtomicSwapX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_swap_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1529,7 +1830,12 @@ BufferAtomicCmpswapX2Mubuf::BufferAtomicCmpswapX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_cmpswap_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1555,7 +1861,12 @@ BufferAtomicAddX2Mubuf::BufferAtomicAddX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1581,7 +1892,12 @@ BufferAtomicSubX2Mubuf::BufferAtomicSubX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_sub_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1607,7 +1923,12 @@ BufferAtomicSminX2Mubuf::BufferAtomicSminX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smin_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSminX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1633,7 +1954,12 @@ BufferAtomicUminX2Mubuf::BufferAtomicUminX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umin_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUminX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1659,7 +1985,12 @@ BufferAtomicSmaxX2Mubuf::BufferAtomicSmaxX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smax_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSmaxX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1685,7 +2016,12 @@ BufferAtomicUmaxX2Mubuf::BufferAtomicUmaxX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umax_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUmaxX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1711,7 +2047,12 @@ BufferAtomicAndX2Mubuf::BufferAtomicAndX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_and_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1737,7 +2078,12 @@ BufferAtomicOrX2Mubuf::BufferAtomicOrX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_or_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1763,7 +2109,12 @@ BufferAtomicXorX2Mubuf::BufferAtomicXorX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_xor_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1789,7 +2140,12 @@ BufferAtomicIncX2Mubuf::BufferAtomicIncX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_inc_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1815,7 +2171,12 @@ BufferAtomicDecX2Mubuf::BufferAtomicDecX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_dec_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecX2Mubuf>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/operand.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/operand.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/scalar_static_resolve.h"
-#include "util/except.h"
 #include <format>
 #include <optional>
 #include <stdexcept>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/smem.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/smem.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/smem.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -43,7 +42,11 @@ SLoadDwordSmem::SLoadDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordSmem>(opcode);
 }
 } // namespace detail
@@ -63,7 +66,12 @@ SLoadDwordx2Smem::SLoadDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -83,7 +91,12 @@ SLoadDwordx4Smem::SLoadDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx4Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -103,7 +116,12 @@ SLoadDwordx8Smem::SLoadDwordx8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx8Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx8Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx8Smem>(opcode);
 }
 } // namespace detail
@@ -123,7 +141,12 @@ SLoadDwordx16Smem::SLoadDwordx16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx16Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx16Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx16Smem>(opcode);
 }
 } // namespace detail
@@ -143,7 +166,12 @@ SScratchLoadDwordSmem::SScratchLoadDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchLoadDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSScratchLoadDwordSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_load_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchLoadDwordSmem>(opcode);
 }
 } // namespace detail
@@ -163,7 +191,12 @@ SScratchLoadDwordx2Smem::SScratchLoadDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSScratchLoadDwordx2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_load_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchLoadDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -183,7 +216,12 @@ SScratchLoadDwordx4Smem::SScratchLoadDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSScratchLoadDwordx4Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_load_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchLoadDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -203,7 +241,12 @@ SBufferLoadDwordSmem::SBufferLoadDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordSmem>(opcode);
 }
 } // namespace detail
@@ -223,7 +266,12 @@ SBufferLoadDwordx2Smem::SBufferLoadDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -243,7 +291,12 @@ SBufferLoadDwordx4Smem::SBufferLoadDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx4Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -263,7 +316,12 @@ SBufferLoadDwordx8Smem::SBufferLoadDwordx8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx8Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx8Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx8Smem>(opcode);
 }
 } // namespace detail
@@ -283,7 +341,12 @@ SBufferLoadDwordx16Smem::SBufferLoadDwordx16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx16Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx16Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx16Smem>(opcode);
 }
 } // namespace detail
@@ -303,7 +366,12 @@ SStoreDwordSmem::SStoreDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSStoreDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSStoreDwordSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_store_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SStoreDwordSmem>(opcode);
 }
 } // namespace detail
@@ -323,7 +391,12 @@ SStoreDwordx2Smem::SStoreDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSStoreDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSStoreDwordx2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_store_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SStoreDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -343,7 +416,12 @@ SStoreDwordx4Smem::SStoreDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSStoreDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSStoreDwordx4Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_store_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SStoreDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -363,7 +441,12 @@ SScratchStoreDwordSmem::SScratchStoreDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchStoreDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSScratchStoreDwordSmem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_store_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchStoreDwordSmem>(opcode);
 }
 } // namespace detail
@@ -383,7 +466,12 @@ SScratchStoreDwordx2Smem::SScratchStoreDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchStoreDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSScratchStoreDwordx2Smem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_store_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchStoreDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -403,7 +491,12 @@ SScratchStoreDwordx4Smem::SScratchStoreDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchStoreDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSScratchStoreDwordx4Smem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_store_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchStoreDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -423,7 +516,12 @@ SBufferStoreDwordSmem::SBufferStoreDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferStoreDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferStoreDwordSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_store_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferStoreDwordSmem>(opcode);
 }
 } // namespace detail
@@ -443,7 +541,12 @@ SBufferStoreDwordx2Smem::SBufferStoreDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferStoreDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferStoreDwordx2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_store_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferStoreDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -463,7 +566,12 @@ SBufferStoreDwordx4Smem::SBufferStoreDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferStoreDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferStoreDwordx4Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_store_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferStoreDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -476,7 +584,11 @@ SDcacheInvSmem::SDcacheInvSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_inv", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheInvSmem>(opcode);
 }
 } // namespace detail
@@ -489,7 +601,11 @@ SDcacheWbSmem::SDcacheWbSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheWbSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheWbSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_wb", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheWbSmem>(opcode);
 }
 } // namespace detail
@@ -502,7 +618,12 @@ SDcacheInvVolSmem::SDcacheInvVolSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheInvVolSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheInvVolSmem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_inv_vol", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheInvVolSmem>(opcode);
 }
 } // namespace detail
@@ -515,7 +636,12 @@ SDcacheWbVolSmem::SDcacheWbVolSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheWbVolSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheWbVolSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_wb_vol", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheWbVolSmem>(opcode);
 }
 } // namespace detail
@@ -530,7 +656,11 @@ SMemtimeSmem::SMemtimeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMemtimeSmem(const MachineInst *opcode) {
+DecodeResult decodeSMemtimeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_memtime", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMemtimeSmem>(opcode);
 }
 } // namespace detail
@@ -545,7 +675,12 @@ SMemrealtimeSmem::SMemrealtimeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMemrealtimeSmem(const MachineInst *opcode) {
+DecodeResult decodeSMemrealtimeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_memrealtime", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMemrealtimeSmem>(opcode);
 }
 } // namespace detail
@@ -564,7 +699,11 @@ SAtcProbeSmem::SAtcProbeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtcProbeSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtcProbeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atc_probe", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtcProbeSmem>(opcode);
 }
 } // namespace detail
@@ -583,7 +722,12 @@ SAtcProbeBufferSmem::SAtcProbeBufferSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtcProbeBufferSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtcProbeBufferSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atc_probe_buffer", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtcProbeBufferSmem>(opcode);
 }
 } // namespace detail
@@ -600,7 +744,12 @@ SDcacheDiscardSmem::SDcacheDiscardSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheDiscardSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheDiscardSmem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_discard", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheDiscardSmem>(opcode);
 }
 } // namespace detail
@@ -617,7 +766,12 @@ SDcacheDiscardX2Smem::SDcacheDiscardX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheDiscardX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheDiscardX2Smem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_discard_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheDiscardX2Smem>(opcode);
 }
 } // namespace detail
@@ -637,7 +791,12 @@ SBufferAtomicSwapSmem::SBufferAtomicSwapSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSwapSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSwapSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_swap", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSwapSmem>(opcode);
 }
 } // namespace detail
@@ -657,7 +816,12 @@ SBufferAtomicCmpswapSmem::SBufferAtomicCmpswapSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicCmpswapSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicCmpswapSmem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_cmpswap", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicCmpswapSmem>(opcode);
 }
 } // namespace detail
@@ -677,7 +841,12 @@ SBufferAtomicAddSmem::SBufferAtomicAddSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicAddSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicAddSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_add", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicAddSmem>(opcode);
 }
 } // namespace detail
@@ -697,7 +866,12 @@ SBufferAtomicSubSmem::SBufferAtomicSubSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSubSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSubSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_sub", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSubSmem>(opcode);
 }
 } // namespace detail
@@ -717,7 +891,12 @@ SBufferAtomicSminSmem::SBufferAtomicSminSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSminSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSminSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_smin", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSminSmem>(opcode);
 }
 } // namespace detail
@@ -737,7 +916,12 @@ SBufferAtomicUminSmem::SBufferAtomicUminSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicUminSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicUminSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_umin", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicUminSmem>(opcode);
 }
 } // namespace detail
@@ -757,7 +941,12 @@ SBufferAtomicSmaxSmem::SBufferAtomicSmaxSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSmaxSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSmaxSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_smax", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSmaxSmem>(opcode);
 }
 } // namespace detail
@@ -777,7 +966,12 @@ SBufferAtomicUmaxSmem::SBufferAtomicUmaxSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicUmaxSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicUmaxSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_umax", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicUmaxSmem>(opcode);
 }
 } // namespace detail
@@ -797,7 +991,12 @@ SBufferAtomicAndSmem::SBufferAtomicAndSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicAndSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicAndSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_and", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicAndSmem>(opcode);
 }
 } // namespace detail
@@ -817,7 +1016,12 @@ SBufferAtomicOrSmem::SBufferAtomicOrSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicOrSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicOrSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_or", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicOrSmem>(opcode);
 }
 } // namespace detail
@@ -837,7 +1041,12 @@ SBufferAtomicXorSmem::SBufferAtomicXorSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicXorSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicXorSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_xor", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicXorSmem>(opcode);
 }
 } // namespace detail
@@ -857,7 +1066,12 @@ SBufferAtomicIncSmem::SBufferAtomicIncSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicIncSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicIncSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_inc", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicIncSmem>(opcode);
 }
 } // namespace detail
@@ -877,7 +1091,12 @@ SBufferAtomicDecSmem::SBufferAtomicDecSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicDecSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicDecSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_dec", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicDecSmem>(opcode);
 }
 } // namespace detail
@@ -897,7 +1116,12 @@ SBufferAtomicSwapX2Smem::SBufferAtomicSwapX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSwapX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSwapX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_swap_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSwapX2Smem>(opcode);
 }
 } // namespace detail
@@ -917,7 +1141,12 @@ SBufferAtomicCmpswapX2Smem::SBufferAtomicCmpswapX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicCmpswapX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicCmpswapX2Smem(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_cmpswap_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicCmpswapX2Smem>(opcode);
 }
 } // namespace detail
@@ -937,7 +1166,12 @@ SBufferAtomicAddX2Smem::SBufferAtomicAddX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicAddX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicAddX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_add_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicAddX2Smem>(opcode);
 }
 } // namespace detail
@@ -957,7 +1191,12 @@ SBufferAtomicSubX2Smem::SBufferAtomicSubX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSubX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSubX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_sub_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSubX2Smem>(opcode);
 }
 } // namespace detail
@@ -977,7 +1216,12 @@ SBufferAtomicSminX2Smem::SBufferAtomicSminX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSminX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSminX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_smin_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSminX2Smem>(opcode);
 }
 } // namespace detail
@@ -997,7 +1241,12 @@ SBufferAtomicUminX2Smem::SBufferAtomicUminX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicUminX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicUminX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_umin_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicUminX2Smem>(opcode);
 }
 } // namespace detail
@@ -1017,7 +1266,12 @@ SBufferAtomicSmaxX2Smem::SBufferAtomicSmaxX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSmaxX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSmaxX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_smax_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSmaxX2Smem>(opcode);
 }
 } // namespace detail
@@ -1037,7 +1291,12 @@ SBufferAtomicUmaxX2Smem::SBufferAtomicUmaxX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicUmaxX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicUmaxX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_umax_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicUmaxX2Smem>(opcode);
 }
 } // namespace detail
@@ -1057,7 +1316,12 @@ SBufferAtomicAndX2Smem::SBufferAtomicAndX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicAndX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicAndX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_and_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicAndX2Smem>(opcode);
 }
 } // namespace detail
@@ -1077,7 +1341,12 @@ SBufferAtomicOrX2Smem::SBufferAtomicOrX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicOrX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicOrX2Smem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_or_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicOrX2Smem>(opcode);
 }
 } // namespace detail
@@ -1097,7 +1366,12 @@ SBufferAtomicXorX2Smem::SBufferAtomicXorX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicXorX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicXorX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_xor_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicXorX2Smem>(opcode);
 }
 } // namespace detail
@@ -1117,7 +1391,12 @@ SBufferAtomicIncX2Smem::SBufferAtomicIncX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicIncX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicIncX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_inc_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicIncX2Smem>(opcode);
 }
 } // namespace detail
@@ -1137,7 +1416,12 @@ SBufferAtomicDecX2Smem::SBufferAtomicDecX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicDecX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicDecX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_dec_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicDecX2Smem>(opcode);
 }
 } // namespace detail
@@ -1157,7 +1441,12 @@ SAtomicSwapSmem::SAtomicSwapSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSwapSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSwapSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_swap", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSwapSmem>(opcode);
 }
 } // namespace detail
@@ -1177,7 +1466,12 @@ SAtomicCmpswapSmem::SAtomicCmpswapSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicCmpswapSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicCmpswapSmem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_cmpswap", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicCmpswapSmem>(opcode);
 }
 } // namespace detail
@@ -1197,7 +1491,11 @@ SAtomicAddSmem::SAtomicAddSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicAddSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicAddSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_add", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicAddSmem>(opcode);
 }
 } // namespace detail
@@ -1217,7 +1515,11 @@ SAtomicSubSmem::SAtomicSubSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSubSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSubSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_sub", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSubSmem>(opcode);
 }
 } // namespace detail
@@ -1237,7 +1539,12 @@ SAtomicSminSmem::SAtomicSminSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSminSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSminSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_smin", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSminSmem>(opcode);
 }
 } // namespace detail
@@ -1257,7 +1564,12 @@ SAtomicUminSmem::SAtomicUminSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicUminSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicUminSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_umin", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicUminSmem>(opcode);
 }
 } // namespace detail
@@ -1277,7 +1589,12 @@ SAtomicSmaxSmem::SAtomicSmaxSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSmaxSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSmaxSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_smax", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSmaxSmem>(opcode);
 }
 } // namespace detail
@@ -1297,7 +1614,12 @@ SAtomicUmaxSmem::SAtomicUmaxSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicUmaxSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicUmaxSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_umax", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicUmaxSmem>(opcode);
 }
 } // namespace detail
@@ -1317,7 +1639,11 @@ SAtomicAndSmem::SAtomicAndSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicAndSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicAndSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_and", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicAndSmem>(opcode);
 }
 } // namespace detail
@@ -1337,7 +1663,11 @@ SAtomicOrSmem::SAtomicOrSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicOrSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicOrSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_or", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicOrSmem>(opcode);
 }
 } // namespace detail
@@ -1357,7 +1687,11 @@ SAtomicXorSmem::SAtomicXorSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicXorSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicXorSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_xor", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicXorSmem>(opcode);
 }
 } // namespace detail
@@ -1377,7 +1711,11 @@ SAtomicIncSmem::SAtomicIncSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicIncSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicIncSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_inc", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicIncSmem>(opcode);
 }
 } // namespace detail
@@ -1397,7 +1735,11 @@ SAtomicDecSmem::SAtomicDecSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicDecSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicDecSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_dec", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicDecSmem>(opcode);
 }
 } // namespace detail
@@ -1417,7 +1759,12 @@ SAtomicSwapX2Smem::SAtomicSwapX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSwapX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSwapX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_swap_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSwapX2Smem>(opcode);
 }
 } // namespace detail
@@ -1437,7 +1784,12 @@ SAtomicCmpswapX2Smem::SAtomicCmpswapX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicCmpswapX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicCmpswapX2Smem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_cmpswap_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicCmpswapX2Smem>(opcode);
 }
 } // namespace detail
@@ -1457,7 +1809,12 @@ SAtomicAddX2Smem::SAtomicAddX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicAddX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicAddX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_add_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicAddX2Smem>(opcode);
 }
 } // namespace detail
@@ -1477,7 +1834,12 @@ SAtomicSubX2Smem::SAtomicSubX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSubX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSubX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_sub_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSubX2Smem>(opcode);
 }
 } // namespace detail
@@ -1497,7 +1859,12 @@ SAtomicSminX2Smem::SAtomicSminX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSminX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSminX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_smin_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSminX2Smem>(opcode);
 }
 } // namespace detail
@@ -1517,7 +1884,12 @@ SAtomicUminX2Smem::SAtomicUminX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicUminX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicUminX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_umin_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicUminX2Smem>(opcode);
 }
 } // namespace detail
@@ -1537,7 +1909,12 @@ SAtomicSmaxX2Smem::SAtomicSmaxX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSmaxX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSmaxX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_smax_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSmaxX2Smem>(opcode);
 }
 } // namespace detail
@@ -1557,7 +1934,12 @@ SAtomicUmaxX2Smem::SAtomicUmaxX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicUmaxX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicUmaxX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_umax_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicUmaxX2Smem>(opcode);
 }
 } // namespace detail
@@ -1577,7 +1959,12 @@ SAtomicAndX2Smem::SAtomicAndX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicAndX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicAndX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_and_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicAndX2Smem>(opcode);
 }
 } // namespace detail
@@ -1597,7 +1984,12 @@ SAtomicOrX2Smem::SAtomicOrX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicOrX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicOrX2Smem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_or_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicOrX2Smem>(opcode);
 }
 } // namespace detail
@@ -1617,7 +2009,12 @@ SAtomicXorX2Smem::SAtomicXorX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicXorX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicXorX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_xor_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicXorX2Smem>(opcode);
 }
 } // namespace detail
@@ -1637,7 +2034,12 @@ SAtomicIncX2Smem::SAtomicIncX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicIncX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicIncX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_inc_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicIncX2Smem>(opcode);
 }
 } // namespace detail
@@ -1657,7 +2059,12 @@ SAtomicDecX2Smem::SAtomicDecX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicDecX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicDecX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_dec_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicDecX2Smem>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/sop1.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/sop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -29,7 +28,11 @@ SMovB32Sop1::SMovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -52,7 +55,11 @@ SMovB64Sop1::SMovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -78,7 +85,11 @@ SCmovB32Sop1::SCmovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -105,7 +116,11 @@ SCmovB64Sop1::SCmovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -129,7 +144,11 @@ SNotB32Sop1::SNotB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB32Sop1>(opcode);
 }
 } // namespace detail
@@ -154,7 +173,11 @@ SNotB64Sop1::SNotB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB64Sop1>(opcode);
 }
 } // namespace detail
@@ -178,7 +201,11 @@ SWqmB32Sop1::SWqmB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB32Sop1>(opcode);
 }
 } // namespace detail
@@ -203,7 +230,11 @@ SWqmB64Sop1::SWqmB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB64Sop1>(opcode);
 }
 } // namespace detail
@@ -224,7 +255,11 @@ SBrevB32Sop1::SBrevB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB32Sop1>(opcode);
 }
 } // namespace detail
@@ -246,7 +281,11 @@ SBrevB64Sop1::SBrevB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB64Sop1>(opcode);
 }
 } // namespace detail
@@ -270,7 +309,12 @@ SBcnt0I32B32Sop1::SBcnt0I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -295,7 +339,12 @@ SBcnt0I32B64Sop1::SBcnt0I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -319,7 +368,12 @@ SBcnt1I32B32Sop1::SBcnt1I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -344,7 +398,12 @@ SBcnt1I32B64Sop1::SBcnt1I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -365,7 +424,11 @@ SFf0I32B32Sop1::SFf0I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf0I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf0I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff0_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf0I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -387,7 +450,11 @@ SFf0I32B64Sop1::SFf0I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf0I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf0I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff0_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf0I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -408,7 +475,11 @@ SFf1I32B32Sop1::SFf1I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf1I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf1I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff1_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf1I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -430,7 +501,11 @@ SFf1I32B64Sop1::SFf1I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf1I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf1I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff1_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf1I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -451,7 +526,12 @@ SFlbitI32B32Sop1::SFlbitI32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -473,7 +553,12 @@ SFlbitI32B64Sop1::SFlbitI32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -494,7 +579,11 @@ SFlbitI32Sop1::SFlbitI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32Sop1>(opcode);
 }
 } // namespace detail
@@ -516,7 +605,12 @@ SFlbitI32I64Sop1::SFlbitI32I64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32I64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32I64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32_i64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32I64Sop1>(opcode);
 }
 } // namespace detail
@@ -538,7 +632,11 @@ SSextI32I8Sop1::SSextI32I8Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i8", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I8Sop1>(opcode);
 }
 } // namespace detail
@@ -560,7 +658,12 @@ SSextI32I16Sop1::SSextI32I16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I16Sop1>(opcode);
 }
 } // namespace detail
@@ -582,7 +685,12 @@ SBitset0B32Sop1::SBitset0B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B32Sop1>(opcode);
 }
 } // namespace detail
@@ -604,7 +712,12 @@ SBitset0B64Sop1::SBitset0B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B64Sop1>(opcode);
 }
 } // namespace detail
@@ -626,7 +739,12 @@ SBitset1B32Sop1::SBitset1B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B32Sop1>(opcode);
 }
 } // namespace detail
@@ -648,7 +766,12 @@ SBitset1B64Sop1::SBitset1B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B64Sop1>(opcode);
 }
 } // namespace detail
@@ -666,7 +789,11 @@ SGetpcB64Sop1::SGetpcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetpcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSGetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_getpc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetpcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -685,7 +812,11 @@ SSetpcB64Sop1::SSetpcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetpcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_setpc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetpcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -708,7 +839,11 @@ SSwappcB64Sop1::SSwappcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSwappcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSwappcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_swappc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSwappcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -726,7 +861,11 @@ SRfeB64Sop1::SRfeB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRfeB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSRfeB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_rfe_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRfeB64Sop1>(opcode);
 }
 } // namespace detail
@@ -758,7 +897,12 @@ SAndSaveexecB64Sop1::SAndSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -791,7 +935,12 @@ SOrSaveexecB64Sop1::SOrSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -823,7 +972,12 @@ SXorSaveexecB64Sop1::SXorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -855,7 +1009,12 @@ SAndn2SaveexecB64Sop1::SAndn2SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn2_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -887,7 +1046,12 @@ SOrn2SaveexecB64Sop1::SOrn2SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_orn2_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -919,7 +1083,12 @@ SNandSaveexecB64Sop1::SNandSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nand_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -951,7 +1120,12 @@ SNorSaveexecB64Sop1::SNorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -983,7 +1157,12 @@ SXnorSaveexecB64Sop1::SXnorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xnor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1007,7 +1186,12 @@ SQuadmaskB32Sop1::SQuadmaskB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1032,7 +1216,12 @@ SQuadmaskB64Sop1::SQuadmaskB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1052,7 +1241,12 @@ SMovrelsB32Sop1::SMovrelsB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrels_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1072,7 +1266,12 @@ SMovrelsB64Sop1::SMovrelsB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrels_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1096,7 +1295,12 @@ SMovreldB32Sop1::SMovreldB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1121,7 +1325,12 @@ SMovreldB64Sop1::SMovreldB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1141,7 +1350,12 @@ SCbranchJoinSop1::SCbranchJoinSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchJoinSop1(const MachineInst *opcode) {
+DecodeResult decodeSCbranchJoinSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cbranch_join", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchJoinSop1>(opcode);
 }
 } // namespace detail
@@ -1165,7 +1379,11 @@ SAbsI32Sop1::SAbsI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_abs_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsI32Sop1>(opcode);
 }
 } // namespace detail
@@ -1189,7 +1407,12 @@ SSetGprIdxIdxSop1::SSetGprIdxIdxSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetGprIdxIdxSop1(const MachineInst *opcode) {
+DecodeResult decodeSSetGprIdxIdxSop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_set_gpr_idx_idx", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetGprIdxIdxSop1>(opcode);
 }
 } // namespace detail
@@ -1221,7 +1444,12 @@ SAndn1SaveexecB64Sop1::SAndn1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1253,7 +1481,12 @@ SOrn1SaveexecB64Sop1::SOrn1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_orn1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1285,7 +1518,12 @@ SAndn1WrexecB64Sop1::SAndn1WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn1WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn1WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn1_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn1WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1317,7 +1555,12 @@ SAndn2WrexecB64Sop1::SAndn2WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn2WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn2_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1338,7 +1581,12 @@ SBitreplicateB64B32Sop1::SBitreplicateB64B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitreplicate_b64_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitreplicateB64B32Sop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/sop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/sop2.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/sop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -37,7 +36,11 @@ SAddU32Sop2::SAddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -67,7 +70,11 @@ SSubU32Sop2::SSubU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubU32Sop2>(opcode);
 }
 } // namespace detail
@@ -97,7 +104,11 @@ SAddI32Sop2::SAddI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddI32Sop2>(opcode);
 }
 } // namespace detail
@@ -127,7 +138,11 @@ SSubI32Sop2::SSubI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubI32Sop2>(opcode);
 }
 } // namespace detail
@@ -160,7 +175,11 @@ SAddcU32Sop2::SAddcU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddcU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddcU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_addc_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddcU32Sop2>(opcode);
 }
 } // namespace detail
@@ -193,7 +212,11 @@ SSubbU32Sop2::SSubbU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubbU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubbU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_subb_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubbU32Sop2>(opcode);
 }
 } // namespace detail
@@ -223,7 +246,11 @@ SMinI32Sop2::SMinI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinI32Sop2>(opcode);
 }
 } // namespace detail
@@ -253,7 +280,11 @@ SMinU32Sop2::SMinU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinU32Sop2>(opcode);
 }
 } // namespace detail
@@ -283,7 +314,11 @@ SMaxI32Sop2::SMaxI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxI32Sop2>(opcode);
 }
 } // namespace detail
@@ -313,7 +348,11 @@ SMaxU32Sop2::SMaxU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxU32Sop2>(opcode);
 }
 } // namespace detail
@@ -343,7 +382,12 @@ SCselectB32Sop2::SCselectB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCselectB32Sop2>(opcode);
 }
 } // namespace detail
@@ -375,7 +419,12 @@ SCselectB64Sop2::SCselectB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCselectB64Sop2>(opcode);
 }
 } // namespace detail
@@ -405,7 +454,11 @@ SAndB32Sop2::SAndB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndB32Sop2>(opcode);
 }
 } // namespace detail
@@ -437,7 +490,11 @@ SAndB64Sop2::SAndB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndB64Sop2>(opcode);
 }
 } // namespace detail
@@ -468,7 +525,11 @@ SOrB32Sop2::SOrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -501,7 +562,11 @@ SOrB64Sop2::SOrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -531,7 +596,11 @@ SXorB32Sop2::SXorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -563,7 +632,11 @@ SXorB64Sop2::SXorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -593,7 +666,11 @@ SAndn2B32Sop2::SAndn2B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_andn2_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2B32Sop2>(opcode);
 }
 } // namespace detail
@@ -625,7 +702,11 @@ SAndn2B64Sop2::SAndn2B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_andn2_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2B64Sop2>(opcode);
 }
 } // namespace detail
@@ -655,7 +736,11 @@ SOrn2B32Sop2::SOrn2B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_orn2_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2B32Sop2>(opcode);
 }
 } // namespace detail
@@ -687,7 +772,11 @@ SOrn2B64Sop2::SOrn2B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_orn2_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2B64Sop2>(opcode);
 }
 } // namespace detail
@@ -717,7 +806,11 @@ SNandB32Sop2::SNandB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandB32Sop2>(opcode);
 }
 } // namespace detail
@@ -749,7 +842,11 @@ SNandB64Sop2::SNandB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandB64Sop2>(opcode);
 }
 } // namespace detail
@@ -779,7 +876,11 @@ SNorB32Sop2::SNorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -811,7 +912,11 @@ SNorB64Sop2::SNorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -841,7 +946,11 @@ SXnorB32Sop2::SXnorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -873,7 +982,11 @@ SXnorB64Sop2::SXnorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -903,7 +1016,11 @@ SLshlB32Sop2::SLshlB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshlB32Sop2>(opcode);
 }
 } // namespace detail
@@ -934,7 +1051,11 @@ SLshlB64Sop2::SLshlB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshlB64Sop2>(opcode);
 }
 } // namespace detail
@@ -964,7 +1085,11 @@ SLshrB32Sop2::SLshrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -995,7 +1120,11 @@ SLshrB64Sop2::SLshrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1025,7 +1154,11 @@ SAshrI32Sop2::SAshrI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAshrI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1056,7 +1189,11 @@ SAshrI64Sop2::SAshrI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAshrI64Sop2>(opcode);
 }
 } // namespace detail
@@ -1083,7 +1220,11 @@ SBfmB32Sop2::SBfmB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfmB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1110,7 +1251,11 @@ SBfmB64Sop2::SBfmB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfmB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1137,7 +1282,11 @@ SMulI32Sop2::SMulI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1167,7 +1316,11 @@ SBfeU32Sop2::SBfeU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1197,7 +1350,11 @@ SBfeI32Sop2::SBfeI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1228,7 +1385,11 @@ SBfeU64Sop2::SBfeU64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeU64Sop2>(opcode);
 }
 } // namespace detail
@@ -1259,7 +1420,11 @@ SBfeI64Sop2::SBfeI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeI64Sop2>(opcode);
 }
 } // namespace detail
@@ -1279,7 +1444,12 @@ SCbranchGForkSop2::SCbranchGForkSop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchGForkSop2(const MachineInst *opcode) {
+DecodeResult decodeSCbranchGForkSop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cbranch_g_fork", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchGForkSop2>(opcode);
 }
 } // namespace detail
@@ -1309,7 +1479,12 @@ SAbsdiffI32Sop2::SAbsdiffI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_absdiff_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsdiffI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1338,7 +1513,12 @@ SRfeRestoreB64Sop2::SRfeRestoreB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRfeRestoreB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSRfeRestoreB64Sop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_rfe_restore_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRfeRestoreB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1365,7 +1545,11 @@ SMulHiU32Sop2::SMulHiU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulHiU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1392,7 +1576,11 @@ SMulHiI32Sop2::SMulHiI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulHiI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1422,7 +1610,12 @@ SLshl1AddU32Sop2::SLshl1AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl1_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl1AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1452,7 +1645,12 @@ SLshl2AddU32Sop2::SLshl2AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl2_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl2AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1482,7 +1680,12 @@ SLshl3AddU32Sop2::SLshl3AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl3_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl3AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1512,7 +1715,12 @@ SLshl4AddU32Sop2::SLshl4AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl4_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl4AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1541,7 +1749,12 @@ SPackLlB32B16Sop2::SPackLlB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_ll_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackLlB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1569,7 +1782,12 @@ SPackLhB32B16Sop2::SPackLhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_lh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackLhB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1596,7 +1814,12 @@ SPackHhB32B16Sop2::SPackHhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_hh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackHhB32B16Sop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/sopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/sopc.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/sopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -35,7 +34,11 @@ SCmpEqI32Sopc::SCmpEqI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqI32Sopc>(opcode);
 }
 } // namespace detail
@@ -63,7 +66,11 @@ SCmpLgI32Sopc::SCmpLgI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgI32Sopc>(opcode);
 }
 } // namespace detail
@@ -91,7 +98,11 @@ SCmpGtI32Sopc::SCmpGtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -119,7 +130,11 @@ SCmpGeI32Sopc::SCmpGeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -147,7 +162,11 @@ SCmpLtI32Sopc::SCmpLtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -175,7 +194,11 @@ SCmpLeI32Sopc::SCmpLeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -203,7 +226,11 @@ SCmpEqU32Sopc::SCmpEqU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqU32Sopc>(opcode);
 }
 } // namespace detail
@@ -231,7 +258,11 @@ SCmpLgU32Sopc::SCmpLgU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgU32Sopc>(opcode);
 }
 } // namespace detail
@@ -259,7 +290,11 @@ SCmpGtU32Sopc::SCmpGtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -287,7 +322,11 @@ SCmpGeU32Sopc::SCmpGeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -315,7 +354,11 @@ SCmpLtU32Sopc::SCmpLtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -343,7 +386,11 @@ SCmpLeU32Sopc::SCmpLeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -371,7 +418,12 @@ SBitcmp0B32Sopc::SBitcmp0B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp0B32Sopc>(opcode);
 }
 } // namespace detail
@@ -399,7 +451,12 @@ SBitcmp1B32Sopc::SBitcmp1B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp1B32Sopc>(opcode);
 }
 } // namespace detail
@@ -428,7 +485,12 @@ SBitcmp0B64Sopc::SBitcmp0B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp0B64Sopc>(opcode);
 }
 } // namespace detail
@@ -457,7 +519,12 @@ SBitcmp1B64Sopc::SBitcmp1B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp1B64Sopc>(opcode);
 }
 } // namespace detail
@@ -482,7 +549,11 @@ SSetvskipSopc::SSetvskipSopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetvskipSopc(const MachineInst *opcode) {
+DecodeResult decodeSSetvskipSopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_setvskip", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetvskipSopc>(opcode);
 }
 } // namespace detail
@@ -508,7 +579,12 @@ SSetGprIdxOnSopc::SSetGprIdxOnSopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetGprIdxOnSopc(const MachineInst *opcode) {
+DecodeResult decodeSSetGprIdxOnSopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_set_gpr_idx_on", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetGprIdxOnSopc>(opcode);
 }
 } // namespace detail
@@ -538,7 +614,11 @@ SCmpEqU64Sopc::SCmpEqU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqU64Sopc>(opcode);
 }
 } // namespace detail
@@ -568,7 +648,11 @@ SCmpLgU64Sopc::SCmpLgU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgU64Sopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/sopk.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -24,7 +23,11 @@ SMovkI32Sopk::SMovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_movk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -46,7 +49,11 @@ SCmovkI32Sopk::SCmovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmovk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -66,7 +73,11 @@ SCmpkEqI32Sopk::SCmpkEqI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkEqI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkEqI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_eq_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkEqI32Sopk>(opcode);
 }
 } // namespace detail
@@ -86,7 +97,11 @@ SCmpkLgI32Sopk::SCmpkLgI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLgI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLgI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lg_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLgI32Sopk>(opcode);
 }
 } // namespace detail
@@ -106,7 +121,11 @@ SCmpkGtI32Sopk::SCmpkGtI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGtI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_gt_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGtI32Sopk>(opcode);
 }
 } // namespace detail
@@ -126,7 +145,11 @@ SCmpkGeI32Sopk::SCmpkGeI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGeI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_ge_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGeI32Sopk>(opcode);
 }
 } // namespace detail
@@ -146,7 +169,11 @@ SCmpkLtI32Sopk::SCmpkLtI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLtI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lt_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLtI32Sopk>(opcode);
 }
 } // namespace detail
@@ -166,7 +193,11 @@ SCmpkLeI32Sopk::SCmpkLeI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLeI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_le_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLeI32Sopk>(opcode);
 }
 } // namespace detail
@@ -186,7 +217,11 @@ SCmpkEqU32Sopk::SCmpkEqU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkEqU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkEqU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_eq_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkEqU32Sopk>(opcode);
 }
 } // namespace detail
@@ -206,7 +241,11 @@ SCmpkLgU32Sopk::SCmpkLgU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLgU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLgU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lg_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLgU32Sopk>(opcode);
 }
 } // namespace detail
@@ -226,7 +265,11 @@ SCmpkGtU32Sopk::SCmpkGtU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGtU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_gt_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGtU32Sopk>(opcode);
 }
 } // namespace detail
@@ -246,7 +289,11 @@ SCmpkGeU32Sopk::SCmpkGeU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGeU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_ge_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGeU32Sopk>(opcode);
 }
 } // namespace detail
@@ -266,7 +313,11 @@ SCmpkLtU32Sopk::SCmpkLtU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLtU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lt_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLtU32Sopk>(opcode);
 }
 } // namespace detail
@@ -286,7 +337,11 @@ SCmpkLeU32Sopk::SCmpkLeU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLeU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_le_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLeU32Sopk>(opcode);
 }
 } // namespace detail
@@ -307,7 +362,11 @@ SAddkI32Sopk::SAddkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSAddkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_addk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -325,7 +384,11 @@ SMulkI32Sopk::SMulkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_mulk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -342,7 +405,12 @@ SCbranchIForkSopk::SCbranchIForkSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchIForkSopk(const MachineInst *opcode) {
+DecodeResult decodeSCbranchIForkSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cbranch_i_fork", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchIForkSopk>(opcode);
 }
 } // namespace detail
@@ -359,7 +427,11 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_getreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -376,7 +448,11 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -395,7 +471,12 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_imm32_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregImm32B32Sopk>(opcode);
 }
 } // namespace detail
@@ -418,7 +499,11 @@ SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCallB64Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCallB64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_call_b64", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCallB64Sopk>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/sopp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/sopp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/sopp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -22,7 +21,11 @@ SNopSopp::SNopSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode) {
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_nop", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNopSopp>(opcode);
 }
 } // namespace detail
@@ -36,7 +39,11 @@ SEndpgmSopp::SEndpgmSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSopp>(opcode);
 }
 } // namespace detail
@@ -53,7 +60,11 @@ SBranchSopp::SBranchSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode) {
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_branch", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBranchSopp>(opcode);
 }
 } // namespace detail
@@ -71,7 +82,11 @@ SWakeupSopp::SWakeupSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode) {
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wakeup", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWakeupSopp>(opcode);
 }
 } // namespace detail
@@ -91,7 +106,12 @@ SCbranchScc0Sopp::SCbranchScc0Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc0", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc0Sopp>(opcode);
 }
 } // namespace detail
@@ -116,7 +136,12 @@ SCbranchScc1Sopp::SCbranchScc1Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc1", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc1Sopp>(opcode);
 }
 } // namespace detail
@@ -141,7 +166,12 @@ SCbranchVcczSopp::SCbranchVcczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVcczSopp>(opcode);
 }
 } // namespace detail
@@ -166,7 +196,12 @@ SCbranchVccnzSopp::SCbranchVccnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVccnzSopp>(opcode);
 }
 } // namespace detail
@@ -191,7 +226,12 @@ SCbranchExeczSopp::SCbranchExeczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExeczSopp>(opcode);
 }
 } // namespace detail
@@ -216,7 +256,12 @@ SCbranchExecnzSopp::SCbranchExecnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExecnzSopp>(opcode);
 }
 } // namespace detail
@@ -235,7 +280,11 @@ SBarrierSopp::SBarrierSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBarrierSopp(const MachineInst *opcode) {
+DecodeResult decodeSBarrierSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_barrier", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBarrierSopp>(opcode);
 }
 } // namespace detail
@@ -250,7 +299,11 @@ SSetkillSopp::SSetkillSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetkillSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetkillSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setkill", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetkillSopp>(opcode);
 }
 } // namespace detail
@@ -266,7 +319,11 @@ SWaitcntSopp::SWaitcntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_waitcnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntSopp>(opcode);
 }
 } // namespace detail
@@ -281,7 +338,11 @@ SSethaltSopp::SSethaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sethalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSethaltSopp>(opcode);
 }
 } // namespace detail
@@ -296,7 +357,11 @@ SSleepSopp::SSleepSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode) {
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sleep", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSleepSopp>(opcode);
 }
 } // namespace detail
@@ -311,7 +376,11 @@ SSetprioSopp::SSetprioSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setprio", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetprioSopp>(opcode);
 }
 } // namespace detail
@@ -329,7 +398,11 @@ SSendmsgSopp::SSendmsgSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsg", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsgSopp>(opcode);
 }
 } // namespace detail
@@ -347,7 +420,12 @@ SSendmsghaltSopp::SSendmsghaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsghalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsghaltSopp>(opcode);
 }
 } // namespace detail
@@ -362,7 +440,11 @@ STrapSopp::STrapSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode) {
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_trap", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STrapSopp>(opcode);
 }
 } // namespace detail
@@ -375,7 +457,11 @@ SIcacheInvSopp::SIcacheInvSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode) {
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_icache_inv", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIcacheInvSopp>(opcode);
 }
 } // namespace detail
@@ -390,7 +476,12 @@ SIncperflevelSopp::SIncperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_incperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIncperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -405,7 +496,12 @@ SDecperflevelSopp::SDecperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_decperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDecperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -421,7 +517,12 @@ STtracedataSopp::STtracedataSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode) {
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_ttracedata", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STtracedataSopp>(opcode);
 }
 } // namespace detail
@@ -436,7 +537,12 @@ SCbranchCdbgsysSopp::SCbranchCdbgsysSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysSopp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysSopp>(opcode);
 }
 } // namespace detail
@@ -451,7 +557,12 @@ SCbranchCdbguserSopp::SCbranchCdbguserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbguserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbguserSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbguser", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbguserSopp>(opcode);
 }
 } // namespace detail
@@ -466,7 +577,12 @@ SCbranchCdbgsysOrUserSopp::SCbranchCdbgsysOrUserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys_or_user", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysOrUserSopp>(opcode);
 }
 } // namespace detail
@@ -481,7 +597,12 @@ SCbranchCdbgsysAndUserSopp::SCbranchCdbgsysAndUserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys_and_user", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysAndUserSopp>(opcode);
 }
 } // namespace detail
@@ -495,7 +616,12 @@ SEndpgmSavedSopp::SEndpgmSavedSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm_saved", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSavedSopp>(opcode);
 }
 } // namespace detail
@@ -508,7 +634,12 @@ SSetGprIdxOffSopp::SSetGprIdxOffSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetGprIdxOffSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetGprIdxOffSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_set_gpr_idx_off", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetGprIdxOffSopp>(opcode);
 }
 } // namespace detail
@@ -528,7 +659,12 @@ SSetGprIdxModeSopp::SSetGprIdxModeSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetGprIdxModeSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetGprIdxModeSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_set_gpr_idx_mode", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetGprIdxModeSopp>(opcode);
 }
 } // namespace detail
@@ -542,7 +678,12 @@ SEndpgmOrderedPsDoneSopp::SEndpgmOrderedPsDoneSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm_ordered_ps_done", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmOrderedPsDoneSopp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/vintrp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/vintrp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/vintrp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -29,7 +28,12 @@ VInterpP1F32Vintrp::VInterpP1F32Vintrp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP1F32Vintrp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP1F32Vintrp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vintrp::validate_encoding(
+      "v_interp_p1_f32", reinterpret_cast<const Vintrp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP1F32Vintrp>(opcode);
 }
 } // namespace detail
@@ -52,7 +56,12 @@ VInterpP2F32Vintrp::VInterpP2F32Vintrp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2F32Vintrp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2F32Vintrp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vintrp::validate_encoding(
+      "v_interp_p2_f32", reinterpret_cast<const Vintrp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2F32Vintrp>(opcode);
 }
 } // namespace detail
@@ -74,7 +83,12 @@ VInterpMovF32Vintrp::VInterpMovF32Vintrp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpMovF32Vintrp(const MachineInst *opcode) {
+DecodeResult decodeVInterpMovF32Vintrp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vintrp::validate_encoding(
+      "v_interp_mov_f32", reinterpret_cast<const Vintrp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpMovF32Vintrp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/vop1.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/vop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -23,7 +22,14 @@ VNopVop1::VNopVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode) {
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_nop_sdwa"
+                                                                                 : "v_nop_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop1>(opcode);
 }
 } // namespace detail
@@ -72,7 +78,14 @@ VMovB32Vop1::VMovB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mov_b32_sdwa"
+                                                                                 : "v_mov_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop1>(opcode);
 }
 } // namespace detail
@@ -86,14 +99,20 @@ VReadfirstlaneB32Vop1::VReadfirstlaneB32Vop1(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_readfirstlane_b32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support SDWA";
   return std::make_unique<VReadfirstlaneB32Vop1>(opcode);
 }
 } // namespace detail
@@ -112,14 +131,19 @@ VCvtI32F64Vop1::VCvtI32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CVT_I32_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_I32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_i32_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CVT_I32_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_I32_F64 does not support SDWA";
   return std::make_unique<VCvtI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -137,14 +161,19 @@ VCvtF64I32Vop1::VCvtF64I32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CVT_F64_I32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F64_I32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_f64_i32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_I32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_I32 does not support SDWA";
   return std::make_unique<VCvtF64I32Vop1>(opcode);
 }
 } // namespace detail
@@ -194,7 +223,15 @@ VCvtF32I32Vop1::VCvtF32I32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_i32_sdwa"
+          : "v_cvt_f32_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop1>(opcode);
 }
 } // namespace detail
@@ -244,7 +281,15 @@ VCvtF32U32Vop1::VCvtF32U32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_u32_sdwa"
+          : "v_cvt_f32_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop1>(opcode);
 }
 } // namespace detail
@@ -294,7 +339,15 @@ VCvtU32F32Vop1::VCvtU32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_u32_f32_sdwa"
+          : "v_cvt_u32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -344,7 +397,15 @@ VCvtI32F32Vop1::VCvtI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_i32_f32_sdwa"
+          : "v_cvt_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -394,7 +455,15 @@ VCvtF16F32Vop1::VCvtF16F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f16_f32_sdwa"
+          : "v_cvt_f16_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop1>(opcode);
 }
 } // namespace detail
@@ -451,7 +520,15 @@ VCvtF32F16Vop1::VCvtF32F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_f16_sdwa"
+          : "v_cvt_f32_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop1>(opcode);
 }
 } // namespace detail
@@ -501,7 +578,16 @@ VCvtRpiI32F32Vop1::VCvtRpiI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtRpiI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_rpi_i32_f32_sdwa"
+          : "v_cvt_rpi_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtRpiI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -551,7 +637,16 @@ VCvtFlrI32F32Vop1::VCvtFlrI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtFlrI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_flr_i32_f32_sdwa"
+          : "v_cvt_flr_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFlrI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -601,7 +696,16 @@ VCvtOffF32I4Vop1::VCvtOffF32I4Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_off_f32_i4_sdwa"
+          : "v_cvt_off_f32_i4_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop1>(opcode);
 }
 } // namespace detail
@@ -620,14 +724,19 @@ VCvtF32F64Vop1::VCvtF32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CVT_F32_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_f32_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F32_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F32_F64 does not support SDWA";
   return std::make_unique<VCvtF32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -645,14 +754,19 @@ VCvtF64F32Vop1::VCvtF64F32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CVT_F64_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F64_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_f64_f32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support SDWA";
   return std::make_unique<VCvtF64F32Vop1>(opcode);
 }
 } // namespace detail
@@ -702,7 +816,16 @@ VCvtF32Ubyte0Vop1::VCvtF32Ubyte0Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte0_sdwa"
+          : "v_cvt_f32_ubyte0_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop1>(opcode);
 }
 } // namespace detail
@@ -752,7 +875,16 @@ VCvtF32Ubyte1Vop1::VCvtF32Ubyte1Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte1_sdwa"
+          : "v_cvt_f32_ubyte1_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop1>(opcode);
 }
 } // namespace detail
@@ -802,7 +934,16 @@ VCvtF32Ubyte2Vop1::VCvtF32Ubyte2Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte2_sdwa"
+          : "v_cvt_f32_ubyte2_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop1>(opcode);
 }
 } // namespace detail
@@ -852,7 +993,16 @@ VCvtF32Ubyte3Vop1::VCvtF32Ubyte3Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte3_sdwa"
+          : "v_cvt_f32_ubyte3_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop1>(opcode);
 }
 } // namespace detail
@@ -871,14 +1021,19 @@ VCvtU32F64Vop1::VCvtU32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CVT_U32_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_U32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_u32_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CVT_U32_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_U32_F64 does not support SDWA";
   return std::make_unique<VCvtU32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -896,14 +1051,19 @@ VCvtF64U32Vop1::VCvtF64U32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CVT_F64_U32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F64_U32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_f64_u32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_U32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_U32 does not support SDWA";
   return std::make_unique<VCvtF64U32Vop1>(opcode);
 }
 } // namespace detail
@@ -922,14 +1082,19 @@ VTruncF64Vop1::VTruncF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_TRUNC_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_TRUNC_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_trunc_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_TRUNC_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_TRUNC_F64 does not support SDWA";
   return std::make_unique<VTruncF64Vop1>(opcode);
 }
 } // namespace detail
@@ -948,14 +1113,19 @@ VCeilF64Vop1::VCeilF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CEIL_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CEIL_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_ceil_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CEIL_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CEIL_F64 does not support SDWA";
   return std::make_unique<VCeilF64Vop1>(opcode);
 }
 } // namespace detail
@@ -974,14 +1144,19 @@ VRndneF64Vop1::VRndneF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_RNDNE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_RNDNE_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_rndne_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support SDWA";
   return std::make_unique<VRndneF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1000,14 +1175,19 @@ VFloorF64Vop1::VFloorF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_FLOOR_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FLOOR_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_floor_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_FLOOR_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FLOOR_F64 does not support SDWA";
   return std::make_unique<VFloorF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1056,7 +1236,15 @@ VFractF32Vop1::VFractF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_fract_f32_sdwa"
+          : "v_fract_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1105,7 +1293,15 @@ VTruncF32Vop1::VTruncF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_trunc_f32_sdwa"
+          : "v_trunc_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1154,7 +1350,14 @@ VCeilF32Vop1::VCeilF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ceil_f32_sdwa"
+                                                                                 : "v_ceil_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1203,7 +1406,15 @@ VRndneF32Vop1::VRndneF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_rndne_f32_sdwa"
+          : "v_rndne_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1252,7 +1463,15 @@ VFloorF32Vop1::VFloorF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_floor_f32_sdwa"
+          : "v_floor_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1301,7 +1520,14 @@ VExpF32Vop1::VExpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_exp_f32_sdwa"
+                                                                                 : "v_exp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1350,7 +1576,14 @@ VLogF32Vop1::VLogF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_log_f32_sdwa"
+                                                                                 : "v_log_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1399,7 +1632,14 @@ VRcpF32Vop1::VRcpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rcp_f32_sdwa"
+                                                                                 : "v_rcp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1449,7 +1689,16 @@ VRcpIflagF32Vop1::VRcpIflagF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_rcp_iflag_f32_sdwa"
+          : "v_rcp_iflag_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1498,7 +1747,14 @@ VRsqF32Vop1::VRsqF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rsq_f32_sdwa"
+                                                                                 : "v_rsq_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1517,14 +1773,19 @@ VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_RCP_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_RCP_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_rcp_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support SDWA";
   return std::make_unique<VRcpF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1543,14 +1804,19 @@ VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_RSQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_RSQ_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_rsq_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support SDWA";
   return std::make_unique<VRsqF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1599,7 +1865,14 @@ VSqrtF32Vop1::VSqrtF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sqrt_f32_sdwa"
+                                                                                 : "v_sqrt_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1618,14 +1891,19 @@ VSqrtF64Vop1::VSqrtF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_SQRT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_SQRT_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_sqrt_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support SDWA";
   return std::make_unique<VSqrtF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1674,7 +1952,14 @@ VSinF32Vop1::VSinF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sin_f32_sdwa"
+                                                                                 : "v_sin_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1723,7 +2008,14 @@ VCosF32Vop1::VCosF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_cos_f32_sdwa"
+                                                                                 : "v_cos_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1772,7 +2064,14 @@ VNotB32Vop1::VNotB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_not_b32_sdwa"
+                                                                                 : "v_not_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop1>(opcode);
 }
 } // namespace detail
@@ -1821,7 +2120,15 @@ VBfrevB32Vop1::VBfrevB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_bfrev_b32_sdwa"
+          : "v_bfrev_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop1>(opcode);
 }
 } // namespace detail
@@ -1870,7 +2177,14 @@ VFfbhU32Vop1::VFfbhU32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhU32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFfbhU32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ffbh_u32_sdwa"
+                                                                                 : "v_ffbh_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhU32Vop1>(opcode);
 }
 } // namespace detail
@@ -1919,7 +2233,14 @@ VFfblB32Vop1::VFfblB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfblB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFfblB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ffbl_b32_sdwa"
+                                                                                 : "v_ffbl_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfblB32Vop1>(opcode);
 }
 } // namespace detail
@@ -1968,7 +2289,14 @@ VFfbhI32Vop1::VFfbhI32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhI32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFfbhI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ffbh_i32_sdwa"
+                                                                                 : "v_ffbh_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhI32Vop1>(opcode);
 }
 } // namespace detail
@@ -1987,14 +2315,20 @@ VFrexpExpI32F64Vop1::VFrexpExpI32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_FREXP_EXP_I32_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FREXP_EXP_I32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_frexp_exp_i32_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_EXP_I32_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_EXP_I32_F64 does not support SDWA";
   return std::make_unique<VFrexpExpI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -2013,14 +2347,20 @@ VFrexpMantF64Vop1::VFrexpMantF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_FREXP_MANT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FREXP_MANT_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_frexp_mant_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_MANT_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_MANT_F64 does not support SDWA";
   return std::make_unique<VFrexpMantF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2039,14 +2379,19 @@ VFractF64Vop1::VFractF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_FRACT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FRACT_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_fract_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_FRACT_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FRACT_F64 does not support SDWA";
   return std::make_unique<VFractF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2096,7 +2441,16 @@ VFrexpExpI32F32Vop1::VFrexpExpI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_exp_i32_f32_sdwa"
+          : "v_frexp_exp_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -2146,7 +2500,16 @@ VFrexpMantF32Vop1::VFrexpMantF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_mant_f32_sdwa"
+          : "v_frexp_mant_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop1>(opcode);
 }
 } // namespace detail
@@ -2159,7 +2522,11 @@ VClrexcpVop1::VClrexcpVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClrexcpVop1(const MachineInst *opcode) {
+DecodeResult decodeVClrexcpVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop1::validate_encoding(
+      "v_clrexcp_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClrexcpVop1>(opcode);
 }
 } // namespace detail
@@ -2209,7 +2576,16 @@ VScreenPartition4seB32Vop1::VScreenPartition4seB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVScreenPartition4seB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVScreenPartition4seB32Vop1(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_screen_partition_4se_b32_sdwa"
+          : "v_screen_partition_4se_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VScreenPartition4seB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2260,7 +2636,15 @@ VCvtF16U16Vop1::VCvtF16U16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f16_u16_sdwa"
+          : "v_cvt_f16_u16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop1>(opcode);
 }
 } // namespace detail
@@ -2317,7 +2701,15 @@ VCvtF16I16Vop1::VCvtF16I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f16_i16_sdwa"
+          : "v_cvt_f16_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop1>(opcode);
 }
 } // namespace detail
@@ -2374,7 +2766,15 @@ VCvtU16F16Vop1::VCvtU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_u16_f16_sdwa"
+          : "v_cvt_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2431,7 +2831,15 @@ VCvtI16F16Vop1::VCvtI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_i16_f16_sdwa"
+          : "v_cvt_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2487,7 +2895,14 @@ VRcpF16Vop1::VRcpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rcp_f16_sdwa"
+                                                                                 : "v_rcp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2543,7 +2958,14 @@ VSqrtF16Vop1::VSqrtF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sqrt_f16_sdwa"
+                                                                                 : "v_sqrt_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2599,7 +3021,14 @@ VRsqF16Vop1::VRsqF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rsq_f16_sdwa"
+                                                                                 : "v_rsq_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2655,7 +3084,14 @@ VLogF16Vop1::VLogF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_log_f16_sdwa"
+                                                                                 : "v_log_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2711,7 +3147,14 @@ VExpF16Vop1::VExpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_exp_f16_sdwa"
+                                                                                 : "v_exp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2768,7 +3211,16 @@ VFrexpMantF16Vop1::VFrexpMantF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_mant_f16_sdwa"
+          : "v_frexp_mant_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2825,7 +3277,16 @@ VFrexpExpI16F16Vop1::VFrexpExpI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_exp_i16_f16_sdwa"
+          : "v_frexp_exp_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2881,7 +3342,15 @@ VFloorF16Vop1::VFloorF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_floor_f16_sdwa"
+          : "v_floor_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2937,7 +3406,14 @@ VCeilF16Vop1::VCeilF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ceil_f16_sdwa"
+                                                                                 : "v_ceil_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2993,7 +3469,15 @@ VTruncF16Vop1::VTruncF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_trunc_f16_sdwa"
+          : "v_trunc_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3049,7 +3533,15 @@ VRndneF16Vop1::VRndneF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_rndne_f16_sdwa"
+          : "v_rndne_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3105,7 +3597,15 @@ VFractF16Vop1::VFractF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_fract_f16_sdwa"
+          : "v_fract_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3161,7 +3661,14 @@ VSinF16Vop1::VSinF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sin_f16_sdwa"
+                                                                                 : "v_sin_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3217,7 +3724,14 @@ VCosF16Vop1::VCosF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_cos_f16_sdwa"
+                                                                                 : "v_cos_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3274,7 +3788,16 @@ VCvtNormI16F16Vop1::VCvtNormI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_norm_i16_f16_sdwa"
+          : "v_cvt_norm_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3331,7 +3854,16 @@ VCvtNormU16F16Vop1::VCvtNormU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_norm_u16_f16_sdwa"
+          : "v_cvt_norm_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3387,7 +3919,16 @@ VSatPkU8I16Vop1::VSatPkU8I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_sat_pk_u8_i16_sdwa"
+          : "v_sat_pk_u8_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop1>(opcode);
 }
 } // namespace detail
@@ -3409,14 +3950,19 @@ VSwapB32Vop1::VSwapB32Vop1(const MachineInst *inst)
   dst_operands_[1] = &src0;
   num_src_ = 2;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_SWAP_B32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_SWAP_B32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_swap_b32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B32 does not support SDWA";
   return std::make_unique<VSwapB32Vop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/vop2.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/vop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -67,7 +66,16 @@ VCndmaskB32Vop2::VCndmaskB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cndmask_b32_sdwa"
+          : "v_cndmask_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop2>(opcode);
 }
 } // namespace detail
@@ -122,7 +130,14 @@ VAddF32Vop2::VAddF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_f32_sdwa"
+                                                                                 : "v_add_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop2>(opcode);
 }
 } // namespace detail
@@ -177,7 +192,14 @@ VSubF32Vop2::VSubF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_f32_sdwa"
+                                                                                 : "v_sub_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop2>(opcode);
 }
 } // namespace detail
@@ -233,7 +255,15 @@ VSubrevF32Vop2::VSubrevF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_f32_sdwa"
+          : "v_subrev_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop2>(opcode);
 }
 } // namespace detail
@@ -289,7 +319,16 @@ VMulLegacyF32Vop2::VMulLegacyF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLegacyF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulLegacyF32Vop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_legacy_f32_sdwa"
+          : "v_mul_legacy_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLegacyF32Vop2>(opcode);
 }
 } // namespace detail
@@ -344,7 +383,14 @@ VMulF32Vop2::VMulF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mul_f32_sdwa"
+                                                                                 : "v_mul_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop2>(opcode);
 }
 } // namespace detail
@@ -400,7 +446,15 @@ VMulI32I24Vop2::VMulI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_i32_i24_sdwa"
+          : "v_mul_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -456,7 +510,16 @@ VMulHiI32I24Vop2::VMulHiI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_hi_i32_i24_sdwa"
+          : "v_mul_hi_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -512,7 +575,15 @@ VMulU32U24Vop2::VMulU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_u32_u24_sdwa"
+          : "v_mul_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -568,7 +639,16 @@ VMulHiU32U24Vop2::VMulHiU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_hi_u32_u24_sdwa"
+          : "v_mul_hi_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -623,7 +703,14 @@ VMinF32Vop2::VMinF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_f32_sdwa"
+                                                                                 : "v_min_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF32Vop2>(opcode);
 }
 } // namespace detail
@@ -678,7 +765,14 @@ VMaxF32Vop2::VMaxF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_f32_sdwa"
+                                                                                 : "v_max_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF32Vop2>(opcode);
 }
 } // namespace detail
@@ -733,7 +827,14 @@ VMinI32Vop2::VMinI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_i32_sdwa"
+                                                                                 : "v_min_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop2>(opcode);
 }
 } // namespace detail
@@ -788,7 +889,14 @@ VMaxI32Vop2::VMaxI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_i32_sdwa"
+                                                                                 : "v_max_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop2>(opcode);
 }
 } // namespace detail
@@ -843,7 +951,14 @@ VMinU32Vop2::VMinU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_u32_sdwa"
+                                                                                 : "v_min_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop2>(opcode);
 }
 } // namespace detail
@@ -898,7 +1013,14 @@ VMaxU32Vop2::VMaxU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_u32_sdwa"
+                                                                                 : "v_max_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop2>(opcode);
 }
 } // namespace detail
@@ -954,7 +1076,16 @@ VLshrrevB32Vop2::VLshrrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshrrev_b32_sdwa"
+          : "v_lshrrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1010,7 +1141,16 @@ VAshrrevI32Vop2::VAshrrevI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_ashrrev_i32_sdwa"
+          : "v_ashrrev_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop2>(opcode);
 }
 } // namespace detail
@@ -1066,7 +1206,16 @@ VLshlrevB32Vop2::VLshlrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshlrev_b32_sdwa"
+          : "v_lshlrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1121,7 +1270,14 @@ VAndB32Vop2::VAndB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_and_b32_sdwa"
+                                                                                 : "v_and_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1176,7 +1332,14 @@ VOrB32Vop2::VOrB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_or_b32_sdwa"
+                                                                                 : "v_or_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1231,7 +1394,14 @@ VXorB32Vop2::VXorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_xor_b32_sdwa"
+                                                                                 : "v_xor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1260,12 +1430,17 @@ VMacF32Vop2::VMacF32Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MAC_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMacF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_mac_f32_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MAC_F32 does not support SDWA";
   return std::make_unique<VMacF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1290,14 +1465,19 @@ VMadmkF32Vop2::VMadmkF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_MADMK_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MADMK_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadmkF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMadmkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_madmk_f32_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_MADMK_F32 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MADMK_F32 does not support SDWA";
   return std::make_unique<VMadmkF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1322,14 +1502,19 @@ VMadakF32Vop2::VMadakF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_MADAK_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MADAK_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadakF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMadakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_madak_f32_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_MADAK_F32 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MADAK_F32 does not support SDWA";
   return std::make_unique<VMadakF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1388,7 +1573,15 @@ VAddCoU32Vop2::VAddCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_add_co_u32_sdwa"
+          : "v_add_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1447,7 +1640,15 @@ VSubCoU32Vop2::VSubCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_sub_co_u32_sdwa"
+          : "v_sub_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1506,7 +1707,16 @@ VSubrevCoU32Vop2::VSubrevCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_co_u32_sdwa"
+          : "v_subrev_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1568,7 +1778,15 @@ VAddcCoU32Vop2::VAddcCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddcCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddcCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_addc_co_u32_sdwa"
+          : "v_addc_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddcCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1630,7 +1848,15 @@ VSubbCoU32Vop2::VSubbCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubbCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubbCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subb_co_u32_sdwa"
+          : "v_subb_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubbCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1692,7 +1918,16 @@ VSubbrevCoU32Vop2::VSubbrevCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubbrevCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubbrevCoU32Vop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subbrev_co_u32_sdwa"
+          : "v_subbrev_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubbrevCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1748,7 +1983,14 @@ VAddF16Vop2::VAddF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_f16_sdwa"
+                                                                                 : "v_add_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1810,7 +2052,14 @@ VSubF16Vop2::VSubF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_f16_sdwa"
+                                                                                 : "v_sub_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1873,7 +2122,15 @@ VSubrevF16Vop2::VSubrevF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_f16_sdwa"
+          : "v_subrev_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1935,7 +2192,14 @@ VMulF16Vop2::VMulF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mul_f16_sdwa"
+                                                                                 : "v_mul_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1971,12 +2235,17 @@ VMacF16Vop2::VMacF16Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MAC_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_mac_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MAC_F16 does not support SDWA";
   return std::make_unique<VMacF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2009,14 +2278,19 @@ VMadmkF16Vop2::VMadmkF16Vop2(const MachineInst *inst)
       Operand(16, OperandType::OPR_SIMM32,
               static_cast<int>(
                   (reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_MADMK_F16 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MADMK_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadmkF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMadmkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_madmk_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_MADMK_F16 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MADMK_F16 does not support SDWA";
   return std::make_unique<VMadmkF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2049,14 +2323,19 @@ VMadakF16Vop2::VMadakF16Vop2(const MachineInst *inst)
       Operand(16, OperandType::OPR_SIMM32,
               static_cast<int>(
                   (reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_MADAK_F16 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MADAK_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadakF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMadakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_madak_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_MADAK_F16 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MADAK_F16 does not support SDWA";
   return std::make_unique<VMadakF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2118,7 +2397,14 @@ VAddU16Vop2::VAddU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_u16_sdwa"
+                                                                                 : "v_add_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2180,7 +2466,14 @@ VSubU16Vop2::VSubU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_u16_sdwa"
+                                                                                 : "v_sub_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2243,7 +2536,15 @@ VSubrevU16Vop2::VSubrevU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_u16_sdwa"
+          : "v_subrev_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2306,7 +2607,15 @@ VMulLoU16Vop2::VMulLoU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_lo_u16_sdwa"
+          : "v_mul_lo_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2369,7 +2678,16 @@ VLshlrevB16Vop2::VLshlrevB16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB16Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshlrev_b16_sdwa"
+          : "v_lshlrev_b16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB16Vop2>(opcode);
 }
 } // namespace detail
@@ -2432,7 +2750,16 @@ VLshrrevB16Vop2::VLshrrevB16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB16Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshrrev_b16_sdwa"
+          : "v_lshrrev_b16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB16Vop2>(opcode);
 }
 } // namespace detail
@@ -2495,7 +2822,16 @@ VAshrrevI16Vop2::VAshrrevI16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI16Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_ashrrev_i16_sdwa"
+          : "v_ashrrev_i16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI16Vop2>(opcode);
 }
 } // namespace detail
@@ -2557,7 +2893,14 @@ VMaxF16Vop2::VMaxF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_f16_sdwa"
+                                                                                 : "v_max_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2619,7 +2962,14 @@ VMinF16Vop2::VMinF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_f16_sdwa"
+                                                                                 : "v_min_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2681,7 +3031,14 @@ VMaxU16Vop2::VMaxU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_u16_sdwa"
+                                                                                 : "v_max_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2743,7 +3100,14 @@ VMaxI16Vop2::VMaxI16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_i16_sdwa"
+                                                                                 : "v_max_i16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI16Vop2>(opcode);
 }
 } // namespace detail
@@ -2805,7 +3169,14 @@ VMinU16Vop2::VMinU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_u16_sdwa"
+                                                                                 : "v_min_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2867,7 +3238,14 @@ VMinI16Vop2::VMinI16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_i16_sdwa"
+                                                                                 : "v_min_i16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI16Vop2>(opcode);
 }
 } // namespace detail
@@ -2929,7 +3307,15 @@ VLdexpF16Vop2::VLdexpF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_ldexp_f16_sdwa"
+          : "v_ldexp_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2990,7 +3376,14 @@ VAddU32Vop2::VAddU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_u32_sdwa"
+                                                                                 : "v_add_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddU32Vop2>(opcode);
 }
 } // namespace detail
@@ -3045,7 +3438,14 @@ VSubU32Vop2::VSubU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_u32_sdwa"
+                                                                                 : "v_sub_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubU32Vop2>(opcode);
 }
 } // namespace detail
@@ -3101,7 +3501,15 @@ VSubrevU32Vop2::VSubrevU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_u32_sdwa"
+          : "v_subrev_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevU32Vop2>(opcode);
 }
 } // namespace detail
@@ -3130,12 +3538,18 @@ VDot2cF32F16Vop2::VDot2cF32F16Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT2C_F32_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot2cF32F16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_dot2c_f32_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT2C_F32_F16 does not support SDWA";
   return std::make_unique<VDot2cF32F16Vop2>(opcode);
 }
 } // namespace detail
@@ -3164,12 +3578,18 @@ VDot2cI32I16Vop2::VDot2cI32I16Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT2C_I32_I16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cI32I16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot2cI32I16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_dot2c_i32_i16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT2C_I32_I16 does not support SDWA";
   return std::make_unique<VDot2cI32I16Vop2>(opcode);
 }
 } // namespace detail
@@ -3198,12 +3618,18 @@ VDot4cI32I8Vop2::VDot4cI32I8Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT4C_I32_I8 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot4cI32I8Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_dot4c_i32_i8_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT4C_I32_I8 does not support SDWA";
   return std::make_unique<VDot4cI32I8Vop2>(opcode);
 }
 } // namespace detail
@@ -3232,12 +3658,18 @@ VDot8cI32I4Vop2::VDot8cI32I4Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT8C_I32_I4 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8cI32I4Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot8cI32I4Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_dot8c_i32_i4_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT8C_I32_I4 does not support SDWA";
   return std::make_unique<VDot8cI32I4Vop2>(opcode);
 }
 } // namespace detail
@@ -3266,12 +3698,17 @@ VFmacF32Vop2::VFmacF32Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAC_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_fmac_f32_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_F32 does not support SDWA";
   return std::make_unique<VFmacF32Vop2>(opcode);
 }
 } // namespace detail
@@ -3300,12 +3737,17 @@ VPkFmacF16Vop2::VPkFmacF16Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_PK_FMAC_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_pk_fmac_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_PK_FMAC_F16 does not support SDWA";
   return std::make_unique<VPkFmacF16Vop2>(opcode);
 }
 } // namespace detail
@@ -3360,7 +3802,14 @@ VXnorB32Vop2::VXnorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_xnor_b32_sdwa"
+                                                                                 : "v_xnor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/vop3.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/vop3.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -30,7 +29,12 @@ VInterpP1F32Vop3::VInterpP1F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP1F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpP1F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_p1_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP1F32Vop3>(opcode);
 }
 } // namespace detail
@@ -53,7 +57,12 @@ VInterpP2F32Vop3::VInterpP2F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_p2_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2F32Vop3>(opcode);
 }
 } // namespace detail
@@ -75,7 +84,12 @@ VInterpMovF32Vop3::VInterpMovF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpMovF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpMovF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_mov_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpMovF32Vop3>(opcode);
 }
 } // namespace detail
@@ -88,7 +102,11 @@ VNopVop3::VNopVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode) {
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_nop", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop3>(opcode);
 }
 } // namespace detail
@@ -105,7 +123,11 @@ VMovB32Vop3::VMovB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mov_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop3>(opcode);
 }
 } // namespace detail
@@ -122,7 +144,12 @@ VReadfirstlaneB32Vop3::VReadfirstlaneB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_readfirstlane_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VReadfirstlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -139,7 +166,11 @@ VCvtI32F64Vop3::VCvtI32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_i32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -156,7 +187,11 @@ VCvtF64I32Vop3::VCvtF64I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f64_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF64I32Vop3>(opcode);
 }
 } // namespace detail
@@ -173,7 +208,11 @@ VCvtF32I32Vop3::VCvtF32I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop3>(opcode);
 }
 } // namespace detail
@@ -190,7 +229,11 @@ VCvtF32U32Vop3::VCvtF32U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop3>(opcode);
 }
 } // namespace detail
@@ -207,7 +250,11 @@ VCvtU32F32Vop3::VCvtU32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_u32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -224,7 +271,11 @@ VCvtI32F32Vop3::VCvtI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -241,7 +292,11 @@ VCvtF16F32Vop3::VCvtF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -264,7 +319,11 @@ VCvtF32F16Vop3::VCvtF32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -281,7 +340,12 @@ VCvtRpiI32F32Vop3::VCvtRpiI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtRpiI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_rpi_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtRpiI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -298,7 +362,12 @@ VCvtFlrI32F32Vop3::VCvtFlrI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtFlrI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_flr_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFlrI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -315,7 +384,12 @@ VCvtOffF32I4Vop3::VCvtOffF32I4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_off_f32_i4", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop3>(opcode);
 }
 } // namespace detail
@@ -332,7 +406,11 @@ VCvtF32F64Vop3::VCvtF32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -349,7 +427,11 @@ VCvtF64F32Vop3::VCvtF64F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f64_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF64F32Vop3>(opcode);
 }
 } // namespace detail
@@ -366,7 +448,12 @@ VCvtF32Ubyte0Vop3::VCvtF32Ubyte0Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte0", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop3>(opcode);
 }
 } // namespace detail
@@ -383,7 +470,12 @@ VCvtF32Ubyte1Vop3::VCvtF32Ubyte1Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte1", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop3>(opcode);
 }
 } // namespace detail
@@ -400,7 +492,12 @@ VCvtF32Ubyte2Vop3::VCvtF32Ubyte2Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte2", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop3>(opcode);
 }
 } // namespace detail
@@ -417,7 +514,12 @@ VCvtF32Ubyte3Vop3::VCvtF32Ubyte3Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte3", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop3>(opcode);
 }
 } // namespace detail
@@ -434,7 +536,11 @@ VCvtU32F64Vop3::VCvtU32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_u32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -451,7 +557,11 @@ VCvtF64U32Vop3::VCvtF64U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f64_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF64U32Vop3>(opcode);
 }
 } // namespace detail
@@ -468,7 +578,11 @@ VTruncF64Vop3::VTruncF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trunc_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF64Vop3>(opcode);
 }
 } // namespace detail
@@ -485,7 +599,11 @@ VCeilF64Vop3::VCeilF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ceil_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF64Vop3>(opcode);
 }
 } // namespace detail
@@ -502,7 +620,11 @@ VRndneF64Vop3::VRndneF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rndne_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF64Vop3>(opcode);
 }
 } // namespace detail
@@ -519,7 +641,11 @@ VFloorF64Vop3::VFloorF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_floor_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF64Vop3>(opcode);
 }
 } // namespace detail
@@ -536,7 +662,11 @@ VFractF32Vop3::VFractF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fract_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop3>(opcode);
 }
 } // namespace detail
@@ -553,7 +683,11 @@ VTruncF32Vop3::VTruncF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trunc_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop3>(opcode);
 }
 } // namespace detail
@@ -570,7 +704,11 @@ VCeilF32Vop3::VCeilF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ceil_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop3>(opcode);
 }
 } // namespace detail
@@ -587,7 +725,11 @@ VRndneF32Vop3::VRndneF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rndne_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop3>(opcode);
 }
 } // namespace detail
@@ -604,7 +746,11 @@ VFloorF32Vop3::VFloorF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_floor_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop3>(opcode);
 }
 } // namespace detail
@@ -621,7 +767,11 @@ VExpF32Vop3::VExpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_exp_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -638,7 +788,11 @@ VLogF32Vop3::VLogF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_log_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop3>(opcode);
 }
 } // namespace detail
@@ -655,7 +809,11 @@ VRcpF32Vop3::VRcpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -672,7 +830,12 @@ VRcpIflagF32Vop3::VRcpIflagF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_iflag_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop3>(opcode);
 }
 } // namespace detail
@@ -689,7 +852,11 @@ VRsqF32Vop3::VRsqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rsq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -706,7 +873,11 @@ VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -723,7 +894,11 @@ VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rsq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -740,7 +915,11 @@ VSqrtF32Vop3::VSqrtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sqrt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -757,7 +936,11 @@ VSqrtF64Vop3::VSqrtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sqrt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -774,7 +957,11 @@ VSinF32Vop3::VSinF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sin_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop3>(opcode);
 }
 } // namespace detail
@@ -791,7 +978,11 @@ VCosF32Vop3::VCosF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cos_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop3>(opcode);
 }
 } // namespace detail
@@ -808,7 +999,11 @@ VNotB32Vop3::VNotB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_not_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop3>(opcode);
 }
 } // namespace detail
@@ -825,7 +1020,11 @@ VBfrevB32Vop3::VBfrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfrev_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -842,7 +1041,11 @@ VFfbhU32Vop3::VFfbhU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFfbhU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ffbh_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhU32Vop3>(opcode);
 }
 } // namespace detail
@@ -859,7 +1062,11 @@ VFfblB32Vop3::VFfblB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfblB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFfblB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ffbl_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfblB32Vop3>(opcode);
 }
 } // namespace detail
@@ -876,7 +1083,11 @@ VFfbhI32Vop3::VFfbhI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFfbhI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ffbh_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhI32Vop3>(opcode);
 }
 } // namespace detail
@@ -893,7 +1104,12 @@ VFrexpExpI32F64Vop3::VFrexpExpI32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_exp_i32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -910,7 +1126,12 @@ VFrexpMantF64Vop3::VFrexpMantF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_mant_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF64Vop3>(opcode);
 }
 } // namespace detail
@@ -927,7 +1148,11 @@ VFractF64Vop3::VFractF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fract_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF64Vop3>(opcode);
 }
 } // namespace detail
@@ -944,7 +1169,12 @@ VFrexpExpI32F32Vop3::VFrexpExpI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_exp_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -961,7 +1191,12 @@ VFrexpMantF32Vop3::VFrexpMantF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_mant_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop3>(opcode);
 }
 } // namespace detail
@@ -974,7 +1209,11 @@ VClrexcpVop3::VClrexcpVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClrexcpVop3(const MachineInst *opcode) {
+DecodeResult decodeVClrexcpVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_clrexcp", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClrexcpVop3>(opcode);
 }
 } // namespace detail
@@ -991,7 +1230,12 @@ VScreenPartition4seB32Vop3::VScreenPartition4seB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVScreenPartition4seB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVScreenPartition4seB32Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_screen_partition_4se_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VScreenPartition4seB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1008,7 +1252,11 @@ VCvtF16U16Vop3::VCvtF16U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f16_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop3>(opcode);
 }
 } // namespace detail
@@ -1031,7 +1279,11 @@ VCvtF16I16Vop3::VCvtF16I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f16_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop3>(opcode);
 }
 } // namespace detail
@@ -1054,7 +1306,11 @@ VCvtU16F16Vop3::VCvtU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_u16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1077,7 +1333,11 @@ VCvtI16F16Vop3::VCvtI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1100,7 +1360,11 @@ VRcpF16Vop3::VRcpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1123,7 +1387,11 @@ VSqrtF16Vop3::VSqrtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sqrt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1146,7 +1414,11 @@ VRsqF16Vop3::VRsqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rsq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1169,7 +1441,11 @@ VLogF16Vop3::VLogF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_log_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1192,7 +1468,11 @@ VExpF16Vop3::VExpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_exp_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1215,7 +1495,12 @@ VFrexpMantF16Vop3::VFrexpMantF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_mant_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1238,7 +1523,12 @@ VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_exp_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1261,7 +1551,11 @@ VFloorF16Vop3::VFloorF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_floor_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1284,7 +1578,11 @@ VCeilF16Vop3::VCeilF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ceil_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1307,7 +1605,11 @@ VTruncF16Vop3::VTruncF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trunc_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1330,7 +1632,11 @@ VRndneF16Vop3::VRndneF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rndne_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1353,7 +1659,11 @@ VFractF16Vop3::VFractF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fract_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1376,7 +1686,11 @@ VSinF16Vop3::VSinF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sin_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1399,7 +1713,11 @@ VCosF16Vop3::VCosF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cos_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1422,7 +1740,12 @@ VCvtNormI16F16Vop3::VCvtNormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_norm_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1445,7 +1768,12 @@ VCvtNormU16F16Vop3::VCvtNormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_norm_u16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1468,7 +1796,12 @@ VSatPkU8I16Vop3::VSatPkU8I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sat_pk_u8_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop3>(opcode);
 }
 } // namespace detail
@@ -1493,7 +1826,11 @@ VSwapB32Vop3::VSwapB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwapB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSwapB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_swap_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSwapB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1514,7 +1851,12 @@ VCndmaskB32Vop3::VCndmaskB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cndmask_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1533,7 +1875,11 @@ VAddF32Vop3::VAddF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1552,7 +1898,11 @@ VSubF32Vop3::VSubF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1571,7 +1921,11 @@ VSubrevF32Vop3::VSubrevF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1590,7 +1944,12 @@ VMulLegacyF32Vop3::VMulLegacyF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLegacyF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_legacy_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLegacyF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1609,7 +1968,11 @@ VMulF32Vop3::VMulF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1628,7 +1991,11 @@ VMulI32I24Vop3::VMulI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_i32_i24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -1647,7 +2014,12 @@ VMulHiI32I24Vop3::VMulHiI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_i32_i24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -1666,7 +2038,11 @@ VMulU32U24Vop3::VMulU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_u32_u24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -1685,7 +2061,12 @@ VMulHiU32U24Vop3::VMulHiU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_u32_u24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -1704,7 +2085,11 @@ VMinF32Vop3::VMinF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1723,7 +2108,11 @@ VMaxF32Vop3::VMaxF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1742,7 +2131,11 @@ VMinI32Vop3::VMinI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop3>(opcode);
 }
 } // namespace detail
@@ -1761,7 +2154,11 @@ VMaxI32Vop3::VMaxI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop3>(opcode);
 }
 } // namespace detail
@@ -1780,7 +2177,11 @@ VMinU32Vop3::VMinU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop3>(opcode);
 }
 } // namespace detail
@@ -1799,7 +2200,11 @@ VMaxU32Vop3::VMaxU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop3>(opcode);
 }
 } // namespace detail
@@ -1818,7 +2223,12 @@ VLshrrevB32Vop3::VLshrrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshrrev_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1837,7 +2247,12 @@ VAshrrevI32Vop3::VAshrrevI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashrrev_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop3>(opcode);
 }
 } // namespace detail
@@ -1856,7 +2271,12 @@ VLshlrevB32Vop3::VLshlrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshlrev_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1875,7 +2295,11 @@ VAndB32Vop3::VAndB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_and_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1894,7 +2318,11 @@ VOrB32Vop3::VOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_or_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1913,7 +2341,11 @@ VXorB32Vop3::VXorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xor_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1933,7 +2365,11 @@ VMacF32Vop3::VMacF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMacF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mac_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMacF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1952,7 +2388,11 @@ VAddF16Vop3::VAddF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1977,7 +2417,11 @@ VSubF16Vop3::VSubF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2002,7 +2446,11 @@ VSubrevF16Vop3::VSubrevF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2027,7 +2475,11 @@ VMulF16Vop3::VMulF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2053,7 +2505,11 @@ VMacF16Vop3::VMacF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMacF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mac_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMacF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2078,7 +2534,11 @@ VAddU16Vop3::VAddU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2103,7 +2563,11 @@ VSubU16Vop3::VSubU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2128,7 +2592,11 @@ VSubrevU16Vop3::VSubrevU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2153,7 +2621,11 @@ VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_lo_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2178,7 +2650,12 @@ VLshlrevB16Vop3::VLshlrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshlrev_b16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -2203,7 +2680,12 @@ VLshrrevB16Vop3::VLshrrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshrrev_b16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -2228,7 +2710,12 @@ VAshrrevI16Vop3::VAshrrevI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashrrev_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI16Vop3>(opcode);
 }
 } // namespace detail
@@ -2253,7 +2740,11 @@ VMaxF16Vop3::VMaxF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2278,7 +2769,11 @@ VMinF16Vop3::VMinF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2303,7 +2798,11 @@ VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2328,7 +2827,11 @@ VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI16Vop3>(opcode);
 }
 } // namespace detail
@@ -2353,7 +2856,11 @@ VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2378,7 +2885,11 @@ VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI16Vop3>(opcode);
 }
 } // namespace detail
@@ -2403,7 +2914,11 @@ VLdexpF16Vop3::VLdexpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ldexp_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2428,7 +2943,11 @@ VAddU32Vop3::VAddU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2447,7 +2966,11 @@ VSubU32Vop3::VSubU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2466,7 +2989,11 @@ VSubrevU32Vop3::VSubrevU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2486,7 +3013,12 @@ VDot2cF32F16Vop3::VDot2cF32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot2cF32F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot2c_f32_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2cF32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -2506,7 +3038,12 @@ VDot2cI32I16Vop3::VDot2cI32I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cI32I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot2cI32I16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot2c_i32_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2cI32I16Vop3>(opcode);
 }
 } // namespace detail
@@ -2526,7 +3063,12 @@ VDot4cI32I8Vop3::VDot4cI32I8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot4cI32I8Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot4c_i32_i8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot4cI32I8Vop3>(opcode);
 }
 } // namespace detail
@@ -2546,7 +3088,12 @@ VDot8cI32I4Vop3::VDot8cI32I4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8cI32I4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot8cI32I4Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot8c_i32_i4", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot8cI32I4Vop3>(opcode);
 }
 } // namespace detail
@@ -2566,7 +3113,11 @@ VFmacF32Vop3::VFmacF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fmac_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2586,7 +3137,11 @@ VPkFmacF16Vop3::VPkFmacF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPkFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_pk_fmac_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkFmacF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2605,7 +3160,11 @@ VXnorB32Vop3::VXnorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xnor_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2626,7 +3185,12 @@ VMadLegacyF32Vop3::VMadLegacyF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadLegacyF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_legacy_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadLegacyF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2647,7 +3211,11 @@ VMadF32Vop3::VMadF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2668,7 +3236,11 @@ VMadI32I24Vop3::VMadI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_i32_i24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -2689,7 +3261,11 @@ VMadU32U24Vop3::VMadU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_u32_u24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -2710,7 +3286,11 @@ VCubeidF32Vop3::VCubeidF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubeid_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubeidF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2731,7 +3311,11 @@ VCubescF32Vop3::VCubescF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubesc_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubescF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2752,7 +3336,11 @@ VCubetcF32Vop3::VCubetcF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubetc_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubetcF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2773,7 +3361,11 @@ VCubemaF32Vop3::VCubemaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubema_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubemaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2794,7 +3386,11 @@ VBfeU32Vop3::VBfeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfe_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2815,7 +3411,11 @@ VBfeI32Vop3::VBfeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfe_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -2836,7 +3436,11 @@ VBfiB32Vop3::VBfiB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfi_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfiB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2857,7 +3461,11 @@ VFmaF32Vop3::VFmaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2878,7 +3486,11 @@ VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF64Vop3>(opcode);
 }
 } // namespace detail
@@ -2899,7 +3511,11 @@ VLerpU8Vop3::VLerpU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lerp_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLerpU8Vop3>(opcode);
 }
 } // namespace detail
@@ -2920,7 +3536,12 @@ VAlignbitB32Vop3::VAlignbitB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_alignbit_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbitB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2941,7 +3562,12 @@ VAlignbyteB32Vop3::VAlignbyteB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_alignbyte_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbyteB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2962,7 +3588,11 @@ VMin3F32Vop3::VMin3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -2983,7 +3613,11 @@ VMin3I32Vop3::VMin3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -3004,7 +3638,11 @@ VMin3U32Vop3::VMin3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3025,7 +3663,11 @@ VMax3F32Vop3::VMax3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3046,7 +3688,11 @@ VMax3I32Vop3::VMax3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -3067,7 +3713,11 @@ VMax3U32Vop3::VMax3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3088,7 +3738,11 @@ VMed3F32Vop3::VMed3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3109,7 +3763,11 @@ VMed3I32Vop3::VMed3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -3130,7 +3788,11 @@ VMed3U32Vop3::VMed3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3151,7 +3813,11 @@ VSadU8Vop3::VSadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3172,7 +3838,11 @@ VSadHiU8Vop3::VSadHiU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_hi_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadHiU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3193,7 +3863,11 @@ VSadU16Vop3::VSadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -3214,7 +3888,11 @@ VSadU32Vop3::VSadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3235,7 +3913,12 @@ VCvtPkU8F32Vop3::VCvtPkU8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_u8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3256,7 +3939,12 @@ VDivFixupF32Vop3::VDivFixupF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3277,7 +3965,12 @@ VDivFixupF64Vop3::VDivFixupF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF64Vop3>(opcode);
 }
 } // namespace detail
@@ -3301,7 +3994,12 @@ VDivFmasF32Vop3::VDivFmasF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fmas_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFmasF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3325,7 +4023,12 @@ VDivFmasF64Vop3::VDivFmasF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fmas_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFmasF64Vop3>(opcode);
 }
 } // namespace detail
@@ -3346,7 +4049,11 @@ VMsadU8Vop3::VMsadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_msad_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMsadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3367,7 +4074,12 @@ VQsadPkU16U8Vop3::VQsadPkU16U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_qsad_pk_u16_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VQsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -3388,7 +4100,12 @@ VMqsadPkU16U8Vop3::VMqsadPkU16U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mqsad_pk_u16_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMqsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -3409,7 +4126,12 @@ VMqsadU32U8Vop3::VMqsadU32U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mqsad_u32_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMqsadU32U8Vop3>(opcode);
 }
 } // namespace detail
@@ -3430,7 +4152,12 @@ VMadLegacyF16Vop3::VMadLegacyF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadLegacyF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadLegacyF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_legacy_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadLegacyF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3457,7 +4184,12 @@ VMadLegacyU16Vop3::VMadLegacyU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadLegacyU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadLegacyU16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_legacy_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadLegacyU16Vop3>(opcode);
 }
 } // namespace detail
@@ -3484,7 +4216,12 @@ VMadLegacyI16Vop3::VMadLegacyI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadLegacyI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadLegacyI16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_legacy_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadLegacyI16Vop3>(opcode);
 }
 } // namespace detail
@@ -3511,7 +4248,11 @@ VPermB32Vop3::VPermB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_perm_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPermB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3532,7 +4273,12 @@ VFmaLegacyF16Vop3::VFmaLegacyF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaLegacyF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaLegacyF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_legacy_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaLegacyF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3559,7 +4305,12 @@ VDivFixupLegacyF16Vop3::VDivFixupLegacyF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupLegacyF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupLegacyF16Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_legacy_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupLegacyF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3585,7 +4336,12 @@ VCvtPkaccumU8F32Vop3::VCvtPkaccumU8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkaccumU8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkaccumU8F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pkaccum_u8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkaccumU8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3606,7 +4362,11 @@ VMadU32U16Vop3::VMadU32U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_u32_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3627,7 +4387,11 @@ VMadI32I16Vop3::VMadI32I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_i32_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3648,7 +4412,11 @@ VXadU32Vop3::VXadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xad_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3669,7 +4437,11 @@ VMin3F16Vop3::VMin3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3696,7 +4468,11 @@ VMin3I16Vop3::VMin3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3723,7 +4499,11 @@ VMin3U16Vop3::VMin3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3750,7 +4530,11 @@ VMax3F16Vop3::VMax3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3777,7 +4561,11 @@ VMax3I16Vop3::VMax3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3804,7 +4592,11 @@ VMax3U16Vop3::VMax3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3831,7 +4623,11 @@ VMed3F16Vop3::VMed3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3858,7 +4654,11 @@ VMed3I16Vop3::VMed3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3885,7 +4685,11 @@ VMed3U16Vop3::VMed3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3912,7 +4716,12 @@ VLshlAddU32Vop3::VLshlAddU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshl_add_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlAddU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3933,7 +4742,12 @@ VAddLshlU32Vop3::VAddLshlU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_lshl_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddLshlU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3954,7 +4768,11 @@ VAdd3U32Vop3::VAdd3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAdd3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3975,7 +4793,11 @@ VLshlOrB32Vop3::VLshlOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshl_or_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3996,7 +4818,11 @@ VAndOrB32Vop3::VAndOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_and_or_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4017,7 +4843,11 @@ VOr3B32Vop3::VOr3B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_or3_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOr3B32Vop3>(opcode);
 }
 } // namespace detail
@@ -4038,7 +4868,11 @@ VMadF16Vop3::VMadF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4065,7 +4899,11 @@ VMadU16Vop3::VMadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -4092,7 +4930,11 @@ VMadI16Vop3::VMadI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI16Vop3>(opcode);
 }
 } // namespace detail
@@ -4119,7 +4961,11 @@ VFmaF16Vop3::VFmaF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4146,7 +4992,12 @@ VDivFixupF16Vop3::VDivFixupF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4171,7 +5022,12 @@ VInterpP1llF16Vop3::VInterpP1llF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP1llF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpP1llF16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_p1ll_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP1llF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4192,7 +5048,12 @@ VInterpP1lvF16Vop3::VInterpP1lvF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP1lvF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpP1lvF16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_p1lv_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP1lvF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4213,7 +5074,12 @@ VInterpP2LegacyF16Vop3::VInterpP2LegacyF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2LegacyF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2LegacyF16Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_p2_legacy_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2LegacyF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4234,7 +5100,12 @@ VInterpP2F16Vop3::VInterpP2F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_p2_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4253,7 +5124,11 @@ VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4272,7 +5147,11 @@ VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4291,7 +5170,11 @@ VMinF64Vop3::VMinF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4310,7 +5193,11 @@ VMaxF64Vop3::VMaxF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4329,7 +5216,11 @@ VLdexpF64Vop3::VLdexpF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ldexp_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4348,7 +5239,11 @@ VMulLoU32Vop3::VMulLoU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_lo_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4367,7 +5262,11 @@ VMulHiU32Vop3::VMulHiU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4386,7 +5285,11 @@ VMulHiI32Vop3::VMulHiI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4405,7 +5308,11 @@ VLdexpF32Vop3::VLdexpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ldexp_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4424,7 +5331,12 @@ VReadlaneB32Vop3::VReadlaneB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_readlane_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VReadlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4444,7 +5356,12 @@ VWritelaneB32Vop3::VWritelaneB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_writelane_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VWritelaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4463,7 +5380,12 @@ VBcntU32B32Vop3::VBcntU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bcnt_u32_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBcntU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -4482,7 +5404,12 @@ VMbcntLoU32B32Vop3::VMbcntLoU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mbcnt_lo_u32_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntLoU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -4501,7 +5428,12 @@ VMbcntHiU32B32Vop3::VMbcntHiU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mbcnt_hi_u32_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntHiU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -4520,7 +5452,12 @@ VLshlrevB64Vop3::VLshlrevB64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshlrev_b64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -4539,7 +5476,12 @@ VLshrrevB64Vop3::VLshrrevB64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshrrev_b64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -4558,7 +5500,12 @@ VAshrrevI64Vop3::VAshrrevI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashrrev_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI64Vop3>(opcode);
 }
 } // namespace detail
@@ -4577,7 +5524,12 @@ VTrigPreopF64Vop3::VTrigPreopF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trig_preop_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTrigPreopF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4596,7 +5548,11 @@ VBfmB32Vop3::VBfmB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfm_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfmB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4615,7 +5571,12 @@ VCvtPknormI16F32Vop3::VCvtPknormI16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormI16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_i16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormI16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4634,7 +5595,12 @@ VCvtPknormU16F32Vop3::VCvtPknormU16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormU16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_u16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormU16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4653,7 +5619,12 @@ VCvtPkrtzF16F32Vop3::VCvtPkrtzF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pkrtz_f16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkrtzF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4672,7 +5643,12 @@ VCvtPkU16U32Vop3::VCvtPkU16U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_u16_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU16U32Vop3>(opcode);
 }
 } // namespace detail
@@ -4691,7 +5667,12 @@ VCvtPkI16I32Vop3::VCvtPkI16I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_i16_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkI16I32Vop3>(opcode);
 }
 } // namespace detail
@@ -4710,7 +5691,12 @@ VCvtPknormI16F16Vop3::VCvtPknormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4729,7 +5715,12 @@ VCvtPknormU16F16Vop3::VCvtPknormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_u16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4748,7 +5739,11 @@ VAddI32Vop3::VAddI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4767,7 +5762,11 @@ VSubI32Vop3::VSubI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4786,7 +5785,11 @@ VAddI16Vop3::VAddI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddI16Vop3>(opcode);
 }
 } // namespace detail
@@ -4811,7 +5814,11 @@ VSubI16Vop3::VSubI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubI16Vop3>(opcode);
 }
 } // namespace detail
@@ -4836,7 +5843,12 @@ VPackB32F16Vop3::VPackB32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_pack_b32_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPackB32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4855,7 +5867,12 @@ VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_class_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4878,7 +5895,12 @@ VCmpxClassF32Vop3::VCmpxClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_class_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4897,7 +5919,12 @@ VCmpClassF64Vop3::VCmpClassF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_class_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4920,7 +5947,12 @@ VCmpxClassF64Vop3::VCmpxClassF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_class_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4939,7 +5971,12 @@ VCmpClassF16Vop3::VCmpClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_class_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4962,7 +5999,12 @@ VCmpxClassF16Vop3::VCmpxClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_class_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4981,7 +6023,11 @@ VCmpFF16Vop3::VCmpFF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5000,7 +6046,11 @@ VCmpLtF16Vop3::VCmpLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5019,7 +6069,11 @@ VCmpEqF16Vop3::VCmpEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5038,7 +6092,11 @@ VCmpLeF16Vop3::VCmpLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5057,7 +6115,11 @@ VCmpGtF16Vop3::VCmpGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5076,7 +6138,11 @@ VCmpLgF16Vop3::VCmpLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5095,7 +6161,11 @@ VCmpGeF16Vop3::VCmpGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5114,7 +6184,11 @@ VCmpOF16Vop3::VCmpOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_o_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5133,7 +6207,11 @@ VCmpUF16Vop3::VCmpUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_u_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5152,7 +6230,11 @@ VCmpNgeF16Vop3::VCmpNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5171,7 +6253,11 @@ VCmpNlgF16Vop3::VCmpNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5190,7 +6276,11 @@ VCmpNgtF16Vop3::VCmpNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ngt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5209,7 +6299,11 @@ VCmpNleF16Vop3::VCmpNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nle_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5228,7 +6322,11 @@ VCmpNeqF16Vop3::VCmpNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_neq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5247,7 +6345,11 @@ VCmpNltF16Vop3::VCmpNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5266,7 +6368,11 @@ VCmpTruF16Vop3::VCmpTruF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_tru_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTruF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5289,7 +6395,11 @@ VCmpxFF16Vop3::VCmpxFF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5312,7 +6422,11 @@ VCmpxLtF16Vop3::VCmpxLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5335,7 +6449,11 @@ VCmpxEqF16Vop3::VCmpxEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5358,7 +6476,11 @@ VCmpxLeF16Vop3::VCmpxLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5381,7 +6503,11 @@ VCmpxGtF16Vop3::VCmpxGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5404,7 +6530,11 @@ VCmpxLgF16Vop3::VCmpxLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5427,7 +6557,11 @@ VCmpxGeF16Vop3::VCmpxGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5450,7 +6584,11 @@ VCmpxOF16Vop3::VCmpxOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_o_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5473,7 +6611,11 @@ VCmpxUF16Vop3::VCmpxUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_u_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5496,7 +6638,12 @@ VCmpxNgeF16Vop3::VCmpxNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5519,7 +6666,12 @@ VCmpxNlgF16Vop3::VCmpxNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5542,7 +6694,12 @@ VCmpxNgtF16Vop3::VCmpxNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ngt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5565,7 +6722,12 @@ VCmpxNleF16Vop3::VCmpxNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nle_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5588,7 +6750,12 @@ VCmpxNeqF16Vop3::VCmpxNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_neq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5611,7 +6778,12 @@ VCmpxNltF16Vop3::VCmpxNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5634,7 +6806,12 @@ VCmpxTruF16Vop3::VCmpxTruF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_tru_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTruF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5653,7 +6830,11 @@ VCmpFF32Vop3::VCmpFF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5672,7 +6853,11 @@ VCmpLtF32Vop3::VCmpLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5691,7 +6876,11 @@ VCmpEqF32Vop3::VCmpEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5710,7 +6899,11 @@ VCmpLeF32Vop3::VCmpLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5729,7 +6922,11 @@ VCmpGtF32Vop3::VCmpGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5748,7 +6945,11 @@ VCmpLgF32Vop3::VCmpLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5767,7 +6968,11 @@ VCmpGeF32Vop3::VCmpGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5786,7 +6991,11 @@ VCmpOF32Vop3::VCmpOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_o_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5805,7 +7014,11 @@ VCmpUF32Vop3::VCmpUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_u_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5824,7 +7037,11 @@ VCmpNgeF32Vop3::VCmpNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5843,7 +7060,11 @@ VCmpNlgF32Vop3::VCmpNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5862,7 +7083,11 @@ VCmpNgtF32Vop3::VCmpNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ngt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5881,7 +7106,11 @@ VCmpNleF32Vop3::VCmpNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nle_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5900,7 +7129,11 @@ VCmpNeqF32Vop3::VCmpNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_neq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5919,7 +7152,11 @@ VCmpNltF32Vop3::VCmpNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5938,7 +7175,11 @@ VCmpTruF32Vop3::VCmpTruF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_tru_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTruF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5961,7 +7202,11 @@ VCmpxFF32Vop3::VCmpxFF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5984,7 +7229,11 @@ VCmpxLtF32Vop3::VCmpxLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6007,7 +7256,11 @@ VCmpxEqF32Vop3::VCmpxEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6030,7 +7283,11 @@ VCmpxLeF32Vop3::VCmpxLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6053,7 +7310,11 @@ VCmpxGtF32Vop3::VCmpxGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6076,7 +7337,11 @@ VCmpxLgF32Vop3::VCmpxLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6099,7 +7364,11 @@ VCmpxGeF32Vop3::VCmpxGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6122,7 +7391,11 @@ VCmpxOF32Vop3::VCmpxOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_o_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6145,7 +7418,11 @@ VCmpxUF32Vop3::VCmpxUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_u_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6168,7 +7445,12 @@ VCmpxNgeF32Vop3::VCmpxNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6191,7 +7473,12 @@ VCmpxNlgF32Vop3::VCmpxNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6214,7 +7501,12 @@ VCmpxNgtF32Vop3::VCmpxNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ngt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6237,7 +7529,12 @@ VCmpxNleF32Vop3::VCmpxNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nle_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6260,7 +7557,12 @@ VCmpxNeqF32Vop3::VCmpxNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_neq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6283,7 +7585,12 @@ VCmpxNltF32Vop3::VCmpxNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6306,7 +7613,12 @@ VCmpxTruF32Vop3::VCmpxTruF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_tru_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTruF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6325,7 +7637,11 @@ VCmpFF64Vop3::VCmpFF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6344,7 +7660,11 @@ VCmpLtF64Vop3::VCmpLtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6363,7 +7683,11 @@ VCmpEqF64Vop3::VCmpEqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6382,7 +7706,11 @@ VCmpLeF64Vop3::VCmpLeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6401,7 +7729,11 @@ VCmpGtF64Vop3::VCmpGtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6420,7 +7752,11 @@ VCmpLgF64Vop3::VCmpLgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6439,7 +7775,11 @@ VCmpGeF64Vop3::VCmpGeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6458,7 +7798,11 @@ VCmpOF64Vop3::VCmpOF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_o_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6477,7 +7821,11 @@ VCmpUF64Vop3::VCmpUF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_u_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6496,7 +7844,11 @@ VCmpNgeF64Vop3::VCmpNgeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6515,7 +7867,11 @@ VCmpNlgF64Vop3::VCmpNlgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6534,7 +7890,11 @@ VCmpNgtF64Vop3::VCmpNgtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ngt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6553,7 +7913,11 @@ VCmpNleF64Vop3::VCmpNleF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nle_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6572,7 +7936,11 @@ VCmpNeqF64Vop3::VCmpNeqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_neq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6591,7 +7959,11 @@ VCmpNltF64Vop3::VCmpNltF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6610,7 +7982,11 @@ VCmpTruF64Vop3::VCmpTruF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_tru_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTruF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6633,7 +8009,11 @@ VCmpxFF64Vop3::VCmpxFF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6656,7 +8036,11 @@ VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6679,7 +8063,11 @@ VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6702,7 +8090,11 @@ VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6725,7 +8117,11 @@ VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6748,7 +8144,11 @@ VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6771,7 +8171,11 @@ VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6794,7 +8198,11 @@ VCmpxOF64Vop3::VCmpxOF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_o_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6817,7 +8225,11 @@ VCmpxUF64Vop3::VCmpxUF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_u_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6840,7 +8252,12 @@ VCmpxNgeF64Vop3::VCmpxNgeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6863,7 +8280,12 @@ VCmpxNlgF64Vop3::VCmpxNlgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6886,7 +8308,12 @@ VCmpxNgtF64Vop3::VCmpxNgtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ngt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6909,7 +8336,12 @@ VCmpxNleF64Vop3::VCmpxNleF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nle_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6932,7 +8364,12 @@ VCmpxNeqF64Vop3::VCmpxNeqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_neq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6955,7 +8392,12 @@ VCmpxNltF64Vop3::VCmpxNltF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6978,7 +8420,12 @@ VCmpxTruF64Vop3::VCmpxTruF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_tru_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTruF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6997,7 +8444,11 @@ VCmpFI16Vop3::VCmpFI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7016,7 +8467,11 @@ VCmpLtI16Vop3::VCmpLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7035,7 +8490,11 @@ VCmpEqI16Vop3::VCmpEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7054,7 +8513,11 @@ VCmpLeI16Vop3::VCmpLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7073,7 +8536,11 @@ VCmpGtI16Vop3::VCmpGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7092,7 +8559,11 @@ VCmpNeI16Vop3::VCmpNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7111,7 +8582,11 @@ VCmpGeI16Vop3::VCmpGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7130,7 +8605,11 @@ VCmpTI16Vop3::VCmpTI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7149,7 +8628,11 @@ VCmpFU16Vop3::VCmpFU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7168,7 +8651,11 @@ VCmpLtU16Vop3::VCmpLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7187,7 +8674,11 @@ VCmpEqU16Vop3::VCmpEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7206,7 +8697,11 @@ VCmpLeU16Vop3::VCmpLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7225,7 +8720,11 @@ VCmpGtU16Vop3::VCmpGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7244,7 +8743,11 @@ VCmpNeU16Vop3::VCmpNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7263,7 +8766,11 @@ VCmpGeU16Vop3::VCmpGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7282,7 +8789,11 @@ VCmpTU16Vop3::VCmpTU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7305,7 +8816,11 @@ VCmpxFI16Vop3::VCmpxFI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7328,7 +8843,11 @@ VCmpxLtI16Vop3::VCmpxLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7351,7 +8870,11 @@ VCmpxEqI16Vop3::VCmpxEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7374,7 +8897,11 @@ VCmpxLeI16Vop3::VCmpxLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7397,7 +8924,11 @@ VCmpxGtI16Vop3::VCmpxGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7420,7 +8951,11 @@ VCmpxNeI16Vop3::VCmpxNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7443,7 +8978,11 @@ VCmpxGeI16Vop3::VCmpxGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7466,7 +9005,11 @@ VCmpxTI16Vop3::VCmpxTI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7489,7 +9032,11 @@ VCmpxFU16Vop3::VCmpxFU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7512,7 +9059,11 @@ VCmpxLtU16Vop3::VCmpxLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7535,7 +9086,11 @@ VCmpxEqU16Vop3::VCmpxEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7558,7 +9113,11 @@ VCmpxLeU16Vop3::VCmpxLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7581,7 +9140,11 @@ VCmpxGtU16Vop3::VCmpxGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7604,7 +9167,11 @@ VCmpxNeU16Vop3::VCmpxNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7627,7 +9194,11 @@ VCmpxGeU16Vop3::VCmpxGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7650,7 +9221,11 @@ VCmpxTU16Vop3::VCmpxTU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7669,7 +9244,11 @@ VCmpFI32Vop3::VCmpFI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7688,7 +9267,11 @@ VCmpLtI32Vop3::VCmpLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7707,7 +9290,11 @@ VCmpEqI32Vop3::VCmpEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7726,7 +9313,11 @@ VCmpLeI32Vop3::VCmpLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7745,7 +9336,11 @@ VCmpGtI32Vop3::VCmpGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7764,7 +9359,11 @@ VCmpNeI32Vop3::VCmpNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7783,7 +9382,11 @@ VCmpGeI32Vop3::VCmpGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7802,7 +9405,11 @@ VCmpTI32Vop3::VCmpTI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7821,7 +9428,11 @@ VCmpFU32Vop3::VCmpFU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7840,7 +9451,11 @@ VCmpLtU32Vop3::VCmpLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7859,7 +9474,11 @@ VCmpEqU32Vop3::VCmpEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7878,7 +9497,11 @@ VCmpLeU32Vop3::VCmpLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7897,7 +9520,11 @@ VCmpGtU32Vop3::VCmpGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7916,7 +9543,11 @@ VCmpNeU32Vop3::VCmpNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7935,7 +9566,11 @@ VCmpGeU32Vop3::VCmpGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7954,7 +9589,11 @@ VCmpTU32Vop3::VCmpTU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7977,7 +9616,11 @@ VCmpxFI32Vop3::VCmpxFI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8000,7 +9643,11 @@ VCmpxLtI32Vop3::VCmpxLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8023,7 +9670,11 @@ VCmpxEqI32Vop3::VCmpxEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8046,7 +9697,11 @@ VCmpxLeI32Vop3::VCmpxLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8069,7 +9724,11 @@ VCmpxGtI32Vop3::VCmpxGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8092,7 +9751,11 @@ VCmpxNeI32Vop3::VCmpxNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8115,7 +9778,11 @@ VCmpxGeI32Vop3::VCmpxGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8138,7 +9805,11 @@ VCmpxTI32Vop3::VCmpxTI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8161,7 +9832,11 @@ VCmpxFU32Vop3::VCmpxFU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8184,7 +9859,11 @@ VCmpxLtU32Vop3::VCmpxLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8207,7 +9886,11 @@ VCmpxEqU32Vop3::VCmpxEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8230,7 +9913,11 @@ VCmpxLeU32Vop3::VCmpxLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8253,7 +9940,11 @@ VCmpxGtU32Vop3::VCmpxGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8276,7 +9967,11 @@ VCmpxNeU32Vop3::VCmpxNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8299,7 +9994,11 @@ VCmpxGeU32Vop3::VCmpxGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8322,7 +10021,11 @@ VCmpxTU32Vop3::VCmpxTU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8341,7 +10044,11 @@ VCmpFI64Vop3::VCmpFI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8360,7 +10067,11 @@ VCmpLtI64Vop3::VCmpLtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8379,7 +10090,11 @@ VCmpEqI64Vop3::VCmpEqI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8398,7 +10113,11 @@ VCmpLeI64Vop3::VCmpLeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8417,7 +10136,11 @@ VCmpGtI64Vop3::VCmpGtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8436,7 +10159,11 @@ VCmpNeI64Vop3::VCmpNeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8455,7 +10182,11 @@ VCmpGeI64Vop3::VCmpGeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8474,7 +10205,11 @@ VCmpTI64Vop3::VCmpTI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8493,7 +10228,11 @@ VCmpFU64Vop3::VCmpFU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8512,7 +10251,11 @@ VCmpLtU64Vop3::VCmpLtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8531,7 +10274,11 @@ VCmpEqU64Vop3::VCmpEqU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8550,7 +10297,11 @@ VCmpLeU64Vop3::VCmpLeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8569,7 +10320,11 @@ VCmpGtU64Vop3::VCmpGtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8588,7 +10343,11 @@ VCmpNeU64Vop3::VCmpNeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8607,7 +10366,11 @@ VCmpGeU64Vop3::VCmpGeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8626,7 +10389,11 @@ VCmpTU64Vop3::VCmpTU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8649,7 +10416,11 @@ VCmpxFI64Vop3::VCmpxFI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8672,7 +10443,11 @@ VCmpxLtI64Vop3::VCmpxLtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8695,7 +10470,11 @@ VCmpxEqI64Vop3::VCmpxEqI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8718,7 +10497,11 @@ VCmpxLeI64Vop3::VCmpxLeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8741,7 +10524,11 @@ VCmpxGtI64Vop3::VCmpxGtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8764,7 +10551,11 @@ VCmpxNeI64Vop3::VCmpxNeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8787,7 +10578,11 @@ VCmpxGeI64Vop3::VCmpxGeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8810,7 +10605,11 @@ VCmpxTI64Vop3::VCmpxTI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8833,7 +10632,11 @@ VCmpxFU64Vop3::VCmpxFU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8856,7 +10659,11 @@ VCmpxLtU64Vop3::VCmpxLtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8879,7 +10686,11 @@ VCmpxEqU64Vop3::VCmpxEqU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8902,7 +10713,11 @@ VCmpxLeU64Vop3::VCmpxLeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8925,7 +10740,11 @@ VCmpxGtU64Vop3::VCmpxGtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8948,7 +10767,11 @@ VCmpxNeU64Vop3::VCmpxNeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8971,7 +10794,11 @@ VCmpxGeU64Vop3::VCmpxGeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8994,7 +10821,11 @@ VCmpxTU64Vop3::VCmpxTU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU64Vop3>(opcode);
 }
 } // namespace detail
@@ -9015,7 +10846,12 @@ VAddCoU32Vop3SdstEnc::VAddCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_add_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9036,7 +10872,12 @@ VSubCoU32Vop3SdstEnc::VSubCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_sub_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9057,7 +10898,12 @@ VSubrevCoU32Vop3SdstEnc::VSubrevCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_subrev_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9080,7 +10926,12 @@ VAddcCoU32Vop3SdstEnc::VAddcCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddcCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddcCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_addc_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddcCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9103,7 +10954,12 @@ VSubbCoU32Vop3SdstEnc::VSubbCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubbCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubbCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_subb_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubbCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9126,7 +10982,12 @@ VSubbrevCoU32Vop3SdstEnc::VSubbrevCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubbrevCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubbrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_subbrev_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubbrevCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9149,7 +11010,12 @@ VDivScaleF32Vop3SdstEnc::VDivScaleF32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_div_scale_f32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivScaleF32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9172,7 +11038,12 @@ VDivScaleF64Vop3SdstEnc::VDivScaleF64Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_div_scale_f64", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivScaleF64Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9195,7 +11066,12 @@ VMadU64U32Vop3SdstEnc::VMadU64U32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_mad_u64_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU64U32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9218,7 +11094,12 @@ VMadI64I32Vop3SdstEnc::VMadI64I32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_mad_i64_i32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI64I32Vop3SdstEnc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/vop3p.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -29,7 +28,11 @@ VPkMadI16Vop3p::VPkMadI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mad_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMadI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -48,7 +51,12 @@ VPkMulLoU16Vop3p::VPkMulLoU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mul_lo_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMulLoU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -67,7 +75,11 @@ VPkAddI16Vop3p::VPkAddI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -86,7 +98,11 @@ VPkSubI16Vop3p::VPkSubI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_sub_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkSubI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -105,7 +121,12 @@ VPkLshlrevB16Vop3p::VPkLshlrevB16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_lshlrev_b16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkLshlrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -124,7 +145,12 @@ VPkLshrrevB16Vop3p::VPkLshrrevB16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_lshrrev_b16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkLshrrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -143,7 +169,12 @@ VPkAshrrevI16Vop3p::VPkAshrrevI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_ashrrev_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAshrrevI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -162,7 +193,11 @@ VPkMaxI16Vop3p::VPkMaxI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_max_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaxI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -181,7 +216,11 @@ VPkMinI16Vop3p::VPkMinI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_min_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -202,7 +241,11 @@ VPkMadU16Vop3p::VPkMadU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mad_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMadU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -221,7 +264,11 @@ VPkAddU16Vop3p::VPkAddU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -240,7 +287,11 @@ VPkSubU16Vop3p::VPkSubU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_sub_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkSubU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -259,7 +310,11 @@ VPkMaxU16Vop3p::VPkMaxU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_max_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaxU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -278,7 +333,11 @@ VPkMinU16Vop3p::VPkMinU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_min_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -299,7 +358,11 @@ VPkFmaF16Vop3p::VPkFmaF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_fma_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkFmaF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -318,7 +381,11 @@ VPkAddF16Vop3p::VPkAddF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -337,7 +404,11 @@ VPkMulF16Vop3p::VPkMulF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mul_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMulF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -356,7 +427,11 @@ VPkMinF16Vop3p::VPkMinF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_min_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -375,7 +450,11 @@ VPkMaxF16Vop3p::VPkMaxF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_max_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaxF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -396,7 +475,12 @@ VMadMixF32Vop3p::VMadMixF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadMixF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVMadMixF32Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_mad_mix_f32", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadMixF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -418,7 +502,12 @@ VMadMixloF16Vop3p::VMadMixloF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadMixloF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVMadMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_mad_mixlo_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadMixloF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -446,7 +535,12 @@ VMadMixhiF16Vop3p::VMadMixhiF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadMixhiF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVMadMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_mad_mixhi_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadMixhiF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -473,7 +567,12 @@ VDot2F32F16Vop3p::VDot2F32F16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2F32F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2F32F16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_f32_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2F32F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -494,7 +593,12 @@ VDot2I32I16Vop3p::VDot2I32I16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2I32I16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2I32I16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_i32_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2I32I16Vop3p>(opcode);
 }
 } // namespace detail
@@ -515,7 +619,12 @@ VDot2U32U16Vop3p::VDot2U32U16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2U32U16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2U32U16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_u32_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2U32U16Vop3p>(opcode);
 }
 } // namespace detail
@@ -536,7 +645,12 @@ VDot4I32I8Vop3p::VDot4I32I8Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4I32I8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4I32I8Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot4_i32_i8", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot4I32I8Vop3p>(opcode);
 }
 } // namespace detail
@@ -557,7 +671,12 @@ VDot4U32U8Vop3p::VDot4U32U8Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot4_u32_u8", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot4U32U8Vop3p>(opcode);
 }
 } // namespace detail
@@ -578,7 +697,12 @@ VDot8I32I4Vop3p::VDot8I32I4Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8I32I4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8I32I4Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot8_i32_i4", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot8I32I4Vop3p>(opcode);
 }
 } // namespace detail
@@ -599,7 +723,12 @@ VDot8U32U4Vop3p::VDot8U32U4Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot8_u32_u4", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot8U32U4Vop3p>(opcode);
 }
 } // namespace detail
@@ -620,7 +749,12 @@ VAccvgprReadVop3p::VAccvgprReadVop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAccvgprReadVop3p(const MachineInst *opcode) {
+DecodeResult decodeVAccvgprReadVop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_accvgpr_read", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAccvgprReadVop3p>(opcode);
 }
 } // namespace detail
@@ -638,7 +772,12 @@ VAccvgprWriteVop3p::VAccvgprWriteVop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAccvgprWriteVop3p(const MachineInst *opcode) {
+DecodeResult decodeVAccvgprWriteVop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_accvgpr_write", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAccvgprWriteVop3p>(opcode);
 }
 } // namespace detail
@@ -664,7 +803,12 @@ VMfmaF3232x32x1f32Vop3pMfma::VMfmaF3232x32x1f32Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x1f32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x1f32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x1f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x1f32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -690,7 +834,12 @@ VMfmaF3216x16x1f32Vop3pMfma::VMfmaF3216x16x1f32Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x1f32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x1f32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x1f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x1f32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -716,7 +865,12 @@ VMfmaF324x4x1f32Vop3pMfma::VMfmaF324x4x1f32Vop3pMfma(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF324x4x1f32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF324x4x1f32Vop3pMfma(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_4x4x1f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF324x4x1f32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -742,7 +896,12 @@ VMfmaF3232x32x2f32Vop3pMfma::VMfmaF3232x32x2f32Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x2f32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x2f32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x2f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x2f32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -768,7 +927,12 @@ VMfmaF3216x16x4f32Vop3pMfma::VMfmaF3216x16x4f32Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x4f32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x4f32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x4f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x4f32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -794,7 +958,12 @@ VMfmaF3232x32x4f16Vop3pMfma::VMfmaF3232x32x4f16Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x4f16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x4f16Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x4f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x4f16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -820,7 +989,12 @@ VMfmaF3216x16x4f16Vop3pMfma::VMfmaF3216x16x4f16Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x4f16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x4f16Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x4f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x4f16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -846,7 +1020,12 @@ VMfmaF324x4x4f16Vop3pMfma::VMfmaF324x4x4f16Vop3pMfma(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF324x4x4f16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF324x4x4f16Vop3pMfma(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_4x4x4f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF324x4x4f16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -872,7 +1051,12 @@ VMfmaF3232x32x8f16Vop3pMfma::VMfmaF3232x32x8f16Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x8f16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x8f16Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x8f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x8f16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -898,7 +1082,13 @@ VMfmaF3216x16x16f16Vop3pMfma::VMfmaF3216x16x16f16Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x16f16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x16f16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x16f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x16f16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -924,7 +1114,12 @@ VMfmaI3232x32x4i8Vop3pMfma::VMfmaI3232x32x4i8Vop3pMfma(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI3232x32x4i8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI3232x32x4i8Vop3pMfma(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_32x32x4i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI3232x32x4i8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -950,7 +1145,12 @@ VMfmaI3216x16x4i8Vop3pMfma::VMfmaI3216x16x4i8Vop3pMfma(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI3216x16x4i8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI3216x16x4i8Vop3pMfma(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_16x16x4i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI3216x16x4i8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -976,7 +1176,12 @@ VMfmaI324x4x4i8Vop3pMfma::VMfmaI324x4x4i8Vop3pMfma(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI324x4x4i8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI324x4x4i8Vop3pMfma(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_4x4x4i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI324x4x4i8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1002,7 +1207,12 @@ VMfmaI3232x32x8i8Vop3pMfma::VMfmaI3232x32x8i8Vop3pMfma(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI3232x32x8i8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI3232x32x8i8Vop3pMfma(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_32x32x8i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI3232x32x8i8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1028,7 +1238,12 @@ VMfmaI3216x16x16i8Vop3pMfma::VMfmaI3216x16x16i8Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI3216x16x16i8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI3216x16x16i8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_16x16x16i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI3216x16x16i8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1054,7 +1269,13 @@ VMfmaF3232x32x2bf16Vop3pMfma::VMfmaF3232x32x2bf16Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x2bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x2bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x2bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x2bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1080,7 +1301,13 @@ VMfmaF3216x16x2bf16Vop3pMfma::VMfmaF3216x16x2bf16Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x2bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x2bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x2bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x2bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1106,7 +1333,12 @@ VMfmaF324x4x2bf16Vop3pMfma::VMfmaF324x4x2bf16Vop3pMfma(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF324x4x2bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF324x4x2bf16Vop3pMfma(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_4x4x2bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF324x4x2bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1132,7 +1364,13 @@ VMfmaF3232x32x4bf16Vop3pMfma::VMfmaF3232x32x4bf16Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x4bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x4bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x4bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x4bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1158,7 +1396,13 @@ VMfmaF3216x16x8bf16Vop3pMfma::VMfmaF3216x16x8bf16Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x8bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x8bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x8bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x8bf16Vop3pMfma>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/vopc.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/vopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -31,8 +30,6 @@ VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_CLASS_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -60,7 +57,18 @@ VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_class_f32_sdwa"
+          : "v_cmp_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F32 does not support DPP";
   return std::make_unique<VCmpClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -85,8 +93,6 @@ VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_CLASS_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -116,7 +122,18 @@ VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_class_f32_sdwa"
+          : "v_cmpx_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F32 does not support DPP";
   return std::make_unique<VCmpxClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -137,15 +154,21 @@ VCmpClassF64Vopc::VCmpClassF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_class_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support SDWA";
   return std::make_unique<VCmpClassF64Vopc>(opcode);
 }
 } // namespace detail
@@ -168,17 +191,23 @@ VCmpxClassF64Vopc::VCmpxClassF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_class_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support SDWA";
   return std::make_unique<VCmpxClassF64Vopc>(opcode);
 }
 } // namespace detail
@@ -202,8 +231,6 @@ VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_CLASS_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -231,7 +258,18 @@ VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_class_f16_sdwa"
+          : "v_cmp_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F16 does not support DPP";
   return std::make_unique<VCmpClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -257,8 +295,6 @@ VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_CLASS_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -288,7 +324,18 @@ VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_class_f16_sdwa"
+          : "v_cmpx_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F16 does not support DPP";
   return std::make_unique<VCmpxClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -311,8 +358,6 @@ VCmpFF16Vopc::VCmpFF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -340,7 +385,17 @@ VCmpFF16Vopc::VCmpFF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_f16_sdwa"
+          : "v_cmp_f_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F16 does not support DPP";
   return std::make_unique<VCmpFF16Vopc>(opcode);
 }
 } // namespace detail
@@ -364,8 +419,6 @@ VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -393,7 +446,17 @@ VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_f16_sdwa"
+          : "v_cmp_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F16 does not support DPP";
   return std::make_unique<VCmpLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -417,8 +480,6 @@ VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -446,7 +507,17 @@ VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_f16_sdwa"
+          : "v_cmp_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F16 does not support DPP";
   return std::make_unique<VCmpEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -470,8 +541,6 @@ VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -499,7 +568,17 @@ VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_f16_sdwa"
+          : "v_cmp_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F16 does not support DPP";
   return std::make_unique<VCmpLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -523,8 +602,6 @@ VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -552,7 +629,17 @@ VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_f16_sdwa"
+          : "v_cmp_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F16 does not support DPP";
   return std::make_unique<VCmpGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -576,8 +663,6 @@ VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -605,7 +690,17 @@ VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lg_f16_sdwa"
+          : "v_cmp_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F16 does not support DPP";
   return std::make_unique<VCmpLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -629,8 +724,6 @@ VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -658,7 +751,17 @@ VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_f16_sdwa"
+          : "v_cmp_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F16 does not support DPP";
   return std::make_unique<VCmpGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -681,8 +784,6 @@ VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_O_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -710,7 +811,17 @@ VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_o_f16_sdwa"
+          : "v_cmp_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F16 does not support DPP";
   return std::make_unique<VCmpOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -733,8 +844,6 @@ VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_U_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -762,7 +871,17 @@ VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_u_f16_sdwa"
+          : "v_cmp_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F16 does not support DPP";
   return std::make_unique<VCmpUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -786,8 +905,6 @@ VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -815,7 +932,17 @@ VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nge_f16_sdwa"
+          : "v_cmp_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F16 does not support DPP";
   return std::make_unique<VCmpNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -839,8 +966,6 @@ VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -868,7 +993,17 @@ VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlg_f16_sdwa"
+          : "v_cmp_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F16 does not support DPP";
   return std::make_unique<VCmpNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -892,8 +1027,6 @@ VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -921,7 +1054,17 @@ VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ngt_f16_sdwa"
+          : "v_cmp_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F16 does not support DPP";
   return std::make_unique<VCmpNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -945,8 +1088,6 @@ VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -974,7 +1115,17 @@ VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nle_f16_sdwa"
+          : "v_cmp_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F16 does not support DPP";
   return std::make_unique<VCmpNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -998,8 +1149,6 @@ VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NEQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1027,7 +1176,17 @@ VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_neq_f16_sdwa"
+          : "v_cmp_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F16 does not support DPP";
   return std::make_unique<VCmpNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1051,8 +1210,6 @@ VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1080,7 +1237,17 @@ VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlt_f16_sdwa"
+          : "v_cmp_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F16 does not support DPP";
   return std::make_unique<VCmpNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1104,8 +1271,6 @@ VCmpTruF16Vopc::VCmpTruF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_TRU_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1133,7 +1298,17 @@ VCmpTruF16Vopc::VCmpTruF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_tru_f16_sdwa"
+          : "v_cmp_tru_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F16 does not support DPP";
   return std::make_unique<VCmpTruF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1159,8 +1334,6 @@ VCmpxFF16Vopc::VCmpxFF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1190,7 +1363,17 @@ VCmpxFF16Vopc::VCmpxFF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_f16_sdwa"
+          : "v_cmpx_f_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F16 does not support DPP";
   return std::make_unique<VCmpxFF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1216,8 +1399,6 @@ VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1247,7 +1428,17 @@ VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_f16_sdwa"
+          : "v_cmpx_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F16 does not support DPP";
   return std::make_unique<VCmpxLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1273,8 +1464,6 @@ VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1304,7 +1493,17 @@ VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_f16_sdwa"
+          : "v_cmpx_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F16 does not support DPP";
   return std::make_unique<VCmpxEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1330,8 +1529,6 @@ VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1361,7 +1558,17 @@ VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_f16_sdwa"
+          : "v_cmpx_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F16 does not support DPP";
   return std::make_unique<VCmpxLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1387,8 +1594,6 @@ VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1418,7 +1623,17 @@ VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_f16_sdwa"
+          : "v_cmpx_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F16 does not support DPP";
   return std::make_unique<VCmpxGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1444,8 +1659,6 @@ VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1475,7 +1688,17 @@ VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lg_f16_sdwa"
+          : "v_cmpx_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F16 does not support DPP";
   return std::make_unique<VCmpxLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1501,8 +1724,6 @@ VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1532,7 +1753,17 @@ VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_f16_sdwa"
+          : "v_cmpx_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F16 does not support DPP";
   return std::make_unique<VCmpxGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1558,8 +1789,6 @@ VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_O_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1589,7 +1818,17 @@ VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_o_f16_sdwa"
+          : "v_cmpx_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F16 does not support DPP";
   return std::make_unique<VCmpxOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1615,8 +1854,6 @@ VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_U_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1646,7 +1883,17 @@ VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_u_f16_sdwa"
+          : "v_cmpx_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F16 does not support DPP";
   return std::make_unique<VCmpxUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1672,8 +1919,6 @@ VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1703,7 +1948,18 @@ VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nge_f16_sdwa"
+          : "v_cmpx_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F16 does not support DPP";
   return std::make_unique<VCmpxNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1729,8 +1985,6 @@ VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1760,7 +2014,18 @@ VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlg_f16_sdwa"
+          : "v_cmpx_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F16 does not support DPP";
   return std::make_unique<VCmpxNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1786,8 +2051,6 @@ VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1817,7 +2080,18 @@ VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ngt_f16_sdwa"
+          : "v_cmpx_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F16 does not support DPP";
   return std::make_unique<VCmpxNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1843,8 +2117,6 @@ VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1874,7 +2146,18 @@ VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nle_f16_sdwa"
+          : "v_cmpx_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F16 does not support DPP";
   return std::make_unique<VCmpxNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1900,8 +2183,6 @@ VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NEQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1931,7 +2212,18 @@ VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_neq_f16_sdwa"
+          : "v_cmpx_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F16 does not support DPP";
   return std::make_unique<VCmpxNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1957,8 +2249,6 @@ VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1988,7 +2278,18 @@ VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlt_f16_sdwa"
+          : "v_cmpx_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F16 does not support DPP";
   return std::make_unique<VCmpxNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -2014,8 +2315,6 @@ VCmpxTruF16Vopc::VCmpxTruF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_TRU_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2045,7 +2344,18 @@ VCmpxTruF16Vopc::VCmpxTruF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_tru_f16_sdwa"
+          : "v_cmpx_tru_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F16 does not support DPP";
   return std::make_unique<VCmpxTruF16Vopc>(opcode);
 }
 } // namespace detail
@@ -2067,8 +2377,6 @@ VCmpFF32Vopc::VCmpFF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2096,7 +2404,17 @@ VCmpFF32Vopc::VCmpFF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_f32_sdwa"
+          : "v_cmp_f_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F32 does not support DPP";
   return std::make_unique<VCmpFF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2119,8 +2437,6 @@ VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2148,7 +2464,17 @@ VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_f32_sdwa"
+          : "v_cmp_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F32 does not support DPP";
   return std::make_unique<VCmpLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2171,8 +2497,6 @@ VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2200,7 +2524,17 @@ VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_f32_sdwa"
+          : "v_cmp_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F32 does not support DPP";
   return std::make_unique<VCmpEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2223,8 +2557,6 @@ VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2252,7 +2584,17 @@ VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_f32_sdwa"
+          : "v_cmp_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F32 does not support DPP";
   return std::make_unique<VCmpLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2275,8 +2617,6 @@ VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2304,7 +2644,17 @@ VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_f32_sdwa"
+          : "v_cmp_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F32 does not support DPP";
   return std::make_unique<VCmpGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2327,8 +2677,6 @@ VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2356,7 +2704,17 @@ VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lg_f32_sdwa"
+          : "v_cmp_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F32 does not support DPP";
   return std::make_unique<VCmpLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2379,8 +2737,6 @@ VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2408,7 +2764,17 @@ VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_f32_sdwa"
+          : "v_cmp_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F32 does not support DPP";
   return std::make_unique<VCmpGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2430,8 +2796,6 @@ VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_O_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2459,7 +2823,17 @@ VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_o_f32_sdwa"
+          : "v_cmp_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F32 does not support DPP";
   return std::make_unique<VCmpOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2481,8 +2855,6 @@ VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_U_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2510,7 +2882,17 @@ VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_u_f32_sdwa"
+          : "v_cmp_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F32 does not support DPP";
   return std::make_unique<VCmpUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2533,8 +2915,6 @@ VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2562,7 +2942,17 @@ VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nge_f32_sdwa"
+          : "v_cmp_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F32 does not support DPP";
   return std::make_unique<VCmpNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2585,8 +2975,6 @@ VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2614,7 +3002,17 @@ VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlg_f32_sdwa"
+          : "v_cmp_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F32 does not support DPP";
   return std::make_unique<VCmpNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2637,8 +3035,6 @@ VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2666,7 +3062,17 @@ VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ngt_f32_sdwa"
+          : "v_cmp_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F32 does not support DPP";
   return std::make_unique<VCmpNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2689,8 +3095,6 @@ VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2718,7 +3122,17 @@ VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nle_f32_sdwa"
+          : "v_cmp_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F32 does not support DPP";
   return std::make_unique<VCmpNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2741,8 +3155,6 @@ VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NEQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2770,7 +3182,17 @@ VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_neq_f32_sdwa"
+          : "v_cmp_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F32 does not support DPP";
   return std::make_unique<VCmpNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2793,8 +3215,6 @@ VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2822,7 +3242,17 @@ VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlt_f32_sdwa"
+          : "v_cmp_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F32 does not support DPP";
   return std::make_unique<VCmpNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2845,8 +3275,6 @@ VCmpTruF32Vopc::VCmpTruF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_TRU_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2874,7 +3302,17 @@ VCmpTruF32Vopc::VCmpTruF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_tru_f32_sdwa"
+          : "v_cmp_tru_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F32 does not support DPP";
   return std::make_unique<VCmpTruF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2899,8 +3337,6 @@ VCmpxFF32Vopc::VCmpxFF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2930,7 +3366,17 @@ VCmpxFF32Vopc::VCmpxFF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_f32_sdwa"
+          : "v_cmpx_f_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F32 does not support DPP";
   return std::make_unique<VCmpxFF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2955,8 +3401,6 @@ VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2986,7 +3430,17 @@ VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_f32_sdwa"
+          : "v_cmpx_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F32 does not support DPP";
   return std::make_unique<VCmpxLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3011,8 +3465,6 @@ VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3042,7 +3494,17 @@ VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_f32_sdwa"
+          : "v_cmpx_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F32 does not support DPP";
   return std::make_unique<VCmpxEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3067,8 +3529,6 @@ VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3098,7 +3558,17 @@ VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_f32_sdwa"
+          : "v_cmpx_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F32 does not support DPP";
   return std::make_unique<VCmpxLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3123,8 +3593,6 @@ VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3154,7 +3622,17 @@ VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_f32_sdwa"
+          : "v_cmpx_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F32 does not support DPP";
   return std::make_unique<VCmpxGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3179,8 +3657,6 @@ VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3210,7 +3686,17 @@ VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lg_f32_sdwa"
+          : "v_cmpx_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F32 does not support DPP";
   return std::make_unique<VCmpxLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3235,8 +3721,6 @@ VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3266,7 +3750,17 @@ VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_f32_sdwa"
+          : "v_cmpx_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F32 does not support DPP";
   return std::make_unique<VCmpxGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3291,8 +3785,6 @@ VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_O_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3322,7 +3814,17 @@ VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_o_f32_sdwa"
+          : "v_cmpx_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F32 does not support DPP";
   return std::make_unique<VCmpxOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3347,8 +3849,6 @@ VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_U_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3378,7 +3878,17 @@ VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_u_f32_sdwa"
+          : "v_cmpx_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F32 does not support DPP";
   return std::make_unique<VCmpxUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3403,8 +3913,6 @@ VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3434,7 +3942,18 @@ VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nge_f32_sdwa"
+          : "v_cmpx_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F32 does not support DPP";
   return std::make_unique<VCmpxNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3459,8 +3978,6 @@ VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3490,7 +4007,18 @@ VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlg_f32_sdwa"
+          : "v_cmpx_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F32 does not support DPP";
   return std::make_unique<VCmpxNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3515,8 +4043,6 @@ VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3546,7 +4072,18 @@ VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ngt_f32_sdwa"
+          : "v_cmpx_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F32 does not support DPP";
   return std::make_unique<VCmpxNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3571,8 +4108,6 @@ VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3602,7 +4137,18 @@ VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nle_f32_sdwa"
+          : "v_cmpx_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F32 does not support DPP";
   return std::make_unique<VCmpxNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3627,8 +4173,6 @@ VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NEQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3658,7 +4202,18 @@ VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_neq_f32_sdwa"
+          : "v_cmpx_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F32 does not support DPP";
   return std::make_unique<VCmpxNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3683,8 +4238,6 @@ VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3714,7 +4267,18 @@ VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlt_f32_sdwa"
+          : "v_cmpx_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F32 does not support DPP";
   return std::make_unique<VCmpxNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3739,8 +4303,6 @@ VCmpxTruF32Vopc::VCmpxTruF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_TRU_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3770,7 +4332,18 @@ VCmpxTruF32Vopc::VCmpxTruF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_tru_f32_sdwa"
+          : "v_cmpx_tru_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F32 does not support DPP";
   return std::make_unique<VCmpxTruF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3791,15 +4364,20 @@ VCmpFF64Vopc::VCmpFF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_F_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_f_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F64 does not support SDWA";
   return std::make_unique<VCmpFF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3820,15 +4398,20 @@ VCmpLtF64Vopc::VCmpLtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support SDWA";
   return std::make_unique<VCmpLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3849,15 +4432,20 @@ VCmpEqF64Vopc::VCmpEqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_eq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support SDWA";
   return std::make_unique<VCmpEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3878,15 +4466,20 @@ VCmpLeF64Vopc::VCmpLeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_le_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support SDWA";
   return std::make_unique<VCmpLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3907,15 +4500,20 @@ VCmpGtF64Vopc::VCmpGtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_gt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support SDWA";
   return std::make_unique<VCmpGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3936,15 +4534,20 @@ VCmpLgF64Vopc::VCmpLgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support SDWA";
   return std::make_unique<VCmpLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3965,15 +4568,20 @@ VCmpGeF64Vopc::VCmpGeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support SDWA";
   return std::make_unique<VCmpGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3994,15 +4602,20 @@ VCmpOF64Vopc::VCmpOF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_O_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_O_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_o_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support SDWA";
   return std::make_unique<VCmpOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4023,15 +4636,20 @@ VCmpUF64Vopc::VCmpUF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_U_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_U_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_u_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support SDWA";
   return std::make_unique<VCmpUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4052,15 +4670,20 @@ VCmpNgeF64Vopc::VCmpNgeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support SDWA";
   return std::make_unique<VCmpNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4081,15 +4704,20 @@ VCmpNlgF64Vopc::VCmpNlgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nlg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support SDWA";
   return std::make_unique<VCmpNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4110,15 +4738,20 @@ VCmpNgtF64Vopc::VCmpNgtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ngt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support SDWA";
   return std::make_unique<VCmpNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4139,15 +4772,20 @@ VCmpNleF64Vopc::VCmpNleF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nle_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support SDWA";
   return std::make_unique<VCmpNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4168,15 +4806,20 @@ VCmpNeqF64Vopc::VCmpNeqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_neq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support SDWA";
   return std::make_unique<VCmpNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4197,15 +4840,20 @@ VCmpNltF64Vopc::VCmpNltF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nlt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support SDWA";
   return std::make_unique<VCmpNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4226,15 +4874,20 @@ VCmpTruF64Vopc::VCmpTruF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_TRU_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_TRU_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_tru_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F64 does not support SDWA";
   return std::make_unique<VCmpTruF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4257,17 +4910,22 @@ VCmpxFF64Vopc::VCmpxFF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_F_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_f_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F64 does not support SDWA";
   return std::make_unique<VCmpxFF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4290,17 +4948,22 @@ VCmpxLtF64Vopc::VCmpxLtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support SDWA";
   return std::make_unique<VCmpxLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4323,17 +4986,22 @@ VCmpxEqF64Vopc::VCmpxEqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_eq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support SDWA";
   return std::make_unique<VCmpxEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4356,17 +5024,22 @@ VCmpxLeF64Vopc::VCmpxLeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_le_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support SDWA";
   return std::make_unique<VCmpxLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4389,17 +5062,22 @@ VCmpxGtF64Vopc::VCmpxGtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_gt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support SDWA";
   return std::make_unique<VCmpxGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4422,17 +5100,22 @@ VCmpxLgF64Vopc::VCmpxLgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support SDWA";
   return std::make_unique<VCmpxLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4455,17 +5138,22 @@ VCmpxGeF64Vopc::VCmpxGeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support SDWA";
   return std::make_unique<VCmpxGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4488,17 +5176,22 @@ VCmpxOF64Vopc::VCmpxOF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_O_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_O_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_o_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support SDWA";
   return std::make_unique<VCmpxOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4521,17 +5214,22 @@ VCmpxUF64Vopc::VCmpxUF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_U_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_U_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_u_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support SDWA";
   return std::make_unique<VCmpxUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4554,17 +5252,23 @@ VCmpxNgeF64Vopc::VCmpxNgeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support SDWA";
   return std::make_unique<VCmpxNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4587,17 +5291,23 @@ VCmpxNlgF64Vopc::VCmpxNlgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nlg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support SDWA";
   return std::make_unique<VCmpxNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4620,17 +5330,23 @@ VCmpxNgtF64Vopc::VCmpxNgtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ngt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support SDWA";
   return std::make_unique<VCmpxNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4653,17 +5369,23 @@ VCmpxNleF64Vopc::VCmpxNleF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nle_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support SDWA";
   return std::make_unique<VCmpxNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4686,17 +5408,23 @@ VCmpxNeqF64Vopc::VCmpxNeqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_neq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support SDWA";
   return std::make_unique<VCmpxNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4719,17 +5447,23 @@ VCmpxNltF64Vopc::VCmpxNltF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nlt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support SDWA";
   return std::make_unique<VCmpxNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4752,17 +5486,23 @@ VCmpxTruF64Vopc::VCmpxTruF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_TRU_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_TRU_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_tru_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F64 does not support SDWA";
   return std::make_unique<VCmpxTruF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4785,8 +5525,6 @@ VCmpFI16Vopc::VCmpFI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4814,7 +5552,17 @@ VCmpFI16Vopc::VCmpFI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_i16_sdwa"
+          : "v_cmp_f_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I16 does not support DPP";
   return std::make_unique<VCmpFI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4838,8 +5586,6 @@ VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4867,7 +5613,17 @@ VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_i16_sdwa"
+          : "v_cmp_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I16 does not support DPP";
   return std::make_unique<VCmpLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4891,8 +5647,6 @@ VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4920,7 +5674,17 @@ VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_i16_sdwa"
+          : "v_cmp_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I16 does not support DPP";
   return std::make_unique<VCmpEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4944,8 +5708,6 @@ VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4973,7 +5735,17 @@ VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_i16_sdwa"
+          : "v_cmp_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I16 does not support DPP";
   return std::make_unique<VCmpLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4997,8 +5769,6 @@ VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5026,7 +5796,17 @@ VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_i16_sdwa"
+          : "v_cmp_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I16 does not support DPP";
   return std::make_unique<VCmpGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5050,8 +5830,6 @@ VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5079,7 +5857,17 @@ VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_i16_sdwa"
+          : "v_cmp_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I16 does not support DPP";
   return std::make_unique<VCmpNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5103,8 +5891,6 @@ VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5132,7 +5918,17 @@ VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_i16_sdwa"
+          : "v_cmp_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I16 does not support DPP";
   return std::make_unique<VCmpGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5155,8 +5951,6 @@ VCmpTI16Vopc::VCmpTI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5184,7 +5978,17 @@ VCmpTI16Vopc::VCmpTI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_i16_sdwa"
+          : "v_cmp_t_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I16 does not support DPP";
   return std::make_unique<VCmpTI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5207,8 +6011,6 @@ VCmpFU16Vopc::VCmpFU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5236,7 +6038,17 @@ VCmpFU16Vopc::VCmpFU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_u16_sdwa"
+          : "v_cmp_f_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U16 does not support DPP";
   return std::make_unique<VCmpFU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5260,8 +6072,6 @@ VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5289,7 +6099,17 @@ VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_u16_sdwa"
+          : "v_cmp_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U16 does not support DPP";
   return std::make_unique<VCmpLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5313,8 +6133,6 @@ VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5342,7 +6160,17 @@ VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_u16_sdwa"
+          : "v_cmp_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U16 does not support DPP";
   return std::make_unique<VCmpEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5366,8 +6194,6 @@ VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5395,7 +6221,17 @@ VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_u16_sdwa"
+          : "v_cmp_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U16 does not support DPP";
   return std::make_unique<VCmpLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5419,8 +6255,6 @@ VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5448,7 +6282,17 @@ VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_u16_sdwa"
+          : "v_cmp_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U16 does not support DPP";
   return std::make_unique<VCmpGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5472,8 +6316,6 @@ VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5501,7 +6343,17 @@ VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_u16_sdwa"
+          : "v_cmp_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U16 does not support DPP";
   return std::make_unique<VCmpNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5525,8 +6377,6 @@ VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5554,7 +6404,17 @@ VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_u16_sdwa"
+          : "v_cmp_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U16 does not support DPP";
   return std::make_unique<VCmpGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5577,8 +6437,6 @@ VCmpTU16Vopc::VCmpTU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5606,7 +6464,17 @@ VCmpTU16Vopc::VCmpTU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_u16_sdwa"
+          : "v_cmp_t_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U16 does not support DPP";
   return std::make_unique<VCmpTU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5632,8 +6500,6 @@ VCmpxFI16Vopc::VCmpxFI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5663,7 +6529,17 @@ VCmpxFI16Vopc::VCmpxFI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_i16_sdwa"
+          : "v_cmpx_f_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I16 does not support DPP";
   return std::make_unique<VCmpxFI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5689,8 +6565,6 @@ VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5720,7 +6594,17 @@ VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_i16_sdwa"
+          : "v_cmpx_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I16 does not support DPP";
   return std::make_unique<VCmpxLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5746,8 +6630,6 @@ VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5777,7 +6659,17 @@ VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_i16_sdwa"
+          : "v_cmpx_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I16 does not support DPP";
   return std::make_unique<VCmpxEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5803,8 +6695,6 @@ VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5834,7 +6724,17 @@ VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_i16_sdwa"
+          : "v_cmpx_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I16 does not support DPP";
   return std::make_unique<VCmpxLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5860,8 +6760,6 @@ VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5891,7 +6789,17 @@ VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_i16_sdwa"
+          : "v_cmpx_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I16 does not support DPP";
   return std::make_unique<VCmpxGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5917,8 +6825,6 @@ VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5948,7 +6854,17 @@ VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_i16_sdwa"
+          : "v_cmpx_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I16 does not support DPP";
   return std::make_unique<VCmpxNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5974,8 +6890,6 @@ VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6005,7 +6919,17 @@ VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_i16_sdwa"
+          : "v_cmpx_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I16 does not support DPP";
   return std::make_unique<VCmpxGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6031,8 +6955,6 @@ VCmpxTI16Vopc::VCmpxTI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6062,7 +6984,17 @@ VCmpxTI16Vopc::VCmpxTI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_i16_sdwa"
+          : "v_cmpx_t_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I16 does not support DPP";
   return std::make_unique<VCmpxTI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6088,8 +7020,6 @@ VCmpxFU16Vopc::VCmpxFU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6119,7 +7049,17 @@ VCmpxFU16Vopc::VCmpxFU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_u16_sdwa"
+          : "v_cmpx_f_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U16 does not support DPP";
   return std::make_unique<VCmpxFU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6145,8 +7085,6 @@ VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6176,7 +7114,17 @@ VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_u16_sdwa"
+          : "v_cmpx_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U16 does not support DPP";
   return std::make_unique<VCmpxLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6202,8 +7150,6 @@ VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6233,7 +7179,17 @@ VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_u16_sdwa"
+          : "v_cmpx_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U16 does not support DPP";
   return std::make_unique<VCmpxEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6259,8 +7215,6 @@ VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6290,7 +7244,17 @@ VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_u16_sdwa"
+          : "v_cmpx_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U16 does not support DPP";
   return std::make_unique<VCmpxLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6316,8 +7280,6 @@ VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6347,7 +7309,17 @@ VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_u16_sdwa"
+          : "v_cmpx_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U16 does not support DPP";
   return std::make_unique<VCmpxGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6373,8 +7345,6 @@ VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6404,7 +7374,17 @@ VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_u16_sdwa"
+          : "v_cmpx_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U16 does not support DPP";
   return std::make_unique<VCmpxNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6430,8 +7410,6 @@ VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6461,7 +7439,17 @@ VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_u16_sdwa"
+          : "v_cmpx_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U16 does not support DPP";
   return std::make_unique<VCmpxGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6487,8 +7475,6 @@ VCmpxTU16Vopc::VCmpxTU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6518,7 +7504,17 @@ VCmpxTU16Vopc::VCmpxTU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_u16_sdwa"
+          : "v_cmpx_t_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U16 does not support DPP";
   return std::make_unique<VCmpxTU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6540,8 +7536,6 @@ VCmpFI32Vopc::VCmpFI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6569,7 +7563,17 @@ VCmpFI32Vopc::VCmpFI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_i32_sdwa"
+          : "v_cmp_f_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I32 does not support DPP";
   return std::make_unique<VCmpFI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6592,8 +7596,6 @@ VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6621,7 +7623,17 @@ VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_i32_sdwa"
+          : "v_cmp_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I32 does not support DPP";
   return std::make_unique<VCmpLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6644,8 +7656,6 @@ VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6673,7 +7683,17 @@ VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_i32_sdwa"
+          : "v_cmp_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I32 does not support DPP";
   return std::make_unique<VCmpEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6696,8 +7716,6 @@ VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6725,7 +7743,17 @@ VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_i32_sdwa"
+          : "v_cmp_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I32 does not support DPP";
   return std::make_unique<VCmpLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6748,8 +7776,6 @@ VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6777,7 +7803,17 @@ VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_i32_sdwa"
+          : "v_cmp_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I32 does not support DPP";
   return std::make_unique<VCmpGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6800,8 +7836,6 @@ VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6829,7 +7863,17 @@ VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_i32_sdwa"
+          : "v_cmp_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I32 does not support DPP";
   return std::make_unique<VCmpNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6852,8 +7896,6 @@ VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6881,7 +7923,17 @@ VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_i32_sdwa"
+          : "v_cmp_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I32 does not support DPP";
   return std::make_unique<VCmpGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6903,8 +7955,6 @@ VCmpTI32Vopc::VCmpTI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6932,7 +7982,17 @@ VCmpTI32Vopc::VCmpTI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_i32_sdwa"
+          : "v_cmp_t_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I32 does not support DPP";
   return std::make_unique<VCmpTI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6954,8 +8014,6 @@ VCmpFU32Vopc::VCmpFU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6983,7 +8041,17 @@ VCmpFU32Vopc::VCmpFU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_u32_sdwa"
+          : "v_cmp_f_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U32 does not support DPP";
   return std::make_unique<VCmpFU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7006,8 +8074,6 @@ VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7035,7 +8101,17 @@ VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_u32_sdwa"
+          : "v_cmp_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U32 does not support DPP";
   return std::make_unique<VCmpLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7058,8 +8134,6 @@ VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7087,7 +8161,17 @@ VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_u32_sdwa"
+          : "v_cmp_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U32 does not support DPP";
   return std::make_unique<VCmpEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7110,8 +8194,6 @@ VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7139,7 +8221,17 @@ VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_u32_sdwa"
+          : "v_cmp_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U32 does not support DPP";
   return std::make_unique<VCmpLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7162,8 +8254,6 @@ VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7191,7 +8281,17 @@ VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_u32_sdwa"
+          : "v_cmp_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U32 does not support DPP";
   return std::make_unique<VCmpGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7214,8 +8314,6 @@ VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7243,7 +8341,17 @@ VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_u32_sdwa"
+          : "v_cmp_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U32 does not support DPP";
   return std::make_unique<VCmpNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7266,8 +8374,6 @@ VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7295,7 +8401,17 @@ VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_u32_sdwa"
+          : "v_cmp_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U32 does not support DPP";
   return std::make_unique<VCmpGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7317,8 +8433,6 @@ VCmpTU32Vopc::VCmpTU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7346,7 +8460,17 @@ VCmpTU32Vopc::VCmpTU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_u32_sdwa"
+          : "v_cmp_t_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U32 does not support DPP";
   return std::make_unique<VCmpTU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7371,8 +8495,6 @@ VCmpxFI32Vopc::VCmpxFI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7402,7 +8524,17 @@ VCmpxFI32Vopc::VCmpxFI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_i32_sdwa"
+          : "v_cmpx_f_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I32 does not support DPP";
   return std::make_unique<VCmpxFI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7427,8 +8559,6 @@ VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7458,7 +8588,17 @@ VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_i32_sdwa"
+          : "v_cmpx_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I32 does not support DPP";
   return std::make_unique<VCmpxLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7483,8 +8623,6 @@ VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7514,7 +8652,17 @@ VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_i32_sdwa"
+          : "v_cmpx_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I32 does not support DPP";
   return std::make_unique<VCmpxEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7539,8 +8687,6 @@ VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7570,7 +8716,17 @@ VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_i32_sdwa"
+          : "v_cmpx_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I32 does not support DPP";
   return std::make_unique<VCmpxLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7595,8 +8751,6 @@ VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7626,7 +8780,17 @@ VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_i32_sdwa"
+          : "v_cmpx_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I32 does not support DPP";
   return std::make_unique<VCmpxGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7651,8 +8815,6 @@ VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7682,7 +8844,17 @@ VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_i32_sdwa"
+          : "v_cmpx_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I32 does not support DPP";
   return std::make_unique<VCmpxNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7707,8 +8879,6 @@ VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7738,7 +8908,17 @@ VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_i32_sdwa"
+          : "v_cmpx_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I32 does not support DPP";
   return std::make_unique<VCmpxGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7763,8 +8943,6 @@ VCmpxTI32Vopc::VCmpxTI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7794,7 +8972,17 @@ VCmpxTI32Vopc::VCmpxTI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_i32_sdwa"
+          : "v_cmpx_t_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I32 does not support DPP";
   return std::make_unique<VCmpxTI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7819,8 +9007,6 @@ VCmpxFU32Vopc::VCmpxFU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7850,7 +9036,17 @@ VCmpxFU32Vopc::VCmpxFU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_u32_sdwa"
+          : "v_cmpx_f_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U32 does not support DPP";
   return std::make_unique<VCmpxFU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7875,8 +9071,6 @@ VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7906,7 +9100,17 @@ VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_u32_sdwa"
+          : "v_cmpx_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U32 does not support DPP";
   return std::make_unique<VCmpxLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7931,8 +9135,6 @@ VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7962,7 +9164,17 @@ VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_u32_sdwa"
+          : "v_cmpx_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U32 does not support DPP";
   return std::make_unique<VCmpxEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7987,8 +9199,6 @@ VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8018,7 +9228,17 @@ VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_u32_sdwa"
+          : "v_cmpx_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U32 does not support DPP";
   return std::make_unique<VCmpxLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8043,8 +9263,6 @@ VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8074,7 +9292,17 @@ VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_u32_sdwa"
+          : "v_cmpx_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U32 does not support DPP";
   return std::make_unique<VCmpxGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8099,8 +9327,6 @@ VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8130,7 +9356,17 @@ VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_u32_sdwa"
+          : "v_cmpx_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U32 does not support DPP";
   return std::make_unique<VCmpxNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8155,8 +9391,6 @@ VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8186,7 +9420,17 @@ VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_u32_sdwa"
+          : "v_cmpx_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U32 does not support DPP";
   return std::make_unique<VCmpxGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8211,8 +9455,6 @@ VCmpxTU32Vopc::VCmpxTU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8242,7 +9484,17 @@ VCmpxTU32Vopc::VCmpxTU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_u32_sdwa"
+          : "v_cmpx_t_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U32 does not support DPP";
   return std::make_unique<VCmpxTU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8263,15 +9515,20 @@ VCmpFI64Vopc::VCmpFI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_F_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_f_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I64 does not support SDWA";
   return std::make_unique<VCmpFI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8292,15 +9549,20 @@ VCmpLtI64Vopc::VCmpLtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support SDWA";
   return std::make_unique<VCmpLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8321,15 +9583,20 @@ VCmpEqI64Vopc::VCmpEqI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_eq_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support SDWA";
   return std::make_unique<VCmpEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8350,15 +9617,20 @@ VCmpLeI64Vopc::VCmpLeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_le_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support SDWA";
   return std::make_unique<VCmpLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8379,15 +9651,20 @@ VCmpGtI64Vopc::VCmpGtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_gt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support SDWA";
   return std::make_unique<VCmpGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8408,15 +9685,20 @@ VCmpNeI64Vopc::VCmpNeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ne_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support SDWA";
   return std::make_unique<VCmpNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8437,15 +9719,20 @@ VCmpGeI64Vopc::VCmpGeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ge_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support SDWA";
   return std::make_unique<VCmpGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8466,15 +9753,20 @@ VCmpTI64Vopc::VCmpTI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_T_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_t_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I64 does not support SDWA";
   return std::make_unique<VCmpTI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8495,15 +9787,20 @@ VCmpFU64Vopc::VCmpFU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_F_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_f_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U64 does not support SDWA";
   return std::make_unique<VCmpFU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8524,15 +9821,20 @@ VCmpLtU64Vopc::VCmpLtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support SDWA";
   return std::make_unique<VCmpLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8553,15 +9855,20 @@ VCmpEqU64Vopc::VCmpEqU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_eq_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support SDWA";
   return std::make_unique<VCmpEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8582,15 +9889,20 @@ VCmpLeU64Vopc::VCmpLeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_le_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support SDWA";
   return std::make_unique<VCmpLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8611,15 +9923,20 @@ VCmpGtU64Vopc::VCmpGtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_gt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support SDWA";
   return std::make_unique<VCmpGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8640,15 +9957,20 @@ VCmpNeU64Vopc::VCmpNeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ne_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support SDWA";
   return std::make_unique<VCmpNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8669,15 +9991,20 @@ VCmpGeU64Vopc::VCmpGeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ge_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support SDWA";
   return std::make_unique<VCmpGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8698,15 +10025,20 @@ VCmpTU64Vopc::VCmpTU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_T_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_t_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U64 does not support SDWA";
   return std::make_unique<VCmpTU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8729,17 +10061,22 @@ VCmpxFI64Vopc::VCmpxFI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_F_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_f_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I64 does not support SDWA";
   return std::make_unique<VCmpxFI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8762,17 +10099,22 @@ VCmpxLtI64Vopc::VCmpxLtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support SDWA";
   return std::make_unique<VCmpxLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8795,17 +10137,22 @@ VCmpxEqI64Vopc::VCmpxEqI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_eq_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support SDWA";
   return std::make_unique<VCmpxEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8828,17 +10175,22 @@ VCmpxLeI64Vopc::VCmpxLeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_le_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support SDWA";
   return std::make_unique<VCmpxLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8861,17 +10213,22 @@ VCmpxGtI64Vopc::VCmpxGtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_gt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support SDWA";
   return std::make_unique<VCmpxGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8894,17 +10251,22 @@ VCmpxNeI64Vopc::VCmpxNeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ne_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support SDWA";
   return std::make_unique<VCmpxNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8927,17 +10289,22 @@ VCmpxGeI64Vopc::VCmpxGeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ge_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support SDWA";
   return std::make_unique<VCmpxGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8960,17 +10327,22 @@ VCmpxTI64Vopc::VCmpxTI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_T_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_t_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I64 does not support SDWA";
   return std::make_unique<VCmpxTI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8993,17 +10365,22 @@ VCmpxFU64Vopc::VCmpxFU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_F_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_f_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U64 does not support SDWA";
   return std::make_unique<VCmpxFU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9026,17 +10403,22 @@ VCmpxLtU64Vopc::VCmpxLtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support SDWA";
   return std::make_unique<VCmpxLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9059,17 +10441,22 @@ VCmpxEqU64Vopc::VCmpxEqU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_eq_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support SDWA";
   return std::make_unique<VCmpxEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9092,17 +10479,22 @@ VCmpxLeU64Vopc::VCmpxLeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_le_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support SDWA";
   return std::make_unique<VCmpxLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9125,17 +10517,22 @@ VCmpxGtU64Vopc::VCmpxGtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_gt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support SDWA";
   return std::make_unique<VCmpxGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9158,17 +10555,22 @@ VCmpxNeU64Vopc::VCmpxNeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ne_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support SDWA";
   return std::make_unique<VCmpxNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9191,17 +10593,22 @@ VCmpxGeU64Vopc::VCmpxGeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ge_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support SDWA";
   return std::make_unique<VCmpxGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9224,17 +10631,22 @@ VCmpxTU64Vopc::VCmpxTU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_T_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_t_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U64 does not support SDWA";
   return std::make_unique<VCmpxTU64Vopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/decoder.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/decoder.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/vop3p.h"
-#include "util/except.h"
 #include <array>
 #include <bit>
 #include <format>
@@ -15,1419 +14,1866 @@ namespace rocjitsu {
 namespace cdna2 {
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddF64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxF64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinF64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicPkAddF16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSminMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUminMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferInvl2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSbyteMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadShortD16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSshortMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUbyteMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUshortMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreByteMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreLdsDwordMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreShortMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferWbinvl1Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferWbinvl1VolMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferWbl2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAppendDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsBpermuteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsConsumeDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsBarrierDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsInitDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaBrDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaPDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaVDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsNopDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPermuteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2st64B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2st64B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadAddtidB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB128Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB96Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI8D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU16D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU16D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU8D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSwizzleB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrapRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2st64B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2st64B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteAddtidB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB128Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB16D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB96Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddF64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxF64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinF64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSminFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSminX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUminFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUminX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordx2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordx3Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordx4Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSbyteFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadShortD16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadShortD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSshortFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUbyteFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUshortFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreByteD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreByteFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordx2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordx3Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordx4Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreShortD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreShortFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicAddMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicAndMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicCmpswapMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicDecMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicIncMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicOrMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSmaxMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSminMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSubMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSwapMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicUmaxMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicUminMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicXorMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGetResinfoMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipPckSgnMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadPckSgnMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStorePckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddcU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn1WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtcProbeBufferSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtcProbeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicAddSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicAddX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicAndSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicAndX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicCmpswapSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicCmpswapX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicDecSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicDecX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicIncSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicIncX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicOrSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicOrX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSmaxSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSmaxX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSminSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSminX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSubSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSubX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSwapSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSwapX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicUmaxSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicUmaxX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicUminSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicUminX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicXorSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicXorX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBarrierSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicAddSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicAddX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicAndSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicAndX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicCmpswapSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicCmpswapX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicDecSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicDecX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicIncSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicIncX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicOrSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicOrX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSmaxSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSmaxX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSminSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSminX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSubSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSubX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSwapSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSwapX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicUmaxSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicUmaxX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicUminSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicUminX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicXorSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicXorX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferStoreDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferStoreDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferStoreDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCallB64Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbguserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchGForkSop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchIForkSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchJoinSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkEqI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkEqU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGeI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGeU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGtI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGtU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLeI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLeU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLgI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLgU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLtI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLtU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheDiscardSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheDiscardX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheInvVolSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheWbSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheWbVolSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf0I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf0I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf1I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf1I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32I64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetpcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMemrealtimeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMemtimeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRfeB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRfeRestoreB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchLoadDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchStoreDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchStoreDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchStoreDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetGprIdxIdxSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetGprIdxModeSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetGprIdxOffSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetGprIdxOnSopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetkillSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetpcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetvskipSopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSStoreDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSStoreDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSStoreDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubbU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSwappcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAccvgprMovB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAccvgprMovB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAccvgprReadVop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAccvgprWriteVop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddcCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddcCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClrexcpVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClrexcpVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkaccumU8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormI16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormU16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupLegacyF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2F32F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2I32I16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2U32U16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cI32I16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cI32I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4I32I8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8I32I4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8cI32I4Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8cI32I4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhI32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhU32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfblB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfblB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaLegacyF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMacF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMacF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMacF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadLegacyF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadLegacyF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadLegacyI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadLegacyU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadMixF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadMixhiF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadMixloF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadakF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadakF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadmkF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadmkF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x16bf161kVop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x16f16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x1f32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x2bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x4bf161kVop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x4f16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x4f32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x8bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x1f32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x2bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x2f32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x4bf161kVop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x4bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x4f16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x8bf161kVop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x8f16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF324x4x1f32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF324x4x2bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF324x4x4bf161kVop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF324x4x4f16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF6416x16x4f64Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF644x4x4f64Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI3216x16x16i8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI3216x16x4i8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI3232x32x4i8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI3232x32x8i8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI324x4x4i8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLegacyF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmaF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMovB32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVScreenPartition4seB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVScreenPartition4seB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubbCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubbCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubbrevCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubbrevCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwapB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode);
+DecodeResult decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddF64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxF64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinF64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrMubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicPkAddF16Mubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferInvl2Mubuf(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXMubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadShortD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreByteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreLdsDwordMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreShortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferWbinvl1Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferWbinvl1VolMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferWbl2Mubuf(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAppendDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsBpermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsConsumeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsBarrierDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsInitDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaBrDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaPDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaVDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsNopDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2st64B32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2st64B64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadAddtidB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI8D16HiDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU16D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU16D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU8D16HiDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSwizzleB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrapRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2st64B32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2st64B64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteAddtidB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB16D16HiDs(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB8D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchgRtnB32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchgRtnB64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddF64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapFlat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxF64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinF64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrX2Flat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordx2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordx3Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordx4Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadShortD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadShortD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreByteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreByteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordx2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordx3Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordx4Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreShortD16HiFlat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreShortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicAddMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicAndMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicCmpswapMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicDecMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicIncMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicOrMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSubMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSwapMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicUmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicUminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicXorMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGetResinfoMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipPckMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipPckSgnMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadPckMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadPckSgnMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStorePckMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddcU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn1WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtcProbeBufferSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtcProbeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicAddSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicAddX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicAndSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicAndX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicCmpswapSmem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicCmpswapX2Smem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicDecSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicDecX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicIncSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicIncX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicOrSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicOrX2Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSmaxSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSmaxX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSminSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSminX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSubSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSubX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSwapSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSwapX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicUmaxSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicUmaxX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicUminSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicUminX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicXorSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicXorX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBarrierSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicAddSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicAddX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicAndSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicAndX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicCmpswapSmem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicCmpswapX2Smem(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicDecSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicDecX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicIncSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicIncX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicOrSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicOrX2Smem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSmaxSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSmaxX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSminSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSminX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSubSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSubX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSwapSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSwapX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicUmaxSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicUmaxX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicUminSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicUminX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicXorSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicXorX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx16Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx4Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx8Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferStoreDwordSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferStoreDwordx2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferStoreDwordx4Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCallB64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysSopp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbguserSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchGForkSop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchIForkSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchJoinSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkEqI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkEqU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLgI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLgU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheDiscardSmem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheDiscardX2Smem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheInvVolSmem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheWbSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheWbVolSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf0I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf0I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf1I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf1I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32I64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx16Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx4Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx8Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMemrealtimeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMemtimeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRfeB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRfeRestoreB64Sop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchLoadDwordSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchLoadDwordx2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchLoadDwordx4Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchStoreDwordSmem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchStoreDwordx2Smem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchStoreDwordx4Smem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetGprIdxIdxSop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetGprIdxModeSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetGprIdxOffSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetGprIdxOnSopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetkillSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetvskipSopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSStoreDwordSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSStoreDwordx2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSStoreDwordx4Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubbU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSwappcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAccvgprMovB32Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAccvgprMovB32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAccvgprReadVop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAccvgprWriteVop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddcCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddcCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClrexcpVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClrexcpVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFlrI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFlrI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkaccumU8F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtRpiI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtRpiI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupLegacyF16Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2F32F16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2I32I16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2U32U16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cF32F16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cF32F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cI32I16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cI32I16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4I32I8Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4cI32I8Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4cI32I8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8I32I4Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8cI32I4Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8cI32I4Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhU32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfblB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfblB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaLegacyF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadLegacyF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadLegacyI16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadLegacyU16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadMixF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadmkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadmkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x16bf161kVop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x16f16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x1f32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x2bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x4bf161kVop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x4f16Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x4f32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x8bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x1f32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x2bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x2f32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x4bf161kVop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x4bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x4f16Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x8bf161kVop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x8f16Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF324x4x1f32Vop3pMfma(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF324x4x2bf16Vop3pMfma(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF324x4x4bf161kVop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF324x4x4f16Vop3pMfma(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF6416x16x4f64Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF644x4x4f64Vop3pMfma(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI3216x16x16i8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI3216x16x4i8Vop3pMfma(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI3232x32x4i8Vop3pMfma(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI3232x32x8i8Vop3pMfma(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI324x4x4i8Vop3pMfma(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmaF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMovB32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVScreenPartition4seB32Vop1(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVScreenPartition4seB32Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubbCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubbCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubbrevCoU32Vop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubbrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwapB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 } // namespace detail
 
 struct DecoderImpl {
 public:
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 
 private:
-  using DecodeFunc = std::unique_ptr<Instruction> (*)(const MachineInst *);
-  static std::unique_ptr<Instruction> decodeInvalid(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopp(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSmem(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3p(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeDs(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeFlat(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMubuf(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMtbuf(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMimg(const MachineInst *opcode);
+  using DecodeFunc = DecodeResult (*)(const MachineInst *, const DecodeErrorEmitter &);
+  static DecodeResult decodeInvalid(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMtbuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
   static const std::array<DecodeFunc, 512> primary_decode_table;
   static const std::array<DecodeFunc, 256> sub_decode_vopc;
   static const std::array<DecodeFunc, 256> sub_decode_vop1;
@@ -1444,83 +1890,96 @@ private:
   static const std::array<DecodeFunc, 256> sub_decode_mimg;
 };
 
-std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
-  return DecoderImpl::decode(opcode);
+DecodeResult Decoder::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  return DecoderImpl::decode(opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decode(const MachineInst *opcode) {
+DecodeResult DecoderImpl::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
   Sop1MachineInst op = std::bit_cast<decltype(op)>(*opcode);
-  return primary_decode_table[op.encoding](opcode);
+  return primary_decode_table[op.encoding](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decodeInvalid(const MachineInst *opcode) {
-  throw util::InvalidInst(std::format("{:X}", *opcode));
-  return nullptr;
+DecodeResult DecoderImpl::decodeInvalid(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  return emit_error.emit() << "Invalid instruction opcode: " << std::format("{:X}", *opcode);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vopc[op.op](opcode);
+  return sub_decode_vopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop1[op.op](opcode);
+  return sub_decode_vop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sop1[op.op](opcode);
+  return sub_decode_sop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopc[op.op](opcode);
+  return sub_decode_sopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopp(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopp::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopp[op.op](opcode);
+  return sub_decode_sopp[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSmem(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Smem::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_smem[op.op](opcode);
+  return sub_decode_smem[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop3::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3[op.op](opcode);
+  return sub_decode_vop3[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3p(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3p(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Vop3p::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3p[op.op](opcode);
+  return sub_decode_vop3p[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeDs(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeDs(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
   Ds::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_ds[op.op](opcode);
+  return sub_decode_ds[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeFlat(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeFlat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Flat::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_flat[op.op](opcode);
+  return sub_decode_flat[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMubuf(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Mubuf::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mubuf[op.op](opcode);
+  return sub_decode_mubuf[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMtbuf(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMtbuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Mtbuf::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mtbuf[op.op](opcode);
+  return sub_decode_mtbuf[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMimg(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Mimg::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mimg[op.op](opcode);
+  return sub_decode_mimg[op.op](opcode, emit_error);
 }
 
 const std::array<DecoderImpl::DecodeFunc, 512> DecoderImpl::primary_decode_table = {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/decoder.h
@@ -8,6 +8,7 @@
 #define ROCJITSU_ISA_ARCH_AMDGPU_CDNA2_DECODER_H_
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/machine_insts.h"
+#include "rocjitsu/isa/decode_result.h"
 #include <array>
 #include <cstddef>
 #include <memory>
@@ -21,7 +22,7 @@ namespace cdna2 {
 class Decoder {
 public:
   static constexpr std::size_t kMaxInstructionWords = 4;
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 };
 
 } // namespace cdna2

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/ds.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/ds.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/ds.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -35,7 +34,11 @@ DsAddU32Ds::DsAddU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU32Ds>(opcode);
 }
 } // namespace detail
@@ -62,7 +65,11 @@ DsSubU32Ds::DsSubU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU32Ds>(opcode);
 }
 } // namespace detail
@@ -89,7 +96,11 @@ DsRsubU32Ds::DsRsubU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU32Ds>(opcode);
 }
 } // namespace detail
@@ -116,7 +127,11 @@ DsIncU32Ds::DsIncU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU32Ds>(opcode);
 }
 } // namespace detail
@@ -143,7 +158,11 @@ DsDecU32Ds::DsDecU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU32Ds>(opcode);
 }
 } // namespace detail
@@ -170,7 +189,11 @@ DsMinI32Ds::DsMinI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI32Ds>(opcode);
 }
 } // namespace detail
@@ -197,7 +220,11 @@ DsMaxI32Ds::DsMaxI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI32Ds>(opcode);
 }
 } // namespace detail
@@ -224,7 +251,11 @@ DsMinU32Ds::DsMinU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU32Ds>(opcode);
 }
 } // namespace detail
@@ -251,7 +282,11 @@ DsMaxU32Ds::DsMaxU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU32Ds>(opcode);
 }
 } // namespace detail
@@ -278,7 +313,11 @@ DsAndB32Ds::DsAndB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB32Ds>(opcode);
 }
 } // namespace detail
@@ -305,7 +344,11 @@ DsOrB32Ds::DsOrB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB32Ds>(opcode);
 }
 } // namespace detail
@@ -332,7 +375,11 @@ DsXorB32Ds::DsXorB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB32Ds>(opcode);
 }
 } // namespace detail
@@ -365,7 +412,11 @@ DsMskorB32Ds::DsMskorB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB32Ds>(opcode);
 }
 } // namespace detail
@@ -390,7 +441,11 @@ DsWriteB32Ds::DsWriteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB32Ds>(opcode);
 }
 } // namespace detail
@@ -421,7 +476,11 @@ DsWrite2B32Ds::DsWrite2B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2B32Ds>(opcode);
 }
 } // namespace detail
@@ -452,7 +511,12 @@ DsWrite2st64B32Ds::DsWrite2st64B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2st64B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2st64B32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2st64_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2st64B32Ds>(opcode);
 }
 } // namespace detail
@@ -485,7 +549,11 @@ DsCmpstB32Ds::DsCmpstB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstB32Ds>(opcode);
 }
 } // namespace detail
@@ -518,7 +586,11 @@ DsCmpstF32Ds::DsCmpstF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstF32Ds>(opcode);
 }
 } // namespace detail
@@ -545,7 +617,11 @@ DsMinF32Ds::DsMinF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinF32Ds>(opcode);
 }
 } // namespace detail
@@ -572,7 +648,11 @@ DsMaxF32Ds::DsMaxF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxF32Ds>(opcode);
 }
 } // namespace detail
@@ -585,7 +665,11 @@ DsNopDs::DsNopDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsNopDs(const MachineInst *opcode) {
+DecodeResult decodeDsNopDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Ds::validate_encoding("ds_nop", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsNopDs>(opcode);
 }
 } // namespace detail
@@ -612,7 +696,11 @@ DsAddF32Ds::DsAddF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddF32Ds>(opcode);
 }
 } // namespace detail
@@ -637,7 +725,12 @@ DsWriteAddtidB32Ds::DsWriteAddtidB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteAddtidB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteAddtidB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_addtid_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteAddtidB32Ds>(opcode);
 }
 } // namespace detail
@@ -662,7 +755,11 @@ DsWriteB8Ds::DsWriteB8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB8Ds>(opcode);
 }
 } // namespace detail
@@ -687,7 +784,11 @@ DsWriteB16Ds::DsWriteB16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB16Ds>(opcode);
 }
 } // namespace detail
@@ -720,7 +821,11 @@ DsAddRtnU32Ds::DsAddRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -753,7 +858,11 @@ DsSubRtnU32Ds::DsSubRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -786,7 +895,11 @@ DsRsubRtnU32Ds::DsRsubRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -819,7 +932,11 @@ DsIncRtnU32Ds::DsIncRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -852,7 +969,11 @@ DsDecRtnU32Ds::DsDecRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -885,7 +1006,11 @@ DsMinRtnI32Ds::DsMinRtnI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI32Ds>(opcode);
 }
 } // namespace detail
@@ -918,7 +1043,11 @@ DsMaxRtnI32Ds::DsMaxRtnI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI32Ds>(opcode);
 }
 } // namespace detail
@@ -951,7 +1080,11 @@ DsMinRtnU32Ds::DsMinRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -984,7 +1117,11 @@ DsMaxRtnU32Ds::DsMaxRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -1017,7 +1154,11 @@ DsAndRtnB32Ds::DsAndRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1050,7 +1191,11 @@ DsOrRtnB32Ds::DsOrRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1083,7 +1228,11 @@ DsXorRtnB32Ds::DsXorRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1122,7 +1271,12 @@ DsMskorRtnB32Ds::DsMskorRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1155,7 +1309,12 @@ DsWrxchgRtnB32Ds::DsWrxchgRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchgRtnB32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchgRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1194,7 +1353,12 @@ DsWrxchg2RtnB32Ds::DsWrxchg2RtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2RtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1233,7 +1397,12 @@ DsWrxchg2st64RtnB32Ds::DsWrxchg2st64RtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2st64_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2st64RtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1272,7 +1441,12 @@ DsCmpstRtnB32Ds::DsCmpstRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1311,7 +1485,12 @@ DsCmpstRtnF32Ds::DsCmpstRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnF32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1344,7 +1523,11 @@ DsMinRtnF32Ds::DsMinRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1377,7 +1560,11 @@ DsMaxRtnF32Ds::DsMaxRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1415,7 +1602,11 @@ DsWrapRtnB32Ds::DsWrapRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrapRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrapRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrap_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrapRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1448,7 +1639,11 @@ DsAddRtnF32Ds::DsAddRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1473,7 +1668,11 @@ DsReadB32Ds::DsReadB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB32Ds>(opcode);
 }
 } // namespace detail
@@ -1498,7 +1697,11 @@ DsRead2B32Ds::DsRead2B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2B32Ds>(opcode);
 }
 } // namespace detail
@@ -1523,7 +1726,12 @@ DsRead2st64B32Ds::DsRead2st64B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2st64B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2st64B32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2st64_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2st64B32Ds>(opcode);
 }
 } // namespace detail
@@ -1548,7 +1756,11 @@ DsReadI8Ds::DsReadI8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadI8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI8Ds>(opcode);
 }
 } // namespace detail
@@ -1573,7 +1785,11 @@ DsReadU8Ds::DsReadU8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU8Ds>(opcode);
 }
 } // namespace detail
@@ -1598,7 +1814,11 @@ DsReadI16Ds::DsReadI16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadI16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI16Ds>(opcode);
 }
 } // namespace detail
@@ -1623,7 +1843,11 @@ DsReadU16Ds::DsReadU16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU16Ds>(opcode);
 }
 } // namespace detail
@@ -1644,7 +1868,11 @@ DsSwizzleB32Ds::DsSwizzleB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSwizzleB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSwizzleB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_swizzle_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSwizzleB32Ds>(opcode);
 }
 } // namespace detail
@@ -1671,7 +1899,11 @@ DsPermuteB32Ds::DsPermuteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPermuteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsPermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_permute_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPermuteB32Ds>(opcode);
 }
 } // namespace detail
@@ -1698,7 +1930,12 @@ DsBpermuteB32Ds::DsBpermuteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsBpermuteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsBpermuteB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_bpermute_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsBpermuteB32Ds>(opcode);
 }
 } // namespace detail
@@ -1725,7 +1962,11 @@ DsAddU64Ds::DsAddU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU64Ds>(opcode);
 }
 } // namespace detail
@@ -1752,7 +1993,11 @@ DsSubU64Ds::DsSubU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU64Ds>(opcode);
 }
 } // namespace detail
@@ -1779,7 +2024,11 @@ DsRsubU64Ds::DsRsubU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU64Ds>(opcode);
 }
 } // namespace detail
@@ -1806,7 +2055,11 @@ DsIncU64Ds::DsIncU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU64Ds>(opcode);
 }
 } // namespace detail
@@ -1833,7 +2086,11 @@ DsDecU64Ds::DsDecU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU64Ds>(opcode);
 }
 } // namespace detail
@@ -1860,7 +2117,11 @@ DsMinI64Ds::DsMinI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI64Ds>(opcode);
 }
 } // namespace detail
@@ -1887,7 +2148,11 @@ DsMaxI64Ds::DsMaxI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI64Ds>(opcode);
 }
 } // namespace detail
@@ -1914,7 +2179,11 @@ DsMinU64Ds::DsMinU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU64Ds>(opcode);
 }
 } // namespace detail
@@ -1941,7 +2210,11 @@ DsMaxU64Ds::DsMaxU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU64Ds>(opcode);
 }
 } // namespace detail
@@ -1968,7 +2241,11 @@ DsAndB64Ds::DsAndB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB64Ds>(opcode);
 }
 } // namespace detail
@@ -1995,7 +2272,11 @@ DsOrB64Ds::DsOrB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB64Ds>(opcode);
 }
 } // namespace detail
@@ -2022,7 +2303,11 @@ DsXorB64Ds::DsXorB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB64Ds>(opcode);
 }
 } // namespace detail
@@ -2055,7 +2340,11 @@ DsMskorB64Ds::DsMskorB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB64Ds>(opcode);
 }
 } // namespace detail
@@ -2080,7 +2369,11 @@ DsWriteB64Ds::DsWriteB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB64Ds>(opcode);
 }
 } // namespace detail
@@ -2111,7 +2404,11 @@ DsWrite2B64Ds::DsWrite2B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2B64Ds>(opcode);
 }
 } // namespace detail
@@ -2142,7 +2439,12 @@ DsWrite2st64B64Ds::DsWrite2st64B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2st64B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2st64B64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2st64_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2st64B64Ds>(opcode);
 }
 } // namespace detail
@@ -2175,7 +2477,11 @@ DsCmpstB64Ds::DsCmpstB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstB64Ds>(opcode);
 }
 } // namespace detail
@@ -2208,7 +2514,11 @@ DsCmpstF64Ds::DsCmpstF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstF64Ds>(opcode);
 }
 } // namespace detail
@@ -2235,7 +2545,11 @@ DsMinF64Ds::DsMinF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinF64Ds>(opcode);
 }
 } // namespace detail
@@ -2262,7 +2576,11 @@ DsMaxF64Ds::DsMaxF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxF64Ds>(opcode);
 }
 } // namespace detail
@@ -2287,7 +2605,12 @@ DsWriteB8D16HiDs::DsWriteB8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB8D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2312,7 +2635,12 @@ DsWriteB16D16HiDs::DsWriteB16D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB16D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB16D16HiDs(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b16_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB16D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2337,7 +2665,11 @@ DsReadU8D16Ds::DsReadU8D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU8D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u8_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU8D16Ds>(opcode);
 }
 } // namespace detail
@@ -2368,7 +2700,12 @@ DsReadU8D16HiDs::DsReadU8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsReadU8D16HiDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2399,7 +2736,11 @@ DsReadI8D16Ds::DsReadI8D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI8D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i8_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI8D16Ds>(opcode);
 }
 } // namespace detail
@@ -2430,7 +2771,12 @@ DsReadI8D16HiDs::DsReadI8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsReadI8D16HiDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2461,7 +2807,11 @@ DsReadU16D16Ds::DsReadU16D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU16D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU16D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u16_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU16D16Ds>(opcode);
 }
 } // namespace detail
@@ -2492,7 +2842,12 @@ DsReadU16D16HiDs::DsReadU16D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU16D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsReadU16D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u16_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU16D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2525,7 +2880,11 @@ DsAddF64Ds::DsAddF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddF64Ds>(opcode);
 }
 } // namespace detail
@@ -2558,7 +2917,11 @@ DsAddRtnU64Ds::DsAddRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2591,7 +2954,11 @@ DsSubRtnU64Ds::DsSubRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2624,7 +2991,11 @@ DsRsubRtnU64Ds::DsRsubRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2657,7 +3028,11 @@ DsIncRtnU64Ds::DsIncRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2690,7 +3065,11 @@ DsDecRtnU64Ds::DsDecRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2723,7 +3102,11 @@ DsMinRtnI64Ds::DsMinRtnI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI64Ds>(opcode);
 }
 } // namespace detail
@@ -2756,7 +3139,11 @@ DsMaxRtnI64Ds::DsMaxRtnI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI64Ds>(opcode);
 }
 } // namespace detail
@@ -2789,7 +3176,11 @@ DsMinRtnU64Ds::DsMinRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2822,7 +3213,11 @@ DsMaxRtnU64Ds::DsMaxRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2855,7 +3250,11 @@ DsAndRtnB64Ds::DsAndRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2888,7 +3287,11 @@ DsOrRtnB64Ds::DsOrRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2921,7 +3324,11 @@ DsXorRtnB64Ds::DsXorRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2960,7 +3367,12 @@ DsMskorRtnB64Ds::DsMskorRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2993,7 +3405,12 @@ DsWrxchgRtnB64Ds::DsWrxchgRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchgRtnB64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchgRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3032,7 +3449,12 @@ DsWrxchg2RtnB64Ds::DsWrxchg2RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3071,7 +3493,12 @@ DsWrxchg2st64RtnB64Ds::DsWrxchg2st64RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2st64_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2st64RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3110,7 +3537,12 @@ DsCmpstRtnB64Ds::DsCmpstRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnB64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3149,7 +3581,12 @@ DsCmpstRtnF64Ds::DsCmpstRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnF64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -3182,7 +3619,11 @@ DsMinRtnF64Ds::DsMinRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -3215,7 +3656,11 @@ DsMaxRtnF64Ds::DsMaxRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -3240,7 +3685,11 @@ DsReadB64Ds::DsReadB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB64Ds>(opcode);
 }
 } // namespace detail
@@ -3265,7 +3714,11 @@ DsRead2B64Ds::DsRead2B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2B64Ds>(opcode);
 }
 } // namespace detail
@@ -3290,7 +3743,12 @@ DsRead2st64B64Ds::DsRead2st64B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2st64B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2st64B64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2st64_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2st64B64Ds>(opcode);
 }
 } // namespace detail
@@ -3323,7 +3781,11 @@ DsAddRtnF64Ds::DsAddRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -3356,7 +3818,12 @@ DsCondxchg32RtnB64Ds::DsCondxchg32RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_condxchg32_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCondxchg32RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3369,7 +3836,12 @@ DsGwsSemaReleaseAllDs::DsGwsSemaReleaseAllDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_release_all", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaReleaseAllDs>(opcode);
 }
 } // namespace detail
@@ -3384,7 +3856,11 @@ DsGwsInitDs::DsGwsInitDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsInitDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsInitDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_init", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsInitDs>(opcode);
 }
 } // namespace detail
@@ -3397,7 +3873,11 @@ DsGwsSemaVDs::DsGwsSemaVDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaVDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaVDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_v", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaVDs>(opcode);
 }
 } // namespace detail
@@ -3412,7 +3892,11 @@ DsGwsSemaBrDs::DsGwsSemaBrDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaBrDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaBrDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_br", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaBrDs>(opcode);
 }
 } // namespace detail
@@ -3425,7 +3909,11 @@ DsGwsSemaPDs::DsGwsSemaPDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaPDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaPDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_p", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaPDs>(opcode);
 }
 } // namespace detail
@@ -3440,7 +3928,11 @@ DsGwsBarrierDs::DsGwsBarrierDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsBarrierDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsBarrierDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_barrier", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsBarrierDs>(opcode);
 }
 } // namespace detail
@@ -3465,7 +3957,12 @@ DsReadAddtidB32Ds::DsReadAddtidB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadAddtidB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadAddtidB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_addtid_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadAddtidB32Ds>(opcode);
 }
 } // namespace detail
@@ -3490,7 +3987,11 @@ DsConsumeDs::DsConsumeDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsConsumeDs(const MachineInst *opcode) {
+DecodeResult decodeDsConsumeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_consume", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsConsumeDs>(opcode);
 }
 } // namespace detail
@@ -3515,7 +4016,11 @@ DsAppendDs::DsAppendDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAppendDs(const MachineInst *opcode) {
+DecodeResult decodeDsAppendDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_append", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAppendDs>(opcode);
 }
 } // namespace detail
@@ -3540,7 +4045,11 @@ DsWriteB96Ds::DsWriteB96Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB96Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b96", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB96Ds>(opcode);
 }
 } // namespace detail
@@ -3565,7 +4074,11 @@ DsWriteB128Ds::DsWriteB128Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB128Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b128", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB128Ds>(opcode);
 }
 } // namespace detail
@@ -3590,7 +4103,11 @@ DsReadB96Ds::DsReadB96Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB96Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b96", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB96Ds>(opcode);
 }
 } // namespace detail
@@ -3615,7 +4132,11 @@ DsReadB128Ds::DsReadB128Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB128Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b128", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB128Ds>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/encodings.h
@@ -10,6 +10,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna2/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
+#include "rocjitsu/isa/decode_result.h"
 #include "rocjitsu/isa/instruction.h"
 #include <array>
 #include <cstdint>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/flat.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/flat.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/flat.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -47,7 +46,12 @@ FlatLoadUbyteFlat::FlatLoadUbyteFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUbyteFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ubyte", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUbyteFlat>(opcode);
 }
 } // namespace detail
@@ -86,7 +90,12 @@ FlatLoadSbyteFlat::FlatLoadSbyteFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSbyteFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sbyte", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSbyteFlat>(opcode);
 }
 } // namespace detail
@@ -125,7 +134,12 @@ FlatLoadUshortFlat::FlatLoadUshortFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUshortFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ushort", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUshortFlat>(opcode);
 }
 } // namespace detail
@@ -164,7 +178,12 @@ FlatLoadSshortFlat::FlatLoadSshortFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSshortFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sshort", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSshortFlat>(opcode);
 }
 } // namespace detail
@@ -203,7 +222,12 @@ FlatLoadDwordFlat::FlatLoadDwordFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dword", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordFlat>(opcode);
 }
 } // namespace detail
@@ -242,7 +266,12 @@ FlatLoadDwordx2Flat::FlatLoadDwordx2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordx2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordx2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dwordx2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordx2Flat>(opcode);
 }
 } // namespace detail
@@ -281,7 +310,12 @@ FlatLoadDwordx3Flat::FlatLoadDwordx3Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordx3Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordx3Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dwordx3", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordx3Flat>(opcode);
 }
 } // namespace detail
@@ -320,7 +354,12 @@ FlatLoadDwordx4Flat::FlatLoadDwordx4Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordx4Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordx4Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dwordx4", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordx4Flat>(opcode);
 }
 } // namespace detail
@@ -359,7 +398,12 @@ FlatStoreByteFlat::FlatStoreByteFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreByteFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreByteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_byte", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreByteFlat>(opcode);
 }
 } // namespace detail
@@ -398,7 +442,12 @@ FlatStoreByteD16HiFlat::FlatStoreByteD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreByteD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreByteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_byte_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreByteD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -437,7 +486,12 @@ FlatStoreShortFlat::FlatStoreShortFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreShortFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreShortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_short", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreShortFlat>(opcode);
 }
 } // namespace detail
@@ -476,7 +530,12 @@ FlatStoreShortD16HiFlat::FlatStoreShortD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreShortD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreShortD16HiFlat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_short_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreShortD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -515,7 +574,12 @@ FlatStoreDwordFlat::FlatStoreDwordFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dword", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordFlat>(opcode);
 }
 } // namespace detail
@@ -554,7 +618,12 @@ FlatStoreDwordx2Flat::FlatStoreDwordx2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordx2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordx2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dwordx2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordx2Flat>(opcode);
 }
 } // namespace detail
@@ -593,7 +662,12 @@ FlatStoreDwordx3Flat::FlatStoreDwordx3Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordx3Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordx3Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dwordx3", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordx3Flat>(opcode);
 }
 } // namespace detail
@@ -632,7 +706,12 @@ FlatStoreDwordx4Flat::FlatStoreDwordx4Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordx4Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordx4Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dwordx4", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordx4Flat>(opcode);
 }
 } // namespace detail
@@ -671,7 +750,12 @@ FlatLoadUbyteD16Flat::FlatLoadUbyteD16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ubyte_d16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUbyteD16Flat>(opcode);
 }
 } // namespace detail
@@ -717,7 +801,12 @@ FlatLoadUbyteD16HiFlat::FlatLoadUbyteD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ubyte_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUbyteD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -763,7 +852,12 @@ FlatLoadSbyteD16Flat::FlatLoadSbyteD16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sbyte_d16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSbyteD16Flat>(opcode);
 }
 } // namespace detail
@@ -809,7 +903,12 @@ FlatLoadSbyteD16HiFlat::FlatLoadSbyteD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sbyte_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSbyteD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -855,7 +954,12 @@ FlatLoadShortD16Flat::FlatLoadShortD16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadShortD16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadShortD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_short_d16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadShortD16Flat>(opcode);
 }
 } // namespace detail
@@ -901,7 +1005,12 @@ FlatLoadShortD16HiFlat::FlatLoadShortD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadShortD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadShortD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_short_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadShortD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -954,7 +1063,12 @@ FlatAtomicSwapFlat::FlatAtomicSwapFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_swap", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapFlat>(opcode);
 }
 } // namespace detail
@@ -1000,7 +1114,12 @@ FlatAtomicCmpswapFlat::FlatAtomicCmpswapFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapFlat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_cmpswap", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapFlat>(opcode);
 }
 } // namespace detail
@@ -1046,7 +1165,12 @@ FlatAtomicAddFlat::FlatAtomicAddFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddFlat>(opcode);
 }
 } // namespace detail
@@ -1092,7 +1216,12 @@ FlatAtomicSubFlat::FlatAtomicSubFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_sub", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubFlat>(opcode);
 }
 } // namespace detail
@@ -1138,7 +1267,12 @@ FlatAtomicSminFlat::FlatAtomicSminFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSminFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smin", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSminFlat>(opcode);
 }
 } // namespace detail
@@ -1184,7 +1318,12 @@ FlatAtomicUminFlat::FlatAtomicUminFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUminFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umin", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUminFlat>(opcode);
 }
 } // namespace detail
@@ -1230,7 +1369,12 @@ FlatAtomicSmaxFlat::FlatAtomicSmaxFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smax", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSmaxFlat>(opcode);
 }
 } // namespace detail
@@ -1276,7 +1420,12 @@ FlatAtomicUmaxFlat::FlatAtomicUmaxFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umax", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUmaxFlat>(opcode);
 }
 } // namespace detail
@@ -1322,7 +1471,12 @@ FlatAtomicAndFlat::FlatAtomicAndFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_and", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndFlat>(opcode);
 }
 } // namespace detail
@@ -1368,7 +1522,12 @@ FlatAtomicOrFlat::FlatAtomicOrFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_or", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrFlat>(opcode);
 }
 } // namespace detail
@@ -1414,7 +1573,12 @@ FlatAtomicXorFlat::FlatAtomicXorFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_xor", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorFlat>(opcode);
 }
 } // namespace detail
@@ -1460,7 +1624,12 @@ FlatAtomicIncFlat::FlatAtomicIncFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_inc", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncFlat>(opcode);
 }
 } // namespace detail
@@ -1506,7 +1675,12 @@ FlatAtomicDecFlat::FlatAtomicDecFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_dec", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecFlat>(opcode);
 }
 } // namespace detail
@@ -1552,7 +1726,12 @@ FlatAtomicAddF64Flat::FlatAtomicAddF64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddF64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddF64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add_f64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddF64Flat>(opcode);
 }
 } // namespace detail
@@ -1598,7 +1777,12 @@ FlatAtomicMinF64Flat::FlatAtomicMinF64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinF64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinF64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_min_f64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinF64Flat>(opcode);
 }
 } // namespace detail
@@ -1644,7 +1828,12 @@ FlatAtomicMaxF64Flat::FlatAtomicMaxF64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxF64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxF64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_max_f64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxF64Flat>(opcode);
 }
 } // namespace detail
@@ -1690,7 +1879,12 @@ FlatAtomicSwapX2Flat::FlatAtomicSwapX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_swap_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapX2Flat>(opcode);
 }
 } // namespace detail
@@ -1736,7 +1930,12 @@ FlatAtomicCmpswapX2Flat::FlatAtomicCmpswapX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_cmpswap_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapX2Flat>(opcode);
 }
 } // namespace detail
@@ -1782,7 +1981,12 @@ FlatAtomicAddX2Flat::FlatAtomicAddX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddX2Flat>(opcode);
 }
 } // namespace detail
@@ -1828,7 +2032,12 @@ FlatAtomicSubX2Flat::FlatAtomicSubX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_sub_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubX2Flat>(opcode);
 }
 } // namespace detail
@@ -1874,7 +2083,12 @@ FlatAtomicSminX2Flat::FlatAtomicSminX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSminX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smin_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSminX2Flat>(opcode);
 }
 } // namespace detail
@@ -1920,7 +2134,12 @@ FlatAtomicUminX2Flat::FlatAtomicUminX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUminX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umin_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUminX2Flat>(opcode);
 }
 } // namespace detail
@@ -1966,7 +2185,12 @@ FlatAtomicSmaxX2Flat::FlatAtomicSmaxX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smax_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSmaxX2Flat>(opcode);
 }
 } // namespace detail
@@ -2012,7 +2236,12 @@ FlatAtomicUmaxX2Flat::FlatAtomicUmaxX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umax_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUmaxX2Flat>(opcode);
 }
 } // namespace detail
@@ -2058,7 +2287,12 @@ FlatAtomicAndX2Flat::FlatAtomicAndX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_and_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndX2Flat>(opcode);
 }
 } // namespace detail
@@ -2104,7 +2338,12 @@ FlatAtomicOrX2Flat::FlatAtomicOrX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrX2Flat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_or_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrX2Flat>(opcode);
 }
 } // namespace detail
@@ -2150,7 +2389,12 @@ FlatAtomicXorX2Flat::FlatAtomicXorX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_xor_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorX2Flat>(opcode);
 }
 } // namespace detail
@@ -2196,7 +2440,12 @@ FlatAtomicIncX2Flat::FlatAtomicIncX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_inc_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncX2Flat>(opcode);
 }
 } // namespace detail
@@ -2242,7 +2491,12 @@ FlatAtomicDecX2Flat::FlatAtomicDecX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_dec_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecX2Flat>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mimg.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mimg.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/mimg.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -30,7 +29,11 @@ ImageLoadMimg::ImageLoadMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMimg>(opcode);
 }
 } // namespace detail
@@ -53,7 +56,12 @@ ImageLoadMipMimg::ImageLoadMipMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipMimg>(opcode);
 }
 } // namespace detail
@@ -76,7 +84,12 @@ ImageLoadPckMimg::ImageLoadPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadPckMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadPckMimg>(opcode);
 }
 } // namespace detail
@@ -99,7 +112,12 @@ ImageLoadPckSgnMimg::ImageLoadPckSgnMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadPckSgnMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadPckSgnMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_pck_sgn", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadPckSgnMimg>(opcode);
 }
 } // namespace detail
@@ -122,7 +140,12 @@ ImageLoadMipPckMimg::ImageLoadMipPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipPckMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipPckMimg>(opcode);
 }
 } // namespace detail
@@ -145,7 +168,12 @@ ImageLoadMipPckSgnMimg::ImageLoadMipPckSgnMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipPckSgnMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipPckSgnMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_pck_sgn", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipPckSgnMimg>(opcode);
 }
 } // namespace detail
@@ -168,7 +196,11 @@ ImageStoreMimg::ImageStoreMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMimg>(opcode);
 }
 } // namespace detail
@@ -191,7 +223,12 @@ ImageStoreMipMimg::ImageStoreMipMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipMimg>(opcode);
 }
 } // namespace detail
@@ -214,7 +251,12 @@ ImageStorePckMimg::ImageStorePckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStorePckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStorePckMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStorePckMimg>(opcode);
 }
 } // namespace detail
@@ -237,7 +279,12 @@ ImageStoreMipPckMimg::ImageStoreMipPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipPckMimg>(opcode);
 }
 } // namespace detail
@@ -260,7 +307,12 @@ ImageGetResinfoMimg::ImageGetResinfoMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGetResinfoMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGetResinfoMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_get_resinfo", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGetResinfoMimg>(opcode);
 }
 } // namespace detail
@@ -284,7 +336,12 @@ ImageAtomicSwapMimg::ImageAtomicSwapMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSwapMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSwapMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_swap", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSwapMimg>(opcode);
 }
 } // namespace detail
@@ -308,7 +365,12 @@ ImageAtomicCmpswapMimg::ImageAtomicCmpswapMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicCmpswapMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicCmpswapMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_cmpswap", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicCmpswapMimg>(opcode);
 }
 } // namespace detail
@@ -332,7 +394,12 @@ ImageAtomicAddMimg::ImageAtomicAddMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicAddMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicAddMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_add", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicAddMimg>(opcode);
 }
 } // namespace detail
@@ -356,7 +423,12 @@ ImageAtomicSubMimg::ImageAtomicSubMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSubMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSubMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_sub", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSubMimg>(opcode);
 }
 } // namespace detail
@@ -380,7 +452,12 @@ ImageAtomicSminMimg::ImageAtomicSminMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSminMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_smin", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSminMimg>(opcode);
 }
 } // namespace detail
@@ -404,7 +481,12 @@ ImageAtomicUminMimg::ImageAtomicUminMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicUminMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicUminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_umin", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicUminMimg>(opcode);
 }
 } // namespace detail
@@ -428,7 +510,12 @@ ImageAtomicSmaxMimg::ImageAtomicSmaxMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSmaxMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_smax", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSmaxMimg>(opcode);
 }
 } // namespace detail
@@ -452,7 +539,12 @@ ImageAtomicUmaxMimg::ImageAtomicUmaxMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicUmaxMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicUmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_umax", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicUmaxMimg>(opcode);
 }
 } // namespace detail
@@ -476,7 +568,12 @@ ImageAtomicAndMimg::ImageAtomicAndMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicAndMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicAndMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_and", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicAndMimg>(opcode);
 }
 } // namespace detail
@@ -500,7 +597,12 @@ ImageAtomicOrMimg::ImageAtomicOrMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicOrMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicOrMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_or", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicOrMimg>(opcode);
 }
 } // namespace detail
@@ -524,7 +626,12 @@ ImageAtomicXorMimg::ImageAtomicXorMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicXorMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicXorMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_xor", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicXorMimg>(opcode);
 }
 } // namespace detail
@@ -548,7 +655,12 @@ ImageAtomicIncMimg::ImageAtomicIncMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicIncMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicIncMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_inc", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicIncMimg>(opcode);
 }
 } // namespace detail
@@ -572,7 +684,12 @@ ImageAtomicDecMimg::ImageAtomicDecMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicDecMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicDecMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_dec", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicDecMimg>(opcode);
 }
 } // namespace detail
@@ -597,7 +714,12 @@ ImageSampleMimg::ImageSampleMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleMimg(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleMimg>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mtbuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mtbuf.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/mtbuf.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -46,7 +45,12 @@ TbufferLoadFormatXMtbuf::TbufferLoadFormatXMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -74,7 +78,12 @@ TbufferLoadFormatXyMtbuf::TbufferLoadFormatXyMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xy", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -102,7 +111,12 @@ TbufferLoadFormatXyzMtbuf::TbufferLoadFormatXyzMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xyz", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -130,7 +144,12 @@ TbufferLoadFormatXyzwMtbuf::TbufferLoadFormatXyzwMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xyzw", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -158,7 +177,12 @@ TbufferStoreFormatXMtbuf::TbufferStoreFormatXMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -186,7 +210,12 @@ TbufferStoreFormatXyMtbuf::TbufferStoreFormatXyMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xy", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -214,7 +243,12 @@ TbufferStoreFormatXyzMtbuf::TbufferStoreFormatXyzMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xyz", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -242,7 +276,12 @@ TbufferStoreFormatXyzwMtbuf::TbufferStoreFormatXyzwMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xyzw", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -270,7 +309,12 @@ TbufferLoadFormatD16XMtbuf::TbufferLoadFormatD16XMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_d16_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XMtbuf>(opcode);
 }
 } // namespace detail
@@ -304,7 +348,13 @@ TbufferLoadFormatD16XyMtbuf::TbufferLoadFormatD16XyMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_format_d16_xy",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XyMtbuf>(opcode);
 }
 } // namespace detail
@@ -332,7 +382,13 @@ TbufferLoadFormatD16XyzMtbuf::TbufferLoadFormatD16XyzMtbuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_format_d16_xyz",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -366,7 +422,13 @@ TbufferLoadFormatD16XyzwMtbuf::TbufferLoadFormatD16XyzwMtbuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_format_d16_xyzw",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -394,7 +456,13 @@ TbufferStoreFormatD16XMtbuf::TbufferStoreFormatD16XMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_x",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XMtbuf>(opcode);
 }
 } // namespace detail
@@ -422,7 +490,13 @@ TbufferStoreFormatD16XyMtbuf::TbufferStoreFormatD16XyMtbuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_xy",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XyMtbuf>(opcode);
 }
 } // namespace detail
@@ -450,7 +524,13 @@ TbufferStoreFormatD16XyzMtbuf::TbufferStoreFormatD16XyzMtbuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_xyz",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -478,7 +558,13 @@ TbufferStoreFormatD16XyzwMtbuf::TbufferStoreFormatD16XyzwMtbuf(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_xyzw",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XyzwMtbuf>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mubuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mubuf.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/mubuf.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -46,7 +45,12 @@ BufferLoadFormatXMubuf::BufferLoadFormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXMubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -74,7 +78,12 @@ BufferLoadFormatXyMubuf::BufferLoadFormatXyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -102,7 +111,12 @@ BufferLoadFormatXyzMubuf::BufferLoadFormatXyzMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xyz", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -130,7 +144,12 @@ BufferLoadFormatXyzwMubuf::BufferLoadFormatXyzwMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xyzw", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -158,7 +177,12 @@ BufferStoreFormatXMubuf::BufferStoreFormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -186,7 +210,12 @@ BufferStoreFormatXyMubuf::BufferStoreFormatXyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -214,7 +243,12 @@ BufferStoreFormatXyzMubuf::BufferStoreFormatXyzMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xyz", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -242,7 +276,12 @@ BufferStoreFormatXyzwMubuf::BufferStoreFormatXyzwMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xyzw", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -270,7 +309,12 @@ BufferLoadFormatD16XMubuf::BufferLoadFormatD16XMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_d16_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XMubuf>(opcode);
 }
 } // namespace detail
@@ -305,7 +349,12 @@ BufferLoadFormatD16XyMubuf::BufferLoadFormatD16XyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_d16_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XyMubuf>(opcode);
 }
 } // namespace detail
@@ -333,7 +382,13 @@ BufferLoadFormatD16XyzMubuf::BufferLoadFormatD16XyzMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_format_d16_xyz",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XyzMubuf>(opcode);
 }
 } // namespace detail
@@ -368,7 +423,13 @@ BufferLoadFormatD16XyzwMubuf::BufferLoadFormatD16XyzwMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_format_d16_xyzw",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -396,7 +457,12 @@ BufferStoreFormatD16XMubuf::BufferStoreFormatD16XMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_d16_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XMubuf>(opcode);
 }
 } // namespace detail
@@ -424,7 +490,13 @@ BufferStoreFormatD16XyMubuf::BufferStoreFormatD16XyMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_xy",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XyMubuf>(opcode);
 }
 } // namespace detail
@@ -452,7 +524,13 @@ BufferStoreFormatD16XyzMubuf::BufferStoreFormatD16XyzMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_xyz",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XyzMubuf>(opcode);
 }
 } // namespace detail
@@ -480,7 +558,13 @@ BufferStoreFormatD16XyzwMubuf::BufferStoreFormatD16XyzwMubuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_xyzw",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -508,7 +592,12 @@ BufferLoadUbyteMubuf::BufferLoadUbyteMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUbyteMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ubyte", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUbyteMubuf>(opcode);
 }
 } // namespace detail
@@ -536,7 +625,12 @@ BufferLoadSbyteMubuf::BufferLoadSbyteMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSbyteMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sbyte", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSbyteMubuf>(opcode);
 }
 } // namespace detail
@@ -564,7 +658,12 @@ BufferLoadUshortMubuf::BufferLoadUshortMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUshortMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ushort", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUshortMubuf>(opcode);
 }
 } // namespace detail
@@ -592,7 +691,12 @@ BufferLoadSshortMubuf::BufferLoadSshortMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSshortMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sshort", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSshortMubuf>(opcode);
 }
 } // namespace detail
@@ -620,7 +724,12 @@ BufferLoadDwordMubuf::BufferLoadDwordMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dword", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordMubuf>(opcode);
 }
 } // namespace detail
@@ -648,7 +757,12 @@ BufferLoadDwordx2Mubuf::BufferLoadDwordx2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dwordx2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordx2Mubuf>(opcode);
 }
 } // namespace detail
@@ -676,7 +790,12 @@ BufferLoadDwordx3Mubuf::BufferLoadDwordx3Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dwordx3", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordx3Mubuf>(opcode);
 }
 } // namespace detail
@@ -704,7 +823,12 @@ BufferLoadDwordx4Mubuf::BufferLoadDwordx4Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dwordx4", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordx4Mubuf>(opcode);
 }
 } // namespace detail
@@ -732,7 +856,12 @@ BufferStoreByteMubuf::BufferStoreByteMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreByteMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreByteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_byte", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreByteMubuf>(opcode);
 }
 } // namespace detail
@@ -760,7 +889,12 @@ BufferStoreByteD16HiMubuf::BufferStoreByteD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_byte_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreByteD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -788,7 +922,12 @@ BufferStoreShortMubuf::BufferStoreShortMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreShortMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreShortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_short", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreShortMubuf>(opcode);
 }
 } // namespace detail
@@ -816,7 +955,12 @@ BufferStoreShortD16HiMubuf::BufferStoreShortD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_short_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreShortD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -844,7 +988,12 @@ BufferStoreDwordMubuf::BufferStoreDwordMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dword", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordMubuf>(opcode);
 }
 } // namespace detail
@@ -872,7 +1021,12 @@ BufferStoreDwordx2Mubuf::BufferStoreDwordx2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dwordx2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordx2Mubuf>(opcode);
 }
 } // namespace detail
@@ -900,7 +1054,12 @@ BufferStoreDwordx3Mubuf::BufferStoreDwordx3Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dwordx3", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordx3Mubuf>(opcode);
 }
 } // namespace detail
@@ -928,7 +1087,12 @@ BufferStoreDwordx4Mubuf::BufferStoreDwordx4Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dwordx4", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordx4Mubuf>(opcode);
 }
 } // namespace detail
@@ -956,7 +1120,12 @@ BufferLoadUbyteD16Mubuf::BufferLoadUbyteD16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ubyte_d16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUbyteD16Mubuf>(opcode);
 }
 } // namespace detail
@@ -991,7 +1160,12 @@ BufferLoadUbyteD16HiMubuf::BufferLoadUbyteD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ubyte_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUbyteD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -1026,7 +1200,12 @@ BufferLoadSbyteD16Mubuf::BufferLoadSbyteD16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sbyte_d16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSbyteD16Mubuf>(opcode);
 }
 } // namespace detail
@@ -1061,7 +1240,12 @@ BufferLoadSbyteD16HiMubuf::BufferLoadSbyteD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sbyte_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSbyteD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -1096,7 +1280,12 @@ BufferLoadShortD16Mubuf::BufferLoadShortD16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadShortD16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadShortD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_short_d16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadShortD16Mubuf>(opcode);
 }
 } // namespace detail
@@ -1131,7 +1320,12 @@ BufferLoadShortD16HiMubuf::BufferLoadShortD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_short_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadShortD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -1166,7 +1360,13 @@ BufferLoadFormatD16HiXMubuf::BufferLoadFormatD16HiXMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_format_d16_hi_x",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16HiXMubuf>(opcode);
 }
 } // namespace detail
@@ -1201,7 +1401,13 @@ BufferStoreFormatD16HiXMubuf::BufferStoreFormatD16HiXMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_hi_x",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16HiXMubuf>(opcode);
 }
 } // namespace detail
@@ -1214,7 +1420,12 @@ BufferWbl2Mubuf::BufferWbl2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferWbl2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferWbl2Mubuf(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_wbl2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferWbl2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1227,7 +1438,12 @@ BufferInvl2Mubuf::BufferInvl2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferInvl2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferInvl2Mubuf(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_invl2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferInvl2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1245,7 +1461,12 @@ BufferStoreLdsDwordMubuf::BufferStoreLdsDwordMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreLdsDwordMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreLdsDwordMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_lds_dword", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreLdsDwordMubuf>(opcode);
 }
 } // namespace detail
@@ -1258,7 +1479,12 @@ BufferWbinvl1Mubuf::BufferWbinvl1Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferWbinvl1Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferWbinvl1Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_wbinvl1", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferWbinvl1Mubuf>(opcode);
 }
 } // namespace detail
@@ -1271,7 +1497,12 @@ BufferWbinvl1VolMubuf::BufferWbinvl1VolMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferWbinvl1VolMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferWbinvl1VolMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_wbinvl1_vol", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferWbinvl1VolMubuf>(opcode);
 }
 } // namespace detail
@@ -1301,7 +1532,12 @@ BufferAtomicSwapMubuf::BufferAtomicSwapMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_swap", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapMubuf>(opcode);
 }
 } // namespace detail
@@ -1336,7 +1572,12 @@ BufferAtomicCmpswapMubuf::BufferAtomicCmpswapMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_cmpswap", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapMubuf>(opcode);
 }
 } // namespace detail
@@ -1366,7 +1607,12 @@ BufferAtomicAddMubuf::BufferAtomicAddMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddMubuf>(opcode);
 }
 } // namespace detail
@@ -1396,7 +1642,12 @@ BufferAtomicSubMubuf::BufferAtomicSubMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_sub", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubMubuf>(opcode);
 }
 } // namespace detail
@@ -1426,7 +1677,12 @@ BufferAtomicSminMubuf::BufferAtomicSminMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSminMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smin", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSminMubuf>(opcode);
 }
 } // namespace detail
@@ -1456,7 +1712,12 @@ BufferAtomicUminMubuf::BufferAtomicUminMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUminMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umin", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUminMubuf>(opcode);
 }
 } // namespace detail
@@ -1486,7 +1747,12 @@ BufferAtomicSmaxMubuf::BufferAtomicSmaxMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smax", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSmaxMubuf>(opcode);
 }
 } // namespace detail
@@ -1516,7 +1782,12 @@ BufferAtomicUmaxMubuf::BufferAtomicUmaxMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umax", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUmaxMubuf>(opcode);
 }
 } // namespace detail
@@ -1546,7 +1817,12 @@ BufferAtomicAndMubuf::BufferAtomicAndMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_and", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndMubuf>(opcode);
 }
 } // namespace detail
@@ -1576,7 +1852,12 @@ BufferAtomicOrMubuf::BufferAtomicOrMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrMubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_or", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrMubuf>(opcode);
 }
 } // namespace detail
@@ -1606,7 +1887,12 @@ BufferAtomicXorMubuf::BufferAtomicXorMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_xor", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorMubuf>(opcode);
 }
 } // namespace detail
@@ -1636,7 +1922,12 @@ BufferAtomicIncMubuf::BufferAtomicIncMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_inc", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncMubuf>(opcode);
 }
 } // namespace detail
@@ -1666,7 +1957,12 @@ BufferAtomicDecMubuf::BufferAtomicDecMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_dec", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecMubuf>(opcode);
 }
 } // namespace detail
@@ -1696,7 +1992,12 @@ BufferAtomicAddF32Mubuf::BufferAtomicAddF32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_f32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddF32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1726,7 +2027,12 @@ BufferAtomicPkAddF16Mubuf::BufferAtomicPkAddF16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicPkAddF16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicPkAddF16Mubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_pk_add_f16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicPkAddF16Mubuf>(opcode);
 }
 } // namespace detail
@@ -1756,7 +2062,12 @@ BufferAtomicAddF64Mubuf::BufferAtomicAddF64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddF64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_f64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddF64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1786,7 +2097,12 @@ BufferAtomicMinF64Mubuf::BufferAtomicMinF64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinF64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinF64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_min_f64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinF64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1816,7 +2132,12 @@ BufferAtomicMaxF64Mubuf::BufferAtomicMaxF64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxF64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxF64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_max_f64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxF64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1846,7 +2167,12 @@ BufferAtomicSwapX2Mubuf::BufferAtomicSwapX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_swap_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1881,7 +2207,12 @@ BufferAtomicCmpswapX2Mubuf::BufferAtomicCmpswapX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_cmpswap_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1911,7 +2242,12 @@ BufferAtomicAddX2Mubuf::BufferAtomicAddX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1941,7 +2277,12 @@ BufferAtomicSubX2Mubuf::BufferAtomicSubX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_sub_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1971,7 +2312,12 @@ BufferAtomicSminX2Mubuf::BufferAtomicSminX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smin_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSminX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2001,7 +2347,12 @@ BufferAtomicUminX2Mubuf::BufferAtomicUminX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umin_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUminX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2031,7 +2382,12 @@ BufferAtomicSmaxX2Mubuf::BufferAtomicSmaxX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smax_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSmaxX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2061,7 +2417,12 @@ BufferAtomicUmaxX2Mubuf::BufferAtomicUmaxX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umax_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUmaxX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2091,7 +2452,12 @@ BufferAtomicAndX2Mubuf::BufferAtomicAndX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_and_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2121,7 +2487,12 @@ BufferAtomicOrX2Mubuf::BufferAtomicOrX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_or_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2151,7 +2522,12 @@ BufferAtomicXorX2Mubuf::BufferAtomicXorX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_xor_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2181,7 +2557,12 @@ BufferAtomicIncX2Mubuf::BufferAtomicIncX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_inc_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2211,7 +2592,12 @@ BufferAtomicDecX2Mubuf::BufferAtomicDecX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_dec_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecX2Mubuf>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/operand.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/operand.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/scalar_static_resolve.h"
-#include "util/except.h"
 #include <format>
 #include <optional>
 #include <stdexcept>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/smem.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/smem.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/smem.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -43,7 +42,11 @@ SLoadDwordSmem::SLoadDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordSmem>(opcode);
 }
 } // namespace detail
@@ -63,7 +66,12 @@ SLoadDwordx2Smem::SLoadDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -83,7 +91,12 @@ SLoadDwordx4Smem::SLoadDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx4Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -103,7 +116,12 @@ SLoadDwordx8Smem::SLoadDwordx8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx8Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx8Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx8Smem>(opcode);
 }
 } // namespace detail
@@ -123,7 +141,12 @@ SLoadDwordx16Smem::SLoadDwordx16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx16Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx16Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx16Smem>(opcode);
 }
 } // namespace detail
@@ -143,7 +166,12 @@ SScratchLoadDwordSmem::SScratchLoadDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchLoadDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSScratchLoadDwordSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_load_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchLoadDwordSmem>(opcode);
 }
 } // namespace detail
@@ -163,7 +191,12 @@ SScratchLoadDwordx2Smem::SScratchLoadDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSScratchLoadDwordx2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_load_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchLoadDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -183,7 +216,12 @@ SScratchLoadDwordx4Smem::SScratchLoadDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSScratchLoadDwordx4Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_load_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchLoadDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -203,7 +241,12 @@ SBufferLoadDwordSmem::SBufferLoadDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordSmem>(opcode);
 }
 } // namespace detail
@@ -223,7 +266,12 @@ SBufferLoadDwordx2Smem::SBufferLoadDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -243,7 +291,12 @@ SBufferLoadDwordx4Smem::SBufferLoadDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx4Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -263,7 +316,12 @@ SBufferLoadDwordx8Smem::SBufferLoadDwordx8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx8Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx8Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx8Smem>(opcode);
 }
 } // namespace detail
@@ -283,7 +341,12 @@ SBufferLoadDwordx16Smem::SBufferLoadDwordx16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx16Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx16Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx16Smem>(opcode);
 }
 } // namespace detail
@@ -303,7 +366,12 @@ SStoreDwordSmem::SStoreDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSStoreDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSStoreDwordSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_store_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SStoreDwordSmem>(opcode);
 }
 } // namespace detail
@@ -323,7 +391,12 @@ SStoreDwordx2Smem::SStoreDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSStoreDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSStoreDwordx2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_store_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SStoreDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -343,7 +416,12 @@ SStoreDwordx4Smem::SStoreDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSStoreDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSStoreDwordx4Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_store_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SStoreDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -363,7 +441,12 @@ SScratchStoreDwordSmem::SScratchStoreDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchStoreDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSScratchStoreDwordSmem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_store_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchStoreDwordSmem>(opcode);
 }
 } // namespace detail
@@ -383,7 +466,12 @@ SScratchStoreDwordx2Smem::SScratchStoreDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchStoreDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSScratchStoreDwordx2Smem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_store_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchStoreDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -403,7 +491,12 @@ SScratchStoreDwordx4Smem::SScratchStoreDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchStoreDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSScratchStoreDwordx4Smem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_store_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchStoreDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -423,7 +516,12 @@ SBufferStoreDwordSmem::SBufferStoreDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferStoreDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferStoreDwordSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_store_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferStoreDwordSmem>(opcode);
 }
 } // namespace detail
@@ -443,7 +541,12 @@ SBufferStoreDwordx2Smem::SBufferStoreDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferStoreDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferStoreDwordx2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_store_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferStoreDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -463,7 +566,12 @@ SBufferStoreDwordx4Smem::SBufferStoreDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferStoreDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferStoreDwordx4Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_store_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferStoreDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -476,7 +584,11 @@ SDcacheInvSmem::SDcacheInvSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_inv", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheInvSmem>(opcode);
 }
 } // namespace detail
@@ -489,7 +601,11 @@ SDcacheWbSmem::SDcacheWbSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheWbSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheWbSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_wb", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheWbSmem>(opcode);
 }
 } // namespace detail
@@ -502,7 +618,12 @@ SDcacheInvVolSmem::SDcacheInvVolSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheInvVolSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheInvVolSmem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_inv_vol", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheInvVolSmem>(opcode);
 }
 } // namespace detail
@@ -515,7 +636,12 @@ SDcacheWbVolSmem::SDcacheWbVolSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheWbVolSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheWbVolSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_wb_vol", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheWbVolSmem>(opcode);
 }
 } // namespace detail
@@ -530,7 +656,11 @@ SMemtimeSmem::SMemtimeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMemtimeSmem(const MachineInst *opcode) {
+DecodeResult decodeSMemtimeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_memtime", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMemtimeSmem>(opcode);
 }
 } // namespace detail
@@ -545,7 +675,12 @@ SMemrealtimeSmem::SMemrealtimeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMemrealtimeSmem(const MachineInst *opcode) {
+DecodeResult decodeSMemrealtimeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_memrealtime", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMemrealtimeSmem>(opcode);
 }
 } // namespace detail
@@ -564,7 +699,11 @@ SAtcProbeSmem::SAtcProbeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtcProbeSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtcProbeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atc_probe", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtcProbeSmem>(opcode);
 }
 } // namespace detail
@@ -583,7 +722,12 @@ SAtcProbeBufferSmem::SAtcProbeBufferSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtcProbeBufferSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtcProbeBufferSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atc_probe_buffer", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtcProbeBufferSmem>(opcode);
 }
 } // namespace detail
@@ -600,7 +744,12 @@ SDcacheDiscardSmem::SDcacheDiscardSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheDiscardSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheDiscardSmem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_discard", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheDiscardSmem>(opcode);
 }
 } // namespace detail
@@ -617,7 +766,12 @@ SDcacheDiscardX2Smem::SDcacheDiscardX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheDiscardX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheDiscardX2Smem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_discard_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheDiscardX2Smem>(opcode);
 }
 } // namespace detail
@@ -637,7 +791,12 @@ SBufferAtomicSwapSmem::SBufferAtomicSwapSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSwapSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSwapSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_swap", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSwapSmem>(opcode);
 }
 } // namespace detail
@@ -657,7 +816,12 @@ SBufferAtomicCmpswapSmem::SBufferAtomicCmpswapSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicCmpswapSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicCmpswapSmem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_cmpswap", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicCmpswapSmem>(opcode);
 }
 } // namespace detail
@@ -677,7 +841,12 @@ SBufferAtomicAddSmem::SBufferAtomicAddSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicAddSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicAddSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_add", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicAddSmem>(opcode);
 }
 } // namespace detail
@@ -697,7 +866,12 @@ SBufferAtomicSubSmem::SBufferAtomicSubSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSubSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSubSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_sub", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSubSmem>(opcode);
 }
 } // namespace detail
@@ -717,7 +891,12 @@ SBufferAtomicSminSmem::SBufferAtomicSminSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSminSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSminSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_smin", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSminSmem>(opcode);
 }
 } // namespace detail
@@ -737,7 +916,12 @@ SBufferAtomicUminSmem::SBufferAtomicUminSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicUminSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicUminSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_umin", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicUminSmem>(opcode);
 }
 } // namespace detail
@@ -757,7 +941,12 @@ SBufferAtomicSmaxSmem::SBufferAtomicSmaxSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSmaxSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSmaxSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_smax", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSmaxSmem>(opcode);
 }
 } // namespace detail
@@ -777,7 +966,12 @@ SBufferAtomicUmaxSmem::SBufferAtomicUmaxSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicUmaxSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicUmaxSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_umax", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicUmaxSmem>(opcode);
 }
 } // namespace detail
@@ -797,7 +991,12 @@ SBufferAtomicAndSmem::SBufferAtomicAndSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicAndSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicAndSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_and", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicAndSmem>(opcode);
 }
 } // namespace detail
@@ -817,7 +1016,12 @@ SBufferAtomicOrSmem::SBufferAtomicOrSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicOrSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicOrSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_or", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicOrSmem>(opcode);
 }
 } // namespace detail
@@ -837,7 +1041,12 @@ SBufferAtomicXorSmem::SBufferAtomicXorSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicXorSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicXorSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_xor", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicXorSmem>(opcode);
 }
 } // namespace detail
@@ -857,7 +1066,12 @@ SBufferAtomicIncSmem::SBufferAtomicIncSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicIncSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicIncSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_inc", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicIncSmem>(opcode);
 }
 } // namespace detail
@@ -877,7 +1091,12 @@ SBufferAtomicDecSmem::SBufferAtomicDecSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicDecSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicDecSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_dec", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicDecSmem>(opcode);
 }
 } // namespace detail
@@ -897,7 +1116,12 @@ SBufferAtomicSwapX2Smem::SBufferAtomicSwapX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSwapX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSwapX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_swap_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSwapX2Smem>(opcode);
 }
 } // namespace detail
@@ -917,7 +1141,12 @@ SBufferAtomicCmpswapX2Smem::SBufferAtomicCmpswapX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicCmpswapX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicCmpswapX2Smem(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_cmpswap_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicCmpswapX2Smem>(opcode);
 }
 } // namespace detail
@@ -937,7 +1166,12 @@ SBufferAtomicAddX2Smem::SBufferAtomicAddX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicAddX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicAddX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_add_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicAddX2Smem>(opcode);
 }
 } // namespace detail
@@ -957,7 +1191,12 @@ SBufferAtomicSubX2Smem::SBufferAtomicSubX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSubX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSubX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_sub_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSubX2Smem>(opcode);
 }
 } // namespace detail
@@ -977,7 +1216,12 @@ SBufferAtomicSminX2Smem::SBufferAtomicSminX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSminX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSminX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_smin_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSminX2Smem>(opcode);
 }
 } // namespace detail
@@ -997,7 +1241,12 @@ SBufferAtomicUminX2Smem::SBufferAtomicUminX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicUminX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicUminX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_umin_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicUminX2Smem>(opcode);
 }
 } // namespace detail
@@ -1017,7 +1266,12 @@ SBufferAtomicSmaxX2Smem::SBufferAtomicSmaxX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSmaxX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSmaxX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_smax_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSmaxX2Smem>(opcode);
 }
 } // namespace detail
@@ -1037,7 +1291,12 @@ SBufferAtomicUmaxX2Smem::SBufferAtomicUmaxX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicUmaxX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicUmaxX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_umax_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicUmaxX2Smem>(opcode);
 }
 } // namespace detail
@@ -1057,7 +1316,12 @@ SBufferAtomicAndX2Smem::SBufferAtomicAndX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicAndX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicAndX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_and_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicAndX2Smem>(opcode);
 }
 } // namespace detail
@@ -1077,7 +1341,12 @@ SBufferAtomicOrX2Smem::SBufferAtomicOrX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicOrX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicOrX2Smem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_or_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicOrX2Smem>(opcode);
 }
 } // namespace detail
@@ -1097,7 +1366,12 @@ SBufferAtomicXorX2Smem::SBufferAtomicXorX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicXorX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicXorX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_xor_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicXorX2Smem>(opcode);
 }
 } // namespace detail
@@ -1117,7 +1391,12 @@ SBufferAtomicIncX2Smem::SBufferAtomicIncX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicIncX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicIncX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_inc_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicIncX2Smem>(opcode);
 }
 } // namespace detail
@@ -1137,7 +1416,12 @@ SBufferAtomicDecX2Smem::SBufferAtomicDecX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicDecX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicDecX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_dec_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicDecX2Smem>(opcode);
 }
 } // namespace detail
@@ -1157,7 +1441,12 @@ SAtomicSwapSmem::SAtomicSwapSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSwapSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSwapSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_swap", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSwapSmem>(opcode);
 }
 } // namespace detail
@@ -1177,7 +1466,12 @@ SAtomicCmpswapSmem::SAtomicCmpswapSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicCmpswapSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicCmpswapSmem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_cmpswap", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicCmpswapSmem>(opcode);
 }
 } // namespace detail
@@ -1197,7 +1491,11 @@ SAtomicAddSmem::SAtomicAddSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicAddSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicAddSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_add", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicAddSmem>(opcode);
 }
 } // namespace detail
@@ -1217,7 +1515,11 @@ SAtomicSubSmem::SAtomicSubSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSubSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSubSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_sub", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSubSmem>(opcode);
 }
 } // namespace detail
@@ -1237,7 +1539,12 @@ SAtomicSminSmem::SAtomicSminSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSminSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSminSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_smin", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSminSmem>(opcode);
 }
 } // namespace detail
@@ -1257,7 +1564,12 @@ SAtomicUminSmem::SAtomicUminSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicUminSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicUminSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_umin", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicUminSmem>(opcode);
 }
 } // namespace detail
@@ -1277,7 +1589,12 @@ SAtomicSmaxSmem::SAtomicSmaxSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSmaxSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSmaxSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_smax", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSmaxSmem>(opcode);
 }
 } // namespace detail
@@ -1297,7 +1614,12 @@ SAtomicUmaxSmem::SAtomicUmaxSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicUmaxSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicUmaxSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_umax", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicUmaxSmem>(opcode);
 }
 } // namespace detail
@@ -1317,7 +1639,11 @@ SAtomicAndSmem::SAtomicAndSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicAndSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicAndSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_and", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicAndSmem>(opcode);
 }
 } // namespace detail
@@ -1337,7 +1663,11 @@ SAtomicOrSmem::SAtomicOrSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicOrSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicOrSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_or", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicOrSmem>(opcode);
 }
 } // namespace detail
@@ -1357,7 +1687,11 @@ SAtomicXorSmem::SAtomicXorSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicXorSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicXorSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_xor", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicXorSmem>(opcode);
 }
 } // namespace detail
@@ -1377,7 +1711,11 @@ SAtomicIncSmem::SAtomicIncSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicIncSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicIncSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_inc", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicIncSmem>(opcode);
 }
 } // namespace detail
@@ -1397,7 +1735,11 @@ SAtomicDecSmem::SAtomicDecSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicDecSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicDecSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_dec", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicDecSmem>(opcode);
 }
 } // namespace detail
@@ -1417,7 +1759,12 @@ SAtomicSwapX2Smem::SAtomicSwapX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSwapX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSwapX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_swap_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSwapX2Smem>(opcode);
 }
 } // namespace detail
@@ -1437,7 +1784,12 @@ SAtomicCmpswapX2Smem::SAtomicCmpswapX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicCmpswapX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicCmpswapX2Smem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_cmpswap_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicCmpswapX2Smem>(opcode);
 }
 } // namespace detail
@@ -1457,7 +1809,12 @@ SAtomicAddX2Smem::SAtomicAddX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicAddX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicAddX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_add_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicAddX2Smem>(opcode);
 }
 } // namespace detail
@@ -1477,7 +1834,12 @@ SAtomicSubX2Smem::SAtomicSubX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSubX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSubX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_sub_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSubX2Smem>(opcode);
 }
 } // namespace detail
@@ -1497,7 +1859,12 @@ SAtomicSminX2Smem::SAtomicSminX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSminX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSminX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_smin_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSminX2Smem>(opcode);
 }
 } // namespace detail
@@ -1517,7 +1884,12 @@ SAtomicUminX2Smem::SAtomicUminX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicUminX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicUminX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_umin_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicUminX2Smem>(opcode);
 }
 } // namespace detail
@@ -1537,7 +1909,12 @@ SAtomicSmaxX2Smem::SAtomicSmaxX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSmaxX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSmaxX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_smax_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSmaxX2Smem>(opcode);
 }
 } // namespace detail
@@ -1557,7 +1934,12 @@ SAtomicUmaxX2Smem::SAtomicUmaxX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicUmaxX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicUmaxX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_umax_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicUmaxX2Smem>(opcode);
 }
 } // namespace detail
@@ -1577,7 +1959,12 @@ SAtomicAndX2Smem::SAtomicAndX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicAndX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicAndX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_and_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicAndX2Smem>(opcode);
 }
 } // namespace detail
@@ -1597,7 +1984,12 @@ SAtomicOrX2Smem::SAtomicOrX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicOrX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicOrX2Smem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_or_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicOrX2Smem>(opcode);
 }
 } // namespace detail
@@ -1617,7 +2009,12 @@ SAtomicXorX2Smem::SAtomicXorX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicXorX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicXorX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_xor_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicXorX2Smem>(opcode);
 }
 } // namespace detail
@@ -1637,7 +2034,12 @@ SAtomicIncX2Smem::SAtomicIncX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicIncX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicIncX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_inc_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicIncX2Smem>(opcode);
 }
 } // namespace detail
@@ -1657,7 +2059,12 @@ SAtomicDecX2Smem::SAtomicDecX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicDecX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicDecX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_dec_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicDecX2Smem>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/sop1.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/sop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -29,7 +28,11 @@ SMovB32Sop1::SMovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -52,7 +55,11 @@ SMovB64Sop1::SMovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -78,7 +85,11 @@ SCmovB32Sop1::SCmovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -105,7 +116,11 @@ SCmovB64Sop1::SCmovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -129,7 +144,11 @@ SNotB32Sop1::SNotB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB32Sop1>(opcode);
 }
 } // namespace detail
@@ -154,7 +173,11 @@ SNotB64Sop1::SNotB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB64Sop1>(opcode);
 }
 } // namespace detail
@@ -178,7 +201,11 @@ SWqmB32Sop1::SWqmB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB32Sop1>(opcode);
 }
 } // namespace detail
@@ -203,7 +230,11 @@ SWqmB64Sop1::SWqmB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB64Sop1>(opcode);
 }
 } // namespace detail
@@ -224,7 +255,11 @@ SBrevB32Sop1::SBrevB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB32Sop1>(opcode);
 }
 } // namespace detail
@@ -246,7 +281,11 @@ SBrevB64Sop1::SBrevB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB64Sop1>(opcode);
 }
 } // namespace detail
@@ -270,7 +309,12 @@ SBcnt0I32B32Sop1::SBcnt0I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -295,7 +339,12 @@ SBcnt0I32B64Sop1::SBcnt0I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -319,7 +368,12 @@ SBcnt1I32B32Sop1::SBcnt1I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -344,7 +398,12 @@ SBcnt1I32B64Sop1::SBcnt1I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -365,7 +424,11 @@ SFf0I32B32Sop1::SFf0I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf0I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf0I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff0_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf0I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -387,7 +450,11 @@ SFf0I32B64Sop1::SFf0I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf0I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf0I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff0_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf0I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -408,7 +475,11 @@ SFf1I32B32Sop1::SFf1I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf1I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf1I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff1_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf1I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -430,7 +501,11 @@ SFf1I32B64Sop1::SFf1I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf1I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf1I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff1_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf1I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -451,7 +526,12 @@ SFlbitI32B32Sop1::SFlbitI32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -473,7 +553,12 @@ SFlbitI32B64Sop1::SFlbitI32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -494,7 +579,11 @@ SFlbitI32Sop1::SFlbitI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32Sop1>(opcode);
 }
 } // namespace detail
@@ -516,7 +605,12 @@ SFlbitI32I64Sop1::SFlbitI32I64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32I64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32I64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32_i64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32I64Sop1>(opcode);
 }
 } // namespace detail
@@ -538,7 +632,11 @@ SSextI32I8Sop1::SSextI32I8Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i8", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I8Sop1>(opcode);
 }
 } // namespace detail
@@ -560,7 +658,12 @@ SSextI32I16Sop1::SSextI32I16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I16Sop1>(opcode);
 }
 } // namespace detail
@@ -582,7 +685,12 @@ SBitset0B32Sop1::SBitset0B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B32Sop1>(opcode);
 }
 } // namespace detail
@@ -604,7 +712,12 @@ SBitset0B64Sop1::SBitset0B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B64Sop1>(opcode);
 }
 } // namespace detail
@@ -626,7 +739,12 @@ SBitset1B32Sop1::SBitset1B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B32Sop1>(opcode);
 }
 } // namespace detail
@@ -648,7 +766,12 @@ SBitset1B64Sop1::SBitset1B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B64Sop1>(opcode);
 }
 } // namespace detail
@@ -666,7 +789,11 @@ SGetpcB64Sop1::SGetpcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetpcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSGetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_getpc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetpcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -685,7 +812,11 @@ SSetpcB64Sop1::SSetpcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetpcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_setpc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetpcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -708,7 +839,11 @@ SSwappcB64Sop1::SSwappcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSwappcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSwappcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_swappc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSwappcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -726,7 +861,11 @@ SRfeB64Sop1::SRfeB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRfeB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSRfeB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_rfe_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRfeB64Sop1>(opcode);
 }
 } // namespace detail
@@ -758,7 +897,12 @@ SAndSaveexecB64Sop1::SAndSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -791,7 +935,12 @@ SOrSaveexecB64Sop1::SOrSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -823,7 +972,12 @@ SXorSaveexecB64Sop1::SXorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -855,7 +1009,12 @@ SAndn2SaveexecB64Sop1::SAndn2SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn2_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -887,7 +1046,12 @@ SOrn2SaveexecB64Sop1::SOrn2SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_orn2_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -919,7 +1083,12 @@ SNandSaveexecB64Sop1::SNandSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nand_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -951,7 +1120,12 @@ SNorSaveexecB64Sop1::SNorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -983,7 +1157,12 @@ SXnorSaveexecB64Sop1::SXnorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xnor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1007,7 +1186,12 @@ SQuadmaskB32Sop1::SQuadmaskB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1032,7 +1216,12 @@ SQuadmaskB64Sop1::SQuadmaskB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1052,7 +1241,12 @@ SMovrelsB32Sop1::SMovrelsB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrels_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1072,7 +1266,12 @@ SMovrelsB64Sop1::SMovrelsB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrels_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1096,7 +1295,12 @@ SMovreldB32Sop1::SMovreldB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1121,7 +1325,12 @@ SMovreldB64Sop1::SMovreldB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1141,7 +1350,12 @@ SCbranchJoinSop1::SCbranchJoinSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchJoinSop1(const MachineInst *opcode) {
+DecodeResult decodeSCbranchJoinSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cbranch_join", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchJoinSop1>(opcode);
 }
 } // namespace detail
@@ -1165,7 +1379,11 @@ SAbsI32Sop1::SAbsI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_abs_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsI32Sop1>(opcode);
 }
 } // namespace detail
@@ -1189,7 +1407,12 @@ SSetGprIdxIdxSop1::SSetGprIdxIdxSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetGprIdxIdxSop1(const MachineInst *opcode) {
+DecodeResult decodeSSetGprIdxIdxSop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_set_gpr_idx_idx", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetGprIdxIdxSop1>(opcode);
 }
 } // namespace detail
@@ -1221,7 +1444,12 @@ SAndn1SaveexecB64Sop1::SAndn1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1253,7 +1481,12 @@ SOrn1SaveexecB64Sop1::SOrn1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_orn1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1285,7 +1518,12 @@ SAndn1WrexecB64Sop1::SAndn1WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn1WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn1WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn1_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn1WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1317,7 +1555,12 @@ SAndn2WrexecB64Sop1::SAndn2WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn2WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn2_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1338,7 +1581,12 @@ SBitreplicateB64B32Sop1::SBitreplicateB64B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitreplicate_b64_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitreplicateB64B32Sop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/sop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/sop2.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/sop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -37,7 +36,11 @@ SAddU32Sop2::SAddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -67,7 +70,11 @@ SSubU32Sop2::SSubU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubU32Sop2>(opcode);
 }
 } // namespace detail
@@ -97,7 +104,11 @@ SAddI32Sop2::SAddI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddI32Sop2>(opcode);
 }
 } // namespace detail
@@ -127,7 +138,11 @@ SSubI32Sop2::SSubI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubI32Sop2>(opcode);
 }
 } // namespace detail
@@ -160,7 +175,11 @@ SAddcU32Sop2::SAddcU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddcU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddcU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_addc_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddcU32Sop2>(opcode);
 }
 } // namespace detail
@@ -193,7 +212,11 @@ SSubbU32Sop2::SSubbU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubbU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubbU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_subb_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubbU32Sop2>(opcode);
 }
 } // namespace detail
@@ -223,7 +246,11 @@ SMinI32Sop2::SMinI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinI32Sop2>(opcode);
 }
 } // namespace detail
@@ -253,7 +280,11 @@ SMinU32Sop2::SMinU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinU32Sop2>(opcode);
 }
 } // namespace detail
@@ -283,7 +314,11 @@ SMaxI32Sop2::SMaxI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxI32Sop2>(opcode);
 }
 } // namespace detail
@@ -313,7 +348,11 @@ SMaxU32Sop2::SMaxU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxU32Sop2>(opcode);
 }
 } // namespace detail
@@ -343,7 +382,12 @@ SCselectB32Sop2::SCselectB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCselectB32Sop2>(opcode);
 }
 } // namespace detail
@@ -375,7 +419,12 @@ SCselectB64Sop2::SCselectB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCselectB64Sop2>(opcode);
 }
 } // namespace detail
@@ -405,7 +454,11 @@ SAndB32Sop2::SAndB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndB32Sop2>(opcode);
 }
 } // namespace detail
@@ -437,7 +490,11 @@ SAndB64Sop2::SAndB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndB64Sop2>(opcode);
 }
 } // namespace detail
@@ -468,7 +525,11 @@ SOrB32Sop2::SOrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -501,7 +562,11 @@ SOrB64Sop2::SOrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -531,7 +596,11 @@ SXorB32Sop2::SXorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -563,7 +632,11 @@ SXorB64Sop2::SXorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -593,7 +666,11 @@ SAndn2B32Sop2::SAndn2B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_andn2_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2B32Sop2>(opcode);
 }
 } // namespace detail
@@ -625,7 +702,11 @@ SAndn2B64Sop2::SAndn2B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_andn2_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2B64Sop2>(opcode);
 }
 } // namespace detail
@@ -655,7 +736,11 @@ SOrn2B32Sop2::SOrn2B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_orn2_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2B32Sop2>(opcode);
 }
 } // namespace detail
@@ -687,7 +772,11 @@ SOrn2B64Sop2::SOrn2B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_orn2_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2B64Sop2>(opcode);
 }
 } // namespace detail
@@ -717,7 +806,11 @@ SNandB32Sop2::SNandB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandB32Sop2>(opcode);
 }
 } // namespace detail
@@ -749,7 +842,11 @@ SNandB64Sop2::SNandB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandB64Sop2>(opcode);
 }
 } // namespace detail
@@ -779,7 +876,11 @@ SNorB32Sop2::SNorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -811,7 +912,11 @@ SNorB64Sop2::SNorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -841,7 +946,11 @@ SXnorB32Sop2::SXnorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -873,7 +982,11 @@ SXnorB64Sop2::SXnorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -903,7 +1016,11 @@ SLshlB32Sop2::SLshlB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshlB32Sop2>(opcode);
 }
 } // namespace detail
@@ -934,7 +1051,11 @@ SLshlB64Sop2::SLshlB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshlB64Sop2>(opcode);
 }
 } // namespace detail
@@ -964,7 +1085,11 @@ SLshrB32Sop2::SLshrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -995,7 +1120,11 @@ SLshrB64Sop2::SLshrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1025,7 +1154,11 @@ SAshrI32Sop2::SAshrI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAshrI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1056,7 +1189,11 @@ SAshrI64Sop2::SAshrI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAshrI64Sop2>(opcode);
 }
 } // namespace detail
@@ -1083,7 +1220,11 @@ SBfmB32Sop2::SBfmB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfmB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1110,7 +1251,11 @@ SBfmB64Sop2::SBfmB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfmB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1137,7 +1282,11 @@ SMulI32Sop2::SMulI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1167,7 +1316,11 @@ SBfeU32Sop2::SBfeU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1197,7 +1350,11 @@ SBfeI32Sop2::SBfeI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1228,7 +1385,11 @@ SBfeU64Sop2::SBfeU64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeU64Sop2>(opcode);
 }
 } // namespace detail
@@ -1259,7 +1420,11 @@ SBfeI64Sop2::SBfeI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeI64Sop2>(opcode);
 }
 } // namespace detail
@@ -1279,7 +1444,12 @@ SCbranchGForkSop2::SCbranchGForkSop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchGForkSop2(const MachineInst *opcode) {
+DecodeResult decodeSCbranchGForkSop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cbranch_g_fork", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchGForkSop2>(opcode);
 }
 } // namespace detail
@@ -1309,7 +1479,12 @@ SAbsdiffI32Sop2::SAbsdiffI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_absdiff_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsdiffI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1338,7 +1513,12 @@ SRfeRestoreB64Sop2::SRfeRestoreB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRfeRestoreB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSRfeRestoreB64Sop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_rfe_restore_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRfeRestoreB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1365,7 +1545,11 @@ SMulHiU32Sop2::SMulHiU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulHiU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1392,7 +1576,11 @@ SMulHiI32Sop2::SMulHiI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulHiI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1422,7 +1610,12 @@ SLshl1AddU32Sop2::SLshl1AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl1_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl1AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1452,7 +1645,12 @@ SLshl2AddU32Sop2::SLshl2AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl2_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl2AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1482,7 +1680,12 @@ SLshl3AddU32Sop2::SLshl3AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl3_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl3AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1512,7 +1715,12 @@ SLshl4AddU32Sop2::SLshl4AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl4_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl4AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1541,7 +1749,12 @@ SPackLlB32B16Sop2::SPackLlB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_ll_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackLlB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1569,7 +1782,12 @@ SPackLhB32B16Sop2::SPackLhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_lh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackLhB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1596,7 +1814,12 @@ SPackHhB32B16Sop2::SPackHhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_hh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackHhB32B16Sop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/sopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/sopc.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/sopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -35,7 +34,11 @@ SCmpEqI32Sopc::SCmpEqI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqI32Sopc>(opcode);
 }
 } // namespace detail
@@ -63,7 +66,11 @@ SCmpLgI32Sopc::SCmpLgI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgI32Sopc>(opcode);
 }
 } // namespace detail
@@ -91,7 +98,11 @@ SCmpGtI32Sopc::SCmpGtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -119,7 +130,11 @@ SCmpGeI32Sopc::SCmpGeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -147,7 +162,11 @@ SCmpLtI32Sopc::SCmpLtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -175,7 +194,11 @@ SCmpLeI32Sopc::SCmpLeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -203,7 +226,11 @@ SCmpEqU32Sopc::SCmpEqU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqU32Sopc>(opcode);
 }
 } // namespace detail
@@ -231,7 +258,11 @@ SCmpLgU32Sopc::SCmpLgU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgU32Sopc>(opcode);
 }
 } // namespace detail
@@ -259,7 +290,11 @@ SCmpGtU32Sopc::SCmpGtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -287,7 +322,11 @@ SCmpGeU32Sopc::SCmpGeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -315,7 +354,11 @@ SCmpLtU32Sopc::SCmpLtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -343,7 +386,11 @@ SCmpLeU32Sopc::SCmpLeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -371,7 +418,12 @@ SBitcmp0B32Sopc::SBitcmp0B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp0B32Sopc>(opcode);
 }
 } // namespace detail
@@ -399,7 +451,12 @@ SBitcmp1B32Sopc::SBitcmp1B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp1B32Sopc>(opcode);
 }
 } // namespace detail
@@ -428,7 +485,12 @@ SBitcmp0B64Sopc::SBitcmp0B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp0B64Sopc>(opcode);
 }
 } // namespace detail
@@ -457,7 +519,12 @@ SBitcmp1B64Sopc::SBitcmp1B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp1B64Sopc>(opcode);
 }
 } // namespace detail
@@ -482,7 +549,11 @@ SSetvskipSopc::SSetvskipSopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetvskipSopc(const MachineInst *opcode) {
+DecodeResult decodeSSetvskipSopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_setvskip", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetvskipSopc>(opcode);
 }
 } // namespace detail
@@ -508,7 +579,12 @@ SSetGprIdxOnSopc::SSetGprIdxOnSopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetGprIdxOnSopc(const MachineInst *opcode) {
+DecodeResult decodeSSetGprIdxOnSopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_set_gpr_idx_on", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetGprIdxOnSopc>(opcode);
 }
 } // namespace detail
@@ -538,7 +614,11 @@ SCmpEqU64Sopc::SCmpEqU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqU64Sopc>(opcode);
 }
 } // namespace detail
@@ -568,7 +648,11 @@ SCmpLgU64Sopc::SCmpLgU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgU64Sopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/sopk.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -24,7 +23,11 @@ SMovkI32Sopk::SMovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_movk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -46,7 +49,11 @@ SCmovkI32Sopk::SCmovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmovk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -66,7 +73,11 @@ SCmpkEqI32Sopk::SCmpkEqI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkEqI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkEqI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_eq_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkEqI32Sopk>(opcode);
 }
 } // namespace detail
@@ -86,7 +97,11 @@ SCmpkLgI32Sopk::SCmpkLgI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLgI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLgI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lg_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLgI32Sopk>(opcode);
 }
 } // namespace detail
@@ -106,7 +121,11 @@ SCmpkGtI32Sopk::SCmpkGtI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGtI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_gt_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGtI32Sopk>(opcode);
 }
 } // namespace detail
@@ -126,7 +145,11 @@ SCmpkGeI32Sopk::SCmpkGeI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGeI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_ge_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGeI32Sopk>(opcode);
 }
 } // namespace detail
@@ -146,7 +169,11 @@ SCmpkLtI32Sopk::SCmpkLtI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLtI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lt_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLtI32Sopk>(opcode);
 }
 } // namespace detail
@@ -166,7 +193,11 @@ SCmpkLeI32Sopk::SCmpkLeI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLeI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_le_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLeI32Sopk>(opcode);
 }
 } // namespace detail
@@ -186,7 +217,11 @@ SCmpkEqU32Sopk::SCmpkEqU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkEqU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkEqU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_eq_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkEqU32Sopk>(opcode);
 }
 } // namespace detail
@@ -206,7 +241,11 @@ SCmpkLgU32Sopk::SCmpkLgU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLgU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLgU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lg_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLgU32Sopk>(opcode);
 }
 } // namespace detail
@@ -226,7 +265,11 @@ SCmpkGtU32Sopk::SCmpkGtU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGtU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_gt_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGtU32Sopk>(opcode);
 }
 } // namespace detail
@@ -246,7 +289,11 @@ SCmpkGeU32Sopk::SCmpkGeU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGeU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_ge_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGeU32Sopk>(opcode);
 }
 } // namespace detail
@@ -266,7 +313,11 @@ SCmpkLtU32Sopk::SCmpkLtU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLtU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lt_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLtU32Sopk>(opcode);
 }
 } // namespace detail
@@ -286,7 +337,11 @@ SCmpkLeU32Sopk::SCmpkLeU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLeU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_le_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLeU32Sopk>(opcode);
 }
 } // namespace detail
@@ -307,7 +362,11 @@ SAddkI32Sopk::SAddkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSAddkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_addk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -325,7 +384,11 @@ SMulkI32Sopk::SMulkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_mulk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -342,7 +405,12 @@ SCbranchIForkSopk::SCbranchIForkSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchIForkSopk(const MachineInst *opcode) {
+DecodeResult decodeSCbranchIForkSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cbranch_i_fork", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchIForkSopk>(opcode);
 }
 } // namespace detail
@@ -359,7 +427,11 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_getreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -376,7 +448,11 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -395,7 +471,12 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_imm32_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregImm32B32Sopk>(opcode);
 }
 } // namespace detail
@@ -418,7 +499,11 @@ SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCallB64Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCallB64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_call_b64", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCallB64Sopk>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/sopp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/sopp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/sopp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -22,7 +21,11 @@ SNopSopp::SNopSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode) {
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_nop", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNopSopp>(opcode);
 }
 } // namespace detail
@@ -36,7 +39,11 @@ SEndpgmSopp::SEndpgmSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSopp>(opcode);
 }
 } // namespace detail
@@ -53,7 +60,11 @@ SBranchSopp::SBranchSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode) {
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_branch", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBranchSopp>(opcode);
 }
 } // namespace detail
@@ -71,7 +82,11 @@ SWakeupSopp::SWakeupSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode) {
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wakeup", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWakeupSopp>(opcode);
 }
 } // namespace detail
@@ -91,7 +106,12 @@ SCbranchScc0Sopp::SCbranchScc0Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc0", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc0Sopp>(opcode);
 }
 } // namespace detail
@@ -116,7 +136,12 @@ SCbranchScc1Sopp::SCbranchScc1Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc1", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc1Sopp>(opcode);
 }
 } // namespace detail
@@ -141,7 +166,12 @@ SCbranchVcczSopp::SCbranchVcczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVcczSopp>(opcode);
 }
 } // namespace detail
@@ -166,7 +196,12 @@ SCbranchVccnzSopp::SCbranchVccnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVccnzSopp>(opcode);
 }
 } // namespace detail
@@ -191,7 +226,12 @@ SCbranchExeczSopp::SCbranchExeczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExeczSopp>(opcode);
 }
 } // namespace detail
@@ -216,7 +256,12 @@ SCbranchExecnzSopp::SCbranchExecnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExecnzSopp>(opcode);
 }
 } // namespace detail
@@ -235,7 +280,11 @@ SBarrierSopp::SBarrierSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBarrierSopp(const MachineInst *opcode) {
+DecodeResult decodeSBarrierSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_barrier", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBarrierSopp>(opcode);
 }
 } // namespace detail
@@ -250,7 +299,11 @@ SSetkillSopp::SSetkillSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetkillSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetkillSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setkill", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetkillSopp>(opcode);
 }
 } // namespace detail
@@ -266,7 +319,11 @@ SWaitcntSopp::SWaitcntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_waitcnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntSopp>(opcode);
 }
 } // namespace detail
@@ -281,7 +338,11 @@ SSethaltSopp::SSethaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sethalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSethaltSopp>(opcode);
 }
 } // namespace detail
@@ -296,7 +357,11 @@ SSleepSopp::SSleepSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode) {
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sleep", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSleepSopp>(opcode);
 }
 } // namespace detail
@@ -311,7 +376,11 @@ SSetprioSopp::SSetprioSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setprio", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetprioSopp>(opcode);
 }
 } // namespace detail
@@ -329,7 +398,11 @@ SSendmsgSopp::SSendmsgSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsg", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsgSopp>(opcode);
 }
 } // namespace detail
@@ -347,7 +420,12 @@ SSendmsghaltSopp::SSendmsghaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsghalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsghaltSopp>(opcode);
 }
 } // namespace detail
@@ -362,7 +440,11 @@ STrapSopp::STrapSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode) {
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_trap", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STrapSopp>(opcode);
 }
 } // namespace detail
@@ -375,7 +457,11 @@ SIcacheInvSopp::SIcacheInvSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode) {
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_icache_inv", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIcacheInvSopp>(opcode);
 }
 } // namespace detail
@@ -390,7 +476,12 @@ SIncperflevelSopp::SIncperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_incperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIncperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -405,7 +496,12 @@ SDecperflevelSopp::SDecperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_decperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDecperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -421,7 +517,12 @@ STtracedataSopp::STtracedataSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode) {
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_ttracedata", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STtracedataSopp>(opcode);
 }
 } // namespace detail
@@ -436,7 +537,12 @@ SCbranchCdbgsysSopp::SCbranchCdbgsysSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysSopp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysSopp>(opcode);
 }
 } // namespace detail
@@ -451,7 +557,12 @@ SCbranchCdbguserSopp::SCbranchCdbguserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbguserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbguserSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbguser", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbguserSopp>(opcode);
 }
 } // namespace detail
@@ -466,7 +577,12 @@ SCbranchCdbgsysOrUserSopp::SCbranchCdbgsysOrUserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys_or_user", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysOrUserSopp>(opcode);
 }
 } // namespace detail
@@ -481,7 +597,12 @@ SCbranchCdbgsysAndUserSopp::SCbranchCdbgsysAndUserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys_and_user", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysAndUserSopp>(opcode);
 }
 } // namespace detail
@@ -495,7 +616,12 @@ SEndpgmSavedSopp::SEndpgmSavedSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm_saved", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSavedSopp>(opcode);
 }
 } // namespace detail
@@ -508,7 +634,12 @@ SSetGprIdxOffSopp::SSetGprIdxOffSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetGprIdxOffSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetGprIdxOffSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_set_gpr_idx_off", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetGprIdxOffSopp>(opcode);
 }
 } // namespace detail
@@ -528,7 +659,12 @@ SSetGprIdxModeSopp::SSetGprIdxModeSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetGprIdxModeSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetGprIdxModeSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_set_gpr_idx_mode", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetGprIdxModeSopp>(opcode);
 }
 } // namespace detail
@@ -542,7 +678,12 @@ SEndpgmOrderedPsDoneSopp::SEndpgmOrderedPsDoneSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm_ordered_ps_done", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmOrderedPsDoneSopp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/vop1.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/vop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -23,7 +22,14 @@ VNopVop1::VNopVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode) {
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_nop_sdwa"
+                                                                                 : "v_nop_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop1>(opcode);
 }
 } // namespace detail
@@ -72,7 +78,14 @@ VMovB32Vop1::VMovB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mov_b32_sdwa"
+                                                                                 : "v_mov_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop1>(opcode);
 }
 } // namespace detail
@@ -86,14 +99,20 @@ VReadfirstlaneB32Vop1::VReadfirstlaneB32Vop1(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_readfirstlane_b32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support SDWA";
   return std::make_unique<VReadfirstlaneB32Vop1>(opcode);
 }
 } // namespace detail
@@ -120,12 +139,17 @@ VCvtI32F64Vop1::VCvtI32F64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_I32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_i32_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_I32_F64 does not support SDWA";
   return std::make_unique<VCvtI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -151,12 +175,17 @@ VCvtF64I32Vop1::VCvtF64I32Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F64_I32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_f64_i32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_I32 does not support SDWA";
   return std::make_unique<VCvtF64I32Vop1>(opcode);
 }
 } // namespace detail
@@ -206,7 +235,15 @@ VCvtF32I32Vop1::VCvtF32I32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_i32_sdwa"
+          : "v_cvt_f32_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop1>(opcode);
 }
 } // namespace detail
@@ -256,7 +293,15 @@ VCvtF32U32Vop1::VCvtF32U32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_u32_sdwa"
+          : "v_cvt_f32_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop1>(opcode);
 }
 } // namespace detail
@@ -306,7 +351,15 @@ VCvtU32F32Vop1::VCvtU32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_u32_f32_sdwa"
+          : "v_cvt_u32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -356,7 +409,15 @@ VCvtI32F32Vop1::VCvtI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_i32_f32_sdwa"
+          : "v_cvt_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -406,7 +467,15 @@ VCvtF16F32Vop1::VCvtF16F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f16_f32_sdwa"
+          : "v_cvt_f16_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop1>(opcode);
 }
 } // namespace detail
@@ -463,7 +532,15 @@ VCvtF32F16Vop1::VCvtF32F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_f16_sdwa"
+          : "v_cvt_f32_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop1>(opcode);
 }
 } // namespace detail
@@ -513,7 +590,16 @@ VCvtRpiI32F32Vop1::VCvtRpiI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtRpiI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_rpi_i32_f32_sdwa"
+          : "v_cvt_rpi_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtRpiI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -563,7 +649,16 @@ VCvtFlrI32F32Vop1::VCvtFlrI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtFlrI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_flr_i32_f32_sdwa"
+          : "v_cvt_flr_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFlrI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -613,7 +708,16 @@ VCvtOffF32I4Vop1::VCvtOffF32I4Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_off_f32_i4_sdwa"
+          : "v_cvt_off_f32_i4_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop1>(opcode);
 }
 } // namespace detail
@@ -640,12 +744,17 @@ VCvtF32F64Vop1::VCvtF32F64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_f32_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F32_F64 does not support SDWA";
   return std::make_unique<VCvtF32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -663,14 +772,19 @@ VCvtF64F32Vop1::VCvtF64F32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CVT_F64_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F64_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_f64_f32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support SDWA";
   return std::make_unique<VCvtF64F32Vop1>(opcode);
 }
 } // namespace detail
@@ -720,7 +834,16 @@ VCvtF32Ubyte0Vop1::VCvtF32Ubyte0Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte0_sdwa"
+          : "v_cvt_f32_ubyte0_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop1>(opcode);
 }
 } // namespace detail
@@ -770,7 +893,16 @@ VCvtF32Ubyte1Vop1::VCvtF32Ubyte1Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte1_sdwa"
+          : "v_cvt_f32_ubyte1_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop1>(opcode);
 }
 } // namespace detail
@@ -820,7 +952,16 @@ VCvtF32Ubyte2Vop1::VCvtF32Ubyte2Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte2_sdwa"
+          : "v_cvt_f32_ubyte2_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop1>(opcode);
 }
 } // namespace detail
@@ -870,7 +1011,16 @@ VCvtF32Ubyte3Vop1::VCvtF32Ubyte3Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte3_sdwa"
+          : "v_cvt_f32_ubyte3_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop1>(opcode);
 }
 } // namespace detail
@@ -897,12 +1047,17 @@ VCvtU32F64Vop1::VCvtU32F64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_U32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_u32_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_U32_F64 does not support SDWA";
   return std::make_unique<VCvtU32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -928,12 +1083,17 @@ VCvtF64U32Vop1::VCvtF64U32Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F64_U32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_f64_u32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_U32 does not support SDWA";
   return std::make_unique<VCvtF64U32Vop1>(opcode);
 }
 } // namespace detail
@@ -960,12 +1120,17 @@ VTruncF64Vop1::VTruncF64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_TRUNC_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_trunc_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_TRUNC_F64 does not support SDWA";
   return std::make_unique<VTruncF64Vop1>(opcode);
 }
 } // namespace detail
@@ -992,12 +1157,17 @@ VCeilF64Vop1::VCeilF64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CEIL_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_ceil_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CEIL_F64 does not support SDWA";
   return std::make_unique<VCeilF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1016,14 +1186,19 @@ VRndneF64Vop1::VRndneF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_RNDNE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_RNDNE_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_rndne_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support SDWA";
   return std::make_unique<VRndneF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1050,12 +1225,17 @@ VFloorF64Vop1::VFloorF64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FLOOR_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_floor_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FLOOR_F64 does not support SDWA";
   return std::make_unique<VFloorF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1104,7 +1284,15 @@ VFractF32Vop1::VFractF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_fract_f32_sdwa"
+          : "v_fract_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1153,7 +1341,15 @@ VTruncF32Vop1::VTruncF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_trunc_f32_sdwa"
+          : "v_trunc_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1202,7 +1398,14 @@ VCeilF32Vop1::VCeilF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ceil_f32_sdwa"
+                                                                                 : "v_ceil_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1251,7 +1454,15 @@ VRndneF32Vop1::VRndneF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_rndne_f32_sdwa"
+          : "v_rndne_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1300,7 +1511,15 @@ VFloorF32Vop1::VFloorF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_floor_f32_sdwa"
+          : "v_floor_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1349,7 +1568,14 @@ VExpF32Vop1::VExpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_exp_f32_sdwa"
+                                                                                 : "v_exp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1398,7 +1624,14 @@ VLogF32Vop1::VLogF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_log_f32_sdwa"
+                                                                                 : "v_log_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1447,7 +1680,14 @@ VRcpF32Vop1::VRcpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rcp_f32_sdwa"
+                                                                                 : "v_rcp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1497,7 +1737,16 @@ VRcpIflagF32Vop1::VRcpIflagF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_rcp_iflag_f32_sdwa"
+          : "v_rcp_iflag_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1546,7 +1795,14 @@ VRsqF32Vop1::VRsqF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rsq_f32_sdwa"
+                                                                                 : "v_rsq_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1565,14 +1821,19 @@ VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_RCP_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_RCP_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_rcp_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support SDWA";
   return std::make_unique<VRcpF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1591,14 +1852,19 @@ VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_RSQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_RSQ_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_rsq_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support SDWA";
   return std::make_unique<VRsqF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1647,7 +1913,14 @@ VSqrtF32Vop1::VSqrtF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sqrt_f32_sdwa"
+                                                                                 : "v_sqrt_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1666,14 +1939,19 @@ VSqrtF64Vop1::VSqrtF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_SQRT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_SQRT_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_sqrt_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support SDWA";
   return std::make_unique<VSqrtF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1722,7 +2000,14 @@ VSinF32Vop1::VSinF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sin_f32_sdwa"
+                                                                                 : "v_sin_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1771,7 +2056,14 @@ VCosF32Vop1::VCosF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_cos_f32_sdwa"
+                                                                                 : "v_cos_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1820,7 +2112,14 @@ VNotB32Vop1::VNotB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_not_b32_sdwa"
+                                                                                 : "v_not_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop1>(opcode);
 }
 } // namespace detail
@@ -1869,7 +2168,15 @@ VBfrevB32Vop1::VBfrevB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_bfrev_b32_sdwa"
+          : "v_bfrev_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop1>(opcode);
 }
 } // namespace detail
@@ -1918,7 +2225,14 @@ VFfbhU32Vop1::VFfbhU32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhU32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFfbhU32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ffbh_u32_sdwa"
+                                                                                 : "v_ffbh_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhU32Vop1>(opcode);
 }
 } // namespace detail
@@ -1967,7 +2281,14 @@ VFfblB32Vop1::VFfblB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfblB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFfblB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ffbl_b32_sdwa"
+                                                                                 : "v_ffbl_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfblB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2016,7 +2337,14 @@ VFfbhI32Vop1::VFfbhI32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhI32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFfbhI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ffbh_i32_sdwa"
+                                                                                 : "v_ffbh_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhI32Vop1>(opcode);
 }
 } // namespace detail
@@ -2043,12 +2371,18 @@ VFrexpExpI32F64Vop1::VFrexpExpI32F64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FREXP_EXP_I32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_frexp_exp_i32_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_EXP_I32_F64 does not support SDWA";
   return std::make_unique<VFrexpExpI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -2075,12 +2409,18 @@ VFrexpMantF64Vop1::VFrexpMantF64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FREXP_MANT_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_frexp_mant_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_MANT_F64 does not support SDWA";
   return std::make_unique<VFrexpMantF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2107,12 +2447,17 @@ VFractF64Vop1::VFractF64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FRACT_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_fract_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FRACT_F64 does not support SDWA";
   return std::make_unique<VFractF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2162,7 +2507,16 @@ VFrexpExpI32F32Vop1::VFrexpExpI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_exp_i32_f32_sdwa"
+          : "v_frexp_exp_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -2212,7 +2566,16 @@ VFrexpMantF32Vop1::VFrexpMantF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_mant_f32_sdwa"
+          : "v_frexp_mant_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop1>(opcode);
 }
 } // namespace detail
@@ -2225,7 +2588,11 @@ VClrexcpVop1::VClrexcpVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClrexcpVop1(const MachineInst *opcode) {
+DecodeResult decodeVClrexcpVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop1::validate_encoding(
+      "v_clrexcp_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClrexcpVop1>(opcode);
 }
 } // namespace detail
@@ -2275,7 +2642,16 @@ VScreenPartition4seB32Vop1::VScreenPartition4seB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVScreenPartition4seB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVScreenPartition4seB32Vop1(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_screen_partition_4se_b32_sdwa"
+          : "v_screen_partition_4se_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VScreenPartition4seB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2326,7 +2702,15 @@ VCvtF16U16Vop1::VCvtF16U16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f16_u16_sdwa"
+          : "v_cvt_f16_u16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop1>(opcode);
 }
 } // namespace detail
@@ -2383,7 +2767,15 @@ VCvtF16I16Vop1::VCvtF16I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f16_i16_sdwa"
+          : "v_cvt_f16_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop1>(opcode);
 }
 } // namespace detail
@@ -2440,7 +2832,15 @@ VCvtU16F16Vop1::VCvtU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_u16_f16_sdwa"
+          : "v_cvt_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2497,7 +2897,15 @@ VCvtI16F16Vop1::VCvtI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_i16_f16_sdwa"
+          : "v_cvt_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2553,7 +2961,14 @@ VRcpF16Vop1::VRcpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rcp_f16_sdwa"
+                                                                                 : "v_rcp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2609,7 +3024,14 @@ VSqrtF16Vop1::VSqrtF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sqrt_f16_sdwa"
+                                                                                 : "v_sqrt_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2665,7 +3087,14 @@ VRsqF16Vop1::VRsqF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rsq_f16_sdwa"
+                                                                                 : "v_rsq_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2721,7 +3150,14 @@ VLogF16Vop1::VLogF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_log_f16_sdwa"
+                                                                                 : "v_log_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2777,7 +3213,14 @@ VExpF16Vop1::VExpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_exp_f16_sdwa"
+                                                                                 : "v_exp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2834,7 +3277,16 @@ VFrexpMantF16Vop1::VFrexpMantF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_mant_f16_sdwa"
+          : "v_frexp_mant_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2891,7 +3343,16 @@ VFrexpExpI16F16Vop1::VFrexpExpI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_exp_i16_f16_sdwa"
+          : "v_frexp_exp_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2947,7 +3408,15 @@ VFloorF16Vop1::VFloorF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_floor_f16_sdwa"
+          : "v_floor_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3003,7 +3472,14 @@ VCeilF16Vop1::VCeilF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ceil_f16_sdwa"
+                                                                                 : "v_ceil_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3059,7 +3535,15 @@ VTruncF16Vop1::VTruncF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_trunc_f16_sdwa"
+          : "v_trunc_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3115,7 +3599,15 @@ VRndneF16Vop1::VRndneF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_rndne_f16_sdwa"
+          : "v_rndne_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3171,7 +3663,15 @@ VFractF16Vop1::VFractF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_fract_f16_sdwa"
+          : "v_fract_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3227,7 +3727,14 @@ VSinF16Vop1::VSinF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sin_f16_sdwa"
+                                                                                 : "v_sin_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3283,7 +3790,14 @@ VCosF16Vop1::VCosF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_cos_f16_sdwa"
+                                                                                 : "v_cos_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3340,7 +3854,16 @@ VCvtNormI16F16Vop1::VCvtNormI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_norm_i16_f16_sdwa"
+          : "v_cvt_norm_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3397,7 +3920,16 @@ VCvtNormU16F16Vop1::VCvtNormU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_norm_u16_f16_sdwa"
+          : "v_cvt_norm_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3453,7 +3985,16 @@ VSatPkU8I16Vop1::VSatPkU8I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_sat_pk_u8_i16_sdwa"
+          : "v_sat_pk_u8_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop1>(opcode);
 }
 } // namespace detail
@@ -3475,14 +4016,19 @@ VSwapB32Vop1::VSwapB32Vop1(const MachineInst *inst)
   dst_operands_[1] = &src0;
   num_src_ = 2;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_SWAP_B32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_SWAP_B32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_swap_b32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B32 does not support SDWA";
   return std::make_unique<VSwapB32Vop1>(opcode);
 }
 } // namespace detail
@@ -3534,7 +4080,16 @@ VAccvgprMovB32Vop1::VAccvgprMovB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAccvgprMovB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVAccvgprMovB32Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_accvgpr_mov_b32_sdwa"
+          : "v_accvgpr_mov_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAccvgprMovB32Vop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/vop2.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/vop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -67,7 +66,16 @@ VCndmaskB32Vop2::VCndmaskB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cndmask_b32_sdwa"
+          : "v_cndmask_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop2>(opcode);
 }
 } // namespace detail
@@ -122,7 +130,14 @@ VAddF32Vop2::VAddF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_f32_sdwa"
+                                                                                 : "v_add_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop2>(opcode);
 }
 } // namespace detail
@@ -177,7 +192,14 @@ VSubF32Vop2::VSubF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_f32_sdwa"
+                                                                                 : "v_sub_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop2>(opcode);
 }
 } // namespace detail
@@ -233,7 +255,15 @@ VSubrevF32Vop2::VSubrevF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_f32_sdwa"
+          : "v_subrev_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop2>(opcode);
 }
 } // namespace detail
@@ -263,12 +293,17 @@ VFmacF64Vop2::VFmacF64Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAC_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_fmac_f64_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_F64 does not support SDWA";
   return std::make_unique<VFmacF64Vop2>(opcode);
 }
 } // namespace detail
@@ -323,7 +358,14 @@ VMulF32Vop2::VMulF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mul_f32_sdwa"
+                                                                                 : "v_mul_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop2>(opcode);
 }
 } // namespace detail
@@ -379,7 +421,15 @@ VMulI32I24Vop2::VMulI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_i32_i24_sdwa"
+          : "v_mul_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -435,7 +485,16 @@ VMulHiI32I24Vop2::VMulHiI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_hi_i32_i24_sdwa"
+          : "v_mul_hi_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -491,7 +550,15 @@ VMulU32U24Vop2::VMulU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_u32_u24_sdwa"
+          : "v_mul_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -547,7 +614,16 @@ VMulHiU32U24Vop2::VMulHiU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_hi_u32_u24_sdwa"
+          : "v_mul_hi_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -602,7 +678,14 @@ VMinF32Vop2::VMinF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_f32_sdwa"
+                                                                                 : "v_min_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF32Vop2>(opcode);
 }
 } // namespace detail
@@ -657,7 +740,14 @@ VMaxF32Vop2::VMaxF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_f32_sdwa"
+                                                                                 : "v_max_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF32Vop2>(opcode);
 }
 } // namespace detail
@@ -712,7 +802,14 @@ VMinI32Vop2::VMinI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_i32_sdwa"
+                                                                                 : "v_min_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop2>(opcode);
 }
 } // namespace detail
@@ -767,7 +864,14 @@ VMaxI32Vop2::VMaxI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_i32_sdwa"
+                                                                                 : "v_max_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop2>(opcode);
 }
 } // namespace detail
@@ -822,7 +926,14 @@ VMinU32Vop2::VMinU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_u32_sdwa"
+                                                                                 : "v_min_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop2>(opcode);
 }
 } // namespace detail
@@ -877,7 +988,14 @@ VMaxU32Vop2::VMaxU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_u32_sdwa"
+                                                                                 : "v_max_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop2>(opcode);
 }
 } // namespace detail
@@ -933,7 +1051,16 @@ VLshrrevB32Vop2::VLshrrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshrrev_b32_sdwa"
+          : "v_lshrrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -989,7 +1116,16 @@ VAshrrevI32Vop2::VAshrrevI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_ashrrev_i32_sdwa"
+          : "v_ashrrev_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop2>(opcode);
 }
 } // namespace detail
@@ -1045,7 +1181,16 @@ VLshlrevB32Vop2::VLshlrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshlrev_b32_sdwa"
+          : "v_lshlrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1100,7 +1245,14 @@ VAndB32Vop2::VAndB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_and_b32_sdwa"
+                                                                                 : "v_and_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1155,7 +1307,14 @@ VOrB32Vop2::VOrB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_or_b32_sdwa"
+                                                                                 : "v_or_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1210,7 +1369,14 @@ VXorB32Vop2::VXorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_xor_b32_sdwa"
+                                                                                 : "v_xor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1239,12 +1405,17 @@ VMacF32Vop2::VMacF32Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MAC_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMacF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_mac_f32_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MAC_F32 does not support SDWA";
   return std::make_unique<VMacF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1269,14 +1440,19 @@ VMadmkF32Vop2::VMadmkF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_MADMK_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MADMK_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadmkF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMadmkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_madmk_f32_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_MADMK_F32 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MADMK_F32 does not support SDWA";
   return std::make_unique<VMadmkF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1301,14 +1477,19 @@ VMadakF32Vop2::VMadakF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_MADAK_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MADAK_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadakF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMadakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_madak_f32_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_MADAK_F32 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MADAK_F32 does not support SDWA";
   return std::make_unique<VMadakF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1367,7 +1548,15 @@ VAddCoU32Vop2::VAddCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_add_co_u32_sdwa"
+          : "v_add_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1426,7 +1615,15 @@ VSubCoU32Vop2::VSubCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_sub_co_u32_sdwa"
+          : "v_sub_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1485,7 +1682,16 @@ VSubrevCoU32Vop2::VSubrevCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_co_u32_sdwa"
+          : "v_subrev_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1547,7 +1753,15 @@ VAddcCoU32Vop2::VAddcCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddcCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddcCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_addc_co_u32_sdwa"
+          : "v_addc_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddcCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1609,7 +1823,15 @@ VSubbCoU32Vop2::VSubbCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubbCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubbCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subb_co_u32_sdwa"
+          : "v_subb_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubbCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1671,7 +1893,16 @@ VSubbrevCoU32Vop2::VSubbrevCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubbrevCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubbrevCoU32Vop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subbrev_co_u32_sdwa"
+          : "v_subbrev_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubbrevCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1727,7 +1958,14 @@ VAddF16Vop2::VAddF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_f16_sdwa"
+                                                                                 : "v_add_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1789,7 +2027,14 @@ VSubF16Vop2::VSubF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_f16_sdwa"
+                                                                                 : "v_sub_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1852,7 +2097,15 @@ VSubrevF16Vop2::VSubrevF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_f16_sdwa"
+          : "v_subrev_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1914,7 +2167,14 @@ VMulF16Vop2::VMulF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mul_f16_sdwa"
+                                                                                 : "v_mul_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1950,12 +2210,17 @@ VMacF16Vop2::VMacF16Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MAC_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_mac_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MAC_F16 does not support SDWA";
   return std::make_unique<VMacF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1988,14 +2253,19 @@ VMadmkF16Vop2::VMadmkF16Vop2(const MachineInst *inst)
       Operand(16, OperandType::OPR_SIMM32,
               static_cast<int>(
                   (reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_MADMK_F16 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MADMK_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadmkF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMadmkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_madmk_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_MADMK_F16 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MADMK_F16 does not support SDWA";
   return std::make_unique<VMadmkF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2028,14 +2298,19 @@ VMadakF16Vop2::VMadakF16Vop2(const MachineInst *inst)
       Operand(16, OperandType::OPR_SIMM32,
               static_cast<int>(
                   (reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_MADAK_F16 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MADAK_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadakF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMadakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_madak_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_MADAK_F16 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MADAK_F16 does not support SDWA";
   return std::make_unique<VMadakF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2097,7 +2372,14 @@ VAddU16Vop2::VAddU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_u16_sdwa"
+                                                                                 : "v_add_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2159,7 +2441,14 @@ VSubU16Vop2::VSubU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_u16_sdwa"
+                                                                                 : "v_sub_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2222,7 +2511,15 @@ VSubrevU16Vop2::VSubrevU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_u16_sdwa"
+          : "v_subrev_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2285,7 +2582,15 @@ VMulLoU16Vop2::VMulLoU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_lo_u16_sdwa"
+          : "v_mul_lo_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2348,7 +2653,16 @@ VLshlrevB16Vop2::VLshlrevB16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB16Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshlrev_b16_sdwa"
+          : "v_lshlrev_b16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB16Vop2>(opcode);
 }
 } // namespace detail
@@ -2411,7 +2725,16 @@ VLshrrevB16Vop2::VLshrrevB16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB16Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshrrev_b16_sdwa"
+          : "v_lshrrev_b16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB16Vop2>(opcode);
 }
 } // namespace detail
@@ -2474,7 +2797,16 @@ VAshrrevI16Vop2::VAshrrevI16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI16Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_ashrrev_i16_sdwa"
+          : "v_ashrrev_i16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI16Vop2>(opcode);
 }
 } // namespace detail
@@ -2536,7 +2868,14 @@ VMaxF16Vop2::VMaxF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_f16_sdwa"
+                                                                                 : "v_max_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2598,7 +2937,14 @@ VMinF16Vop2::VMinF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_f16_sdwa"
+                                                                                 : "v_min_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2660,7 +3006,14 @@ VMaxU16Vop2::VMaxU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_u16_sdwa"
+                                                                                 : "v_max_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2722,7 +3075,14 @@ VMaxI16Vop2::VMaxI16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_i16_sdwa"
+                                                                                 : "v_max_i16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI16Vop2>(opcode);
 }
 } // namespace detail
@@ -2784,7 +3144,14 @@ VMinU16Vop2::VMinU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_u16_sdwa"
+                                                                                 : "v_min_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2846,7 +3213,14 @@ VMinI16Vop2::VMinI16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_i16_sdwa"
+                                                                                 : "v_min_i16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI16Vop2>(opcode);
 }
 } // namespace detail
@@ -2908,7 +3282,15 @@ VLdexpF16Vop2::VLdexpF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_ldexp_f16_sdwa"
+          : "v_ldexp_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2969,7 +3351,14 @@ VAddU32Vop2::VAddU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_u32_sdwa"
+                                                                                 : "v_add_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddU32Vop2>(opcode);
 }
 } // namespace detail
@@ -3024,7 +3413,14 @@ VSubU32Vop2::VSubU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_u32_sdwa"
+                                                                                 : "v_sub_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubU32Vop2>(opcode);
 }
 } // namespace detail
@@ -3080,7 +3476,15 @@ VSubrevU32Vop2::VSubrevU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_u32_sdwa"
+          : "v_subrev_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevU32Vop2>(opcode);
 }
 } // namespace detail
@@ -3109,12 +3513,18 @@ VDot2cF32F16Vop2::VDot2cF32F16Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT2C_F32_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot2cF32F16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_dot2c_f32_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT2C_F32_F16 does not support SDWA";
   return std::make_unique<VDot2cF32F16Vop2>(opcode);
 }
 } // namespace detail
@@ -3143,12 +3553,18 @@ VDot2cI32I16Vop2::VDot2cI32I16Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT2C_I32_I16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cI32I16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot2cI32I16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_dot2c_i32_i16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT2C_I32_I16 does not support SDWA";
   return std::make_unique<VDot2cI32I16Vop2>(opcode);
 }
 } // namespace detail
@@ -3177,12 +3593,18 @@ VDot4cI32I8Vop2::VDot4cI32I8Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT4C_I32_I8 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot4cI32I8Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_dot4c_i32_i8_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT4C_I32_I8 does not support SDWA";
   return std::make_unique<VDot4cI32I8Vop2>(opcode);
 }
 } // namespace detail
@@ -3211,12 +3633,18 @@ VDot8cI32I4Vop2::VDot8cI32I4Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT8C_I32_I4 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8cI32I4Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot8cI32I4Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_dot8c_i32_i4_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT8C_I32_I4 does not support SDWA";
   return std::make_unique<VDot8cI32I4Vop2>(opcode);
 }
 } // namespace detail
@@ -3245,12 +3673,17 @@ VFmacF32Vop2::VFmacF32Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAC_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_fmac_f32_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_F32 does not support SDWA";
   return std::make_unique<VFmacF32Vop2>(opcode);
 }
 } // namespace detail
@@ -3279,12 +3712,17 @@ VPkFmacF16Vop2::VPkFmacF16Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_PK_FMAC_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_pk_fmac_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_PK_FMAC_F16 does not support SDWA";
   return std::make_unique<VPkFmacF16Vop2>(opcode);
 }
 } // namespace detail
@@ -3339,7 +3777,14 @@ VXnorB32Vop2::VXnorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_xnor_b32_sdwa"
+                                                                                 : "v_xnor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/vop3.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/vop3.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -21,7 +20,11 @@ VNopVop3::VNopVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode) {
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_nop", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop3>(opcode);
 }
 } // namespace detail
@@ -38,7 +41,11 @@ VMovB32Vop3::VMovB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mov_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop3>(opcode);
 }
 } // namespace detail
@@ -55,7 +62,12 @@ VReadfirstlaneB32Vop3::VReadfirstlaneB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_readfirstlane_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VReadfirstlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -72,7 +84,11 @@ VCvtI32F64Vop3::VCvtI32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_i32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -89,7 +105,11 @@ VCvtF64I32Vop3::VCvtF64I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f64_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF64I32Vop3>(opcode);
 }
 } // namespace detail
@@ -106,7 +126,11 @@ VCvtF32I32Vop3::VCvtF32I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop3>(opcode);
 }
 } // namespace detail
@@ -123,7 +147,11 @@ VCvtF32U32Vop3::VCvtF32U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop3>(opcode);
 }
 } // namespace detail
@@ -140,7 +168,11 @@ VCvtU32F32Vop3::VCvtU32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_u32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -157,7 +189,11 @@ VCvtI32F32Vop3::VCvtI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -174,7 +210,11 @@ VCvtF16F32Vop3::VCvtF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -197,7 +237,11 @@ VCvtF32F16Vop3::VCvtF32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -214,7 +258,12 @@ VCvtRpiI32F32Vop3::VCvtRpiI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtRpiI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_rpi_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtRpiI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -231,7 +280,12 @@ VCvtFlrI32F32Vop3::VCvtFlrI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtFlrI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_flr_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFlrI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -248,7 +302,12 @@ VCvtOffF32I4Vop3::VCvtOffF32I4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_off_f32_i4", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop3>(opcode);
 }
 } // namespace detail
@@ -265,7 +324,11 @@ VCvtF32F64Vop3::VCvtF32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -282,7 +345,11 @@ VCvtF64F32Vop3::VCvtF64F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f64_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF64F32Vop3>(opcode);
 }
 } // namespace detail
@@ -299,7 +366,12 @@ VCvtF32Ubyte0Vop3::VCvtF32Ubyte0Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte0", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop3>(opcode);
 }
 } // namespace detail
@@ -316,7 +388,12 @@ VCvtF32Ubyte1Vop3::VCvtF32Ubyte1Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte1", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop3>(opcode);
 }
 } // namespace detail
@@ -333,7 +410,12 @@ VCvtF32Ubyte2Vop3::VCvtF32Ubyte2Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte2", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop3>(opcode);
 }
 } // namespace detail
@@ -350,7 +432,12 @@ VCvtF32Ubyte3Vop3::VCvtF32Ubyte3Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte3", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop3>(opcode);
 }
 } // namespace detail
@@ -367,7 +454,11 @@ VCvtU32F64Vop3::VCvtU32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_u32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -384,7 +475,11 @@ VCvtF64U32Vop3::VCvtF64U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f64_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF64U32Vop3>(opcode);
 }
 } // namespace detail
@@ -401,7 +496,11 @@ VTruncF64Vop3::VTruncF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trunc_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF64Vop3>(opcode);
 }
 } // namespace detail
@@ -418,7 +517,11 @@ VCeilF64Vop3::VCeilF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ceil_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF64Vop3>(opcode);
 }
 } // namespace detail
@@ -435,7 +538,11 @@ VRndneF64Vop3::VRndneF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rndne_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF64Vop3>(opcode);
 }
 } // namespace detail
@@ -452,7 +559,11 @@ VFloorF64Vop3::VFloorF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_floor_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF64Vop3>(opcode);
 }
 } // namespace detail
@@ -469,7 +580,11 @@ VFractF32Vop3::VFractF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fract_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop3>(opcode);
 }
 } // namespace detail
@@ -486,7 +601,11 @@ VTruncF32Vop3::VTruncF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trunc_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop3>(opcode);
 }
 } // namespace detail
@@ -503,7 +622,11 @@ VCeilF32Vop3::VCeilF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ceil_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop3>(opcode);
 }
 } // namespace detail
@@ -520,7 +643,11 @@ VRndneF32Vop3::VRndneF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rndne_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop3>(opcode);
 }
 } // namespace detail
@@ -537,7 +664,11 @@ VFloorF32Vop3::VFloorF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_floor_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop3>(opcode);
 }
 } // namespace detail
@@ -554,7 +685,11 @@ VExpF32Vop3::VExpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_exp_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -571,7 +706,11 @@ VLogF32Vop3::VLogF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_log_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop3>(opcode);
 }
 } // namespace detail
@@ -588,7 +727,11 @@ VRcpF32Vop3::VRcpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -605,7 +748,12 @@ VRcpIflagF32Vop3::VRcpIflagF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_iflag_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop3>(opcode);
 }
 } // namespace detail
@@ -622,7 +770,11 @@ VRsqF32Vop3::VRsqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rsq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -639,7 +791,11 @@ VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -656,7 +812,11 @@ VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rsq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -673,7 +833,11 @@ VSqrtF32Vop3::VSqrtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sqrt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -690,7 +854,11 @@ VSqrtF64Vop3::VSqrtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sqrt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -707,7 +875,11 @@ VSinF32Vop3::VSinF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sin_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop3>(opcode);
 }
 } // namespace detail
@@ -724,7 +896,11 @@ VCosF32Vop3::VCosF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cos_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop3>(opcode);
 }
 } // namespace detail
@@ -741,7 +917,11 @@ VNotB32Vop3::VNotB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_not_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop3>(opcode);
 }
 } // namespace detail
@@ -758,7 +938,11 @@ VBfrevB32Vop3::VBfrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfrev_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -775,7 +959,11 @@ VFfbhU32Vop3::VFfbhU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFfbhU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ffbh_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhU32Vop3>(opcode);
 }
 } // namespace detail
@@ -792,7 +980,11 @@ VFfblB32Vop3::VFfblB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfblB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFfblB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ffbl_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfblB32Vop3>(opcode);
 }
 } // namespace detail
@@ -809,7 +1001,11 @@ VFfbhI32Vop3::VFfbhI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFfbhI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ffbh_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhI32Vop3>(opcode);
 }
 } // namespace detail
@@ -826,7 +1022,12 @@ VFrexpExpI32F64Vop3::VFrexpExpI32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_exp_i32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -843,7 +1044,12 @@ VFrexpMantF64Vop3::VFrexpMantF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_mant_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF64Vop3>(opcode);
 }
 } // namespace detail
@@ -860,7 +1066,11 @@ VFractF64Vop3::VFractF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fract_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF64Vop3>(opcode);
 }
 } // namespace detail
@@ -877,7 +1087,12 @@ VFrexpExpI32F32Vop3::VFrexpExpI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_exp_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -894,7 +1109,12 @@ VFrexpMantF32Vop3::VFrexpMantF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_mant_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop3>(opcode);
 }
 } // namespace detail
@@ -907,7 +1127,11 @@ VClrexcpVop3::VClrexcpVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClrexcpVop3(const MachineInst *opcode) {
+DecodeResult decodeVClrexcpVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_clrexcp", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClrexcpVop3>(opcode);
 }
 } // namespace detail
@@ -924,7 +1148,12 @@ VScreenPartition4seB32Vop3::VScreenPartition4seB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVScreenPartition4seB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVScreenPartition4seB32Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_screen_partition_4se_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VScreenPartition4seB32Vop3>(opcode);
 }
 } // namespace detail
@@ -941,7 +1170,11 @@ VCvtF16U16Vop3::VCvtF16U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f16_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop3>(opcode);
 }
 } // namespace detail
@@ -964,7 +1197,11 @@ VCvtF16I16Vop3::VCvtF16I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f16_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop3>(opcode);
 }
 } // namespace detail
@@ -987,7 +1224,11 @@ VCvtU16F16Vop3::VCvtU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_u16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1010,7 +1251,11 @@ VCvtI16F16Vop3::VCvtI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1033,7 +1278,11 @@ VRcpF16Vop3::VRcpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1056,7 +1305,11 @@ VSqrtF16Vop3::VSqrtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sqrt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1079,7 +1332,11 @@ VRsqF16Vop3::VRsqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rsq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1102,7 +1359,11 @@ VLogF16Vop3::VLogF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_log_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1125,7 +1386,11 @@ VExpF16Vop3::VExpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_exp_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1148,7 +1413,12 @@ VFrexpMantF16Vop3::VFrexpMantF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_mant_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1171,7 +1441,12 @@ VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_exp_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1194,7 +1469,11 @@ VFloorF16Vop3::VFloorF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_floor_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1217,7 +1496,11 @@ VCeilF16Vop3::VCeilF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ceil_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1240,7 +1523,11 @@ VTruncF16Vop3::VTruncF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trunc_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1263,7 +1550,11 @@ VRndneF16Vop3::VRndneF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rndne_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1286,7 +1577,11 @@ VFractF16Vop3::VFractF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fract_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1309,7 +1604,11 @@ VSinF16Vop3::VSinF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sin_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1332,7 +1631,11 @@ VCosF16Vop3::VCosF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cos_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1355,7 +1658,12 @@ VCvtNormI16F16Vop3::VCvtNormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_norm_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1378,7 +1686,12 @@ VCvtNormU16F16Vop3::VCvtNormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_norm_u16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1401,7 +1714,12 @@ VSatPkU8I16Vop3::VSatPkU8I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sat_pk_u8_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop3>(opcode);
 }
 } // namespace detail
@@ -1426,7 +1744,11 @@ VSwapB32Vop3::VSwapB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwapB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSwapB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_swap_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSwapB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1449,7 +1771,12 @@ VAccvgprMovB32Vop3::VAccvgprMovB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAccvgprMovB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAccvgprMovB32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_accvgpr_mov_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAccvgprMovB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1470,7 +1797,12 @@ VCndmaskB32Vop3::VCndmaskB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cndmask_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1489,7 +1821,11 @@ VAddF32Vop3::VAddF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1508,7 +1844,11 @@ VSubF32Vop3::VSubF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1527,7 +1867,11 @@ VSubrevF32Vop3::VSubrevF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1547,7 +1891,11 @@ VFmacF64Vop3::VFmacF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fmac_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1566,7 +1914,11 @@ VMulF32Vop3::VMulF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1585,7 +1937,11 @@ VMulI32I24Vop3::VMulI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_i32_i24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -1604,7 +1960,12 @@ VMulHiI32I24Vop3::VMulHiI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_i32_i24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -1623,7 +1984,11 @@ VMulU32U24Vop3::VMulU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_u32_u24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -1642,7 +2007,12 @@ VMulHiU32U24Vop3::VMulHiU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_u32_u24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -1661,7 +2031,11 @@ VMinF32Vop3::VMinF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1680,7 +2054,11 @@ VMaxF32Vop3::VMaxF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1699,7 +2077,11 @@ VMinI32Vop3::VMinI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop3>(opcode);
 }
 } // namespace detail
@@ -1718,7 +2100,11 @@ VMaxI32Vop3::VMaxI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop3>(opcode);
 }
 } // namespace detail
@@ -1737,7 +2123,11 @@ VMinU32Vop3::VMinU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop3>(opcode);
 }
 } // namespace detail
@@ -1756,7 +2146,11 @@ VMaxU32Vop3::VMaxU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop3>(opcode);
 }
 } // namespace detail
@@ -1775,7 +2169,12 @@ VLshrrevB32Vop3::VLshrrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshrrev_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1794,7 +2193,12 @@ VAshrrevI32Vop3::VAshrrevI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashrrev_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop3>(opcode);
 }
 } // namespace detail
@@ -1813,7 +2217,12 @@ VLshlrevB32Vop3::VLshlrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshlrev_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1832,7 +2241,11 @@ VAndB32Vop3::VAndB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_and_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1851,7 +2264,11 @@ VOrB32Vop3::VOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_or_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1870,7 +2287,11 @@ VXorB32Vop3::VXorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xor_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1890,7 +2311,11 @@ VMacF32Vop3::VMacF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMacF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mac_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMacF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1909,7 +2334,11 @@ VAddF16Vop3::VAddF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1934,7 +2363,11 @@ VSubF16Vop3::VSubF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1959,7 +2392,11 @@ VSubrevF16Vop3::VSubrevF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1984,7 +2421,11 @@ VMulF16Vop3::VMulF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2010,7 +2451,11 @@ VMacF16Vop3::VMacF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMacF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mac_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMacF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2035,7 +2480,11 @@ VAddU16Vop3::VAddU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2060,7 +2509,11 @@ VSubU16Vop3::VSubU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2085,7 +2538,11 @@ VSubrevU16Vop3::VSubrevU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2110,7 +2567,11 @@ VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_lo_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2135,7 +2596,12 @@ VLshlrevB16Vop3::VLshlrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshlrev_b16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -2160,7 +2626,12 @@ VLshrrevB16Vop3::VLshrrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshrrev_b16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -2185,7 +2656,12 @@ VAshrrevI16Vop3::VAshrrevI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashrrev_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI16Vop3>(opcode);
 }
 } // namespace detail
@@ -2210,7 +2686,11 @@ VMaxF16Vop3::VMaxF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2235,7 +2715,11 @@ VMinF16Vop3::VMinF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2260,7 +2744,11 @@ VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2285,7 +2773,11 @@ VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI16Vop3>(opcode);
 }
 } // namespace detail
@@ -2310,7 +2802,11 @@ VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2335,7 +2831,11 @@ VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI16Vop3>(opcode);
 }
 } // namespace detail
@@ -2360,7 +2860,11 @@ VLdexpF16Vop3::VLdexpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ldexp_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2385,7 +2889,11 @@ VAddU32Vop3::VAddU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2404,7 +2912,11 @@ VSubU32Vop3::VSubU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2423,7 +2935,11 @@ VSubrevU32Vop3::VSubrevU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2443,7 +2959,12 @@ VDot2cF32F16Vop3::VDot2cF32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot2cF32F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot2c_f32_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2cF32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -2463,7 +2984,12 @@ VDot2cI32I16Vop3::VDot2cI32I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cI32I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot2cI32I16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot2c_i32_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2cI32I16Vop3>(opcode);
 }
 } // namespace detail
@@ -2483,7 +3009,12 @@ VDot4cI32I8Vop3::VDot4cI32I8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot4cI32I8Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot4c_i32_i8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot4cI32I8Vop3>(opcode);
 }
 } // namespace detail
@@ -2503,7 +3034,12 @@ VDot8cI32I4Vop3::VDot8cI32I4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8cI32I4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot8cI32I4Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot8c_i32_i4", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot8cI32I4Vop3>(opcode);
 }
 } // namespace detail
@@ -2523,7 +3059,11 @@ VFmacF32Vop3::VFmacF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fmac_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2543,7 +3083,11 @@ VPkFmacF16Vop3::VPkFmacF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPkFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_pk_fmac_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkFmacF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2562,7 +3106,11 @@ VXnorB32Vop3::VXnorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xnor_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2583,7 +3131,12 @@ VMadLegacyF32Vop3::VMadLegacyF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadLegacyF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_legacy_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadLegacyF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2604,7 +3157,11 @@ VMadF32Vop3::VMadF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2625,7 +3182,11 @@ VMadI32I24Vop3::VMadI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_i32_i24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -2646,7 +3207,11 @@ VMadU32U24Vop3::VMadU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_u32_u24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -2667,7 +3232,11 @@ VCubeidF32Vop3::VCubeidF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubeid_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubeidF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2688,7 +3257,11 @@ VCubescF32Vop3::VCubescF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubesc_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubescF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2709,7 +3282,11 @@ VCubetcF32Vop3::VCubetcF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubetc_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubetcF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2730,7 +3307,11 @@ VCubemaF32Vop3::VCubemaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubema_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubemaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2751,7 +3332,11 @@ VBfeU32Vop3::VBfeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfe_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2772,7 +3357,11 @@ VBfeI32Vop3::VBfeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfe_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -2793,7 +3382,11 @@ VBfiB32Vop3::VBfiB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfi_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfiB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2814,7 +3407,11 @@ VFmaF32Vop3::VFmaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2835,7 +3432,11 @@ VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF64Vop3>(opcode);
 }
 } // namespace detail
@@ -2856,7 +3457,11 @@ VLerpU8Vop3::VLerpU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lerp_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLerpU8Vop3>(opcode);
 }
 } // namespace detail
@@ -2877,7 +3482,12 @@ VAlignbitB32Vop3::VAlignbitB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_alignbit_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbitB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2898,7 +3508,12 @@ VAlignbyteB32Vop3::VAlignbyteB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_alignbyte_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbyteB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2919,7 +3534,11 @@ VMin3F32Vop3::VMin3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -2940,7 +3559,11 @@ VMin3I32Vop3::VMin3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -2961,7 +3584,11 @@ VMin3U32Vop3::VMin3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -2982,7 +3609,11 @@ VMax3F32Vop3::VMax3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3003,7 +3634,11 @@ VMax3I32Vop3::VMax3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -3024,7 +3659,11 @@ VMax3U32Vop3::VMax3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3045,7 +3684,11 @@ VMed3F32Vop3::VMed3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3066,7 +3709,11 @@ VMed3I32Vop3::VMed3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -3087,7 +3734,11 @@ VMed3U32Vop3::VMed3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3108,7 +3759,11 @@ VSadU8Vop3::VSadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3129,7 +3784,11 @@ VSadHiU8Vop3::VSadHiU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_hi_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadHiU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3150,7 +3809,11 @@ VSadU16Vop3::VSadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -3171,7 +3834,11 @@ VSadU32Vop3::VSadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3192,7 +3859,12 @@ VCvtPkU8F32Vop3::VCvtPkU8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_u8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3213,7 +3885,12 @@ VDivFixupF32Vop3::VDivFixupF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3234,7 +3911,12 @@ VDivFixupF64Vop3::VDivFixupF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF64Vop3>(opcode);
 }
 } // namespace detail
@@ -3258,7 +3940,12 @@ VDivFmasF32Vop3::VDivFmasF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fmas_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFmasF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3282,7 +3969,12 @@ VDivFmasF64Vop3::VDivFmasF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fmas_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFmasF64Vop3>(opcode);
 }
 } // namespace detail
@@ -3303,7 +3995,11 @@ VMsadU8Vop3::VMsadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_msad_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMsadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3324,7 +4020,12 @@ VQsadPkU16U8Vop3::VQsadPkU16U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_qsad_pk_u16_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VQsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -3345,7 +4046,12 @@ VMqsadPkU16U8Vop3::VMqsadPkU16U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mqsad_pk_u16_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMqsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -3366,7 +4072,12 @@ VMqsadU32U8Vop3::VMqsadU32U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mqsad_u32_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMqsadU32U8Vop3>(opcode);
 }
 } // namespace detail
@@ -3387,7 +4098,12 @@ VMadLegacyF16Vop3::VMadLegacyF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadLegacyF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadLegacyF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_legacy_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadLegacyF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3414,7 +4130,12 @@ VMadLegacyU16Vop3::VMadLegacyU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadLegacyU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadLegacyU16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_legacy_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadLegacyU16Vop3>(opcode);
 }
 } // namespace detail
@@ -3441,7 +4162,12 @@ VMadLegacyI16Vop3::VMadLegacyI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadLegacyI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadLegacyI16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_legacy_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadLegacyI16Vop3>(opcode);
 }
 } // namespace detail
@@ -3468,7 +4194,11 @@ VPermB32Vop3::VPermB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_perm_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPermB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3489,7 +4219,12 @@ VFmaLegacyF16Vop3::VFmaLegacyF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaLegacyF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaLegacyF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_legacy_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaLegacyF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3516,7 +4251,12 @@ VDivFixupLegacyF16Vop3::VDivFixupLegacyF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupLegacyF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupLegacyF16Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_legacy_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupLegacyF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3542,7 +4282,12 @@ VCvtPkaccumU8F32Vop3::VCvtPkaccumU8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkaccumU8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkaccumU8F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pkaccum_u8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkaccumU8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3563,7 +4308,11 @@ VMadU32U16Vop3::VMadU32U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_u32_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3584,7 +4333,11 @@ VMadI32I16Vop3::VMadI32I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_i32_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3605,7 +4358,11 @@ VXadU32Vop3::VXadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xad_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3626,7 +4383,11 @@ VMin3F16Vop3::VMin3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3653,7 +4414,11 @@ VMin3I16Vop3::VMin3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3680,7 +4445,11 @@ VMin3U16Vop3::VMin3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3707,7 +4476,11 @@ VMax3F16Vop3::VMax3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3734,7 +4507,11 @@ VMax3I16Vop3::VMax3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3761,7 +4538,11 @@ VMax3U16Vop3::VMax3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3788,7 +4569,11 @@ VMed3F16Vop3::VMed3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3815,7 +4600,11 @@ VMed3I16Vop3::VMed3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3842,7 +4631,11 @@ VMed3U16Vop3::VMed3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3869,7 +4662,12 @@ VLshlAddU32Vop3::VLshlAddU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshl_add_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlAddU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3890,7 +4688,12 @@ VAddLshlU32Vop3::VAddLshlU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_lshl_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddLshlU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3911,7 +4714,11 @@ VAdd3U32Vop3::VAdd3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAdd3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3932,7 +4739,11 @@ VLshlOrB32Vop3::VLshlOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshl_or_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3953,7 +4764,11 @@ VAndOrB32Vop3::VAndOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_and_or_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3974,7 +4789,11 @@ VOr3B32Vop3::VOr3B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_or3_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOr3B32Vop3>(opcode);
 }
 } // namespace detail
@@ -3995,7 +4814,11 @@ VMadF16Vop3::VMadF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4022,7 +4845,11 @@ VMadU16Vop3::VMadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -4049,7 +4876,11 @@ VMadI16Vop3::VMadI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI16Vop3>(opcode);
 }
 } // namespace detail
@@ -4076,7 +4907,11 @@ VFmaF16Vop3::VFmaF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4103,7 +4938,12 @@ VDivFixupF16Vop3::VDivFixupF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4128,7 +4968,11 @@ VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4147,7 +4991,11 @@ VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4166,7 +5014,11 @@ VMinF64Vop3::VMinF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4185,7 +5037,11 @@ VMaxF64Vop3::VMaxF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4204,7 +5060,11 @@ VLdexpF64Vop3::VLdexpF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ldexp_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4223,7 +5083,11 @@ VMulLoU32Vop3::VMulLoU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_lo_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4242,7 +5106,11 @@ VMulHiU32Vop3::VMulHiU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4261,7 +5129,11 @@ VMulHiI32Vop3::VMulHiI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4280,7 +5152,11 @@ VLdexpF32Vop3::VLdexpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ldexp_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4299,7 +5175,12 @@ VReadlaneB32Vop3::VReadlaneB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_readlane_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VReadlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4319,7 +5200,12 @@ VWritelaneB32Vop3::VWritelaneB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_writelane_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VWritelaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4338,7 +5224,12 @@ VBcntU32B32Vop3::VBcntU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bcnt_u32_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBcntU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -4357,7 +5248,12 @@ VMbcntLoU32B32Vop3::VMbcntLoU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mbcnt_lo_u32_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntLoU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -4376,7 +5272,12 @@ VMbcntHiU32B32Vop3::VMbcntHiU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mbcnt_hi_u32_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntHiU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -4395,7 +5296,12 @@ VLshlrevB64Vop3::VLshlrevB64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshlrev_b64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -4414,7 +5320,12 @@ VLshrrevB64Vop3::VLshrrevB64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshrrev_b64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -4433,7 +5344,12 @@ VAshrrevI64Vop3::VAshrrevI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashrrev_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI64Vop3>(opcode);
 }
 } // namespace detail
@@ -4452,7 +5368,12 @@ VTrigPreopF64Vop3::VTrigPreopF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trig_preop_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTrigPreopF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4471,7 +5392,11 @@ VBfmB32Vop3::VBfmB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfm_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfmB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4490,7 +5415,12 @@ VCvtPknormI16F32Vop3::VCvtPknormI16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormI16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_i16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormI16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4509,7 +5439,12 @@ VCvtPknormU16F32Vop3::VCvtPknormU16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormU16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_u16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormU16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4528,7 +5463,12 @@ VCvtPkrtzF16F32Vop3::VCvtPkrtzF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pkrtz_f16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkrtzF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4547,7 +5487,12 @@ VCvtPkU16U32Vop3::VCvtPkU16U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_u16_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU16U32Vop3>(opcode);
 }
 } // namespace detail
@@ -4566,7 +5511,12 @@ VCvtPkI16I32Vop3::VCvtPkI16I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_i16_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkI16I32Vop3>(opcode);
 }
 } // namespace detail
@@ -4585,7 +5535,12 @@ VCvtPknormI16F16Vop3::VCvtPknormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4604,7 +5559,12 @@ VCvtPknormU16F16Vop3::VCvtPknormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_u16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4623,7 +5583,11 @@ VAddI32Vop3::VAddI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4642,7 +5606,11 @@ VSubI32Vop3::VSubI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4661,7 +5629,11 @@ VAddI16Vop3::VAddI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddI16Vop3>(opcode);
 }
 } // namespace detail
@@ -4686,7 +5658,11 @@ VSubI16Vop3::VSubI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubI16Vop3>(opcode);
 }
 } // namespace detail
@@ -4711,7 +5687,12 @@ VPackB32F16Vop3::VPackB32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_pack_b32_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPackB32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4730,7 +5711,12 @@ VMulLegacyF32Vop3::VMulLegacyF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLegacyF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_legacy_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLegacyF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4749,7 +5735,12 @@ VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_class_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4772,7 +5763,12 @@ VCmpxClassF32Vop3::VCmpxClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_class_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4791,7 +5787,12 @@ VCmpClassF64Vop3::VCmpClassF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_class_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4814,7 +5815,12 @@ VCmpxClassF64Vop3::VCmpxClassF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_class_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4833,7 +5839,12 @@ VCmpClassF16Vop3::VCmpClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_class_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4856,7 +5867,12 @@ VCmpxClassF16Vop3::VCmpxClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_class_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4875,7 +5891,11 @@ VCmpFF16Vop3::VCmpFF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4894,7 +5914,11 @@ VCmpLtF16Vop3::VCmpLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4913,7 +5937,11 @@ VCmpEqF16Vop3::VCmpEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4932,7 +5960,11 @@ VCmpLeF16Vop3::VCmpLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4951,7 +5983,11 @@ VCmpGtF16Vop3::VCmpGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4970,7 +6006,11 @@ VCmpLgF16Vop3::VCmpLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4989,7 +6029,11 @@ VCmpGeF16Vop3::VCmpGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5008,7 +6052,11 @@ VCmpOF16Vop3::VCmpOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_o_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5027,7 +6075,11 @@ VCmpUF16Vop3::VCmpUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_u_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5046,7 +6098,11 @@ VCmpNgeF16Vop3::VCmpNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5065,7 +6121,11 @@ VCmpNlgF16Vop3::VCmpNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5084,7 +6144,11 @@ VCmpNgtF16Vop3::VCmpNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ngt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5103,7 +6167,11 @@ VCmpNleF16Vop3::VCmpNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nle_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5122,7 +6190,11 @@ VCmpNeqF16Vop3::VCmpNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_neq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5141,7 +6213,11 @@ VCmpNltF16Vop3::VCmpNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5160,7 +6236,11 @@ VCmpTruF16Vop3::VCmpTruF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_tru_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTruF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5183,7 +6263,11 @@ VCmpxFF16Vop3::VCmpxFF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5206,7 +6290,11 @@ VCmpxLtF16Vop3::VCmpxLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5229,7 +6317,11 @@ VCmpxEqF16Vop3::VCmpxEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5252,7 +6344,11 @@ VCmpxLeF16Vop3::VCmpxLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5275,7 +6371,11 @@ VCmpxGtF16Vop3::VCmpxGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5298,7 +6398,11 @@ VCmpxLgF16Vop3::VCmpxLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5321,7 +6425,11 @@ VCmpxGeF16Vop3::VCmpxGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5344,7 +6452,11 @@ VCmpxOF16Vop3::VCmpxOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_o_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5367,7 +6479,11 @@ VCmpxUF16Vop3::VCmpxUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_u_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5390,7 +6506,12 @@ VCmpxNgeF16Vop3::VCmpxNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5413,7 +6534,12 @@ VCmpxNlgF16Vop3::VCmpxNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5436,7 +6562,12 @@ VCmpxNgtF16Vop3::VCmpxNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ngt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5459,7 +6590,12 @@ VCmpxNleF16Vop3::VCmpxNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nle_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5482,7 +6618,12 @@ VCmpxNeqF16Vop3::VCmpxNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_neq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5505,7 +6646,12 @@ VCmpxNltF16Vop3::VCmpxNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5528,7 +6674,12 @@ VCmpxTruF16Vop3::VCmpxTruF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_tru_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTruF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5547,7 +6698,11 @@ VCmpFF32Vop3::VCmpFF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5566,7 +6721,11 @@ VCmpLtF32Vop3::VCmpLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5585,7 +6744,11 @@ VCmpEqF32Vop3::VCmpEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5604,7 +6767,11 @@ VCmpLeF32Vop3::VCmpLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5623,7 +6790,11 @@ VCmpGtF32Vop3::VCmpGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5642,7 +6813,11 @@ VCmpLgF32Vop3::VCmpLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5661,7 +6836,11 @@ VCmpGeF32Vop3::VCmpGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5680,7 +6859,11 @@ VCmpOF32Vop3::VCmpOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_o_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5699,7 +6882,11 @@ VCmpUF32Vop3::VCmpUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_u_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5718,7 +6905,11 @@ VCmpNgeF32Vop3::VCmpNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5737,7 +6928,11 @@ VCmpNlgF32Vop3::VCmpNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5756,7 +6951,11 @@ VCmpNgtF32Vop3::VCmpNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ngt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5775,7 +6974,11 @@ VCmpNleF32Vop3::VCmpNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nle_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5794,7 +6997,11 @@ VCmpNeqF32Vop3::VCmpNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_neq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5813,7 +7020,11 @@ VCmpNltF32Vop3::VCmpNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5832,7 +7043,11 @@ VCmpTruF32Vop3::VCmpTruF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_tru_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTruF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5855,7 +7070,11 @@ VCmpxFF32Vop3::VCmpxFF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5878,7 +7097,11 @@ VCmpxLtF32Vop3::VCmpxLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5901,7 +7124,11 @@ VCmpxEqF32Vop3::VCmpxEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5924,7 +7151,11 @@ VCmpxLeF32Vop3::VCmpxLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5947,7 +7178,11 @@ VCmpxGtF32Vop3::VCmpxGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5970,7 +7205,11 @@ VCmpxLgF32Vop3::VCmpxLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5993,7 +7232,11 @@ VCmpxGeF32Vop3::VCmpxGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6016,7 +7259,11 @@ VCmpxOF32Vop3::VCmpxOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_o_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6039,7 +7286,11 @@ VCmpxUF32Vop3::VCmpxUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_u_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6062,7 +7313,12 @@ VCmpxNgeF32Vop3::VCmpxNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6085,7 +7341,12 @@ VCmpxNlgF32Vop3::VCmpxNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6108,7 +7369,12 @@ VCmpxNgtF32Vop3::VCmpxNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ngt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6131,7 +7397,12 @@ VCmpxNleF32Vop3::VCmpxNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nle_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6154,7 +7425,12 @@ VCmpxNeqF32Vop3::VCmpxNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_neq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6177,7 +7453,12 @@ VCmpxNltF32Vop3::VCmpxNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6200,7 +7481,12 @@ VCmpxTruF32Vop3::VCmpxTruF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_tru_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTruF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6219,7 +7505,11 @@ VCmpFF64Vop3::VCmpFF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6238,7 +7528,11 @@ VCmpLtF64Vop3::VCmpLtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6257,7 +7551,11 @@ VCmpEqF64Vop3::VCmpEqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6276,7 +7574,11 @@ VCmpLeF64Vop3::VCmpLeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6295,7 +7597,11 @@ VCmpGtF64Vop3::VCmpGtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6314,7 +7620,11 @@ VCmpLgF64Vop3::VCmpLgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6333,7 +7643,11 @@ VCmpGeF64Vop3::VCmpGeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6352,7 +7666,11 @@ VCmpOF64Vop3::VCmpOF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_o_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6371,7 +7689,11 @@ VCmpUF64Vop3::VCmpUF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_u_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6390,7 +7712,11 @@ VCmpNgeF64Vop3::VCmpNgeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6409,7 +7735,11 @@ VCmpNlgF64Vop3::VCmpNlgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6428,7 +7758,11 @@ VCmpNgtF64Vop3::VCmpNgtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ngt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6447,7 +7781,11 @@ VCmpNleF64Vop3::VCmpNleF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nle_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6466,7 +7804,11 @@ VCmpNeqF64Vop3::VCmpNeqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_neq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6485,7 +7827,11 @@ VCmpNltF64Vop3::VCmpNltF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6504,7 +7850,11 @@ VCmpTruF64Vop3::VCmpTruF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_tru_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTruF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6527,7 +7877,11 @@ VCmpxFF64Vop3::VCmpxFF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6550,7 +7904,11 @@ VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6573,7 +7931,11 @@ VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6596,7 +7958,11 @@ VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6619,7 +7985,11 @@ VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6642,7 +8012,11 @@ VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6665,7 +8039,11 @@ VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6688,7 +8066,11 @@ VCmpxOF64Vop3::VCmpxOF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_o_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6711,7 +8093,11 @@ VCmpxUF64Vop3::VCmpxUF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_u_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6734,7 +8120,12 @@ VCmpxNgeF64Vop3::VCmpxNgeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6757,7 +8148,12 @@ VCmpxNlgF64Vop3::VCmpxNlgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6780,7 +8176,12 @@ VCmpxNgtF64Vop3::VCmpxNgtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ngt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6803,7 +8204,12 @@ VCmpxNleF64Vop3::VCmpxNleF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nle_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6826,7 +8232,12 @@ VCmpxNeqF64Vop3::VCmpxNeqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_neq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6849,7 +8260,12 @@ VCmpxNltF64Vop3::VCmpxNltF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6872,7 +8288,12 @@ VCmpxTruF64Vop3::VCmpxTruF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_tru_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTruF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6891,7 +8312,11 @@ VCmpFI16Vop3::VCmpFI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI16Vop3>(opcode);
 }
 } // namespace detail
@@ -6910,7 +8335,11 @@ VCmpLtI16Vop3::VCmpLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -6929,7 +8358,11 @@ VCmpEqI16Vop3::VCmpEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -6948,7 +8381,11 @@ VCmpLeI16Vop3::VCmpLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -6967,7 +8404,11 @@ VCmpGtI16Vop3::VCmpGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -6986,7 +8427,11 @@ VCmpNeI16Vop3::VCmpNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7005,7 +8450,11 @@ VCmpGeI16Vop3::VCmpGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7024,7 +8473,11 @@ VCmpTI16Vop3::VCmpTI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7043,7 +8496,11 @@ VCmpFU16Vop3::VCmpFU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7062,7 +8519,11 @@ VCmpLtU16Vop3::VCmpLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7081,7 +8542,11 @@ VCmpEqU16Vop3::VCmpEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7100,7 +8565,11 @@ VCmpLeU16Vop3::VCmpLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7119,7 +8588,11 @@ VCmpGtU16Vop3::VCmpGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7138,7 +8611,11 @@ VCmpNeU16Vop3::VCmpNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7157,7 +8634,11 @@ VCmpGeU16Vop3::VCmpGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7176,7 +8657,11 @@ VCmpTU16Vop3::VCmpTU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7199,7 +8684,11 @@ VCmpxFI16Vop3::VCmpxFI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7222,7 +8711,11 @@ VCmpxLtI16Vop3::VCmpxLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7245,7 +8738,11 @@ VCmpxEqI16Vop3::VCmpxEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7268,7 +8765,11 @@ VCmpxLeI16Vop3::VCmpxLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7291,7 +8792,11 @@ VCmpxGtI16Vop3::VCmpxGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7314,7 +8819,11 @@ VCmpxNeI16Vop3::VCmpxNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7337,7 +8846,11 @@ VCmpxGeI16Vop3::VCmpxGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7360,7 +8873,11 @@ VCmpxTI16Vop3::VCmpxTI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7383,7 +8900,11 @@ VCmpxFU16Vop3::VCmpxFU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7406,7 +8927,11 @@ VCmpxLtU16Vop3::VCmpxLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7429,7 +8954,11 @@ VCmpxEqU16Vop3::VCmpxEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7452,7 +8981,11 @@ VCmpxLeU16Vop3::VCmpxLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7475,7 +9008,11 @@ VCmpxGtU16Vop3::VCmpxGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7498,7 +9035,11 @@ VCmpxNeU16Vop3::VCmpxNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7521,7 +9062,11 @@ VCmpxGeU16Vop3::VCmpxGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7544,7 +9089,11 @@ VCmpxTU16Vop3::VCmpxTU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7563,7 +9112,11 @@ VCmpFI32Vop3::VCmpFI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7582,7 +9135,11 @@ VCmpLtI32Vop3::VCmpLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7601,7 +9158,11 @@ VCmpEqI32Vop3::VCmpEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7620,7 +9181,11 @@ VCmpLeI32Vop3::VCmpLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7639,7 +9204,11 @@ VCmpGtI32Vop3::VCmpGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7658,7 +9227,11 @@ VCmpNeI32Vop3::VCmpNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7677,7 +9250,11 @@ VCmpGeI32Vop3::VCmpGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7696,7 +9273,11 @@ VCmpTI32Vop3::VCmpTI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7715,7 +9296,11 @@ VCmpFU32Vop3::VCmpFU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7734,7 +9319,11 @@ VCmpLtU32Vop3::VCmpLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7753,7 +9342,11 @@ VCmpEqU32Vop3::VCmpEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7772,7 +9365,11 @@ VCmpLeU32Vop3::VCmpLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7791,7 +9388,11 @@ VCmpGtU32Vop3::VCmpGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7810,7 +9411,11 @@ VCmpNeU32Vop3::VCmpNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7829,7 +9434,11 @@ VCmpGeU32Vop3::VCmpGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7848,7 +9457,11 @@ VCmpTU32Vop3::VCmpTU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7871,7 +9484,11 @@ VCmpxFI32Vop3::VCmpxFI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7894,7 +9511,11 @@ VCmpxLtI32Vop3::VCmpxLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7917,7 +9538,11 @@ VCmpxEqI32Vop3::VCmpxEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7940,7 +9565,11 @@ VCmpxLeI32Vop3::VCmpxLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7963,7 +9592,11 @@ VCmpxGtI32Vop3::VCmpxGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7986,7 +9619,11 @@ VCmpxNeI32Vop3::VCmpxNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8009,7 +9646,11 @@ VCmpxGeI32Vop3::VCmpxGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8032,7 +9673,11 @@ VCmpxTI32Vop3::VCmpxTI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8055,7 +9700,11 @@ VCmpxFU32Vop3::VCmpxFU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8078,7 +9727,11 @@ VCmpxLtU32Vop3::VCmpxLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8101,7 +9754,11 @@ VCmpxEqU32Vop3::VCmpxEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8124,7 +9781,11 @@ VCmpxLeU32Vop3::VCmpxLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8147,7 +9808,11 @@ VCmpxGtU32Vop3::VCmpxGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8170,7 +9835,11 @@ VCmpxNeU32Vop3::VCmpxNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8193,7 +9862,11 @@ VCmpxGeU32Vop3::VCmpxGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8216,7 +9889,11 @@ VCmpxTU32Vop3::VCmpxTU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8235,7 +9912,11 @@ VCmpFI64Vop3::VCmpFI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8254,7 +9935,11 @@ VCmpLtI64Vop3::VCmpLtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8273,7 +9958,11 @@ VCmpEqI64Vop3::VCmpEqI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8292,7 +9981,11 @@ VCmpLeI64Vop3::VCmpLeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8311,7 +10004,11 @@ VCmpGtI64Vop3::VCmpGtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8330,7 +10027,11 @@ VCmpNeI64Vop3::VCmpNeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8349,7 +10050,11 @@ VCmpGeI64Vop3::VCmpGeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8368,7 +10073,11 @@ VCmpTI64Vop3::VCmpTI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8387,7 +10096,11 @@ VCmpFU64Vop3::VCmpFU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8406,7 +10119,11 @@ VCmpLtU64Vop3::VCmpLtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8425,7 +10142,11 @@ VCmpEqU64Vop3::VCmpEqU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8444,7 +10165,11 @@ VCmpLeU64Vop3::VCmpLeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8463,7 +10188,11 @@ VCmpGtU64Vop3::VCmpGtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8482,7 +10211,11 @@ VCmpNeU64Vop3::VCmpNeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8501,7 +10234,11 @@ VCmpGeU64Vop3::VCmpGeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8520,7 +10257,11 @@ VCmpTU64Vop3::VCmpTU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8543,7 +10284,11 @@ VCmpxFI64Vop3::VCmpxFI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8566,7 +10311,11 @@ VCmpxLtI64Vop3::VCmpxLtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8589,7 +10338,11 @@ VCmpxEqI64Vop3::VCmpxEqI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8612,7 +10365,11 @@ VCmpxLeI64Vop3::VCmpxLeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8635,7 +10392,11 @@ VCmpxGtI64Vop3::VCmpxGtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8658,7 +10419,11 @@ VCmpxNeI64Vop3::VCmpxNeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8681,7 +10446,11 @@ VCmpxGeI64Vop3::VCmpxGeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8704,7 +10473,11 @@ VCmpxTI64Vop3::VCmpxTI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8727,7 +10500,11 @@ VCmpxFU64Vop3::VCmpxFU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8750,7 +10527,11 @@ VCmpxLtU64Vop3::VCmpxLtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8773,7 +10554,11 @@ VCmpxEqU64Vop3::VCmpxEqU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8796,7 +10581,11 @@ VCmpxLeU64Vop3::VCmpxLeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8819,7 +10608,11 @@ VCmpxGtU64Vop3::VCmpxGtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8842,7 +10635,11 @@ VCmpxNeU64Vop3::VCmpxNeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8865,7 +10662,11 @@ VCmpxGeU64Vop3::VCmpxGeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8888,7 +10689,11 @@ VCmpxTU64Vop3::VCmpxTU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8909,7 +10714,12 @@ VAddCoU32Vop3SdstEnc::VAddCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_add_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -8930,7 +10740,12 @@ VSubCoU32Vop3SdstEnc::VSubCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_sub_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -8951,7 +10766,12 @@ VSubrevCoU32Vop3SdstEnc::VSubrevCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_subrev_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -8974,7 +10794,12 @@ VAddcCoU32Vop3SdstEnc::VAddcCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddcCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddcCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_addc_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddcCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -8997,7 +10822,12 @@ VSubbCoU32Vop3SdstEnc::VSubbCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubbCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubbCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_subb_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubbCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9020,7 +10850,12 @@ VSubbrevCoU32Vop3SdstEnc::VSubbrevCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubbrevCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubbrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_subbrev_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubbrevCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9043,7 +10878,12 @@ VDivScaleF32Vop3SdstEnc::VDivScaleF32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_div_scale_f32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivScaleF32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9066,7 +10906,12 @@ VDivScaleF64Vop3SdstEnc::VDivScaleF64Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_div_scale_f64", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivScaleF64Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9089,7 +10934,12 @@ VMadU64U32Vop3SdstEnc::VMadU64U32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_mad_u64_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU64U32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9112,7 +10962,12 @@ VMadI64I32Vop3SdstEnc::VMadI64I32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_mad_i64_i32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI64I32Vop3SdstEnc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/vop3p.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -41,7 +40,11 @@ VPkMadI16Vop3p::VPkMadI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mad_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMadI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -66,7 +69,12 @@ VPkMulLoU16Vop3p::VPkMulLoU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mul_lo_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMulLoU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -91,7 +99,11 @@ VPkAddI16Vop3p::VPkAddI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -116,7 +128,11 @@ VPkSubI16Vop3p::VPkSubI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_sub_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkSubI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -141,7 +157,12 @@ VPkLshlrevB16Vop3p::VPkLshlrevB16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_lshlrev_b16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkLshlrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -160,7 +181,12 @@ VPkLshrrevB16Vop3p::VPkLshrrevB16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_lshrrev_b16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkLshrrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -179,7 +205,12 @@ VPkAshrrevI16Vop3p::VPkAshrrevI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_ashrrev_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAshrrevI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -198,7 +229,11 @@ VPkMaxI16Vop3p::VPkMaxI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_max_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaxI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -223,7 +258,11 @@ VPkMinI16Vop3p::VPkMinI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_min_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -250,7 +289,11 @@ VPkMadU16Vop3p::VPkMadU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mad_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMadU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -275,7 +318,11 @@ VPkAddU16Vop3p::VPkAddU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -300,7 +347,11 @@ VPkSubU16Vop3p::VPkSubU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_sub_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkSubU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -325,7 +376,11 @@ VPkMaxU16Vop3p::VPkMaxU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_max_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaxU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -350,7 +405,11 @@ VPkMinU16Vop3p::VPkMinU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_min_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -377,7 +436,11 @@ VPkFmaF16Vop3p::VPkFmaF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_fma_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkFmaF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -402,7 +465,11 @@ VPkAddF16Vop3p::VPkAddF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -427,7 +494,11 @@ VPkMulF16Vop3p::VPkMulF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mul_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMulF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -452,7 +523,11 @@ VPkMinF16Vop3p::VPkMinF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_min_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -477,7 +552,11 @@ VPkMaxF16Vop3p::VPkMaxF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_max_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaxF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -504,7 +583,12 @@ VMadMixF32Vop3p::VMadMixF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadMixF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVMadMixF32Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_mad_mix_f32", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadMixF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -526,7 +610,12 @@ VMadMixloF16Vop3p::VMadMixloF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadMixloF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVMadMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_mad_mixlo_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadMixloF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -554,7 +643,12 @@ VMadMixhiF16Vop3p::VMadMixhiF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadMixhiF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVMadMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_mad_mixhi_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadMixhiF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -581,7 +675,12 @@ VDot2F32F16Vop3p::VDot2F32F16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2F32F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2F32F16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_f32_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2F32F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -602,7 +701,12 @@ VDot2I32I16Vop3p::VDot2I32I16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2I32I16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2I32I16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_i32_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2I32I16Vop3p>(opcode);
 }
 } // namespace detail
@@ -623,7 +727,12 @@ VDot2U32U16Vop3p::VDot2U32U16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2U32U16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2U32U16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_u32_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2U32U16Vop3p>(opcode);
 }
 } // namespace detail
@@ -644,7 +753,12 @@ VDot4I32I8Vop3p::VDot4I32I8Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4I32I8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4I32I8Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot4_i32_i8", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot4I32I8Vop3p>(opcode);
 }
 } // namespace detail
@@ -665,7 +779,12 @@ VDot4U32U8Vop3p::VDot4U32U8Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot4_u32_u8", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot4U32U8Vop3p>(opcode);
 }
 } // namespace detail
@@ -686,7 +805,12 @@ VDot8I32I4Vop3p::VDot8I32I4Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8I32I4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8I32I4Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot8_i32_i4", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot8I32I4Vop3p>(opcode);
 }
 } // namespace detail
@@ -707,7 +831,12 @@ VDot8U32U4Vop3p::VDot8U32U4Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot8_u32_u4", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot8U32U4Vop3p>(opcode);
 }
 } // namespace detail
@@ -728,7 +857,11 @@ VPkFmaF32Vop3p::VPkFmaF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmaF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkFmaF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_fma_f32", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkFmaF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -747,7 +880,11 @@ VPkMulF32Vop3p::VPkMulF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mul_f32", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMulF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -766,7 +903,11 @@ VPkAddF32Vop3p::VPkAddF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_f32", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -785,7 +926,11 @@ VPkMovB32Vop3p::VPkMovB32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMovB32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMovB32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mov_b32", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMovB32Vop3p>(opcode);
 }
 } // namespace detail
@@ -806,7 +951,12 @@ VAccvgprReadVop3p::VAccvgprReadVop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAccvgprReadVop3p(const MachineInst *opcode) {
+DecodeResult decodeVAccvgprReadVop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_accvgpr_read", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAccvgprReadVop3p>(opcode);
 }
 } // namespace detail
@@ -824,7 +974,12 @@ VAccvgprWriteVop3p::VAccvgprWriteVop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAccvgprWriteVop3p(const MachineInst *opcode) {
+DecodeResult decodeVAccvgprWriteVop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_accvgpr_write", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAccvgprWriteVop3p>(opcode);
 }
 } // namespace detail
@@ -862,7 +1017,12 @@ VMfmaF3232x32x1f32Vop3pMfma::VMfmaF3232x32x1f32Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x1f32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x1f32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x1f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x1f32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -900,7 +1060,12 @@ VMfmaF3216x16x1f32Vop3pMfma::VMfmaF3216x16x1f32Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x1f32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x1f32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x1f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x1f32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -938,7 +1103,12 @@ VMfmaF324x4x1f32Vop3pMfma::VMfmaF324x4x1f32Vop3pMfma(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF324x4x1f32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF324x4x1f32Vop3pMfma(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_4x4x1f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF324x4x1f32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -976,7 +1146,12 @@ VMfmaF3232x32x2f32Vop3pMfma::VMfmaF3232x32x2f32Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x2f32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x2f32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x2f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x2f32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1014,7 +1189,12 @@ VMfmaF3216x16x4f32Vop3pMfma::VMfmaF3216x16x4f32Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x4f32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x4f32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x4f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x4f32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1052,7 +1232,12 @@ VMfmaF3232x32x4f16Vop3pMfma::VMfmaF3232x32x4f16Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x4f16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x4f16Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x4f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x4f16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1090,7 +1275,12 @@ VMfmaF3216x16x4f16Vop3pMfma::VMfmaF3216x16x4f16Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x4f16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x4f16Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x4f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x4f16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1128,7 +1318,12 @@ VMfmaF324x4x4f16Vop3pMfma::VMfmaF324x4x4f16Vop3pMfma(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF324x4x4f16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF324x4x4f16Vop3pMfma(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_4x4x4f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF324x4x4f16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1166,7 +1361,12 @@ VMfmaF3232x32x8f16Vop3pMfma::VMfmaF3232x32x8f16Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x8f16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x8f16Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x8f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x8f16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1204,7 +1404,13 @@ VMfmaF3216x16x16f16Vop3pMfma::VMfmaF3216x16x16f16Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x16f16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x16f16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x16f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x16f16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1242,7 +1448,12 @@ VMfmaI3232x32x4i8Vop3pMfma::VMfmaI3232x32x4i8Vop3pMfma(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI3232x32x4i8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI3232x32x4i8Vop3pMfma(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_32x32x4i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI3232x32x4i8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1280,7 +1491,12 @@ VMfmaI3216x16x4i8Vop3pMfma::VMfmaI3216x16x4i8Vop3pMfma(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI3216x16x4i8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI3216x16x4i8Vop3pMfma(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_16x16x4i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI3216x16x4i8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1318,7 +1534,12 @@ VMfmaI324x4x4i8Vop3pMfma::VMfmaI324x4x4i8Vop3pMfma(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI324x4x4i8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI324x4x4i8Vop3pMfma(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_4x4x4i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI324x4x4i8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1356,7 +1577,12 @@ VMfmaI3232x32x8i8Vop3pMfma::VMfmaI3232x32x8i8Vop3pMfma(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI3232x32x8i8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI3232x32x8i8Vop3pMfma(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_32x32x8i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI3232x32x8i8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1394,7 +1620,12 @@ VMfmaI3216x16x16i8Vop3pMfma::VMfmaI3216x16x16i8Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI3216x16x16i8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI3216x16x16i8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_16x16x16i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI3216x16x16i8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1432,7 +1663,13 @@ VMfmaF3232x32x4bf161kVop3pMfma::VMfmaF3232x32x4bf161kVop3pMfma(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x4bf161kVop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x4bf161kVop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x4bf16_1k", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x4bf161kVop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1470,7 +1707,13 @@ VMfmaF3216x16x4bf161kVop3pMfma::VMfmaF3216x16x4bf161kVop3pMfma(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x4bf161kVop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x4bf161kVop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x4bf16_1k", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x4bf161kVop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1508,7 +1751,13 @@ VMfmaF324x4x4bf161kVop3pMfma::VMfmaF324x4x4bf161kVop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF324x4x4bf161kVop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF324x4x4bf161kVop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_4x4x4bf16_1k", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF324x4x4bf161kVop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1546,7 +1795,13 @@ VMfmaF3232x32x8bf161kVop3pMfma::VMfmaF3232x32x8bf161kVop3pMfma(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x8bf161kVop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x8bf161kVop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x8bf16_1k", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x8bf161kVop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1584,7 +1839,13 @@ VMfmaF3216x16x16bf161kVop3pMfma::VMfmaF3216x16x16bf161kVop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x16bf161kVop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x16bf161kVop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x16bf16_1k", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x16bf161kVop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1622,7 +1883,13 @@ VMfmaF3232x32x2bf16Vop3pMfma::VMfmaF3232x32x2bf16Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x2bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x2bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x2bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x2bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1660,7 +1927,13 @@ VMfmaF3216x16x2bf16Vop3pMfma::VMfmaF3216x16x2bf16Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x2bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x2bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x2bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x2bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1698,7 +1971,12 @@ VMfmaF324x4x2bf16Vop3pMfma::VMfmaF324x4x2bf16Vop3pMfma(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF324x4x2bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF324x4x2bf16Vop3pMfma(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_4x4x2bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF324x4x2bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1736,7 +2014,13 @@ VMfmaF3232x32x4bf16Vop3pMfma::VMfmaF3232x32x4bf16Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x4bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x4bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x4bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x4bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1774,7 +2058,13 @@ VMfmaF3216x16x8bf16Vop3pMfma::VMfmaF3216x16x8bf16Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x8bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x8bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x8bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x8bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1812,7 +2102,12 @@ VMfmaF6416x16x4f64Vop3pMfma::VMfmaF6416x16x4f64Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF6416x16x4f64Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF6416x16x4f64Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f64_16x16x4f64", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF6416x16x4f64Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1850,7 +2145,12 @@ VMfmaF644x4x4f64Vop3pMfma::VMfmaF644x4x4f64Vop3pMfma(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF644x4x4f64Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF644x4x4f64Vop3pMfma(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f64_4x4x4f64", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF644x4x4f64Vop3pMfma>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/vopc.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/vopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -31,8 +30,6 @@ VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_CLASS_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -60,7 +57,18 @@ VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_class_f32_sdwa"
+          : "v_cmp_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F32 does not support DPP";
   return std::make_unique<VCmpClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -85,8 +93,6 @@ VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_CLASS_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -116,7 +122,18 @@ VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_class_f32_sdwa"
+          : "v_cmpx_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F32 does not support DPP";
   return std::make_unique<VCmpxClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -137,15 +154,21 @@ VCmpClassF64Vopc::VCmpClassF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_class_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support SDWA";
   return std::make_unique<VCmpClassF64Vopc>(opcode);
 }
 } // namespace detail
@@ -168,17 +191,23 @@ VCmpxClassF64Vopc::VCmpxClassF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_class_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support SDWA";
   return std::make_unique<VCmpxClassF64Vopc>(opcode);
 }
 } // namespace detail
@@ -202,8 +231,6 @@ VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_CLASS_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -231,7 +258,18 @@ VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_class_f16_sdwa"
+          : "v_cmp_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F16 does not support DPP";
   return std::make_unique<VCmpClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -257,8 +295,6 @@ VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_CLASS_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -288,7 +324,18 @@ VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_class_f16_sdwa"
+          : "v_cmpx_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F16 does not support DPP";
   return std::make_unique<VCmpxClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -311,8 +358,6 @@ VCmpFF16Vopc::VCmpFF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -340,7 +385,17 @@ VCmpFF16Vopc::VCmpFF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_f16_sdwa"
+          : "v_cmp_f_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F16 does not support DPP";
   return std::make_unique<VCmpFF16Vopc>(opcode);
 }
 } // namespace detail
@@ -364,8 +419,6 @@ VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -393,7 +446,17 @@ VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_f16_sdwa"
+          : "v_cmp_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F16 does not support DPP";
   return std::make_unique<VCmpLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -417,8 +480,6 @@ VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -446,7 +507,17 @@ VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_f16_sdwa"
+          : "v_cmp_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F16 does not support DPP";
   return std::make_unique<VCmpEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -470,8 +541,6 @@ VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -499,7 +568,17 @@ VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_f16_sdwa"
+          : "v_cmp_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F16 does not support DPP";
   return std::make_unique<VCmpLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -523,8 +602,6 @@ VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -552,7 +629,17 @@ VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_f16_sdwa"
+          : "v_cmp_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F16 does not support DPP";
   return std::make_unique<VCmpGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -576,8 +663,6 @@ VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -605,7 +690,17 @@ VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lg_f16_sdwa"
+          : "v_cmp_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F16 does not support DPP";
   return std::make_unique<VCmpLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -629,8 +724,6 @@ VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -658,7 +751,17 @@ VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_f16_sdwa"
+          : "v_cmp_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F16 does not support DPP";
   return std::make_unique<VCmpGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -681,8 +784,6 @@ VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_O_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -710,7 +811,17 @@ VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_o_f16_sdwa"
+          : "v_cmp_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F16 does not support DPP";
   return std::make_unique<VCmpOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -733,8 +844,6 @@ VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_U_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -762,7 +871,17 @@ VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_u_f16_sdwa"
+          : "v_cmp_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F16 does not support DPP";
   return std::make_unique<VCmpUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -786,8 +905,6 @@ VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -815,7 +932,17 @@ VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nge_f16_sdwa"
+          : "v_cmp_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F16 does not support DPP";
   return std::make_unique<VCmpNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -839,8 +966,6 @@ VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -868,7 +993,17 @@ VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlg_f16_sdwa"
+          : "v_cmp_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F16 does not support DPP";
   return std::make_unique<VCmpNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -892,8 +1027,6 @@ VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -921,7 +1054,17 @@ VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ngt_f16_sdwa"
+          : "v_cmp_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F16 does not support DPP";
   return std::make_unique<VCmpNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -945,8 +1088,6 @@ VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -974,7 +1115,17 @@ VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nle_f16_sdwa"
+          : "v_cmp_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F16 does not support DPP";
   return std::make_unique<VCmpNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -998,8 +1149,6 @@ VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NEQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1027,7 +1176,17 @@ VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_neq_f16_sdwa"
+          : "v_cmp_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F16 does not support DPP";
   return std::make_unique<VCmpNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1051,8 +1210,6 @@ VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1080,7 +1237,17 @@ VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlt_f16_sdwa"
+          : "v_cmp_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F16 does not support DPP";
   return std::make_unique<VCmpNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1104,8 +1271,6 @@ VCmpTruF16Vopc::VCmpTruF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_TRU_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1133,7 +1298,17 @@ VCmpTruF16Vopc::VCmpTruF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_tru_f16_sdwa"
+          : "v_cmp_tru_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F16 does not support DPP";
   return std::make_unique<VCmpTruF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1159,8 +1334,6 @@ VCmpxFF16Vopc::VCmpxFF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1190,7 +1363,17 @@ VCmpxFF16Vopc::VCmpxFF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_f16_sdwa"
+          : "v_cmpx_f_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F16 does not support DPP";
   return std::make_unique<VCmpxFF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1216,8 +1399,6 @@ VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1247,7 +1428,17 @@ VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_f16_sdwa"
+          : "v_cmpx_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F16 does not support DPP";
   return std::make_unique<VCmpxLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1273,8 +1464,6 @@ VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1304,7 +1493,17 @@ VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_f16_sdwa"
+          : "v_cmpx_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F16 does not support DPP";
   return std::make_unique<VCmpxEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1330,8 +1529,6 @@ VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1361,7 +1558,17 @@ VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_f16_sdwa"
+          : "v_cmpx_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F16 does not support DPP";
   return std::make_unique<VCmpxLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1387,8 +1594,6 @@ VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1418,7 +1623,17 @@ VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_f16_sdwa"
+          : "v_cmpx_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F16 does not support DPP";
   return std::make_unique<VCmpxGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1444,8 +1659,6 @@ VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1475,7 +1688,17 @@ VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lg_f16_sdwa"
+          : "v_cmpx_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F16 does not support DPP";
   return std::make_unique<VCmpxLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1501,8 +1724,6 @@ VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1532,7 +1753,17 @@ VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_f16_sdwa"
+          : "v_cmpx_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F16 does not support DPP";
   return std::make_unique<VCmpxGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1558,8 +1789,6 @@ VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_O_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1589,7 +1818,17 @@ VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_o_f16_sdwa"
+          : "v_cmpx_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F16 does not support DPP";
   return std::make_unique<VCmpxOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1615,8 +1854,6 @@ VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_U_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1646,7 +1883,17 @@ VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_u_f16_sdwa"
+          : "v_cmpx_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F16 does not support DPP";
   return std::make_unique<VCmpxUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1672,8 +1919,6 @@ VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1703,7 +1948,18 @@ VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nge_f16_sdwa"
+          : "v_cmpx_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F16 does not support DPP";
   return std::make_unique<VCmpxNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1729,8 +1985,6 @@ VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1760,7 +2014,18 @@ VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlg_f16_sdwa"
+          : "v_cmpx_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F16 does not support DPP";
   return std::make_unique<VCmpxNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1786,8 +2051,6 @@ VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1817,7 +2080,18 @@ VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ngt_f16_sdwa"
+          : "v_cmpx_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F16 does not support DPP";
   return std::make_unique<VCmpxNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1843,8 +2117,6 @@ VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1874,7 +2146,18 @@ VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nle_f16_sdwa"
+          : "v_cmpx_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F16 does not support DPP";
   return std::make_unique<VCmpxNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1900,8 +2183,6 @@ VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NEQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1931,7 +2212,18 @@ VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_neq_f16_sdwa"
+          : "v_cmpx_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F16 does not support DPP";
   return std::make_unique<VCmpxNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1957,8 +2249,6 @@ VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1988,7 +2278,18 @@ VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlt_f16_sdwa"
+          : "v_cmpx_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F16 does not support DPP";
   return std::make_unique<VCmpxNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -2014,8 +2315,6 @@ VCmpxTruF16Vopc::VCmpxTruF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_TRU_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2045,7 +2344,18 @@ VCmpxTruF16Vopc::VCmpxTruF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_tru_f16_sdwa"
+          : "v_cmpx_tru_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F16 does not support DPP";
   return std::make_unique<VCmpxTruF16Vopc>(opcode);
 }
 } // namespace detail
@@ -2067,8 +2377,6 @@ VCmpFF32Vopc::VCmpFF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2096,7 +2404,17 @@ VCmpFF32Vopc::VCmpFF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_f32_sdwa"
+          : "v_cmp_f_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F32 does not support DPP";
   return std::make_unique<VCmpFF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2119,8 +2437,6 @@ VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2148,7 +2464,17 @@ VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_f32_sdwa"
+          : "v_cmp_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F32 does not support DPP";
   return std::make_unique<VCmpLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2171,8 +2497,6 @@ VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2200,7 +2524,17 @@ VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_f32_sdwa"
+          : "v_cmp_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F32 does not support DPP";
   return std::make_unique<VCmpEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2223,8 +2557,6 @@ VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2252,7 +2584,17 @@ VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_f32_sdwa"
+          : "v_cmp_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F32 does not support DPP";
   return std::make_unique<VCmpLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2275,8 +2617,6 @@ VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2304,7 +2644,17 @@ VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_f32_sdwa"
+          : "v_cmp_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F32 does not support DPP";
   return std::make_unique<VCmpGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2327,8 +2677,6 @@ VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2356,7 +2704,17 @@ VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lg_f32_sdwa"
+          : "v_cmp_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F32 does not support DPP";
   return std::make_unique<VCmpLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2379,8 +2737,6 @@ VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2408,7 +2764,17 @@ VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_f32_sdwa"
+          : "v_cmp_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F32 does not support DPP";
   return std::make_unique<VCmpGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2430,8 +2796,6 @@ VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_O_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2459,7 +2823,17 @@ VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_o_f32_sdwa"
+          : "v_cmp_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F32 does not support DPP";
   return std::make_unique<VCmpOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2481,8 +2855,6 @@ VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_U_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2510,7 +2882,17 @@ VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_u_f32_sdwa"
+          : "v_cmp_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F32 does not support DPP";
   return std::make_unique<VCmpUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2533,8 +2915,6 @@ VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2562,7 +2942,17 @@ VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nge_f32_sdwa"
+          : "v_cmp_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F32 does not support DPP";
   return std::make_unique<VCmpNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2585,8 +2975,6 @@ VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2614,7 +3002,17 @@ VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlg_f32_sdwa"
+          : "v_cmp_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F32 does not support DPP";
   return std::make_unique<VCmpNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2637,8 +3035,6 @@ VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2666,7 +3062,17 @@ VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ngt_f32_sdwa"
+          : "v_cmp_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F32 does not support DPP";
   return std::make_unique<VCmpNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2689,8 +3095,6 @@ VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2718,7 +3122,17 @@ VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nle_f32_sdwa"
+          : "v_cmp_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F32 does not support DPP";
   return std::make_unique<VCmpNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2741,8 +3155,6 @@ VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NEQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2770,7 +3182,17 @@ VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_neq_f32_sdwa"
+          : "v_cmp_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F32 does not support DPP";
   return std::make_unique<VCmpNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2793,8 +3215,6 @@ VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2822,7 +3242,17 @@ VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlt_f32_sdwa"
+          : "v_cmp_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F32 does not support DPP";
   return std::make_unique<VCmpNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2845,8 +3275,6 @@ VCmpTruF32Vopc::VCmpTruF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_TRU_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2874,7 +3302,17 @@ VCmpTruF32Vopc::VCmpTruF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_tru_f32_sdwa"
+          : "v_cmp_tru_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F32 does not support DPP";
   return std::make_unique<VCmpTruF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2899,8 +3337,6 @@ VCmpxFF32Vopc::VCmpxFF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2930,7 +3366,17 @@ VCmpxFF32Vopc::VCmpxFF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_f32_sdwa"
+          : "v_cmpx_f_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F32 does not support DPP";
   return std::make_unique<VCmpxFF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2955,8 +3401,6 @@ VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2986,7 +3430,17 @@ VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_f32_sdwa"
+          : "v_cmpx_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F32 does not support DPP";
   return std::make_unique<VCmpxLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3011,8 +3465,6 @@ VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3042,7 +3494,17 @@ VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_f32_sdwa"
+          : "v_cmpx_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F32 does not support DPP";
   return std::make_unique<VCmpxEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3067,8 +3529,6 @@ VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3098,7 +3558,17 @@ VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_f32_sdwa"
+          : "v_cmpx_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F32 does not support DPP";
   return std::make_unique<VCmpxLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3123,8 +3593,6 @@ VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3154,7 +3622,17 @@ VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_f32_sdwa"
+          : "v_cmpx_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F32 does not support DPP";
   return std::make_unique<VCmpxGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3179,8 +3657,6 @@ VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3210,7 +3686,17 @@ VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lg_f32_sdwa"
+          : "v_cmpx_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F32 does not support DPP";
   return std::make_unique<VCmpxLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3235,8 +3721,6 @@ VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3266,7 +3750,17 @@ VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_f32_sdwa"
+          : "v_cmpx_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F32 does not support DPP";
   return std::make_unique<VCmpxGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3291,8 +3785,6 @@ VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_O_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3322,7 +3814,17 @@ VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_o_f32_sdwa"
+          : "v_cmpx_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F32 does not support DPP";
   return std::make_unique<VCmpxOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3347,8 +3849,6 @@ VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_U_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3378,7 +3878,17 @@ VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_u_f32_sdwa"
+          : "v_cmpx_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F32 does not support DPP";
   return std::make_unique<VCmpxUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3403,8 +3913,6 @@ VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3434,7 +3942,18 @@ VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nge_f32_sdwa"
+          : "v_cmpx_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F32 does not support DPP";
   return std::make_unique<VCmpxNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3459,8 +3978,6 @@ VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3490,7 +4007,18 @@ VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlg_f32_sdwa"
+          : "v_cmpx_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F32 does not support DPP";
   return std::make_unique<VCmpxNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3515,8 +4043,6 @@ VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3546,7 +4072,18 @@ VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ngt_f32_sdwa"
+          : "v_cmpx_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F32 does not support DPP";
   return std::make_unique<VCmpxNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3571,8 +4108,6 @@ VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3602,7 +4137,18 @@ VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nle_f32_sdwa"
+          : "v_cmpx_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F32 does not support DPP";
   return std::make_unique<VCmpxNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3627,8 +4173,6 @@ VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NEQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3658,7 +4202,18 @@ VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_neq_f32_sdwa"
+          : "v_cmpx_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F32 does not support DPP";
   return std::make_unique<VCmpxNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3683,8 +4238,6 @@ VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3714,7 +4267,18 @@ VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlt_f32_sdwa"
+          : "v_cmpx_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F32 does not support DPP";
   return std::make_unique<VCmpxNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3739,8 +4303,6 @@ VCmpxTruF32Vopc::VCmpxTruF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_TRU_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3770,7 +4332,18 @@ VCmpxTruF32Vopc::VCmpxTruF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_tru_f32_sdwa"
+          : "v_cmpx_tru_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F32 does not support DPP";
   return std::make_unique<VCmpxTruF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3791,15 +4364,20 @@ VCmpFF64Vopc::VCmpFF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_F_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_f_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F64 does not support SDWA";
   return std::make_unique<VCmpFF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3820,15 +4398,20 @@ VCmpLtF64Vopc::VCmpLtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support SDWA";
   return std::make_unique<VCmpLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3849,15 +4432,20 @@ VCmpEqF64Vopc::VCmpEqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_eq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support SDWA";
   return std::make_unique<VCmpEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3878,15 +4466,20 @@ VCmpLeF64Vopc::VCmpLeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_le_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support SDWA";
   return std::make_unique<VCmpLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3907,15 +4500,20 @@ VCmpGtF64Vopc::VCmpGtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_gt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support SDWA";
   return std::make_unique<VCmpGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3936,15 +4534,20 @@ VCmpLgF64Vopc::VCmpLgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support SDWA";
   return std::make_unique<VCmpLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3965,15 +4568,20 @@ VCmpGeF64Vopc::VCmpGeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support SDWA";
   return std::make_unique<VCmpGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3994,15 +4602,20 @@ VCmpOF64Vopc::VCmpOF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_O_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_O_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_o_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support SDWA";
   return std::make_unique<VCmpOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4023,15 +4636,20 @@ VCmpUF64Vopc::VCmpUF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_U_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_U_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_u_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support SDWA";
   return std::make_unique<VCmpUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4052,15 +4670,20 @@ VCmpNgeF64Vopc::VCmpNgeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support SDWA";
   return std::make_unique<VCmpNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4081,15 +4704,20 @@ VCmpNlgF64Vopc::VCmpNlgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nlg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support SDWA";
   return std::make_unique<VCmpNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4110,15 +4738,20 @@ VCmpNgtF64Vopc::VCmpNgtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ngt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support SDWA";
   return std::make_unique<VCmpNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4139,15 +4772,20 @@ VCmpNleF64Vopc::VCmpNleF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nle_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support SDWA";
   return std::make_unique<VCmpNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4168,15 +4806,20 @@ VCmpNeqF64Vopc::VCmpNeqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_neq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support SDWA";
   return std::make_unique<VCmpNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4197,15 +4840,20 @@ VCmpNltF64Vopc::VCmpNltF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nlt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support SDWA";
   return std::make_unique<VCmpNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4226,15 +4874,20 @@ VCmpTruF64Vopc::VCmpTruF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_TRU_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_TRU_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_tru_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F64 does not support SDWA";
   return std::make_unique<VCmpTruF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4257,17 +4910,22 @@ VCmpxFF64Vopc::VCmpxFF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_F_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_f_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F64 does not support SDWA";
   return std::make_unique<VCmpxFF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4290,17 +4948,22 @@ VCmpxLtF64Vopc::VCmpxLtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support SDWA";
   return std::make_unique<VCmpxLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4323,17 +4986,22 @@ VCmpxEqF64Vopc::VCmpxEqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_eq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support SDWA";
   return std::make_unique<VCmpxEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4356,17 +5024,22 @@ VCmpxLeF64Vopc::VCmpxLeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_le_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support SDWA";
   return std::make_unique<VCmpxLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4389,17 +5062,22 @@ VCmpxGtF64Vopc::VCmpxGtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_gt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support SDWA";
   return std::make_unique<VCmpxGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4422,17 +5100,22 @@ VCmpxLgF64Vopc::VCmpxLgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support SDWA";
   return std::make_unique<VCmpxLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4455,17 +5138,22 @@ VCmpxGeF64Vopc::VCmpxGeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support SDWA";
   return std::make_unique<VCmpxGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4488,17 +5176,22 @@ VCmpxOF64Vopc::VCmpxOF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_O_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_O_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_o_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support SDWA";
   return std::make_unique<VCmpxOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4521,17 +5214,22 @@ VCmpxUF64Vopc::VCmpxUF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_U_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_U_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_u_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support SDWA";
   return std::make_unique<VCmpxUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4554,17 +5252,23 @@ VCmpxNgeF64Vopc::VCmpxNgeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support SDWA";
   return std::make_unique<VCmpxNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4587,17 +5291,23 @@ VCmpxNlgF64Vopc::VCmpxNlgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nlg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support SDWA";
   return std::make_unique<VCmpxNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4620,17 +5330,23 @@ VCmpxNgtF64Vopc::VCmpxNgtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ngt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support SDWA";
   return std::make_unique<VCmpxNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4653,17 +5369,23 @@ VCmpxNleF64Vopc::VCmpxNleF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nle_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support SDWA";
   return std::make_unique<VCmpxNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4686,17 +5408,23 @@ VCmpxNeqF64Vopc::VCmpxNeqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_neq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support SDWA";
   return std::make_unique<VCmpxNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4719,17 +5447,23 @@ VCmpxNltF64Vopc::VCmpxNltF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nlt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support SDWA";
   return std::make_unique<VCmpxNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4752,17 +5486,23 @@ VCmpxTruF64Vopc::VCmpxTruF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_TRU_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_TRU_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_tru_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F64 does not support SDWA";
   return std::make_unique<VCmpxTruF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4785,8 +5525,6 @@ VCmpFI16Vopc::VCmpFI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4814,7 +5552,17 @@ VCmpFI16Vopc::VCmpFI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_i16_sdwa"
+          : "v_cmp_f_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I16 does not support DPP";
   return std::make_unique<VCmpFI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4838,8 +5586,6 @@ VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4867,7 +5613,17 @@ VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_i16_sdwa"
+          : "v_cmp_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I16 does not support DPP";
   return std::make_unique<VCmpLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4891,8 +5647,6 @@ VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4920,7 +5674,17 @@ VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_i16_sdwa"
+          : "v_cmp_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I16 does not support DPP";
   return std::make_unique<VCmpEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4944,8 +5708,6 @@ VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4973,7 +5735,17 @@ VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_i16_sdwa"
+          : "v_cmp_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I16 does not support DPP";
   return std::make_unique<VCmpLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4997,8 +5769,6 @@ VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5026,7 +5796,17 @@ VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_i16_sdwa"
+          : "v_cmp_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I16 does not support DPP";
   return std::make_unique<VCmpGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5050,8 +5830,6 @@ VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5079,7 +5857,17 @@ VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_i16_sdwa"
+          : "v_cmp_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I16 does not support DPP";
   return std::make_unique<VCmpNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5103,8 +5891,6 @@ VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5132,7 +5918,17 @@ VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_i16_sdwa"
+          : "v_cmp_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I16 does not support DPP";
   return std::make_unique<VCmpGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5155,8 +5951,6 @@ VCmpTI16Vopc::VCmpTI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5184,7 +5978,17 @@ VCmpTI16Vopc::VCmpTI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_i16_sdwa"
+          : "v_cmp_t_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I16 does not support DPP";
   return std::make_unique<VCmpTI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5207,8 +6011,6 @@ VCmpFU16Vopc::VCmpFU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5236,7 +6038,17 @@ VCmpFU16Vopc::VCmpFU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_u16_sdwa"
+          : "v_cmp_f_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U16 does not support DPP";
   return std::make_unique<VCmpFU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5260,8 +6072,6 @@ VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5289,7 +6099,17 @@ VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_u16_sdwa"
+          : "v_cmp_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U16 does not support DPP";
   return std::make_unique<VCmpLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5313,8 +6133,6 @@ VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5342,7 +6160,17 @@ VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_u16_sdwa"
+          : "v_cmp_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U16 does not support DPP";
   return std::make_unique<VCmpEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5366,8 +6194,6 @@ VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5395,7 +6221,17 @@ VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_u16_sdwa"
+          : "v_cmp_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U16 does not support DPP";
   return std::make_unique<VCmpLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5419,8 +6255,6 @@ VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5448,7 +6282,17 @@ VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_u16_sdwa"
+          : "v_cmp_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U16 does not support DPP";
   return std::make_unique<VCmpGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5472,8 +6316,6 @@ VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5501,7 +6343,17 @@ VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_u16_sdwa"
+          : "v_cmp_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U16 does not support DPP";
   return std::make_unique<VCmpNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5525,8 +6377,6 @@ VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5554,7 +6404,17 @@ VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_u16_sdwa"
+          : "v_cmp_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U16 does not support DPP";
   return std::make_unique<VCmpGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5577,8 +6437,6 @@ VCmpTU16Vopc::VCmpTU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5606,7 +6464,17 @@ VCmpTU16Vopc::VCmpTU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_u16_sdwa"
+          : "v_cmp_t_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U16 does not support DPP";
   return std::make_unique<VCmpTU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5632,8 +6500,6 @@ VCmpxFI16Vopc::VCmpxFI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5663,7 +6529,17 @@ VCmpxFI16Vopc::VCmpxFI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_i16_sdwa"
+          : "v_cmpx_f_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I16 does not support DPP";
   return std::make_unique<VCmpxFI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5689,8 +6565,6 @@ VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5720,7 +6594,17 @@ VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_i16_sdwa"
+          : "v_cmpx_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I16 does not support DPP";
   return std::make_unique<VCmpxLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5746,8 +6630,6 @@ VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5777,7 +6659,17 @@ VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_i16_sdwa"
+          : "v_cmpx_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I16 does not support DPP";
   return std::make_unique<VCmpxEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5803,8 +6695,6 @@ VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5834,7 +6724,17 @@ VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_i16_sdwa"
+          : "v_cmpx_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I16 does not support DPP";
   return std::make_unique<VCmpxLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5860,8 +6760,6 @@ VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5891,7 +6789,17 @@ VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_i16_sdwa"
+          : "v_cmpx_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I16 does not support DPP";
   return std::make_unique<VCmpxGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5917,8 +6825,6 @@ VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5948,7 +6854,17 @@ VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_i16_sdwa"
+          : "v_cmpx_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I16 does not support DPP";
   return std::make_unique<VCmpxNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5974,8 +6890,6 @@ VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6005,7 +6919,17 @@ VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_i16_sdwa"
+          : "v_cmpx_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I16 does not support DPP";
   return std::make_unique<VCmpxGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6031,8 +6955,6 @@ VCmpxTI16Vopc::VCmpxTI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6062,7 +6984,17 @@ VCmpxTI16Vopc::VCmpxTI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_i16_sdwa"
+          : "v_cmpx_t_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I16 does not support DPP";
   return std::make_unique<VCmpxTI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6088,8 +7020,6 @@ VCmpxFU16Vopc::VCmpxFU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6119,7 +7049,17 @@ VCmpxFU16Vopc::VCmpxFU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_u16_sdwa"
+          : "v_cmpx_f_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U16 does not support DPP";
   return std::make_unique<VCmpxFU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6145,8 +7085,6 @@ VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6176,7 +7114,17 @@ VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_u16_sdwa"
+          : "v_cmpx_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U16 does not support DPP";
   return std::make_unique<VCmpxLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6202,8 +7150,6 @@ VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6233,7 +7179,17 @@ VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_u16_sdwa"
+          : "v_cmpx_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U16 does not support DPP";
   return std::make_unique<VCmpxEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6259,8 +7215,6 @@ VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6290,7 +7244,17 @@ VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_u16_sdwa"
+          : "v_cmpx_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U16 does not support DPP";
   return std::make_unique<VCmpxLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6316,8 +7280,6 @@ VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6347,7 +7309,17 @@ VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_u16_sdwa"
+          : "v_cmpx_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U16 does not support DPP";
   return std::make_unique<VCmpxGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6373,8 +7345,6 @@ VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6404,7 +7374,17 @@ VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_u16_sdwa"
+          : "v_cmpx_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U16 does not support DPP";
   return std::make_unique<VCmpxNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6430,8 +7410,6 @@ VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6461,7 +7439,17 @@ VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_u16_sdwa"
+          : "v_cmpx_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U16 does not support DPP";
   return std::make_unique<VCmpxGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6487,8 +7475,6 @@ VCmpxTU16Vopc::VCmpxTU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6518,7 +7504,17 @@ VCmpxTU16Vopc::VCmpxTU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_u16_sdwa"
+          : "v_cmpx_t_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U16 does not support DPP";
   return std::make_unique<VCmpxTU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6540,8 +7536,6 @@ VCmpFI32Vopc::VCmpFI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6569,7 +7563,17 @@ VCmpFI32Vopc::VCmpFI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_i32_sdwa"
+          : "v_cmp_f_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I32 does not support DPP";
   return std::make_unique<VCmpFI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6592,8 +7596,6 @@ VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6621,7 +7623,17 @@ VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_i32_sdwa"
+          : "v_cmp_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I32 does not support DPP";
   return std::make_unique<VCmpLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6644,8 +7656,6 @@ VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6673,7 +7683,17 @@ VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_i32_sdwa"
+          : "v_cmp_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I32 does not support DPP";
   return std::make_unique<VCmpEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6696,8 +7716,6 @@ VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6725,7 +7743,17 @@ VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_i32_sdwa"
+          : "v_cmp_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I32 does not support DPP";
   return std::make_unique<VCmpLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6748,8 +7776,6 @@ VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6777,7 +7803,17 @@ VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_i32_sdwa"
+          : "v_cmp_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I32 does not support DPP";
   return std::make_unique<VCmpGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6800,8 +7836,6 @@ VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6829,7 +7863,17 @@ VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_i32_sdwa"
+          : "v_cmp_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I32 does not support DPP";
   return std::make_unique<VCmpNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6852,8 +7896,6 @@ VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6881,7 +7923,17 @@ VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_i32_sdwa"
+          : "v_cmp_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I32 does not support DPP";
   return std::make_unique<VCmpGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6903,8 +7955,6 @@ VCmpTI32Vopc::VCmpTI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6932,7 +7982,17 @@ VCmpTI32Vopc::VCmpTI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_i32_sdwa"
+          : "v_cmp_t_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I32 does not support DPP";
   return std::make_unique<VCmpTI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6954,8 +8014,6 @@ VCmpFU32Vopc::VCmpFU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6983,7 +8041,17 @@ VCmpFU32Vopc::VCmpFU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_u32_sdwa"
+          : "v_cmp_f_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U32 does not support DPP";
   return std::make_unique<VCmpFU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7006,8 +8074,6 @@ VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7035,7 +8101,17 @@ VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_u32_sdwa"
+          : "v_cmp_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U32 does not support DPP";
   return std::make_unique<VCmpLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7058,8 +8134,6 @@ VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7087,7 +8161,17 @@ VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_u32_sdwa"
+          : "v_cmp_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U32 does not support DPP";
   return std::make_unique<VCmpEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7110,8 +8194,6 @@ VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7139,7 +8221,17 @@ VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_u32_sdwa"
+          : "v_cmp_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U32 does not support DPP";
   return std::make_unique<VCmpLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7162,8 +8254,6 @@ VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7191,7 +8281,17 @@ VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_u32_sdwa"
+          : "v_cmp_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U32 does not support DPP";
   return std::make_unique<VCmpGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7214,8 +8314,6 @@ VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7243,7 +8341,17 @@ VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_u32_sdwa"
+          : "v_cmp_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U32 does not support DPP";
   return std::make_unique<VCmpNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7266,8 +8374,6 @@ VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7295,7 +8401,17 @@ VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_u32_sdwa"
+          : "v_cmp_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U32 does not support DPP";
   return std::make_unique<VCmpGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7317,8 +8433,6 @@ VCmpTU32Vopc::VCmpTU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7346,7 +8460,17 @@ VCmpTU32Vopc::VCmpTU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_u32_sdwa"
+          : "v_cmp_t_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U32 does not support DPP";
   return std::make_unique<VCmpTU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7371,8 +8495,6 @@ VCmpxFI32Vopc::VCmpxFI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7402,7 +8524,17 @@ VCmpxFI32Vopc::VCmpxFI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_i32_sdwa"
+          : "v_cmpx_f_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I32 does not support DPP";
   return std::make_unique<VCmpxFI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7427,8 +8559,6 @@ VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7458,7 +8588,17 @@ VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_i32_sdwa"
+          : "v_cmpx_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I32 does not support DPP";
   return std::make_unique<VCmpxLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7483,8 +8623,6 @@ VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7514,7 +8652,17 @@ VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_i32_sdwa"
+          : "v_cmpx_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I32 does not support DPP";
   return std::make_unique<VCmpxEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7539,8 +8687,6 @@ VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7570,7 +8716,17 @@ VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_i32_sdwa"
+          : "v_cmpx_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I32 does not support DPP";
   return std::make_unique<VCmpxLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7595,8 +8751,6 @@ VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7626,7 +8780,17 @@ VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_i32_sdwa"
+          : "v_cmpx_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I32 does not support DPP";
   return std::make_unique<VCmpxGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7651,8 +8815,6 @@ VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7682,7 +8844,17 @@ VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_i32_sdwa"
+          : "v_cmpx_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I32 does not support DPP";
   return std::make_unique<VCmpxNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7707,8 +8879,6 @@ VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7738,7 +8908,17 @@ VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_i32_sdwa"
+          : "v_cmpx_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I32 does not support DPP";
   return std::make_unique<VCmpxGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7763,8 +8943,6 @@ VCmpxTI32Vopc::VCmpxTI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7794,7 +8972,17 @@ VCmpxTI32Vopc::VCmpxTI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_i32_sdwa"
+          : "v_cmpx_t_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I32 does not support DPP";
   return std::make_unique<VCmpxTI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7819,8 +9007,6 @@ VCmpxFU32Vopc::VCmpxFU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7850,7 +9036,17 @@ VCmpxFU32Vopc::VCmpxFU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_u32_sdwa"
+          : "v_cmpx_f_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U32 does not support DPP";
   return std::make_unique<VCmpxFU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7875,8 +9071,6 @@ VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7906,7 +9100,17 @@ VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_u32_sdwa"
+          : "v_cmpx_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U32 does not support DPP";
   return std::make_unique<VCmpxLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7931,8 +9135,6 @@ VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7962,7 +9164,17 @@ VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_u32_sdwa"
+          : "v_cmpx_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U32 does not support DPP";
   return std::make_unique<VCmpxEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7987,8 +9199,6 @@ VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8018,7 +9228,17 @@ VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_u32_sdwa"
+          : "v_cmpx_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U32 does not support DPP";
   return std::make_unique<VCmpxLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8043,8 +9263,6 @@ VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8074,7 +9292,17 @@ VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_u32_sdwa"
+          : "v_cmpx_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U32 does not support DPP";
   return std::make_unique<VCmpxGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8099,8 +9327,6 @@ VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8130,7 +9356,17 @@ VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_u32_sdwa"
+          : "v_cmpx_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U32 does not support DPP";
   return std::make_unique<VCmpxNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8155,8 +9391,6 @@ VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8186,7 +9420,17 @@ VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_u32_sdwa"
+          : "v_cmpx_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U32 does not support DPP";
   return std::make_unique<VCmpxGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8211,8 +9455,6 @@ VCmpxTU32Vopc::VCmpxTU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8242,7 +9484,17 @@ VCmpxTU32Vopc::VCmpxTU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_u32_sdwa"
+          : "v_cmpx_t_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U32 does not support DPP";
   return std::make_unique<VCmpxTU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8263,15 +9515,20 @@ VCmpFI64Vopc::VCmpFI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_F_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_f_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I64 does not support SDWA";
   return std::make_unique<VCmpFI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8292,15 +9549,20 @@ VCmpLtI64Vopc::VCmpLtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support SDWA";
   return std::make_unique<VCmpLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8321,15 +9583,20 @@ VCmpEqI64Vopc::VCmpEqI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_eq_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support SDWA";
   return std::make_unique<VCmpEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8350,15 +9617,20 @@ VCmpLeI64Vopc::VCmpLeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_le_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support SDWA";
   return std::make_unique<VCmpLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8379,15 +9651,20 @@ VCmpGtI64Vopc::VCmpGtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_gt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support SDWA";
   return std::make_unique<VCmpGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8408,15 +9685,20 @@ VCmpNeI64Vopc::VCmpNeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ne_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support SDWA";
   return std::make_unique<VCmpNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8437,15 +9719,20 @@ VCmpGeI64Vopc::VCmpGeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ge_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support SDWA";
   return std::make_unique<VCmpGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8466,15 +9753,20 @@ VCmpTI64Vopc::VCmpTI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_T_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_t_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I64 does not support SDWA";
   return std::make_unique<VCmpTI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8495,15 +9787,20 @@ VCmpFU64Vopc::VCmpFU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_F_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_f_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U64 does not support SDWA";
   return std::make_unique<VCmpFU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8524,15 +9821,20 @@ VCmpLtU64Vopc::VCmpLtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support SDWA";
   return std::make_unique<VCmpLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8553,15 +9855,20 @@ VCmpEqU64Vopc::VCmpEqU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_eq_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support SDWA";
   return std::make_unique<VCmpEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8582,15 +9889,20 @@ VCmpLeU64Vopc::VCmpLeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_le_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support SDWA";
   return std::make_unique<VCmpLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8611,15 +9923,20 @@ VCmpGtU64Vopc::VCmpGtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_gt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support SDWA";
   return std::make_unique<VCmpGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8640,15 +9957,20 @@ VCmpNeU64Vopc::VCmpNeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ne_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support SDWA";
   return std::make_unique<VCmpNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8669,15 +9991,20 @@ VCmpGeU64Vopc::VCmpGeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ge_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support SDWA";
   return std::make_unique<VCmpGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8698,15 +10025,20 @@ VCmpTU64Vopc::VCmpTU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_T_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_t_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U64 does not support SDWA";
   return std::make_unique<VCmpTU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8729,17 +10061,22 @@ VCmpxFI64Vopc::VCmpxFI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_F_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_f_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I64 does not support SDWA";
   return std::make_unique<VCmpxFI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8762,17 +10099,22 @@ VCmpxLtI64Vopc::VCmpxLtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support SDWA";
   return std::make_unique<VCmpxLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8795,17 +10137,22 @@ VCmpxEqI64Vopc::VCmpxEqI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_eq_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support SDWA";
   return std::make_unique<VCmpxEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8828,17 +10175,22 @@ VCmpxLeI64Vopc::VCmpxLeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_le_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support SDWA";
   return std::make_unique<VCmpxLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8861,17 +10213,22 @@ VCmpxGtI64Vopc::VCmpxGtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_gt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support SDWA";
   return std::make_unique<VCmpxGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8894,17 +10251,22 @@ VCmpxNeI64Vopc::VCmpxNeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ne_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support SDWA";
   return std::make_unique<VCmpxNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8927,17 +10289,22 @@ VCmpxGeI64Vopc::VCmpxGeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ge_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support SDWA";
   return std::make_unique<VCmpxGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8960,17 +10327,22 @@ VCmpxTI64Vopc::VCmpxTI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_T_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_t_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I64 does not support SDWA";
   return std::make_unique<VCmpxTI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8993,17 +10365,22 @@ VCmpxFU64Vopc::VCmpxFU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_F_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_f_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U64 does not support SDWA";
   return std::make_unique<VCmpxFU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9026,17 +10403,22 @@ VCmpxLtU64Vopc::VCmpxLtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support SDWA";
   return std::make_unique<VCmpxLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9059,17 +10441,22 @@ VCmpxEqU64Vopc::VCmpxEqU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_eq_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support SDWA";
   return std::make_unique<VCmpxEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9092,17 +10479,22 @@ VCmpxLeU64Vopc::VCmpxLeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_le_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support SDWA";
   return std::make_unique<VCmpxLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9125,17 +10517,22 @@ VCmpxGtU64Vopc::VCmpxGtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_gt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support SDWA";
   return std::make_unique<VCmpxGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9158,17 +10555,22 @@ VCmpxNeU64Vopc::VCmpxNeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ne_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support SDWA";
   return std::make_unique<VCmpxNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9191,17 +10593,22 @@ VCmpxGeU64Vopc::VCmpxGeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ge_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support SDWA";
   return std::make_unique<VCmpxGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9224,17 +10631,22 @@ VCmpxTU64Vopc::VCmpxTU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_T_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_t_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U64 does not support SDWA";
   return std::make_unique<VCmpxTU64Vopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/decoder.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/decoder.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/vop3p.h"
-#include "util/except.h"
 #include <array>
 #include <bit>
 #include <format>
@@ -15,1428 +14,1879 @@ namespace rocjitsu {
 namespace cdna3 {
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddF64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxF64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinF64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicPkAddF16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSminMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUminMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferInvMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSbyteMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadShortD16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSshortMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUbyteMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUshortMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreByteMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreShortMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferWbl2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAppendDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsBpermuteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsConsumeDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsBarrierDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsInitDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaBrDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaPDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaVDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsNopDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPermuteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPkAddBf16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPkAddF16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPkAddRtnBf16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPkAddRtnF16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2st64B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2st64B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadAddtidB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB128Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB96Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI8D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU16D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU16D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU8D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSwizzleB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrapRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2st64B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2st64B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteAddtidB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB128Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB16D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB96Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddF32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddF64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxF64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinF64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicPkAddBf16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicPkAddF16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSminFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSminX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUminFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUminX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordx2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordx3Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordx4Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSbyteFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadShortD16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadShortD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSshortFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUbyteFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUshortFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreByteD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreByteFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordx2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordx3Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordx4Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreShortD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreShortFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddcU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn1WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtcProbeBufferSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtcProbeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicAddSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicAddX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicAndSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicAndX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicCmpswapSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicCmpswapX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicDecSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicDecX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicIncSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicIncX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicOrSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicOrX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSmaxSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSmaxX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSminSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSminX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSubSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSubX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSwapSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSwapX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicUmaxSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicUmaxX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicUminSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicUminX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicXorSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicXorX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBarrierSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicAddSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicAddX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicAndSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicAndX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicCmpswapSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicCmpswapX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicDecSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicDecX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicIncSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicIncX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicOrSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicOrX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSmaxSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSmaxX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSminSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSminX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSubSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSubX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSwapSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSwapX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicUmaxSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicUmaxX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicUminSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicUminX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicXorSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicXorX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferStoreDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferStoreDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferStoreDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCallB64Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbguserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchGForkSop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchIForkSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchJoinSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkEqI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkEqU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGeI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGeU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGtI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGtU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLeI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLeU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLgI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLgU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLtI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLtU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheDiscardSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheDiscardX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheInvVolSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheWbSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheWbVolSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf0I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf0I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf1I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf1I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32I64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetpcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMemrealtimeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMemtimeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRfeB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRfeRestoreB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchLoadDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchStoreDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchStoreDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchStoreDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetGprIdxIdxSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetGprIdxModeSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetGprIdxOffSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetGprIdxOnSopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetValuCoexecModeSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetkillSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetpcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetvskipSopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSStoreDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSStoreDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSStoreDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubbU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSwappcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAccvgprMovB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAccvgprMovB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAccvgprReadVop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAccvgprWriteVop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddcCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddcCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClrexcpVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClrexcpVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Bf8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Bf8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Fp8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Fp8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkBf8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF32Bf8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF32Bf8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF32Fp8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF32Fp8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkFp8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkaccumU8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormI16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormU16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtSrBf8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtSrFp8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupLegacyF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2F32F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2I32I16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2U32U16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cI32I16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cI32I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4I32I8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8I32I4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8cI32I4Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8cI32I4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhI32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhU32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfblB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfblB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaLegacyF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaakF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmamkF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlAddU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMacF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadLegacyF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadLegacyI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadLegacyU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadMixF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadMixhiF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadMixloF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadakF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadmkF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x14bF32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x16Bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x16F16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32Bf8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32Bf8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32Fp8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32Fp8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x44bBf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x44bF16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x4F32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x8Xf32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x12bF32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16Bf8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16Bf8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16Fp8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16Fp8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x2F32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x42bBf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x42bF16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x4Xf32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x8Bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x8F16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF324x4x116bF32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF324x4x416bBf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF324x4x416bF16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF6416x16x4F64Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF644x4x44bF64Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI3216x16x32I8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI3216x16x44bI8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI3232x32x16I8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI3232x32x42bI8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI324x4x416bI8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLegacyF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmaF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMovB32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVScreenPartition4seB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVScreenPartition4seB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x32Bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x32F16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64Bf8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64Bf8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64Fp8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64Fp8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x16Bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x16F16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32Bf8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32Bf8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32Fp8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32Fp8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacI3216x16x64I8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacI3232x32x32I8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubbCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubbCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubbrevCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubbrevCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwapB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode);
+DecodeResult decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddF64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxF64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinF64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrMubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicPkAddF16Mubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferInvMubuf(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXMubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadShortD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreByteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreShortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferWbl2Mubuf(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAppendDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsBpermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsConsumeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsBarrierDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsInitDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaBrDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaPDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaVDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsNopDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPkAddBf16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPkAddF16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPkAddRtnBf16Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPkAddRtnF16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2st64B32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2st64B64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadAddtidB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI8D16HiDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU16D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU16D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU8D16HiDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSwizzleB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrapRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2st64B32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2st64B64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteAddtidB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB16D16HiDs(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB8D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchgRtnB32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchgRtnB64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddF32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddF64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapFlat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxF64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinF64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrX2Flat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicPkAddBf16Flat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicPkAddF16Flat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordx2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordx3Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordx4Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadShortD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadShortD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreByteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreByteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordx2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordx3Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordx4Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreShortD16HiFlat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreShortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddcU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn1WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtcProbeBufferSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtcProbeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicAddSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicAddX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicAndSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicAndX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicCmpswapSmem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicCmpswapX2Smem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicDecSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicDecX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicIncSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicIncX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicOrSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicOrX2Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSmaxSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSmaxX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSminSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSminX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSubSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSubX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSwapSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSwapX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicUmaxSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicUmaxX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicUminSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicUminX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicXorSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicXorX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBarrierSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicAddSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicAddX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicAndSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicAndX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicCmpswapSmem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicCmpswapX2Smem(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicDecSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicDecX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicIncSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicIncX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicOrSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicOrX2Smem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSmaxSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSmaxX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSminSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSminX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSubSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSubX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSwapSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSwapX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicUmaxSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicUmaxX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicUminSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicUminX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicXorSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicXorX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx16Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx4Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx8Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferStoreDwordSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferStoreDwordx2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferStoreDwordx4Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCallB64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysSopp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbguserSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchGForkSop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchIForkSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchJoinSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkEqI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkEqU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLgI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLgU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheDiscardSmem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheDiscardX2Smem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheInvVolSmem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheWbSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheWbVolSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf0I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf0I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf1I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf1I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32I64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx16Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx4Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx8Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMemrealtimeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMemtimeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRfeB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRfeRestoreB64Sop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchLoadDwordSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchLoadDwordx2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchLoadDwordx4Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchStoreDwordSmem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchStoreDwordx2Smem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchStoreDwordx4Smem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetGprIdxIdxSop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetGprIdxModeSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetGprIdxOffSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetGprIdxOnSopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetValuCoexecModeSopp(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetkillSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetvskipSopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSStoreDwordSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSStoreDwordx2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSStoreDwordx4Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubbU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSwappcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAccvgprMovB32Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAccvgprMovB32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAccvgprReadVop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAccvgprWriteVop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddcCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddcCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClrexcpVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClrexcpVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Bf8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Bf8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Fp8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Fp8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFlrI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFlrI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkBf8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF32Bf8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF32Bf8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF32Fp8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF32Fp8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkFp8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkaccumU8F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtRpiI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtRpiI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtSrBf8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtSrFp8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupLegacyF16Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2F32F16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2I32I16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2U32U16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cF32F16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cF32F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cI32I16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cI32I16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4I32I8Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4cI32I8Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4cI32I8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8I32I4Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8cI32I4Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8cI32I4Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhU32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfblB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfblB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaLegacyF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmamkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlAddU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadLegacyF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadLegacyI16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadLegacyU16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadMixF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadmkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x14bF32Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x16Bf16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x16F16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x32Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x32Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x32Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x32Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x44bBf16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x44bF16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x4F32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x8Xf32Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x12bF32Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x16Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x16Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x16Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x16Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x2F32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x42bBf16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x42bF16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x4Xf32Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x8Bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x8F16Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF324x4x116bF32Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF324x4x416bBf16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF324x4x416bF16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF6416x16x4F64Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF644x4x44bF64Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI3216x16x32I8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI3216x16x44bI8Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI3232x32x16I8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI3232x32x42bI8Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI324x4x416bI8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmaF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMovB32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVScreenPartition4seB32Vop1(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVScreenPartition4seB32Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3216x16x32Bf16Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3216x16x32F16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3216x16x64Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3216x16x64Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3216x16x64Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3216x16x64Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3232x32x16Bf16Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3232x32x16F16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3232x32x32Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3232x32x32Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3232x32x32Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3232x32x32Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacI3216x16x64I8Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacI3232x32x32I8Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubbCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubbCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubbrevCoU32Vop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubbrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwapB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 } // namespace detail
 
 struct DecoderImpl {
 public:
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 
 private:
-  using DecodeFunc = std::unique_ptr<Instruction> (*)(const MachineInst *);
-  static std::unique_ptr<Instruction> decodeInvalid(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopp(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSmem(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3p(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeDs(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeFlat(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMubuf(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMtbuf(const MachineInst *opcode);
+  using DecodeFunc = DecodeResult (*)(const MachineInst *, const DecodeErrorEmitter &);
+  static DecodeResult decodeInvalid(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMtbuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
   static const std::array<DecodeFunc, 512> primary_decode_table;
   static const std::array<DecodeFunc, 256> sub_decode_vopc;
   static const std::array<DecodeFunc, 256> sub_decode_vop1;
@@ -1452,78 +1902,90 @@ private:
   static const std::array<DecodeFunc, 16> sub_decode_mtbuf;
 };
 
-std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
-  return DecoderImpl::decode(opcode);
+DecodeResult Decoder::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  return DecoderImpl::decode(opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decode(const MachineInst *opcode) {
+DecodeResult DecoderImpl::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
   Sop1MachineInst op = std::bit_cast<decltype(op)>(*opcode);
-  return primary_decode_table[op.encoding](opcode);
+  return primary_decode_table[op.encoding](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decodeInvalid(const MachineInst *opcode) {
-  throw util::InvalidInst(std::format("{:X}", *opcode));
-  return nullptr;
+DecodeResult DecoderImpl::decodeInvalid(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  return emit_error.emit() << "Invalid instruction opcode: " << std::format("{:X}", *opcode);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vopc[op.op](opcode);
+  return sub_decode_vopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop1[op.op](opcode);
+  return sub_decode_vop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sop1[op.op](opcode);
+  return sub_decode_sop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopc[op.op](opcode);
+  return sub_decode_sopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopp(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopp::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopp[op.op](opcode);
+  return sub_decode_sopp[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSmem(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Smem::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_smem[op.op](opcode);
+  return sub_decode_smem[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop3::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3[op.op](opcode);
+  return sub_decode_vop3[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3p(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3p(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Vop3p::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3p[op.op](opcode);
+  return sub_decode_vop3p[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeDs(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeDs(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
   Ds::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_ds[op.op](opcode);
+  return sub_decode_ds[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeFlat(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeFlat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Flat::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_flat[op.op](opcode);
+  return sub_decode_flat[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMubuf(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Mubuf::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mubuf[op.op](opcode);
+  return sub_decode_mubuf[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMtbuf(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMtbuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Mtbuf::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mtbuf[op.op](opcode);
+  return sub_decode_mtbuf[op.op](opcode, emit_error);
 }
 
 const std::array<DecoderImpl::DecodeFunc, 512> DecoderImpl::primary_decode_table = {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/decoder.h
@@ -8,6 +8,7 @@
 #define ROCJITSU_ISA_ARCH_AMDGPU_CDNA3_DECODER_H_
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/machine_insts.h"
+#include "rocjitsu/isa/decode_result.h"
 #include <array>
 #include <cstddef>
 #include <memory>
@@ -21,7 +22,7 @@ namespace cdna3 {
 class Decoder {
 public:
   static constexpr std::size_t kMaxInstructionWords = 4;
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 };
 
 } // namespace cdna3

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/ds.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/ds.cpp
@@ -8,7 +8,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -36,7 +35,11 @@ DsAddU32Ds::DsAddU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU32Ds>(opcode);
 }
 } // namespace detail
@@ -63,7 +66,11 @@ DsSubU32Ds::DsSubU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU32Ds>(opcode);
 }
 } // namespace detail
@@ -90,7 +97,11 @@ DsRsubU32Ds::DsRsubU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU32Ds>(opcode);
 }
 } // namespace detail
@@ -117,7 +128,11 @@ DsIncU32Ds::DsIncU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU32Ds>(opcode);
 }
 } // namespace detail
@@ -144,7 +159,11 @@ DsDecU32Ds::DsDecU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU32Ds>(opcode);
 }
 } // namespace detail
@@ -171,7 +190,11 @@ DsMinI32Ds::DsMinI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI32Ds>(opcode);
 }
 } // namespace detail
@@ -198,7 +221,11 @@ DsMaxI32Ds::DsMaxI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI32Ds>(opcode);
 }
 } // namespace detail
@@ -225,7 +252,11 @@ DsMinU32Ds::DsMinU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU32Ds>(opcode);
 }
 } // namespace detail
@@ -252,7 +283,11 @@ DsMaxU32Ds::DsMaxU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU32Ds>(opcode);
 }
 } // namespace detail
@@ -279,7 +314,11 @@ DsAndB32Ds::DsAndB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB32Ds>(opcode);
 }
 } // namespace detail
@@ -306,7 +345,11 @@ DsOrB32Ds::DsOrB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB32Ds>(opcode);
 }
 } // namespace detail
@@ -333,7 +376,11 @@ DsXorB32Ds::DsXorB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB32Ds>(opcode);
 }
 } // namespace detail
@@ -366,7 +413,11 @@ DsMskorB32Ds::DsMskorB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB32Ds>(opcode);
 }
 } // namespace detail
@@ -391,7 +442,11 @@ DsWriteB32Ds::DsWriteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB32Ds>(opcode);
 }
 } // namespace detail
@@ -422,7 +477,11 @@ DsWrite2B32Ds::DsWrite2B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2B32Ds>(opcode);
 }
 } // namespace detail
@@ -453,7 +512,12 @@ DsWrite2st64B32Ds::DsWrite2st64B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2st64B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2st64B32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2st64_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2st64B32Ds>(opcode);
 }
 } // namespace detail
@@ -486,7 +550,11 @@ DsCmpstB32Ds::DsCmpstB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstB32Ds>(opcode);
 }
 } // namespace detail
@@ -519,7 +587,11 @@ DsCmpstF32Ds::DsCmpstF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstF32Ds>(opcode);
 }
 } // namespace detail
@@ -546,7 +618,11 @@ DsMinF32Ds::DsMinF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinF32Ds>(opcode);
 }
 } // namespace detail
@@ -573,7 +649,11 @@ DsMaxF32Ds::DsMaxF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxF32Ds>(opcode);
 }
 } // namespace detail
@@ -586,7 +666,11 @@ DsNopDs::DsNopDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsNopDs(const MachineInst *opcode) {
+DecodeResult decodeDsNopDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Ds::validate_encoding("ds_nop", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsNopDs>(opcode);
 }
 } // namespace detail
@@ -613,7 +697,11 @@ DsAddF32Ds::DsAddF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddF32Ds>(opcode);
 }
 } // namespace detail
@@ -635,7 +723,11 @@ DsPkAddF16Ds::DsPkAddF16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPkAddF16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsPkAddF16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_pk_add_f16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPkAddF16Ds>(opcode);
 }
 } // namespace detail
@@ -657,7 +749,11 @@ DsPkAddBf16Ds::DsPkAddBf16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPkAddBf16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsPkAddBf16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_pk_add_bf16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPkAddBf16Ds>(opcode);
 }
 } // namespace detail
@@ -682,7 +778,12 @@ DsWriteAddtidB32Ds::DsWriteAddtidB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteAddtidB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteAddtidB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_addtid_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteAddtidB32Ds>(opcode);
 }
 } // namespace detail
@@ -707,7 +808,11 @@ DsWriteB8Ds::DsWriteB8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB8Ds>(opcode);
 }
 } // namespace detail
@@ -732,7 +837,11 @@ DsWriteB16Ds::DsWriteB16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB16Ds>(opcode);
 }
 } // namespace detail
@@ -765,7 +874,11 @@ DsAddRtnU32Ds::DsAddRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -798,7 +911,11 @@ DsSubRtnU32Ds::DsSubRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -831,7 +948,11 @@ DsRsubRtnU32Ds::DsRsubRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -864,7 +985,11 @@ DsIncRtnU32Ds::DsIncRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -897,7 +1022,11 @@ DsDecRtnU32Ds::DsDecRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -930,7 +1059,11 @@ DsMinRtnI32Ds::DsMinRtnI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI32Ds>(opcode);
 }
 } // namespace detail
@@ -963,7 +1096,11 @@ DsMaxRtnI32Ds::DsMaxRtnI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI32Ds>(opcode);
 }
 } // namespace detail
@@ -996,7 +1133,11 @@ DsMinRtnU32Ds::DsMinRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -1029,7 +1170,11 @@ DsMaxRtnU32Ds::DsMaxRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -1062,7 +1207,11 @@ DsAndRtnB32Ds::DsAndRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1095,7 +1244,11 @@ DsOrRtnB32Ds::DsOrRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1128,7 +1281,11 @@ DsXorRtnB32Ds::DsXorRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1167,7 +1324,12 @@ DsMskorRtnB32Ds::DsMskorRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1200,7 +1362,12 @@ DsWrxchgRtnB32Ds::DsWrxchgRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchgRtnB32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchgRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1239,7 +1406,12 @@ DsWrxchg2RtnB32Ds::DsWrxchg2RtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2RtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1278,7 +1450,12 @@ DsWrxchg2st64RtnB32Ds::DsWrxchg2st64RtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2st64_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2st64RtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1317,7 +1494,12 @@ DsCmpstRtnB32Ds::DsCmpstRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1356,7 +1538,12 @@ DsCmpstRtnF32Ds::DsCmpstRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnF32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1389,7 +1576,11 @@ DsMinRtnF32Ds::DsMinRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1422,7 +1613,11 @@ DsMaxRtnF32Ds::DsMaxRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1460,7 +1655,11 @@ DsWrapRtnB32Ds::DsWrapRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrapRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrapRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrap_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrapRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1493,7 +1692,11 @@ DsAddRtnF32Ds::DsAddRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1518,7 +1721,11 @@ DsReadB32Ds::DsReadB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB32Ds>(opcode);
 }
 } // namespace detail
@@ -1543,7 +1750,11 @@ DsRead2B32Ds::DsRead2B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2B32Ds>(opcode);
 }
 } // namespace detail
@@ -1568,7 +1779,12 @@ DsRead2st64B32Ds::DsRead2st64B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2st64B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2st64B32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2st64_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2st64B32Ds>(opcode);
 }
 } // namespace detail
@@ -1593,7 +1809,11 @@ DsReadI8Ds::DsReadI8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadI8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI8Ds>(opcode);
 }
 } // namespace detail
@@ -1618,7 +1838,11 @@ DsReadU8Ds::DsReadU8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU8Ds>(opcode);
 }
 } // namespace detail
@@ -1643,7 +1867,11 @@ DsReadI16Ds::DsReadI16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadI16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI16Ds>(opcode);
 }
 } // namespace detail
@@ -1668,7 +1896,11 @@ DsReadU16Ds::DsReadU16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU16Ds>(opcode);
 }
 } // namespace detail
@@ -1689,7 +1921,11 @@ DsSwizzleB32Ds::DsSwizzleB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSwizzleB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSwizzleB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_swizzle_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSwizzleB32Ds>(opcode);
 }
 } // namespace detail
@@ -1716,7 +1952,11 @@ DsPermuteB32Ds::DsPermuteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPermuteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsPermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_permute_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPermuteB32Ds>(opcode);
 }
 } // namespace detail
@@ -1743,7 +1983,12 @@ DsBpermuteB32Ds::DsBpermuteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsBpermuteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsBpermuteB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_bpermute_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsBpermuteB32Ds>(opcode);
 }
 } // namespace detail
@@ -1770,7 +2015,11 @@ DsAddU64Ds::DsAddU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU64Ds>(opcode);
 }
 } // namespace detail
@@ -1797,7 +2046,11 @@ DsSubU64Ds::DsSubU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU64Ds>(opcode);
 }
 } // namespace detail
@@ -1824,7 +2077,11 @@ DsRsubU64Ds::DsRsubU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU64Ds>(opcode);
 }
 } // namespace detail
@@ -1851,7 +2108,11 @@ DsIncU64Ds::DsIncU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU64Ds>(opcode);
 }
 } // namespace detail
@@ -1878,7 +2139,11 @@ DsDecU64Ds::DsDecU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU64Ds>(opcode);
 }
 } // namespace detail
@@ -1905,7 +2170,11 @@ DsMinI64Ds::DsMinI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI64Ds>(opcode);
 }
 } // namespace detail
@@ -1932,7 +2201,11 @@ DsMaxI64Ds::DsMaxI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI64Ds>(opcode);
 }
 } // namespace detail
@@ -1959,7 +2232,11 @@ DsMinU64Ds::DsMinU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU64Ds>(opcode);
 }
 } // namespace detail
@@ -1986,7 +2263,11 @@ DsMaxU64Ds::DsMaxU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU64Ds>(opcode);
 }
 } // namespace detail
@@ -2013,7 +2294,11 @@ DsAndB64Ds::DsAndB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB64Ds>(opcode);
 }
 } // namespace detail
@@ -2040,7 +2325,11 @@ DsOrB64Ds::DsOrB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB64Ds>(opcode);
 }
 } // namespace detail
@@ -2067,7 +2356,11 @@ DsXorB64Ds::DsXorB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB64Ds>(opcode);
 }
 } // namespace detail
@@ -2100,7 +2393,11 @@ DsMskorB64Ds::DsMskorB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB64Ds>(opcode);
 }
 } // namespace detail
@@ -2125,7 +2422,11 @@ DsWriteB64Ds::DsWriteB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB64Ds>(opcode);
 }
 } // namespace detail
@@ -2156,7 +2457,11 @@ DsWrite2B64Ds::DsWrite2B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2B64Ds>(opcode);
 }
 } // namespace detail
@@ -2187,7 +2492,12 @@ DsWrite2st64B64Ds::DsWrite2st64B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2st64B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2st64B64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2st64_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2st64B64Ds>(opcode);
 }
 } // namespace detail
@@ -2220,7 +2530,11 @@ DsCmpstB64Ds::DsCmpstB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstB64Ds>(opcode);
 }
 } // namespace detail
@@ -2253,7 +2567,11 @@ DsCmpstF64Ds::DsCmpstF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstF64Ds>(opcode);
 }
 } // namespace detail
@@ -2280,7 +2598,11 @@ DsMinF64Ds::DsMinF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinF64Ds>(opcode);
 }
 } // namespace detail
@@ -2307,7 +2629,11 @@ DsMaxF64Ds::DsMaxF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxF64Ds>(opcode);
 }
 } // namespace detail
@@ -2332,7 +2658,12 @@ DsWriteB8D16HiDs::DsWriteB8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB8D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2357,7 +2688,12 @@ DsWriteB16D16HiDs::DsWriteB16D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB16D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB16D16HiDs(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b16_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB16D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2382,7 +2718,11 @@ DsReadU8D16Ds::DsReadU8D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU8D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u8_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU8D16Ds>(opcode);
 }
 } // namespace detail
@@ -2413,7 +2753,12 @@ DsReadU8D16HiDs::DsReadU8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsReadU8D16HiDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2444,7 +2789,11 @@ DsReadI8D16Ds::DsReadI8D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI8D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i8_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI8D16Ds>(opcode);
 }
 } // namespace detail
@@ -2475,7 +2824,12 @@ DsReadI8D16HiDs::DsReadI8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsReadI8D16HiDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2506,7 +2860,11 @@ DsReadU16D16Ds::DsReadU16D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU16D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU16D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u16_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU16D16Ds>(opcode);
 }
 } // namespace detail
@@ -2537,7 +2895,12 @@ DsReadU16D16HiDs::DsReadU16D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU16D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsReadU16D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u16_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU16D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2570,7 +2933,11 @@ DsAddF64Ds::DsAddF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddF64Ds>(opcode);
 }
 } // namespace detail
@@ -2603,7 +2970,11 @@ DsAddRtnU64Ds::DsAddRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2636,7 +3007,11 @@ DsSubRtnU64Ds::DsSubRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2669,7 +3044,11 @@ DsRsubRtnU64Ds::DsRsubRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2702,7 +3081,11 @@ DsIncRtnU64Ds::DsIncRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2735,7 +3118,11 @@ DsDecRtnU64Ds::DsDecRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2768,7 +3155,11 @@ DsMinRtnI64Ds::DsMinRtnI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI64Ds>(opcode);
 }
 } // namespace detail
@@ -2801,7 +3192,11 @@ DsMaxRtnI64Ds::DsMaxRtnI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI64Ds>(opcode);
 }
 } // namespace detail
@@ -2834,7 +3229,11 @@ DsMinRtnU64Ds::DsMinRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2867,7 +3266,11 @@ DsMaxRtnU64Ds::DsMaxRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2900,7 +3303,11 @@ DsAndRtnB64Ds::DsAndRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2933,7 +3340,11 @@ DsOrRtnB64Ds::DsOrRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2966,7 +3377,11 @@ DsXorRtnB64Ds::DsXorRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3005,7 +3420,12 @@ DsMskorRtnB64Ds::DsMskorRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3038,7 +3458,12 @@ DsWrxchgRtnB64Ds::DsWrxchgRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchgRtnB64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchgRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3077,7 +3502,12 @@ DsWrxchg2RtnB64Ds::DsWrxchg2RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3116,7 +3546,12 @@ DsWrxchg2st64RtnB64Ds::DsWrxchg2st64RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2st64_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2st64RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3155,7 +3590,12 @@ DsCmpstRtnB64Ds::DsCmpstRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnB64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3194,7 +3634,12 @@ DsCmpstRtnF64Ds::DsCmpstRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnF64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -3227,7 +3672,11 @@ DsMinRtnF64Ds::DsMinRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -3260,7 +3709,11 @@ DsMaxRtnF64Ds::DsMaxRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -3285,7 +3738,11 @@ DsReadB64Ds::DsReadB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB64Ds>(opcode);
 }
 } // namespace detail
@@ -3310,7 +3767,11 @@ DsRead2B64Ds::DsRead2B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2B64Ds>(opcode);
 }
 } // namespace detail
@@ -3335,7 +3796,12 @@ DsRead2st64B64Ds::DsRead2st64B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2st64B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2st64B64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2st64_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2st64B64Ds>(opcode);
 }
 } // namespace detail
@@ -3368,7 +3834,11 @@ DsAddRtnF64Ds::DsAddRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -3401,7 +3871,12 @@ DsCondxchg32RtnB64Ds::DsCondxchg32RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_condxchg32_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCondxchg32RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3414,7 +3889,12 @@ DsGwsSemaReleaseAllDs::DsGwsSemaReleaseAllDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_release_all", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaReleaseAllDs>(opcode);
 }
 } // namespace detail
@@ -3429,7 +3909,11 @@ DsGwsInitDs::DsGwsInitDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsInitDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsInitDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_init", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsInitDs>(opcode);
 }
 } // namespace detail
@@ -3442,7 +3926,11 @@ DsGwsSemaVDs::DsGwsSemaVDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaVDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaVDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_v", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaVDs>(opcode);
 }
 } // namespace detail
@@ -3457,7 +3945,11 @@ DsGwsSemaBrDs::DsGwsSemaBrDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaBrDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaBrDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_br", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaBrDs>(opcode);
 }
 } // namespace detail
@@ -3470,7 +3962,11 @@ DsGwsSemaPDs::DsGwsSemaPDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaPDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaPDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_p", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaPDs>(opcode);
 }
 } // namespace detail
@@ -3485,7 +3981,11 @@ DsGwsBarrierDs::DsGwsBarrierDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsBarrierDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsBarrierDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_barrier", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsBarrierDs>(opcode);
 }
 } // namespace detail
@@ -3510,7 +4010,12 @@ DsReadAddtidB32Ds::DsReadAddtidB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadAddtidB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadAddtidB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_addtid_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadAddtidB32Ds>(opcode);
 }
 } // namespace detail
@@ -3538,7 +4043,12 @@ DsPkAddRtnF16Ds::DsPkAddRtnF16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPkAddRtnF16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsPkAddRtnF16Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_pk_add_rtn_f16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPkAddRtnF16Ds>(opcode);
 }
 } // namespace detail
@@ -3566,7 +4076,12 @@ DsPkAddRtnBf16Ds::DsPkAddRtnBf16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPkAddRtnBf16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsPkAddRtnBf16Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_pk_add_rtn_bf16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPkAddRtnBf16Ds>(opcode);
 }
 } // namespace detail
@@ -3591,7 +4106,11 @@ DsConsumeDs::DsConsumeDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsConsumeDs(const MachineInst *opcode) {
+DecodeResult decodeDsConsumeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_consume", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsConsumeDs>(opcode);
 }
 } // namespace detail
@@ -3616,7 +4135,11 @@ DsAppendDs::DsAppendDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAppendDs(const MachineInst *opcode) {
+DecodeResult decodeDsAppendDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_append", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAppendDs>(opcode);
 }
 } // namespace detail
@@ -3641,7 +4164,11 @@ DsWriteB96Ds::DsWriteB96Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB96Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b96", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB96Ds>(opcode);
 }
 } // namespace detail
@@ -3666,7 +4193,11 @@ DsWriteB128Ds::DsWriteB128Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB128Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b128", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB128Ds>(opcode);
 }
 } // namespace detail
@@ -3691,7 +4222,11 @@ DsReadB96Ds::DsReadB96Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB96Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b96", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB96Ds>(opcode);
 }
 } // namespace detail
@@ -3716,7 +4251,11 @@ DsReadB128Ds::DsReadB128Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB128Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b128", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB128Ds>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/encodings.h
@@ -10,6 +10,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna3/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
+#include "rocjitsu/isa/decode_result.h"
 #include "rocjitsu/isa/instruction.h"
 #include <array>
 #include <cstdint>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/flat.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/flat.cpp
@@ -8,7 +8,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -48,7 +47,12 @@ FlatLoadUbyteFlat::FlatLoadUbyteFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUbyteFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ubyte", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUbyteFlat>(opcode);
 }
 } // namespace detail
@@ -87,7 +91,12 @@ FlatLoadSbyteFlat::FlatLoadSbyteFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSbyteFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sbyte", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSbyteFlat>(opcode);
 }
 } // namespace detail
@@ -126,7 +135,12 @@ FlatLoadUshortFlat::FlatLoadUshortFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUshortFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ushort", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUshortFlat>(opcode);
 }
 } // namespace detail
@@ -165,7 +179,12 @@ FlatLoadSshortFlat::FlatLoadSshortFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSshortFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sshort", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSshortFlat>(opcode);
 }
 } // namespace detail
@@ -204,7 +223,12 @@ FlatLoadDwordFlat::FlatLoadDwordFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dword", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordFlat>(opcode);
 }
 } // namespace detail
@@ -243,7 +267,12 @@ FlatLoadDwordx2Flat::FlatLoadDwordx2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordx2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordx2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dwordx2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordx2Flat>(opcode);
 }
 } // namespace detail
@@ -282,7 +311,12 @@ FlatLoadDwordx3Flat::FlatLoadDwordx3Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordx3Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordx3Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dwordx3", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordx3Flat>(opcode);
 }
 } // namespace detail
@@ -321,7 +355,12 @@ FlatLoadDwordx4Flat::FlatLoadDwordx4Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordx4Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordx4Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dwordx4", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordx4Flat>(opcode);
 }
 } // namespace detail
@@ -360,7 +399,12 @@ FlatStoreByteFlat::FlatStoreByteFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreByteFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreByteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_byte", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreByteFlat>(opcode);
 }
 } // namespace detail
@@ -399,7 +443,12 @@ FlatStoreByteD16HiFlat::FlatStoreByteD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreByteD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreByteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_byte_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreByteD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -438,7 +487,12 @@ FlatStoreShortFlat::FlatStoreShortFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreShortFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreShortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_short", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreShortFlat>(opcode);
 }
 } // namespace detail
@@ -477,7 +531,12 @@ FlatStoreShortD16HiFlat::FlatStoreShortD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreShortD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreShortD16HiFlat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_short_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreShortD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -516,7 +575,12 @@ FlatStoreDwordFlat::FlatStoreDwordFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dword", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordFlat>(opcode);
 }
 } // namespace detail
@@ -555,7 +619,12 @@ FlatStoreDwordx2Flat::FlatStoreDwordx2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordx2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordx2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dwordx2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordx2Flat>(opcode);
 }
 } // namespace detail
@@ -594,7 +663,12 @@ FlatStoreDwordx3Flat::FlatStoreDwordx3Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordx3Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordx3Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dwordx3", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordx3Flat>(opcode);
 }
 } // namespace detail
@@ -633,7 +707,12 @@ FlatStoreDwordx4Flat::FlatStoreDwordx4Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordx4Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordx4Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dwordx4", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordx4Flat>(opcode);
 }
 } // namespace detail
@@ -672,7 +751,12 @@ FlatLoadUbyteD16Flat::FlatLoadUbyteD16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ubyte_d16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUbyteD16Flat>(opcode);
 }
 } // namespace detail
@@ -718,7 +802,12 @@ FlatLoadUbyteD16HiFlat::FlatLoadUbyteD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ubyte_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUbyteD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -764,7 +853,12 @@ FlatLoadSbyteD16Flat::FlatLoadSbyteD16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sbyte_d16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSbyteD16Flat>(opcode);
 }
 } // namespace detail
@@ -810,7 +904,12 @@ FlatLoadSbyteD16HiFlat::FlatLoadSbyteD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sbyte_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSbyteD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -856,7 +955,12 @@ FlatLoadShortD16Flat::FlatLoadShortD16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadShortD16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadShortD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_short_d16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadShortD16Flat>(opcode);
 }
 } // namespace detail
@@ -902,7 +1006,12 @@ FlatLoadShortD16HiFlat::FlatLoadShortD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadShortD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadShortD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_short_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadShortD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -955,7 +1064,12 @@ FlatAtomicSwapFlat::FlatAtomicSwapFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_swap", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapFlat>(opcode);
 }
 } // namespace detail
@@ -1001,7 +1115,12 @@ FlatAtomicCmpswapFlat::FlatAtomicCmpswapFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapFlat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_cmpswap", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapFlat>(opcode);
 }
 } // namespace detail
@@ -1047,7 +1166,12 @@ FlatAtomicAddFlat::FlatAtomicAddFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddFlat>(opcode);
 }
 } // namespace detail
@@ -1093,7 +1217,12 @@ FlatAtomicSubFlat::FlatAtomicSubFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_sub", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubFlat>(opcode);
 }
 } // namespace detail
@@ -1139,7 +1268,12 @@ FlatAtomicSminFlat::FlatAtomicSminFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSminFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smin", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSminFlat>(opcode);
 }
 } // namespace detail
@@ -1185,7 +1319,12 @@ FlatAtomicUminFlat::FlatAtomicUminFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUminFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umin", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUminFlat>(opcode);
 }
 } // namespace detail
@@ -1231,7 +1370,12 @@ FlatAtomicSmaxFlat::FlatAtomicSmaxFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smax", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSmaxFlat>(opcode);
 }
 } // namespace detail
@@ -1277,7 +1421,12 @@ FlatAtomicUmaxFlat::FlatAtomicUmaxFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umax", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUmaxFlat>(opcode);
 }
 } // namespace detail
@@ -1323,7 +1472,12 @@ FlatAtomicAndFlat::FlatAtomicAndFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_and", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndFlat>(opcode);
 }
 } // namespace detail
@@ -1369,7 +1523,12 @@ FlatAtomicOrFlat::FlatAtomicOrFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_or", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrFlat>(opcode);
 }
 } // namespace detail
@@ -1415,7 +1574,12 @@ FlatAtomicXorFlat::FlatAtomicXorFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_xor", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorFlat>(opcode);
 }
 } // namespace detail
@@ -1461,7 +1625,12 @@ FlatAtomicIncFlat::FlatAtomicIncFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_inc", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncFlat>(opcode);
 }
 } // namespace detail
@@ -1507,7 +1676,12 @@ FlatAtomicDecFlat::FlatAtomicDecFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_dec", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecFlat>(opcode);
 }
 } // namespace detail
@@ -1553,7 +1727,12 @@ FlatAtomicAddF32Flat::FlatAtomicAddF32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddF32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddF32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add_f32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddF32Flat>(opcode);
 }
 } // namespace detail
@@ -1599,7 +1778,12 @@ FlatAtomicPkAddF16Flat::FlatAtomicPkAddF16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicPkAddF16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicPkAddF16Flat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_pk_add_f16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicPkAddF16Flat>(opcode);
 }
 } // namespace detail
@@ -1645,7 +1829,12 @@ FlatAtomicAddF64Flat::FlatAtomicAddF64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddF64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddF64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add_f64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddF64Flat>(opcode);
 }
 } // namespace detail
@@ -1691,7 +1880,12 @@ FlatAtomicMinF64Flat::FlatAtomicMinF64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinF64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinF64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_min_f64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinF64Flat>(opcode);
 }
 } // namespace detail
@@ -1737,7 +1931,12 @@ FlatAtomicMaxF64Flat::FlatAtomicMaxF64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxF64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxF64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_max_f64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxF64Flat>(opcode);
 }
 } // namespace detail
@@ -1783,7 +1982,12 @@ FlatAtomicPkAddBf16Flat::FlatAtomicPkAddBf16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicPkAddBf16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicPkAddBf16Flat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_pk_add_bf16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicPkAddBf16Flat>(opcode);
 }
 } // namespace detail
@@ -1829,7 +2033,12 @@ FlatAtomicSwapX2Flat::FlatAtomicSwapX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_swap_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapX2Flat>(opcode);
 }
 } // namespace detail
@@ -1875,7 +2084,12 @@ FlatAtomicCmpswapX2Flat::FlatAtomicCmpswapX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_cmpswap_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapX2Flat>(opcode);
 }
 } // namespace detail
@@ -1921,7 +2135,12 @@ FlatAtomicAddX2Flat::FlatAtomicAddX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddX2Flat>(opcode);
 }
 } // namespace detail
@@ -1967,7 +2186,12 @@ FlatAtomicSubX2Flat::FlatAtomicSubX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_sub_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubX2Flat>(opcode);
 }
 } // namespace detail
@@ -2013,7 +2237,12 @@ FlatAtomicSminX2Flat::FlatAtomicSminX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSminX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smin_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSminX2Flat>(opcode);
 }
 } // namespace detail
@@ -2059,7 +2288,12 @@ FlatAtomicUminX2Flat::FlatAtomicUminX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUminX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umin_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUminX2Flat>(opcode);
 }
 } // namespace detail
@@ -2105,7 +2339,12 @@ FlatAtomicSmaxX2Flat::FlatAtomicSmaxX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smax_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSmaxX2Flat>(opcode);
 }
 } // namespace detail
@@ -2151,7 +2390,12 @@ FlatAtomicUmaxX2Flat::FlatAtomicUmaxX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umax_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUmaxX2Flat>(opcode);
 }
 } // namespace detail
@@ -2197,7 +2441,12 @@ FlatAtomicAndX2Flat::FlatAtomicAndX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_and_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndX2Flat>(opcode);
 }
 } // namespace detail
@@ -2243,7 +2492,12 @@ FlatAtomicOrX2Flat::FlatAtomicOrX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrX2Flat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_or_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrX2Flat>(opcode);
 }
 } // namespace detail
@@ -2289,7 +2543,12 @@ FlatAtomicXorX2Flat::FlatAtomicXorX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_xor_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorX2Flat>(opcode);
 }
 } // namespace detail
@@ -2335,7 +2594,12 @@ FlatAtomicIncX2Flat::FlatAtomicIncX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_inc_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncX2Flat>(opcode);
 }
 } // namespace detail
@@ -2381,7 +2645,12 @@ FlatAtomicDecX2Flat::FlatAtomicDecX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_dec_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecX2Flat>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/mtbuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/mtbuf.cpp
@@ -8,7 +8,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -47,7 +46,12 @@ TbufferLoadFormatXMtbuf::TbufferLoadFormatXMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -75,7 +79,12 @@ TbufferLoadFormatXyMtbuf::TbufferLoadFormatXyMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xy", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -103,7 +112,12 @@ TbufferLoadFormatXyzMtbuf::TbufferLoadFormatXyzMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xyz", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -131,7 +145,12 @@ TbufferLoadFormatXyzwMtbuf::TbufferLoadFormatXyzwMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xyzw", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -159,7 +178,12 @@ TbufferStoreFormatXMtbuf::TbufferStoreFormatXMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -187,7 +211,12 @@ TbufferStoreFormatXyMtbuf::TbufferStoreFormatXyMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xy", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -215,7 +244,12 @@ TbufferStoreFormatXyzMtbuf::TbufferStoreFormatXyzMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xyz", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -243,7 +277,12 @@ TbufferStoreFormatXyzwMtbuf::TbufferStoreFormatXyzwMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xyzw", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -271,7 +310,12 @@ TbufferLoadFormatD16XMtbuf::TbufferLoadFormatD16XMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_d16_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XMtbuf>(opcode);
 }
 } // namespace detail
@@ -305,7 +349,13 @@ TbufferLoadFormatD16XyMtbuf::TbufferLoadFormatD16XyMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_format_d16_xy",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XyMtbuf>(opcode);
 }
 } // namespace detail
@@ -333,7 +383,13 @@ TbufferLoadFormatD16XyzMtbuf::TbufferLoadFormatD16XyzMtbuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_format_d16_xyz",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -367,7 +423,13 @@ TbufferLoadFormatD16XyzwMtbuf::TbufferLoadFormatD16XyzwMtbuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_format_d16_xyzw",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -395,7 +457,13 @@ TbufferStoreFormatD16XMtbuf::TbufferStoreFormatD16XMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_x",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XMtbuf>(opcode);
 }
 } // namespace detail
@@ -423,7 +491,13 @@ TbufferStoreFormatD16XyMtbuf::TbufferStoreFormatD16XyMtbuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_xy",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XyMtbuf>(opcode);
 }
 } // namespace detail
@@ -451,7 +525,13 @@ TbufferStoreFormatD16XyzMtbuf::TbufferStoreFormatD16XyzMtbuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_xyz",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -479,7 +559,13 @@ TbufferStoreFormatD16XyzwMtbuf::TbufferStoreFormatD16XyzwMtbuf(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_xyzw",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XyzwMtbuf>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/mubuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/mubuf.cpp
@@ -8,7 +8,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -47,7 +46,12 @@ BufferLoadFormatXMubuf::BufferLoadFormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXMubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -75,7 +79,12 @@ BufferLoadFormatXyMubuf::BufferLoadFormatXyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -103,7 +112,12 @@ BufferLoadFormatXyzMubuf::BufferLoadFormatXyzMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xyz", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -131,7 +145,12 @@ BufferLoadFormatXyzwMubuf::BufferLoadFormatXyzwMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xyzw", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -159,7 +178,12 @@ BufferStoreFormatXMubuf::BufferStoreFormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -187,7 +211,12 @@ BufferStoreFormatXyMubuf::BufferStoreFormatXyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -215,7 +244,12 @@ BufferStoreFormatXyzMubuf::BufferStoreFormatXyzMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xyz", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -243,7 +277,12 @@ BufferStoreFormatXyzwMubuf::BufferStoreFormatXyzwMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xyzw", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -271,7 +310,12 @@ BufferLoadFormatD16XMubuf::BufferLoadFormatD16XMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_d16_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XMubuf>(opcode);
 }
 } // namespace detail
@@ -306,7 +350,12 @@ BufferLoadFormatD16XyMubuf::BufferLoadFormatD16XyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_d16_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XyMubuf>(opcode);
 }
 } // namespace detail
@@ -334,7 +383,13 @@ BufferLoadFormatD16XyzMubuf::BufferLoadFormatD16XyzMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_format_d16_xyz",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XyzMubuf>(opcode);
 }
 } // namespace detail
@@ -369,7 +424,13 @@ BufferLoadFormatD16XyzwMubuf::BufferLoadFormatD16XyzwMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_format_d16_xyzw",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -397,7 +458,12 @@ BufferStoreFormatD16XMubuf::BufferStoreFormatD16XMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_d16_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XMubuf>(opcode);
 }
 } // namespace detail
@@ -425,7 +491,13 @@ BufferStoreFormatD16XyMubuf::BufferStoreFormatD16XyMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_xy",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XyMubuf>(opcode);
 }
 } // namespace detail
@@ -453,7 +525,13 @@ BufferStoreFormatD16XyzMubuf::BufferStoreFormatD16XyzMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_xyz",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XyzMubuf>(opcode);
 }
 } // namespace detail
@@ -481,7 +559,13 @@ BufferStoreFormatD16XyzwMubuf::BufferStoreFormatD16XyzwMubuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_xyzw",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -509,7 +593,12 @@ BufferLoadUbyteMubuf::BufferLoadUbyteMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUbyteMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ubyte", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUbyteMubuf>(opcode);
 }
 } // namespace detail
@@ -537,7 +626,12 @@ BufferLoadSbyteMubuf::BufferLoadSbyteMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSbyteMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sbyte", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSbyteMubuf>(opcode);
 }
 } // namespace detail
@@ -565,7 +659,12 @@ BufferLoadUshortMubuf::BufferLoadUshortMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUshortMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ushort", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUshortMubuf>(opcode);
 }
 } // namespace detail
@@ -593,7 +692,12 @@ BufferLoadSshortMubuf::BufferLoadSshortMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSshortMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sshort", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSshortMubuf>(opcode);
 }
 } // namespace detail
@@ -621,7 +725,12 @@ BufferLoadDwordMubuf::BufferLoadDwordMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dword", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordMubuf>(opcode);
 }
 } // namespace detail
@@ -649,7 +758,12 @@ BufferLoadDwordx2Mubuf::BufferLoadDwordx2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dwordx2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordx2Mubuf>(opcode);
 }
 } // namespace detail
@@ -677,7 +791,12 @@ BufferLoadDwordx3Mubuf::BufferLoadDwordx3Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dwordx3", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordx3Mubuf>(opcode);
 }
 } // namespace detail
@@ -705,7 +824,12 @@ BufferLoadDwordx4Mubuf::BufferLoadDwordx4Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dwordx4", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordx4Mubuf>(opcode);
 }
 } // namespace detail
@@ -733,7 +857,12 @@ BufferStoreByteMubuf::BufferStoreByteMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreByteMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreByteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_byte", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreByteMubuf>(opcode);
 }
 } // namespace detail
@@ -761,7 +890,12 @@ BufferStoreByteD16HiMubuf::BufferStoreByteD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_byte_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreByteD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -789,7 +923,12 @@ BufferStoreShortMubuf::BufferStoreShortMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreShortMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreShortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_short", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreShortMubuf>(opcode);
 }
 } // namespace detail
@@ -817,7 +956,12 @@ BufferStoreShortD16HiMubuf::BufferStoreShortD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_short_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreShortD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -845,7 +989,12 @@ BufferStoreDwordMubuf::BufferStoreDwordMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dword", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordMubuf>(opcode);
 }
 } // namespace detail
@@ -873,7 +1022,12 @@ BufferStoreDwordx2Mubuf::BufferStoreDwordx2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dwordx2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordx2Mubuf>(opcode);
 }
 } // namespace detail
@@ -901,7 +1055,12 @@ BufferStoreDwordx3Mubuf::BufferStoreDwordx3Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dwordx3", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordx3Mubuf>(opcode);
 }
 } // namespace detail
@@ -929,7 +1088,12 @@ BufferStoreDwordx4Mubuf::BufferStoreDwordx4Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dwordx4", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordx4Mubuf>(opcode);
 }
 } // namespace detail
@@ -957,7 +1121,12 @@ BufferLoadUbyteD16Mubuf::BufferLoadUbyteD16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ubyte_d16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUbyteD16Mubuf>(opcode);
 }
 } // namespace detail
@@ -992,7 +1161,12 @@ BufferLoadUbyteD16HiMubuf::BufferLoadUbyteD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ubyte_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUbyteD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -1027,7 +1201,12 @@ BufferLoadSbyteD16Mubuf::BufferLoadSbyteD16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sbyte_d16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSbyteD16Mubuf>(opcode);
 }
 } // namespace detail
@@ -1062,7 +1241,12 @@ BufferLoadSbyteD16HiMubuf::BufferLoadSbyteD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sbyte_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSbyteD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -1097,7 +1281,12 @@ BufferLoadShortD16Mubuf::BufferLoadShortD16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadShortD16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadShortD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_short_d16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadShortD16Mubuf>(opcode);
 }
 } // namespace detail
@@ -1132,7 +1321,12 @@ BufferLoadShortD16HiMubuf::BufferLoadShortD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_short_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadShortD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -1167,7 +1361,13 @@ BufferLoadFormatD16HiXMubuf::BufferLoadFormatD16HiXMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_format_d16_hi_x",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16HiXMubuf>(opcode);
 }
 } // namespace detail
@@ -1202,7 +1402,13 @@ BufferStoreFormatD16HiXMubuf::BufferStoreFormatD16HiXMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_hi_x",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16HiXMubuf>(opcode);
 }
 } // namespace detail
@@ -1215,7 +1421,12 @@ BufferWbl2Mubuf::BufferWbl2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferWbl2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferWbl2Mubuf(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_wbl2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferWbl2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1228,7 +1439,11 @@ BufferInvMubuf::BufferInvMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferInvMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferInvMubuf(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_inv", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferInvMubuf>(opcode);
 }
 } // namespace detail
@@ -1258,7 +1473,12 @@ BufferAtomicSwapMubuf::BufferAtomicSwapMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_swap", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapMubuf>(opcode);
 }
 } // namespace detail
@@ -1293,7 +1513,12 @@ BufferAtomicCmpswapMubuf::BufferAtomicCmpswapMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_cmpswap", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapMubuf>(opcode);
 }
 } // namespace detail
@@ -1323,7 +1548,12 @@ BufferAtomicAddMubuf::BufferAtomicAddMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddMubuf>(opcode);
 }
 } // namespace detail
@@ -1353,7 +1583,12 @@ BufferAtomicSubMubuf::BufferAtomicSubMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_sub", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubMubuf>(opcode);
 }
 } // namespace detail
@@ -1383,7 +1618,12 @@ BufferAtomicSminMubuf::BufferAtomicSminMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSminMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smin", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSminMubuf>(opcode);
 }
 } // namespace detail
@@ -1413,7 +1653,12 @@ BufferAtomicUminMubuf::BufferAtomicUminMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUminMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umin", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUminMubuf>(opcode);
 }
 } // namespace detail
@@ -1443,7 +1688,12 @@ BufferAtomicSmaxMubuf::BufferAtomicSmaxMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smax", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSmaxMubuf>(opcode);
 }
 } // namespace detail
@@ -1473,7 +1723,12 @@ BufferAtomicUmaxMubuf::BufferAtomicUmaxMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umax", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUmaxMubuf>(opcode);
 }
 } // namespace detail
@@ -1503,7 +1758,12 @@ BufferAtomicAndMubuf::BufferAtomicAndMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_and", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndMubuf>(opcode);
 }
 } // namespace detail
@@ -1533,7 +1793,12 @@ BufferAtomicOrMubuf::BufferAtomicOrMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrMubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_or", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrMubuf>(opcode);
 }
 } // namespace detail
@@ -1563,7 +1828,12 @@ BufferAtomicXorMubuf::BufferAtomicXorMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_xor", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorMubuf>(opcode);
 }
 } // namespace detail
@@ -1593,7 +1863,12 @@ BufferAtomicIncMubuf::BufferAtomicIncMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_inc", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncMubuf>(opcode);
 }
 } // namespace detail
@@ -1623,7 +1898,12 @@ BufferAtomicDecMubuf::BufferAtomicDecMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_dec", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecMubuf>(opcode);
 }
 } // namespace detail
@@ -1653,7 +1933,12 @@ BufferAtomicAddF32Mubuf::BufferAtomicAddF32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_f32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddF32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1683,7 +1968,12 @@ BufferAtomicPkAddF16Mubuf::BufferAtomicPkAddF16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicPkAddF16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicPkAddF16Mubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_pk_add_f16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicPkAddF16Mubuf>(opcode);
 }
 } // namespace detail
@@ -1713,7 +2003,12 @@ BufferAtomicAddF64Mubuf::BufferAtomicAddF64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddF64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_f64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddF64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1743,7 +2038,12 @@ BufferAtomicMinF64Mubuf::BufferAtomicMinF64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinF64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinF64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_min_f64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinF64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1773,7 +2073,12 @@ BufferAtomicMaxF64Mubuf::BufferAtomicMaxF64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxF64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxF64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_max_f64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxF64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1803,7 +2108,12 @@ BufferAtomicSwapX2Mubuf::BufferAtomicSwapX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_swap_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1838,7 +2148,12 @@ BufferAtomicCmpswapX2Mubuf::BufferAtomicCmpswapX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_cmpswap_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1868,7 +2183,12 @@ BufferAtomicAddX2Mubuf::BufferAtomicAddX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1898,7 +2218,12 @@ BufferAtomicSubX2Mubuf::BufferAtomicSubX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_sub_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1928,7 +2253,12 @@ BufferAtomicSminX2Mubuf::BufferAtomicSminX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smin_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSminX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1958,7 +2288,12 @@ BufferAtomicUminX2Mubuf::BufferAtomicUminX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umin_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUminX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1988,7 +2323,12 @@ BufferAtomicSmaxX2Mubuf::BufferAtomicSmaxX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smax_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSmaxX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2018,7 +2358,12 @@ BufferAtomicUmaxX2Mubuf::BufferAtomicUmaxX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umax_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUmaxX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2048,7 +2393,12 @@ BufferAtomicAndX2Mubuf::BufferAtomicAndX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_and_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2078,7 +2428,12 @@ BufferAtomicOrX2Mubuf::BufferAtomicOrX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_or_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2108,7 +2463,12 @@ BufferAtomicXorX2Mubuf::BufferAtomicXorX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_xor_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2138,7 +2498,12 @@ BufferAtomicIncX2Mubuf::BufferAtomicIncX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_inc_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2168,7 +2533,12 @@ BufferAtomicDecX2Mubuf::BufferAtomicDecX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_dec_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecX2Mubuf>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/operand.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/operand.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/scalar_static_resolve.h"
-#include "util/except.h"
 #include <format>
 #include <optional>
 #include <stdexcept>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/smem.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/smem.cpp
@@ -8,7 +8,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -44,7 +43,11 @@ SLoadDwordSmem::SLoadDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordSmem>(opcode);
 }
 } // namespace detail
@@ -64,7 +67,12 @@ SLoadDwordx2Smem::SLoadDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -84,7 +92,12 @@ SLoadDwordx4Smem::SLoadDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx4Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -104,7 +117,12 @@ SLoadDwordx8Smem::SLoadDwordx8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx8Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx8Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx8Smem>(opcode);
 }
 } // namespace detail
@@ -124,7 +142,12 @@ SLoadDwordx16Smem::SLoadDwordx16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx16Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx16Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx16Smem>(opcode);
 }
 } // namespace detail
@@ -144,7 +167,12 @@ SScratchLoadDwordSmem::SScratchLoadDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchLoadDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSScratchLoadDwordSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_load_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchLoadDwordSmem>(opcode);
 }
 } // namespace detail
@@ -164,7 +192,12 @@ SScratchLoadDwordx2Smem::SScratchLoadDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSScratchLoadDwordx2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_load_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchLoadDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -184,7 +217,12 @@ SScratchLoadDwordx4Smem::SScratchLoadDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSScratchLoadDwordx4Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_load_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchLoadDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -204,7 +242,12 @@ SBufferLoadDwordSmem::SBufferLoadDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordSmem>(opcode);
 }
 } // namespace detail
@@ -224,7 +267,12 @@ SBufferLoadDwordx2Smem::SBufferLoadDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -244,7 +292,12 @@ SBufferLoadDwordx4Smem::SBufferLoadDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx4Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -264,7 +317,12 @@ SBufferLoadDwordx8Smem::SBufferLoadDwordx8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx8Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx8Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx8Smem>(opcode);
 }
 } // namespace detail
@@ -284,7 +342,12 @@ SBufferLoadDwordx16Smem::SBufferLoadDwordx16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx16Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx16Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx16Smem>(opcode);
 }
 } // namespace detail
@@ -304,7 +367,12 @@ SStoreDwordSmem::SStoreDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSStoreDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSStoreDwordSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_store_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SStoreDwordSmem>(opcode);
 }
 } // namespace detail
@@ -324,7 +392,12 @@ SStoreDwordx2Smem::SStoreDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSStoreDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSStoreDwordx2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_store_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SStoreDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -344,7 +417,12 @@ SStoreDwordx4Smem::SStoreDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSStoreDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSStoreDwordx4Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_store_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SStoreDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -364,7 +442,12 @@ SScratchStoreDwordSmem::SScratchStoreDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchStoreDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSScratchStoreDwordSmem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_store_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchStoreDwordSmem>(opcode);
 }
 } // namespace detail
@@ -384,7 +467,12 @@ SScratchStoreDwordx2Smem::SScratchStoreDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchStoreDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSScratchStoreDwordx2Smem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_store_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchStoreDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -404,7 +492,12 @@ SScratchStoreDwordx4Smem::SScratchStoreDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchStoreDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSScratchStoreDwordx4Smem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_store_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchStoreDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -424,7 +517,12 @@ SBufferStoreDwordSmem::SBufferStoreDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferStoreDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferStoreDwordSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_store_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferStoreDwordSmem>(opcode);
 }
 } // namespace detail
@@ -444,7 +542,12 @@ SBufferStoreDwordx2Smem::SBufferStoreDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferStoreDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferStoreDwordx2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_store_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferStoreDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -464,7 +567,12 @@ SBufferStoreDwordx4Smem::SBufferStoreDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferStoreDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferStoreDwordx4Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_store_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferStoreDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -477,7 +585,11 @@ SDcacheInvSmem::SDcacheInvSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_inv", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheInvSmem>(opcode);
 }
 } // namespace detail
@@ -490,7 +602,11 @@ SDcacheWbSmem::SDcacheWbSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheWbSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheWbSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_wb", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheWbSmem>(opcode);
 }
 } // namespace detail
@@ -503,7 +619,12 @@ SDcacheInvVolSmem::SDcacheInvVolSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheInvVolSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheInvVolSmem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_inv_vol", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheInvVolSmem>(opcode);
 }
 } // namespace detail
@@ -516,7 +637,12 @@ SDcacheWbVolSmem::SDcacheWbVolSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheWbVolSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheWbVolSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_wb_vol", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheWbVolSmem>(opcode);
 }
 } // namespace detail
@@ -531,7 +657,11 @@ SMemtimeSmem::SMemtimeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMemtimeSmem(const MachineInst *opcode) {
+DecodeResult decodeSMemtimeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_memtime", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMemtimeSmem>(opcode);
 }
 } // namespace detail
@@ -546,7 +676,12 @@ SMemrealtimeSmem::SMemrealtimeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMemrealtimeSmem(const MachineInst *opcode) {
+DecodeResult decodeSMemrealtimeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_memrealtime", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMemrealtimeSmem>(opcode);
 }
 } // namespace detail
@@ -565,7 +700,11 @@ SAtcProbeSmem::SAtcProbeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtcProbeSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtcProbeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atc_probe", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtcProbeSmem>(opcode);
 }
 } // namespace detail
@@ -584,7 +723,12 @@ SAtcProbeBufferSmem::SAtcProbeBufferSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtcProbeBufferSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtcProbeBufferSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atc_probe_buffer", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtcProbeBufferSmem>(opcode);
 }
 } // namespace detail
@@ -601,7 +745,12 @@ SDcacheDiscardSmem::SDcacheDiscardSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheDiscardSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheDiscardSmem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_discard", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheDiscardSmem>(opcode);
 }
 } // namespace detail
@@ -618,7 +767,12 @@ SDcacheDiscardX2Smem::SDcacheDiscardX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheDiscardX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheDiscardX2Smem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_discard_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheDiscardX2Smem>(opcode);
 }
 } // namespace detail
@@ -638,7 +792,12 @@ SBufferAtomicSwapSmem::SBufferAtomicSwapSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSwapSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSwapSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_swap", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSwapSmem>(opcode);
 }
 } // namespace detail
@@ -658,7 +817,12 @@ SBufferAtomicCmpswapSmem::SBufferAtomicCmpswapSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicCmpswapSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicCmpswapSmem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_cmpswap", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicCmpswapSmem>(opcode);
 }
 } // namespace detail
@@ -678,7 +842,12 @@ SBufferAtomicAddSmem::SBufferAtomicAddSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicAddSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicAddSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_add", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicAddSmem>(opcode);
 }
 } // namespace detail
@@ -698,7 +867,12 @@ SBufferAtomicSubSmem::SBufferAtomicSubSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSubSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSubSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_sub", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSubSmem>(opcode);
 }
 } // namespace detail
@@ -718,7 +892,12 @@ SBufferAtomicSminSmem::SBufferAtomicSminSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSminSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSminSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_smin", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSminSmem>(opcode);
 }
 } // namespace detail
@@ -738,7 +917,12 @@ SBufferAtomicUminSmem::SBufferAtomicUminSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicUminSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicUminSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_umin", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicUminSmem>(opcode);
 }
 } // namespace detail
@@ -758,7 +942,12 @@ SBufferAtomicSmaxSmem::SBufferAtomicSmaxSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSmaxSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSmaxSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_smax", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSmaxSmem>(opcode);
 }
 } // namespace detail
@@ -778,7 +967,12 @@ SBufferAtomicUmaxSmem::SBufferAtomicUmaxSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicUmaxSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicUmaxSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_umax", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicUmaxSmem>(opcode);
 }
 } // namespace detail
@@ -798,7 +992,12 @@ SBufferAtomicAndSmem::SBufferAtomicAndSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicAndSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicAndSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_and", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicAndSmem>(opcode);
 }
 } // namespace detail
@@ -818,7 +1017,12 @@ SBufferAtomicOrSmem::SBufferAtomicOrSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicOrSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicOrSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_or", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicOrSmem>(opcode);
 }
 } // namespace detail
@@ -838,7 +1042,12 @@ SBufferAtomicXorSmem::SBufferAtomicXorSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicXorSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicXorSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_xor", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicXorSmem>(opcode);
 }
 } // namespace detail
@@ -858,7 +1067,12 @@ SBufferAtomicIncSmem::SBufferAtomicIncSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicIncSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicIncSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_inc", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicIncSmem>(opcode);
 }
 } // namespace detail
@@ -878,7 +1092,12 @@ SBufferAtomicDecSmem::SBufferAtomicDecSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicDecSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicDecSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_dec", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicDecSmem>(opcode);
 }
 } // namespace detail
@@ -898,7 +1117,12 @@ SBufferAtomicSwapX2Smem::SBufferAtomicSwapX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSwapX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSwapX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_swap_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSwapX2Smem>(opcode);
 }
 } // namespace detail
@@ -918,7 +1142,12 @@ SBufferAtomicCmpswapX2Smem::SBufferAtomicCmpswapX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicCmpswapX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicCmpswapX2Smem(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_cmpswap_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicCmpswapX2Smem>(opcode);
 }
 } // namespace detail
@@ -938,7 +1167,12 @@ SBufferAtomicAddX2Smem::SBufferAtomicAddX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicAddX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicAddX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_add_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicAddX2Smem>(opcode);
 }
 } // namespace detail
@@ -958,7 +1192,12 @@ SBufferAtomicSubX2Smem::SBufferAtomicSubX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSubX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSubX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_sub_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSubX2Smem>(opcode);
 }
 } // namespace detail
@@ -978,7 +1217,12 @@ SBufferAtomicSminX2Smem::SBufferAtomicSminX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSminX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSminX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_smin_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSminX2Smem>(opcode);
 }
 } // namespace detail
@@ -998,7 +1242,12 @@ SBufferAtomicUminX2Smem::SBufferAtomicUminX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicUminX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicUminX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_umin_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicUminX2Smem>(opcode);
 }
 } // namespace detail
@@ -1018,7 +1267,12 @@ SBufferAtomicSmaxX2Smem::SBufferAtomicSmaxX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSmaxX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSmaxX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_smax_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSmaxX2Smem>(opcode);
 }
 } // namespace detail
@@ -1038,7 +1292,12 @@ SBufferAtomicUmaxX2Smem::SBufferAtomicUmaxX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicUmaxX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicUmaxX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_umax_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicUmaxX2Smem>(opcode);
 }
 } // namespace detail
@@ -1058,7 +1317,12 @@ SBufferAtomicAndX2Smem::SBufferAtomicAndX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicAndX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicAndX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_and_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicAndX2Smem>(opcode);
 }
 } // namespace detail
@@ -1078,7 +1342,12 @@ SBufferAtomicOrX2Smem::SBufferAtomicOrX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicOrX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicOrX2Smem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_or_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicOrX2Smem>(opcode);
 }
 } // namespace detail
@@ -1098,7 +1367,12 @@ SBufferAtomicXorX2Smem::SBufferAtomicXorX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicXorX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicXorX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_xor_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicXorX2Smem>(opcode);
 }
 } // namespace detail
@@ -1118,7 +1392,12 @@ SBufferAtomicIncX2Smem::SBufferAtomicIncX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicIncX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicIncX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_inc_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicIncX2Smem>(opcode);
 }
 } // namespace detail
@@ -1138,7 +1417,12 @@ SBufferAtomicDecX2Smem::SBufferAtomicDecX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicDecX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicDecX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_dec_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicDecX2Smem>(opcode);
 }
 } // namespace detail
@@ -1158,7 +1442,12 @@ SAtomicSwapSmem::SAtomicSwapSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSwapSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSwapSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_swap", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSwapSmem>(opcode);
 }
 } // namespace detail
@@ -1178,7 +1467,12 @@ SAtomicCmpswapSmem::SAtomicCmpswapSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicCmpswapSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicCmpswapSmem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_cmpswap", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicCmpswapSmem>(opcode);
 }
 } // namespace detail
@@ -1198,7 +1492,11 @@ SAtomicAddSmem::SAtomicAddSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicAddSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicAddSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_add", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicAddSmem>(opcode);
 }
 } // namespace detail
@@ -1218,7 +1516,11 @@ SAtomicSubSmem::SAtomicSubSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSubSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSubSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_sub", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSubSmem>(opcode);
 }
 } // namespace detail
@@ -1238,7 +1540,12 @@ SAtomicSminSmem::SAtomicSminSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSminSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSminSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_smin", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSminSmem>(opcode);
 }
 } // namespace detail
@@ -1258,7 +1565,12 @@ SAtomicUminSmem::SAtomicUminSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicUminSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicUminSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_umin", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicUminSmem>(opcode);
 }
 } // namespace detail
@@ -1278,7 +1590,12 @@ SAtomicSmaxSmem::SAtomicSmaxSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSmaxSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSmaxSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_smax", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSmaxSmem>(opcode);
 }
 } // namespace detail
@@ -1298,7 +1615,12 @@ SAtomicUmaxSmem::SAtomicUmaxSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicUmaxSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicUmaxSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_umax", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicUmaxSmem>(opcode);
 }
 } // namespace detail
@@ -1318,7 +1640,11 @@ SAtomicAndSmem::SAtomicAndSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicAndSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicAndSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_and", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicAndSmem>(opcode);
 }
 } // namespace detail
@@ -1338,7 +1664,11 @@ SAtomicOrSmem::SAtomicOrSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicOrSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicOrSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_or", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicOrSmem>(opcode);
 }
 } // namespace detail
@@ -1358,7 +1688,11 @@ SAtomicXorSmem::SAtomicXorSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicXorSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicXorSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_xor", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicXorSmem>(opcode);
 }
 } // namespace detail
@@ -1378,7 +1712,11 @@ SAtomicIncSmem::SAtomicIncSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicIncSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicIncSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_inc", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicIncSmem>(opcode);
 }
 } // namespace detail
@@ -1398,7 +1736,11 @@ SAtomicDecSmem::SAtomicDecSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicDecSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicDecSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_dec", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicDecSmem>(opcode);
 }
 } // namespace detail
@@ -1418,7 +1760,12 @@ SAtomicSwapX2Smem::SAtomicSwapX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSwapX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSwapX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_swap_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSwapX2Smem>(opcode);
 }
 } // namespace detail
@@ -1438,7 +1785,12 @@ SAtomicCmpswapX2Smem::SAtomicCmpswapX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicCmpswapX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicCmpswapX2Smem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_cmpswap_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicCmpswapX2Smem>(opcode);
 }
 } // namespace detail
@@ -1458,7 +1810,12 @@ SAtomicAddX2Smem::SAtomicAddX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicAddX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicAddX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_add_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicAddX2Smem>(opcode);
 }
 } // namespace detail
@@ -1478,7 +1835,12 @@ SAtomicSubX2Smem::SAtomicSubX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSubX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSubX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_sub_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSubX2Smem>(opcode);
 }
 } // namespace detail
@@ -1498,7 +1860,12 @@ SAtomicSminX2Smem::SAtomicSminX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSminX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSminX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_smin_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSminX2Smem>(opcode);
 }
 } // namespace detail
@@ -1518,7 +1885,12 @@ SAtomicUminX2Smem::SAtomicUminX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicUminX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicUminX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_umin_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicUminX2Smem>(opcode);
 }
 } // namespace detail
@@ -1538,7 +1910,12 @@ SAtomicSmaxX2Smem::SAtomicSmaxX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSmaxX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSmaxX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_smax_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSmaxX2Smem>(opcode);
 }
 } // namespace detail
@@ -1558,7 +1935,12 @@ SAtomicUmaxX2Smem::SAtomicUmaxX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicUmaxX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicUmaxX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_umax_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicUmaxX2Smem>(opcode);
 }
 } // namespace detail
@@ -1578,7 +1960,12 @@ SAtomicAndX2Smem::SAtomicAndX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicAndX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicAndX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_and_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicAndX2Smem>(opcode);
 }
 } // namespace detail
@@ -1598,7 +1985,12 @@ SAtomicOrX2Smem::SAtomicOrX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicOrX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicOrX2Smem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_or_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicOrX2Smem>(opcode);
 }
 } // namespace detail
@@ -1618,7 +2010,12 @@ SAtomicXorX2Smem::SAtomicXorX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicXorX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicXorX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_xor_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicXorX2Smem>(opcode);
 }
 } // namespace detail
@@ -1638,7 +2035,12 @@ SAtomicIncX2Smem::SAtomicIncX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicIncX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicIncX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_inc_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicIncX2Smem>(opcode);
 }
 } // namespace detail
@@ -1658,7 +2060,12 @@ SAtomicDecX2Smem::SAtomicDecX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicDecX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicDecX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_dec_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicDecX2Smem>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/sop1.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/sop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -29,7 +28,11 @@ SMovB32Sop1::SMovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -52,7 +55,11 @@ SMovB64Sop1::SMovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -78,7 +85,11 @@ SCmovB32Sop1::SCmovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -105,7 +116,11 @@ SCmovB64Sop1::SCmovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -129,7 +144,11 @@ SNotB32Sop1::SNotB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB32Sop1>(opcode);
 }
 } // namespace detail
@@ -154,7 +173,11 @@ SNotB64Sop1::SNotB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB64Sop1>(opcode);
 }
 } // namespace detail
@@ -178,7 +201,11 @@ SWqmB32Sop1::SWqmB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB32Sop1>(opcode);
 }
 } // namespace detail
@@ -203,7 +230,11 @@ SWqmB64Sop1::SWqmB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB64Sop1>(opcode);
 }
 } // namespace detail
@@ -224,7 +255,11 @@ SBrevB32Sop1::SBrevB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB32Sop1>(opcode);
 }
 } // namespace detail
@@ -246,7 +281,11 @@ SBrevB64Sop1::SBrevB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB64Sop1>(opcode);
 }
 } // namespace detail
@@ -270,7 +309,12 @@ SBcnt0I32B32Sop1::SBcnt0I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -295,7 +339,12 @@ SBcnt0I32B64Sop1::SBcnt0I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -319,7 +368,12 @@ SBcnt1I32B32Sop1::SBcnt1I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -344,7 +398,12 @@ SBcnt1I32B64Sop1::SBcnt1I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -365,7 +424,11 @@ SFf0I32B32Sop1::SFf0I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf0I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf0I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff0_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf0I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -387,7 +450,11 @@ SFf0I32B64Sop1::SFf0I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf0I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf0I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff0_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf0I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -408,7 +475,11 @@ SFf1I32B32Sop1::SFf1I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf1I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf1I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff1_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf1I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -430,7 +501,11 @@ SFf1I32B64Sop1::SFf1I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf1I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf1I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff1_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf1I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -451,7 +526,12 @@ SFlbitI32B32Sop1::SFlbitI32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -473,7 +553,12 @@ SFlbitI32B64Sop1::SFlbitI32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -494,7 +579,11 @@ SFlbitI32Sop1::SFlbitI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32Sop1>(opcode);
 }
 } // namespace detail
@@ -516,7 +605,12 @@ SFlbitI32I64Sop1::SFlbitI32I64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32I64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32I64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32_i64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32I64Sop1>(opcode);
 }
 } // namespace detail
@@ -538,7 +632,11 @@ SSextI32I8Sop1::SSextI32I8Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i8", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I8Sop1>(opcode);
 }
 } // namespace detail
@@ -560,7 +658,12 @@ SSextI32I16Sop1::SSextI32I16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I16Sop1>(opcode);
 }
 } // namespace detail
@@ -582,7 +685,12 @@ SBitset0B32Sop1::SBitset0B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B32Sop1>(opcode);
 }
 } // namespace detail
@@ -604,7 +712,12 @@ SBitset0B64Sop1::SBitset0B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B64Sop1>(opcode);
 }
 } // namespace detail
@@ -626,7 +739,12 @@ SBitset1B32Sop1::SBitset1B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B32Sop1>(opcode);
 }
 } // namespace detail
@@ -648,7 +766,12 @@ SBitset1B64Sop1::SBitset1B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B64Sop1>(opcode);
 }
 } // namespace detail
@@ -666,7 +789,11 @@ SGetpcB64Sop1::SGetpcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetpcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSGetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_getpc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetpcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -685,7 +812,11 @@ SSetpcB64Sop1::SSetpcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetpcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_setpc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetpcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -708,7 +839,11 @@ SSwappcB64Sop1::SSwappcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSwappcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSwappcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_swappc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSwappcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -726,7 +861,11 @@ SRfeB64Sop1::SRfeB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRfeB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSRfeB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_rfe_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRfeB64Sop1>(opcode);
 }
 } // namespace detail
@@ -758,7 +897,12 @@ SAndSaveexecB64Sop1::SAndSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -791,7 +935,12 @@ SOrSaveexecB64Sop1::SOrSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -823,7 +972,12 @@ SXorSaveexecB64Sop1::SXorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -855,7 +1009,12 @@ SAndn2SaveexecB64Sop1::SAndn2SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn2_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -887,7 +1046,12 @@ SOrn2SaveexecB64Sop1::SOrn2SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_orn2_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -919,7 +1083,12 @@ SNandSaveexecB64Sop1::SNandSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nand_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -951,7 +1120,12 @@ SNorSaveexecB64Sop1::SNorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -983,7 +1157,12 @@ SXnorSaveexecB64Sop1::SXnorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xnor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1007,7 +1186,12 @@ SQuadmaskB32Sop1::SQuadmaskB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1032,7 +1216,12 @@ SQuadmaskB64Sop1::SQuadmaskB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1052,7 +1241,12 @@ SMovrelsB32Sop1::SMovrelsB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrels_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1072,7 +1266,12 @@ SMovrelsB64Sop1::SMovrelsB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrels_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1096,7 +1295,12 @@ SMovreldB32Sop1::SMovreldB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1121,7 +1325,12 @@ SMovreldB64Sop1::SMovreldB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1141,7 +1350,12 @@ SCbranchJoinSop1::SCbranchJoinSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchJoinSop1(const MachineInst *opcode) {
+DecodeResult decodeSCbranchJoinSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cbranch_join", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchJoinSop1>(opcode);
 }
 } // namespace detail
@@ -1165,7 +1379,11 @@ SAbsI32Sop1::SAbsI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_abs_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsI32Sop1>(opcode);
 }
 } // namespace detail
@@ -1189,7 +1407,12 @@ SSetGprIdxIdxSop1::SSetGprIdxIdxSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetGprIdxIdxSop1(const MachineInst *opcode) {
+DecodeResult decodeSSetGprIdxIdxSop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_set_gpr_idx_idx", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetGprIdxIdxSop1>(opcode);
 }
 } // namespace detail
@@ -1221,7 +1444,12 @@ SAndn1SaveexecB64Sop1::SAndn1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1253,7 +1481,12 @@ SOrn1SaveexecB64Sop1::SOrn1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_orn1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1285,7 +1518,12 @@ SAndn1WrexecB64Sop1::SAndn1WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn1WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn1WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn1_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn1WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1317,7 +1555,12 @@ SAndn2WrexecB64Sop1::SAndn2WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn2WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn2_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1338,7 +1581,12 @@ SBitreplicateB64B32Sop1::SBitreplicateB64B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitreplicate_b64_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitreplicateB64B32Sop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/sop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/sop2.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/sop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -37,7 +36,11 @@ SAddU32Sop2::SAddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -67,7 +70,11 @@ SSubU32Sop2::SSubU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubU32Sop2>(opcode);
 }
 } // namespace detail
@@ -97,7 +104,11 @@ SAddI32Sop2::SAddI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddI32Sop2>(opcode);
 }
 } // namespace detail
@@ -127,7 +138,11 @@ SSubI32Sop2::SSubI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubI32Sop2>(opcode);
 }
 } // namespace detail
@@ -160,7 +175,11 @@ SAddcU32Sop2::SAddcU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddcU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddcU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_addc_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddcU32Sop2>(opcode);
 }
 } // namespace detail
@@ -193,7 +212,11 @@ SSubbU32Sop2::SSubbU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubbU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubbU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_subb_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubbU32Sop2>(opcode);
 }
 } // namespace detail
@@ -223,7 +246,11 @@ SMinI32Sop2::SMinI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinI32Sop2>(opcode);
 }
 } // namespace detail
@@ -253,7 +280,11 @@ SMinU32Sop2::SMinU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinU32Sop2>(opcode);
 }
 } // namespace detail
@@ -283,7 +314,11 @@ SMaxI32Sop2::SMaxI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxI32Sop2>(opcode);
 }
 } // namespace detail
@@ -313,7 +348,11 @@ SMaxU32Sop2::SMaxU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxU32Sop2>(opcode);
 }
 } // namespace detail
@@ -343,7 +382,12 @@ SCselectB32Sop2::SCselectB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCselectB32Sop2>(opcode);
 }
 } // namespace detail
@@ -375,7 +419,12 @@ SCselectB64Sop2::SCselectB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCselectB64Sop2>(opcode);
 }
 } // namespace detail
@@ -405,7 +454,11 @@ SAndB32Sop2::SAndB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndB32Sop2>(opcode);
 }
 } // namespace detail
@@ -437,7 +490,11 @@ SAndB64Sop2::SAndB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndB64Sop2>(opcode);
 }
 } // namespace detail
@@ -468,7 +525,11 @@ SOrB32Sop2::SOrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -501,7 +562,11 @@ SOrB64Sop2::SOrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -531,7 +596,11 @@ SXorB32Sop2::SXorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -563,7 +632,11 @@ SXorB64Sop2::SXorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -593,7 +666,11 @@ SAndn2B32Sop2::SAndn2B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_andn2_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2B32Sop2>(opcode);
 }
 } // namespace detail
@@ -625,7 +702,11 @@ SAndn2B64Sop2::SAndn2B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_andn2_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2B64Sop2>(opcode);
 }
 } // namespace detail
@@ -655,7 +736,11 @@ SOrn2B32Sop2::SOrn2B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_orn2_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2B32Sop2>(opcode);
 }
 } // namespace detail
@@ -687,7 +772,11 @@ SOrn2B64Sop2::SOrn2B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_orn2_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2B64Sop2>(opcode);
 }
 } // namespace detail
@@ -717,7 +806,11 @@ SNandB32Sop2::SNandB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandB32Sop2>(opcode);
 }
 } // namespace detail
@@ -749,7 +842,11 @@ SNandB64Sop2::SNandB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandB64Sop2>(opcode);
 }
 } // namespace detail
@@ -779,7 +876,11 @@ SNorB32Sop2::SNorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -811,7 +912,11 @@ SNorB64Sop2::SNorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -841,7 +946,11 @@ SXnorB32Sop2::SXnorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -873,7 +982,11 @@ SXnorB64Sop2::SXnorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -903,7 +1016,11 @@ SLshlB32Sop2::SLshlB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshlB32Sop2>(opcode);
 }
 } // namespace detail
@@ -934,7 +1051,11 @@ SLshlB64Sop2::SLshlB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshlB64Sop2>(opcode);
 }
 } // namespace detail
@@ -964,7 +1085,11 @@ SLshrB32Sop2::SLshrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -995,7 +1120,11 @@ SLshrB64Sop2::SLshrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1025,7 +1154,11 @@ SAshrI32Sop2::SAshrI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAshrI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1056,7 +1189,11 @@ SAshrI64Sop2::SAshrI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAshrI64Sop2>(opcode);
 }
 } // namespace detail
@@ -1083,7 +1220,11 @@ SBfmB32Sop2::SBfmB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfmB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1110,7 +1251,11 @@ SBfmB64Sop2::SBfmB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfmB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1137,7 +1282,11 @@ SMulI32Sop2::SMulI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1167,7 +1316,11 @@ SBfeU32Sop2::SBfeU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1197,7 +1350,11 @@ SBfeI32Sop2::SBfeI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1228,7 +1385,11 @@ SBfeU64Sop2::SBfeU64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeU64Sop2>(opcode);
 }
 } // namespace detail
@@ -1259,7 +1420,11 @@ SBfeI64Sop2::SBfeI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeI64Sop2>(opcode);
 }
 } // namespace detail
@@ -1279,7 +1444,12 @@ SCbranchGForkSop2::SCbranchGForkSop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchGForkSop2(const MachineInst *opcode) {
+DecodeResult decodeSCbranchGForkSop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cbranch_g_fork", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchGForkSop2>(opcode);
 }
 } // namespace detail
@@ -1309,7 +1479,12 @@ SAbsdiffI32Sop2::SAbsdiffI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_absdiff_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsdiffI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1338,7 +1513,12 @@ SRfeRestoreB64Sop2::SRfeRestoreB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRfeRestoreB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSRfeRestoreB64Sop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_rfe_restore_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRfeRestoreB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1365,7 +1545,11 @@ SMulHiU32Sop2::SMulHiU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulHiU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1392,7 +1576,11 @@ SMulHiI32Sop2::SMulHiI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulHiI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1422,7 +1610,12 @@ SLshl1AddU32Sop2::SLshl1AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl1_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl1AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1452,7 +1645,12 @@ SLshl2AddU32Sop2::SLshl2AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl2_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl2AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1482,7 +1680,12 @@ SLshl3AddU32Sop2::SLshl3AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl3_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl3AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1512,7 +1715,12 @@ SLshl4AddU32Sop2::SLshl4AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl4_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl4AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1541,7 +1749,12 @@ SPackLlB32B16Sop2::SPackLlB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_ll_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackLlB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1569,7 +1782,12 @@ SPackLhB32B16Sop2::SPackLhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_lh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackLhB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1596,7 +1814,12 @@ SPackHhB32B16Sop2::SPackHhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_hh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackHhB32B16Sop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/sopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/sopc.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/sopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -35,7 +34,11 @@ SCmpEqI32Sopc::SCmpEqI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqI32Sopc>(opcode);
 }
 } // namespace detail
@@ -63,7 +66,11 @@ SCmpLgI32Sopc::SCmpLgI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgI32Sopc>(opcode);
 }
 } // namespace detail
@@ -91,7 +98,11 @@ SCmpGtI32Sopc::SCmpGtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -119,7 +130,11 @@ SCmpGeI32Sopc::SCmpGeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -147,7 +162,11 @@ SCmpLtI32Sopc::SCmpLtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -175,7 +194,11 @@ SCmpLeI32Sopc::SCmpLeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -203,7 +226,11 @@ SCmpEqU32Sopc::SCmpEqU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqU32Sopc>(opcode);
 }
 } // namespace detail
@@ -231,7 +258,11 @@ SCmpLgU32Sopc::SCmpLgU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgU32Sopc>(opcode);
 }
 } // namespace detail
@@ -259,7 +290,11 @@ SCmpGtU32Sopc::SCmpGtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -287,7 +322,11 @@ SCmpGeU32Sopc::SCmpGeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -315,7 +354,11 @@ SCmpLtU32Sopc::SCmpLtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -343,7 +386,11 @@ SCmpLeU32Sopc::SCmpLeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -371,7 +418,12 @@ SBitcmp0B32Sopc::SBitcmp0B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp0B32Sopc>(opcode);
 }
 } // namespace detail
@@ -399,7 +451,12 @@ SBitcmp1B32Sopc::SBitcmp1B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp1B32Sopc>(opcode);
 }
 } // namespace detail
@@ -428,7 +485,12 @@ SBitcmp0B64Sopc::SBitcmp0B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp0B64Sopc>(opcode);
 }
 } // namespace detail
@@ -457,7 +519,12 @@ SBitcmp1B64Sopc::SBitcmp1B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp1B64Sopc>(opcode);
 }
 } // namespace detail
@@ -482,7 +549,11 @@ SSetvskipSopc::SSetvskipSopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetvskipSopc(const MachineInst *opcode) {
+DecodeResult decodeSSetvskipSopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_setvskip", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetvskipSopc>(opcode);
 }
 } // namespace detail
@@ -508,7 +579,12 @@ SSetGprIdxOnSopc::SSetGprIdxOnSopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetGprIdxOnSopc(const MachineInst *opcode) {
+DecodeResult decodeSSetGprIdxOnSopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_set_gpr_idx_on", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetGprIdxOnSopc>(opcode);
 }
 } // namespace detail
@@ -538,7 +614,11 @@ SCmpEqU64Sopc::SCmpEqU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqU64Sopc>(opcode);
 }
 } // namespace detail
@@ -568,7 +648,11 @@ SCmpLgU64Sopc::SCmpLgU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgU64Sopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/sopk.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -24,7 +23,11 @@ SMovkI32Sopk::SMovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_movk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -46,7 +49,11 @@ SCmovkI32Sopk::SCmovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmovk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -66,7 +73,11 @@ SCmpkEqI32Sopk::SCmpkEqI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkEqI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkEqI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_eq_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkEqI32Sopk>(opcode);
 }
 } // namespace detail
@@ -86,7 +97,11 @@ SCmpkLgI32Sopk::SCmpkLgI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLgI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLgI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lg_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLgI32Sopk>(opcode);
 }
 } // namespace detail
@@ -106,7 +121,11 @@ SCmpkGtI32Sopk::SCmpkGtI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGtI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_gt_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGtI32Sopk>(opcode);
 }
 } // namespace detail
@@ -126,7 +145,11 @@ SCmpkGeI32Sopk::SCmpkGeI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGeI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_ge_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGeI32Sopk>(opcode);
 }
 } // namespace detail
@@ -146,7 +169,11 @@ SCmpkLtI32Sopk::SCmpkLtI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLtI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lt_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLtI32Sopk>(opcode);
 }
 } // namespace detail
@@ -166,7 +193,11 @@ SCmpkLeI32Sopk::SCmpkLeI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLeI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_le_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLeI32Sopk>(opcode);
 }
 } // namespace detail
@@ -186,7 +217,11 @@ SCmpkEqU32Sopk::SCmpkEqU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkEqU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkEqU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_eq_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkEqU32Sopk>(opcode);
 }
 } // namespace detail
@@ -206,7 +241,11 @@ SCmpkLgU32Sopk::SCmpkLgU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLgU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLgU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lg_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLgU32Sopk>(opcode);
 }
 } // namespace detail
@@ -226,7 +265,11 @@ SCmpkGtU32Sopk::SCmpkGtU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGtU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_gt_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGtU32Sopk>(opcode);
 }
 } // namespace detail
@@ -246,7 +289,11 @@ SCmpkGeU32Sopk::SCmpkGeU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGeU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_ge_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGeU32Sopk>(opcode);
 }
 } // namespace detail
@@ -266,7 +313,11 @@ SCmpkLtU32Sopk::SCmpkLtU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLtU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lt_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLtU32Sopk>(opcode);
 }
 } // namespace detail
@@ -286,7 +337,11 @@ SCmpkLeU32Sopk::SCmpkLeU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLeU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_le_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLeU32Sopk>(opcode);
 }
 } // namespace detail
@@ -307,7 +362,11 @@ SAddkI32Sopk::SAddkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSAddkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_addk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -325,7 +384,11 @@ SMulkI32Sopk::SMulkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_mulk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -342,7 +405,12 @@ SCbranchIForkSopk::SCbranchIForkSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchIForkSopk(const MachineInst *opcode) {
+DecodeResult decodeSCbranchIForkSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cbranch_i_fork", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchIForkSopk>(opcode);
 }
 } // namespace detail
@@ -359,7 +427,11 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_getreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -376,7 +448,11 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -395,7 +471,12 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_imm32_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregImm32B32Sopk>(opcode);
 }
 } // namespace detail
@@ -418,7 +499,11 @@ SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCallB64Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCallB64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_call_b64", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCallB64Sopk>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/sopp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/sopp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/sopp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -22,7 +21,11 @@ SNopSopp::SNopSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode) {
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_nop", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNopSopp>(opcode);
 }
 } // namespace detail
@@ -36,7 +39,11 @@ SEndpgmSopp::SEndpgmSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSopp>(opcode);
 }
 } // namespace detail
@@ -53,7 +60,11 @@ SBranchSopp::SBranchSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode) {
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_branch", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBranchSopp>(opcode);
 }
 } // namespace detail
@@ -71,7 +82,11 @@ SWakeupSopp::SWakeupSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode) {
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wakeup", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWakeupSopp>(opcode);
 }
 } // namespace detail
@@ -91,7 +106,12 @@ SCbranchScc0Sopp::SCbranchScc0Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc0", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc0Sopp>(opcode);
 }
 } // namespace detail
@@ -116,7 +136,12 @@ SCbranchScc1Sopp::SCbranchScc1Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc1", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc1Sopp>(opcode);
 }
 } // namespace detail
@@ -141,7 +166,12 @@ SCbranchVcczSopp::SCbranchVcczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVcczSopp>(opcode);
 }
 } // namespace detail
@@ -166,7 +196,12 @@ SCbranchVccnzSopp::SCbranchVccnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVccnzSopp>(opcode);
 }
 } // namespace detail
@@ -191,7 +226,12 @@ SCbranchExeczSopp::SCbranchExeczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExeczSopp>(opcode);
 }
 } // namespace detail
@@ -216,7 +256,12 @@ SCbranchExecnzSopp::SCbranchExecnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExecnzSopp>(opcode);
 }
 } // namespace detail
@@ -235,7 +280,11 @@ SBarrierSopp::SBarrierSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBarrierSopp(const MachineInst *opcode) {
+DecodeResult decodeSBarrierSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_barrier", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBarrierSopp>(opcode);
 }
 } // namespace detail
@@ -250,7 +299,11 @@ SSetkillSopp::SSetkillSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetkillSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetkillSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setkill", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetkillSopp>(opcode);
 }
 } // namespace detail
@@ -266,7 +319,11 @@ SWaitcntSopp::SWaitcntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_waitcnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntSopp>(opcode);
 }
 } // namespace detail
@@ -281,7 +338,11 @@ SSethaltSopp::SSethaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sethalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSethaltSopp>(opcode);
 }
 } // namespace detail
@@ -296,7 +357,11 @@ SSleepSopp::SSleepSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode) {
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sleep", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSleepSopp>(opcode);
 }
 } // namespace detail
@@ -311,7 +376,11 @@ SSetprioSopp::SSetprioSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setprio", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetprioSopp>(opcode);
 }
 } // namespace detail
@@ -329,7 +398,11 @@ SSendmsgSopp::SSendmsgSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsg", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsgSopp>(opcode);
 }
 } // namespace detail
@@ -347,7 +420,12 @@ SSendmsghaltSopp::SSendmsghaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsghalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsghaltSopp>(opcode);
 }
 } // namespace detail
@@ -362,7 +440,11 @@ STrapSopp::STrapSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode) {
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_trap", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STrapSopp>(opcode);
 }
 } // namespace detail
@@ -375,7 +457,11 @@ SIcacheInvSopp::SIcacheInvSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode) {
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_icache_inv", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIcacheInvSopp>(opcode);
 }
 } // namespace detail
@@ -390,7 +476,12 @@ SIncperflevelSopp::SIncperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_incperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIncperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -405,7 +496,12 @@ SDecperflevelSopp::SDecperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_decperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDecperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -421,7 +517,12 @@ STtracedataSopp::STtracedataSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode) {
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_ttracedata", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STtracedataSopp>(opcode);
 }
 } // namespace detail
@@ -436,7 +537,12 @@ SCbranchCdbgsysSopp::SCbranchCdbgsysSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysSopp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysSopp>(opcode);
 }
 } // namespace detail
@@ -451,7 +557,12 @@ SCbranchCdbguserSopp::SCbranchCdbguserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbguserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbguserSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbguser", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbguserSopp>(opcode);
 }
 } // namespace detail
@@ -466,7 +577,12 @@ SCbranchCdbgsysOrUserSopp::SCbranchCdbgsysOrUserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys_or_user", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysOrUserSopp>(opcode);
 }
 } // namespace detail
@@ -481,7 +597,12 @@ SCbranchCdbgsysAndUserSopp::SCbranchCdbgsysAndUserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys_and_user", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysAndUserSopp>(opcode);
 }
 } // namespace detail
@@ -495,7 +616,12 @@ SEndpgmSavedSopp::SEndpgmSavedSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm_saved", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSavedSopp>(opcode);
 }
 } // namespace detail
@@ -508,7 +634,12 @@ SSetGprIdxOffSopp::SSetGprIdxOffSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetGprIdxOffSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetGprIdxOffSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_set_gpr_idx_off", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetGprIdxOffSopp>(opcode);
 }
 } // namespace detail
@@ -528,7 +659,12 @@ SSetGprIdxModeSopp::SSetGprIdxModeSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetGprIdxModeSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetGprIdxModeSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_set_gpr_idx_mode", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetGprIdxModeSopp>(opcode);
 }
 } // namespace detail
@@ -542,7 +678,12 @@ SEndpgmOrderedPsDoneSopp::SEndpgmOrderedPsDoneSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm_ordered_ps_done", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmOrderedPsDoneSopp>(opcode);
 }
 } // namespace detail
@@ -557,7 +698,12 @@ SSetValuCoexecModeSopp::SSetValuCoexecModeSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetValuCoexecModeSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetValuCoexecModeSopp(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_set_valu_coexec_mode", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetValuCoexecModeSopp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/vop1.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/vop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -23,7 +22,14 @@ VNopVop1::VNopVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode) {
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_nop_sdwa"
+                                                                                 : "v_nop_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop1>(opcode);
 }
 } // namespace detail
@@ -72,7 +78,14 @@ VMovB32Vop1::VMovB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mov_b32_sdwa"
+                                                                                 : "v_mov_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop1>(opcode);
 }
 } // namespace detail
@@ -86,14 +99,20 @@ VReadfirstlaneB32Vop1::VReadfirstlaneB32Vop1(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_readfirstlane_b32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support SDWA";
   return std::make_unique<VReadfirstlaneB32Vop1>(opcode);
 }
 } // namespace detail
@@ -120,12 +139,17 @@ VCvtI32F64Vop1::VCvtI32F64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_I32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_i32_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_I32_F64 does not support SDWA";
   return std::make_unique<VCvtI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -151,12 +175,17 @@ VCvtF64I32Vop1::VCvtF64I32Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F64_I32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_f64_i32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_I32 does not support SDWA";
   return std::make_unique<VCvtF64I32Vop1>(opcode);
 }
 } // namespace detail
@@ -206,7 +235,15 @@ VCvtF32I32Vop1::VCvtF32I32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_i32_sdwa"
+          : "v_cvt_f32_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop1>(opcode);
 }
 } // namespace detail
@@ -256,7 +293,15 @@ VCvtF32U32Vop1::VCvtF32U32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_u32_sdwa"
+          : "v_cvt_f32_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop1>(opcode);
 }
 } // namespace detail
@@ -306,7 +351,15 @@ VCvtU32F32Vop1::VCvtU32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_u32_f32_sdwa"
+          : "v_cvt_u32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -356,7 +409,15 @@ VCvtI32F32Vop1::VCvtI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_i32_f32_sdwa"
+          : "v_cvt_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -406,7 +467,15 @@ VCvtF16F32Vop1::VCvtF16F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f16_f32_sdwa"
+          : "v_cvt_f16_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop1>(opcode);
 }
 } // namespace detail
@@ -463,7 +532,15 @@ VCvtF32F16Vop1::VCvtF32F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_f16_sdwa"
+          : "v_cvt_f32_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop1>(opcode);
 }
 } // namespace detail
@@ -513,7 +590,16 @@ VCvtRpiI32F32Vop1::VCvtRpiI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtRpiI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_rpi_i32_f32_sdwa"
+          : "v_cvt_rpi_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtRpiI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -563,7 +649,16 @@ VCvtFlrI32F32Vop1::VCvtFlrI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtFlrI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_flr_i32_f32_sdwa"
+          : "v_cvt_flr_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFlrI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -613,7 +708,16 @@ VCvtOffF32I4Vop1::VCvtOffF32I4Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_off_f32_i4_sdwa"
+          : "v_cvt_off_f32_i4_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop1>(opcode);
 }
 } // namespace detail
@@ -640,12 +744,17 @@ VCvtF32F64Vop1::VCvtF32F64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_f32_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F32_F64 does not support SDWA";
   return std::make_unique<VCvtF32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -663,14 +772,19 @@ VCvtF64F32Vop1::VCvtF64F32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CVT_F64_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F64_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_f64_f32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support SDWA";
   return std::make_unique<VCvtF64F32Vop1>(opcode);
 }
 } // namespace detail
@@ -720,7 +834,16 @@ VCvtF32Ubyte0Vop1::VCvtF32Ubyte0Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte0_sdwa"
+          : "v_cvt_f32_ubyte0_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop1>(opcode);
 }
 } // namespace detail
@@ -770,7 +893,16 @@ VCvtF32Ubyte1Vop1::VCvtF32Ubyte1Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte1_sdwa"
+          : "v_cvt_f32_ubyte1_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop1>(opcode);
 }
 } // namespace detail
@@ -820,7 +952,16 @@ VCvtF32Ubyte2Vop1::VCvtF32Ubyte2Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte2_sdwa"
+          : "v_cvt_f32_ubyte2_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop1>(opcode);
 }
 } // namespace detail
@@ -870,7 +1011,16 @@ VCvtF32Ubyte3Vop1::VCvtF32Ubyte3Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte3_sdwa"
+          : "v_cvt_f32_ubyte3_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop1>(opcode);
 }
 } // namespace detail
@@ -897,12 +1047,17 @@ VCvtU32F64Vop1::VCvtU32F64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_U32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_u32_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_U32_F64 does not support SDWA";
   return std::make_unique<VCvtU32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -928,12 +1083,17 @@ VCvtF64U32Vop1::VCvtF64U32Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F64_U32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_f64_u32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_U32 does not support SDWA";
   return std::make_unique<VCvtF64U32Vop1>(opcode);
 }
 } // namespace detail
@@ -960,12 +1120,17 @@ VTruncF64Vop1::VTruncF64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_TRUNC_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_trunc_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_TRUNC_F64 does not support SDWA";
   return std::make_unique<VTruncF64Vop1>(opcode);
 }
 } // namespace detail
@@ -992,12 +1157,17 @@ VCeilF64Vop1::VCeilF64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CEIL_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_ceil_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CEIL_F64 does not support SDWA";
   return std::make_unique<VCeilF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1016,14 +1186,19 @@ VRndneF64Vop1::VRndneF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_RNDNE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_RNDNE_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_rndne_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support SDWA";
   return std::make_unique<VRndneF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1050,12 +1225,17 @@ VFloorF64Vop1::VFloorF64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FLOOR_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_floor_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FLOOR_F64 does not support SDWA";
   return std::make_unique<VFloorF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1104,7 +1284,15 @@ VFractF32Vop1::VFractF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_fract_f32_sdwa"
+          : "v_fract_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1153,7 +1341,15 @@ VTruncF32Vop1::VTruncF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_trunc_f32_sdwa"
+          : "v_trunc_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1202,7 +1398,14 @@ VCeilF32Vop1::VCeilF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ceil_f32_sdwa"
+                                                                                 : "v_ceil_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1251,7 +1454,15 @@ VRndneF32Vop1::VRndneF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_rndne_f32_sdwa"
+          : "v_rndne_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1300,7 +1511,15 @@ VFloorF32Vop1::VFloorF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_floor_f32_sdwa"
+          : "v_floor_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1349,7 +1568,14 @@ VExpF32Vop1::VExpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_exp_f32_sdwa"
+                                                                                 : "v_exp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1398,7 +1624,14 @@ VLogF32Vop1::VLogF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_log_f32_sdwa"
+                                                                                 : "v_log_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1447,7 +1680,14 @@ VRcpF32Vop1::VRcpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rcp_f32_sdwa"
+                                                                                 : "v_rcp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1497,7 +1737,16 @@ VRcpIflagF32Vop1::VRcpIflagF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_rcp_iflag_f32_sdwa"
+          : "v_rcp_iflag_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1546,7 +1795,14 @@ VRsqF32Vop1::VRsqF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rsq_f32_sdwa"
+                                                                                 : "v_rsq_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1565,14 +1821,19 @@ VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_RCP_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_RCP_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_rcp_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support SDWA";
   return std::make_unique<VRcpF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1591,14 +1852,19 @@ VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_RSQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_RSQ_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_rsq_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support SDWA";
   return std::make_unique<VRsqF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1647,7 +1913,14 @@ VSqrtF32Vop1::VSqrtF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sqrt_f32_sdwa"
+                                                                                 : "v_sqrt_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1666,14 +1939,19 @@ VSqrtF64Vop1::VSqrtF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_SQRT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_SQRT_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_sqrt_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support SDWA";
   return std::make_unique<VSqrtF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1722,7 +2000,14 @@ VSinF32Vop1::VSinF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sin_f32_sdwa"
+                                                                                 : "v_sin_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1771,7 +2056,14 @@ VCosF32Vop1::VCosF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_cos_f32_sdwa"
+                                                                                 : "v_cos_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1820,7 +2112,14 @@ VNotB32Vop1::VNotB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_not_b32_sdwa"
+                                                                                 : "v_not_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop1>(opcode);
 }
 } // namespace detail
@@ -1869,7 +2168,15 @@ VBfrevB32Vop1::VBfrevB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_bfrev_b32_sdwa"
+          : "v_bfrev_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop1>(opcode);
 }
 } // namespace detail
@@ -1918,7 +2225,14 @@ VFfbhU32Vop1::VFfbhU32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhU32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFfbhU32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ffbh_u32_sdwa"
+                                                                                 : "v_ffbh_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhU32Vop1>(opcode);
 }
 } // namespace detail
@@ -1967,7 +2281,14 @@ VFfblB32Vop1::VFfblB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfblB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFfblB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ffbl_b32_sdwa"
+                                                                                 : "v_ffbl_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfblB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2016,7 +2337,14 @@ VFfbhI32Vop1::VFfbhI32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhI32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFfbhI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ffbh_i32_sdwa"
+                                                                                 : "v_ffbh_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhI32Vop1>(opcode);
 }
 } // namespace detail
@@ -2043,12 +2371,18 @@ VFrexpExpI32F64Vop1::VFrexpExpI32F64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FREXP_EXP_I32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_frexp_exp_i32_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_EXP_I32_F64 does not support SDWA";
   return std::make_unique<VFrexpExpI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -2075,12 +2409,18 @@ VFrexpMantF64Vop1::VFrexpMantF64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FREXP_MANT_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_frexp_mant_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_MANT_F64 does not support SDWA";
   return std::make_unique<VFrexpMantF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2107,12 +2447,17 @@ VFractF64Vop1::VFractF64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FRACT_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_fract_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FRACT_F64 does not support SDWA";
   return std::make_unique<VFractF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2162,7 +2507,16 @@ VFrexpExpI32F32Vop1::VFrexpExpI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_exp_i32_f32_sdwa"
+          : "v_frexp_exp_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -2212,7 +2566,16 @@ VFrexpMantF32Vop1::VFrexpMantF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_mant_f32_sdwa"
+          : "v_frexp_mant_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop1>(opcode);
 }
 } // namespace detail
@@ -2225,7 +2588,11 @@ VClrexcpVop1::VClrexcpVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClrexcpVop1(const MachineInst *opcode) {
+DecodeResult decodeVClrexcpVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop1::validate_encoding(
+      "v_clrexcp_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClrexcpVop1>(opcode);
 }
 } // namespace detail
@@ -2275,7 +2642,16 @@ VScreenPartition4seB32Vop1::VScreenPartition4seB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVScreenPartition4seB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVScreenPartition4seB32Vop1(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_screen_partition_4se_b32_sdwa"
+          : "v_screen_partition_4se_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VScreenPartition4seB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2325,7 +2701,14 @@ VMovB64Vop1::VMovB64Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovB64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mov_b64_sdwa"
+                                                                                 : "v_mov_b64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB64Vop1>(opcode);
 }
 } // namespace detail
@@ -2376,7 +2759,15 @@ VCvtF16U16Vop1::VCvtF16U16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f16_u16_sdwa"
+          : "v_cvt_f16_u16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop1>(opcode);
 }
 } // namespace detail
@@ -2433,7 +2824,15 @@ VCvtF16I16Vop1::VCvtF16I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f16_i16_sdwa"
+          : "v_cvt_f16_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop1>(opcode);
 }
 } // namespace detail
@@ -2490,7 +2889,15 @@ VCvtU16F16Vop1::VCvtU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_u16_f16_sdwa"
+          : "v_cvt_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2547,7 +2954,15 @@ VCvtI16F16Vop1::VCvtI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_i16_f16_sdwa"
+          : "v_cvt_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2603,7 +3018,14 @@ VRcpF16Vop1::VRcpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rcp_f16_sdwa"
+                                                                                 : "v_rcp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2659,7 +3081,14 @@ VSqrtF16Vop1::VSqrtF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sqrt_f16_sdwa"
+                                                                                 : "v_sqrt_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2715,7 +3144,14 @@ VRsqF16Vop1::VRsqF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rsq_f16_sdwa"
+                                                                                 : "v_rsq_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2771,7 +3207,14 @@ VLogF16Vop1::VLogF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_log_f16_sdwa"
+                                                                                 : "v_log_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2827,7 +3270,14 @@ VExpF16Vop1::VExpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_exp_f16_sdwa"
+                                                                                 : "v_exp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2884,7 +3334,16 @@ VFrexpMantF16Vop1::VFrexpMantF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_mant_f16_sdwa"
+          : "v_frexp_mant_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2941,7 +3400,16 @@ VFrexpExpI16F16Vop1::VFrexpExpI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_exp_i16_f16_sdwa"
+          : "v_frexp_exp_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2997,7 +3465,15 @@ VFloorF16Vop1::VFloorF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_floor_f16_sdwa"
+          : "v_floor_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3053,7 +3529,14 @@ VCeilF16Vop1::VCeilF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ceil_f16_sdwa"
+                                                                                 : "v_ceil_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3109,7 +3592,15 @@ VTruncF16Vop1::VTruncF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_trunc_f16_sdwa"
+          : "v_trunc_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3165,7 +3656,15 @@ VRndneF16Vop1::VRndneF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_rndne_f16_sdwa"
+          : "v_rndne_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3221,7 +3720,15 @@ VFractF16Vop1::VFractF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_fract_f16_sdwa"
+          : "v_fract_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3277,7 +3784,14 @@ VSinF16Vop1::VSinF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sin_f16_sdwa"
+                                                                                 : "v_sin_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3333,7 +3847,14 @@ VCosF16Vop1::VCosF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_cos_f16_sdwa"
+                                                                                 : "v_cos_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3390,7 +3911,16 @@ VCvtNormI16F16Vop1::VCvtNormI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_norm_i16_f16_sdwa"
+          : "v_cvt_norm_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3447,7 +3977,16 @@ VCvtNormU16F16Vop1::VCvtNormU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_norm_u16_f16_sdwa"
+          : "v_cvt_norm_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3503,7 +4042,16 @@ VSatPkU8I16Vop1::VSatPkU8I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_sat_pk_u8_i16_sdwa"
+          : "v_sat_pk_u8_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop1>(opcode);
 }
 } // namespace detail
@@ -3525,14 +4073,19 @@ VSwapB32Vop1::VSwapB32Vop1(const MachineInst *inst)
   dst_operands_[1] = &src0;
   num_src_ = 2;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_SWAP_B32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_SWAP_B32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_swap_b32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B32 does not support SDWA";
   return std::make_unique<VSwapB32Vop1>(opcode);
 }
 } // namespace detail
@@ -3584,7 +4137,16 @@ VAccvgprMovB32Vop1::VAccvgprMovB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAccvgprMovB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVAccvgprMovB32Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_accvgpr_mov_b32_sdwa"
+          : "v_accvgpr_mov_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAccvgprMovB32Vop1>(opcode);
 }
 } // namespace detail
@@ -3634,7 +4196,15 @@ VCvtF32Fp8Vop1::VCvtF32Fp8Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Fp8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Fp8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_fp8_sdwa"
+          : "v_cvt_f32_fp8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Fp8Vop1>(opcode);
 }
 } // namespace detail
@@ -3684,7 +4254,15 @@ VCvtF32Bf8Vop1::VCvtF32Bf8Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Bf8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Bf8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_bf8_sdwa"
+          : "v_cvt_f32_bf8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Bf8Vop1>(opcode);
 }
 } // namespace detail
@@ -3735,7 +4313,16 @@ VCvtPkF32Fp8Vop1::VCvtPkF32Fp8Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF32Fp8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF32Fp8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_pk_f32_fp8_sdwa"
+          : "v_cvt_pk_f32_fp8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkF32Fp8Vop1>(opcode);
 }
 } // namespace detail
@@ -3786,7 +4373,16 @@ VCvtPkF32Bf8Vop1::VCvtPkF32Bf8Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF32Bf8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF32Bf8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_pk_f32_bf8_sdwa"
+          : "v_cvt_pk_f32_bf8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkF32Bf8Vop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/vop2.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/vop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -67,7 +66,16 @@ VCndmaskB32Vop2::VCndmaskB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cndmask_b32_sdwa"
+          : "v_cndmask_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop2>(opcode);
 }
 } // namespace detail
@@ -122,7 +130,14 @@ VAddF32Vop2::VAddF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_f32_sdwa"
+                                                                                 : "v_add_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop2>(opcode);
 }
 } // namespace detail
@@ -177,7 +192,14 @@ VSubF32Vop2::VSubF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_f32_sdwa"
+                                                                                 : "v_sub_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop2>(opcode);
 }
 } // namespace detail
@@ -233,7 +255,15 @@ VSubrevF32Vop2::VSubrevF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_f32_sdwa"
+          : "v_subrev_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop2>(opcode);
 }
 } // namespace detail
@@ -263,12 +293,17 @@ VFmacF64Vop2::VFmacF64Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAC_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_fmac_f64_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_F64 does not support SDWA";
   return std::make_unique<VFmacF64Vop2>(opcode);
 }
 } // namespace detail
@@ -323,7 +358,14 @@ VMulF32Vop2::VMulF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mul_f32_sdwa"
+                                                                                 : "v_mul_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop2>(opcode);
 }
 } // namespace detail
@@ -379,7 +421,15 @@ VMulI32I24Vop2::VMulI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_i32_i24_sdwa"
+          : "v_mul_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -435,7 +485,16 @@ VMulHiI32I24Vop2::VMulHiI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_hi_i32_i24_sdwa"
+          : "v_mul_hi_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -491,7 +550,15 @@ VMulU32U24Vop2::VMulU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_u32_u24_sdwa"
+          : "v_mul_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -547,7 +614,16 @@ VMulHiU32U24Vop2::VMulHiU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_hi_u32_u24_sdwa"
+          : "v_mul_hi_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -602,7 +678,14 @@ VMinF32Vop2::VMinF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_f32_sdwa"
+                                                                                 : "v_min_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF32Vop2>(opcode);
 }
 } // namespace detail
@@ -657,7 +740,14 @@ VMaxF32Vop2::VMaxF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_f32_sdwa"
+                                                                                 : "v_max_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF32Vop2>(opcode);
 }
 } // namespace detail
@@ -712,7 +802,14 @@ VMinI32Vop2::VMinI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_i32_sdwa"
+                                                                                 : "v_min_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop2>(opcode);
 }
 } // namespace detail
@@ -767,7 +864,14 @@ VMaxI32Vop2::VMaxI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_i32_sdwa"
+                                                                                 : "v_max_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop2>(opcode);
 }
 } // namespace detail
@@ -822,7 +926,14 @@ VMinU32Vop2::VMinU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_u32_sdwa"
+                                                                                 : "v_min_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop2>(opcode);
 }
 } // namespace detail
@@ -877,7 +988,14 @@ VMaxU32Vop2::VMaxU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_u32_sdwa"
+                                                                                 : "v_max_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop2>(opcode);
 }
 } // namespace detail
@@ -933,7 +1051,16 @@ VLshrrevB32Vop2::VLshrrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshrrev_b32_sdwa"
+          : "v_lshrrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -989,7 +1116,16 @@ VAshrrevI32Vop2::VAshrrevI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_ashrrev_i32_sdwa"
+          : "v_ashrrev_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop2>(opcode);
 }
 } // namespace detail
@@ -1045,7 +1181,16 @@ VLshlrevB32Vop2::VLshlrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshlrev_b32_sdwa"
+          : "v_lshlrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1100,7 +1245,14 @@ VAndB32Vop2::VAndB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_and_b32_sdwa"
+                                                                                 : "v_and_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1155,7 +1307,14 @@ VOrB32Vop2::VOrB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_or_b32_sdwa"
+                                                                                 : "v_or_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1210,7 +1369,14 @@ VXorB32Vop2::VXorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_xor_b32_sdwa"
+                                                                                 : "v_xor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1235,14 +1401,19 @@ VFmamkF32Vop2::VFmamkF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_FMAMK_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAMK_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmamkF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmamkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_fmamk_f32_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F32 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F32 does not support SDWA";
   return std::make_unique<VFmamkF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1267,14 +1438,19 @@ VFmaakF32Vop2::VFmaakF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_FMAAK_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAAK_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaakF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmaakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_fmaak_f32_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F32 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F32 does not support SDWA";
   return std::make_unique<VFmaakF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1333,7 +1509,15 @@ VAddCoU32Vop2::VAddCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_add_co_u32_sdwa"
+          : "v_add_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1392,7 +1576,15 @@ VSubCoU32Vop2::VSubCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_sub_co_u32_sdwa"
+          : "v_sub_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1451,7 +1643,16 @@ VSubrevCoU32Vop2::VSubrevCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_co_u32_sdwa"
+          : "v_subrev_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1513,7 +1714,15 @@ VAddcCoU32Vop2::VAddcCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddcCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddcCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_addc_co_u32_sdwa"
+          : "v_addc_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddcCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1575,7 +1784,15 @@ VSubbCoU32Vop2::VSubbCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubbCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubbCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subb_co_u32_sdwa"
+          : "v_subb_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubbCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1637,7 +1854,16 @@ VSubbrevCoU32Vop2::VSubbrevCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubbrevCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubbrevCoU32Vop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subbrev_co_u32_sdwa"
+          : "v_subbrev_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubbrevCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1693,7 +1919,14 @@ VAddF16Vop2::VAddF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_f16_sdwa"
+                                                                                 : "v_add_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1755,7 +1988,14 @@ VSubF16Vop2::VSubF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_f16_sdwa"
+                                                                                 : "v_sub_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1818,7 +2058,15 @@ VSubrevF16Vop2::VSubrevF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_f16_sdwa"
+          : "v_subrev_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1880,7 +2128,14 @@ VMulF16Vop2::VMulF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mul_f16_sdwa"
+                                                                                 : "v_mul_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1916,12 +2171,17 @@ VMacF16Vop2::VMacF16Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MAC_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_mac_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MAC_F16 does not support SDWA";
   return std::make_unique<VMacF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1954,14 +2214,19 @@ VMadmkF16Vop2::VMadmkF16Vop2(const MachineInst *inst)
       Operand(16, OperandType::OPR_SIMM32,
               static_cast<int>(
                   (reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_MADMK_F16 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MADMK_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadmkF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMadmkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_madmk_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_MADMK_F16 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MADMK_F16 does not support SDWA";
   return std::make_unique<VMadmkF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1994,14 +2259,19 @@ VMadakF16Vop2::VMadakF16Vop2(const MachineInst *inst)
       Operand(16, OperandType::OPR_SIMM32,
               static_cast<int>(
                   (reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_MADAK_F16 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MADAK_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadakF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMadakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_madak_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_MADAK_F16 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MADAK_F16 does not support SDWA";
   return std::make_unique<VMadakF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2063,7 +2333,14 @@ VAddU16Vop2::VAddU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_u16_sdwa"
+                                                                                 : "v_add_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2125,7 +2402,14 @@ VSubU16Vop2::VSubU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_u16_sdwa"
+                                                                                 : "v_sub_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2188,7 +2472,15 @@ VSubrevU16Vop2::VSubrevU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_u16_sdwa"
+          : "v_subrev_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2251,7 +2543,15 @@ VMulLoU16Vop2::VMulLoU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_lo_u16_sdwa"
+          : "v_mul_lo_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2314,7 +2614,16 @@ VLshlrevB16Vop2::VLshlrevB16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB16Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshlrev_b16_sdwa"
+          : "v_lshlrev_b16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB16Vop2>(opcode);
 }
 } // namespace detail
@@ -2377,7 +2686,16 @@ VLshrrevB16Vop2::VLshrrevB16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB16Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshrrev_b16_sdwa"
+          : "v_lshrrev_b16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB16Vop2>(opcode);
 }
 } // namespace detail
@@ -2440,7 +2758,16 @@ VAshrrevI16Vop2::VAshrrevI16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI16Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_ashrrev_i16_sdwa"
+          : "v_ashrrev_i16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI16Vop2>(opcode);
 }
 } // namespace detail
@@ -2502,7 +2829,14 @@ VMaxF16Vop2::VMaxF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_f16_sdwa"
+                                                                                 : "v_max_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2564,7 +2898,14 @@ VMinF16Vop2::VMinF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_f16_sdwa"
+                                                                                 : "v_min_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2626,7 +2967,14 @@ VMaxU16Vop2::VMaxU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_u16_sdwa"
+                                                                                 : "v_max_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2688,7 +3036,14 @@ VMaxI16Vop2::VMaxI16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_i16_sdwa"
+                                                                                 : "v_max_i16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI16Vop2>(opcode);
 }
 } // namespace detail
@@ -2750,7 +3105,14 @@ VMinU16Vop2::VMinU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_u16_sdwa"
+                                                                                 : "v_min_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2812,7 +3174,14 @@ VMinI16Vop2::VMinI16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_i16_sdwa"
+                                                                                 : "v_min_i16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI16Vop2>(opcode);
 }
 } // namespace detail
@@ -2874,7 +3243,15 @@ VLdexpF16Vop2::VLdexpF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_ldexp_f16_sdwa"
+          : "v_ldexp_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2935,7 +3312,14 @@ VAddU32Vop2::VAddU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_u32_sdwa"
+                                                                                 : "v_add_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddU32Vop2>(opcode);
 }
 } // namespace detail
@@ -2990,7 +3374,14 @@ VSubU32Vop2::VSubU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_u32_sdwa"
+                                                                                 : "v_sub_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubU32Vop2>(opcode);
 }
 } // namespace detail
@@ -3046,7 +3437,15 @@ VSubrevU32Vop2::VSubrevU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_u32_sdwa"
+          : "v_subrev_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevU32Vop2>(opcode);
 }
 } // namespace detail
@@ -3075,12 +3474,18 @@ VDot2cF32F16Vop2::VDot2cF32F16Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT2C_F32_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot2cF32F16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_dot2c_f32_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT2C_F32_F16 does not support SDWA";
   return std::make_unique<VDot2cF32F16Vop2>(opcode);
 }
 } // namespace detail
@@ -3109,12 +3514,18 @@ VDot2cI32I16Vop2::VDot2cI32I16Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT2C_I32_I16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cI32I16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot2cI32I16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_dot2c_i32_i16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT2C_I32_I16 does not support SDWA";
   return std::make_unique<VDot2cI32I16Vop2>(opcode);
 }
 } // namespace detail
@@ -3143,12 +3554,18 @@ VDot4cI32I8Vop2::VDot4cI32I8Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT4C_I32_I8 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot4cI32I8Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_dot4c_i32_i8_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT4C_I32_I8 does not support SDWA";
   return std::make_unique<VDot4cI32I8Vop2>(opcode);
 }
 } // namespace detail
@@ -3177,12 +3594,18 @@ VDot8cI32I4Vop2::VDot8cI32I4Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT8C_I32_I4 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8cI32I4Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot8cI32I4Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_dot8c_i32_i4_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT8C_I32_I4 does not support SDWA";
   return std::make_unique<VDot8cI32I4Vop2>(opcode);
 }
 } // namespace detail
@@ -3211,12 +3634,17 @@ VFmacF32Vop2::VFmacF32Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAC_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_fmac_f32_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_F32 does not support SDWA";
   return std::make_unique<VFmacF32Vop2>(opcode);
 }
 } // namespace detail
@@ -3245,12 +3673,17 @@ VPkFmacF16Vop2::VPkFmacF16Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_PK_FMAC_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_pk_fmac_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_PK_FMAC_F16 does not support SDWA";
   return std::make_unique<VPkFmacF16Vop2>(opcode);
 }
 } // namespace detail
@@ -3305,7 +3738,14 @@ VXnorB32Vop2::VXnorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_xnor_b32_sdwa"
+                                                                                 : "v_xnor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/vop3.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/vop3.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -21,7 +20,11 @@ VNopVop3::VNopVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode) {
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_nop", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop3>(opcode);
 }
 } // namespace detail
@@ -38,7 +41,11 @@ VMovB32Vop3::VMovB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mov_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop3>(opcode);
 }
 } // namespace detail
@@ -55,7 +62,12 @@ VReadfirstlaneB32Vop3::VReadfirstlaneB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_readfirstlane_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VReadfirstlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -72,7 +84,11 @@ VCvtI32F64Vop3::VCvtI32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_i32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -89,7 +105,11 @@ VCvtF64I32Vop3::VCvtF64I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f64_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF64I32Vop3>(opcode);
 }
 } // namespace detail
@@ -106,7 +126,11 @@ VCvtF32I32Vop3::VCvtF32I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop3>(opcode);
 }
 } // namespace detail
@@ -123,7 +147,11 @@ VCvtF32U32Vop3::VCvtF32U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop3>(opcode);
 }
 } // namespace detail
@@ -140,7 +168,11 @@ VCvtU32F32Vop3::VCvtU32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_u32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -157,7 +189,11 @@ VCvtI32F32Vop3::VCvtI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -174,7 +210,11 @@ VCvtF16F32Vop3::VCvtF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -197,7 +237,11 @@ VCvtF32F16Vop3::VCvtF32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -214,7 +258,12 @@ VCvtRpiI32F32Vop3::VCvtRpiI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtRpiI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_rpi_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtRpiI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -231,7 +280,12 @@ VCvtFlrI32F32Vop3::VCvtFlrI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtFlrI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_flr_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFlrI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -248,7 +302,12 @@ VCvtOffF32I4Vop3::VCvtOffF32I4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_off_f32_i4", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop3>(opcode);
 }
 } // namespace detail
@@ -265,7 +324,11 @@ VCvtF32F64Vop3::VCvtF32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -282,7 +345,11 @@ VCvtF64F32Vop3::VCvtF64F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f64_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF64F32Vop3>(opcode);
 }
 } // namespace detail
@@ -299,7 +366,12 @@ VCvtF32Ubyte0Vop3::VCvtF32Ubyte0Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte0", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop3>(opcode);
 }
 } // namespace detail
@@ -316,7 +388,12 @@ VCvtF32Ubyte1Vop3::VCvtF32Ubyte1Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte1", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop3>(opcode);
 }
 } // namespace detail
@@ -333,7 +410,12 @@ VCvtF32Ubyte2Vop3::VCvtF32Ubyte2Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte2", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop3>(opcode);
 }
 } // namespace detail
@@ -350,7 +432,12 @@ VCvtF32Ubyte3Vop3::VCvtF32Ubyte3Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte3", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop3>(opcode);
 }
 } // namespace detail
@@ -367,7 +454,11 @@ VCvtU32F64Vop3::VCvtU32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_u32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -384,7 +475,11 @@ VCvtF64U32Vop3::VCvtF64U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f64_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF64U32Vop3>(opcode);
 }
 } // namespace detail
@@ -401,7 +496,11 @@ VTruncF64Vop3::VTruncF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trunc_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF64Vop3>(opcode);
 }
 } // namespace detail
@@ -418,7 +517,11 @@ VCeilF64Vop3::VCeilF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ceil_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF64Vop3>(opcode);
 }
 } // namespace detail
@@ -435,7 +538,11 @@ VRndneF64Vop3::VRndneF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rndne_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF64Vop3>(opcode);
 }
 } // namespace detail
@@ -452,7 +559,11 @@ VFloorF64Vop3::VFloorF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_floor_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF64Vop3>(opcode);
 }
 } // namespace detail
@@ -469,7 +580,11 @@ VFractF32Vop3::VFractF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fract_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop3>(opcode);
 }
 } // namespace detail
@@ -486,7 +601,11 @@ VTruncF32Vop3::VTruncF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trunc_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop3>(opcode);
 }
 } // namespace detail
@@ -503,7 +622,11 @@ VCeilF32Vop3::VCeilF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ceil_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop3>(opcode);
 }
 } // namespace detail
@@ -520,7 +643,11 @@ VRndneF32Vop3::VRndneF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rndne_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop3>(opcode);
 }
 } // namespace detail
@@ -537,7 +664,11 @@ VFloorF32Vop3::VFloorF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_floor_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop3>(opcode);
 }
 } // namespace detail
@@ -554,7 +685,11 @@ VExpF32Vop3::VExpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_exp_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -571,7 +706,11 @@ VLogF32Vop3::VLogF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_log_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop3>(opcode);
 }
 } // namespace detail
@@ -588,7 +727,11 @@ VRcpF32Vop3::VRcpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -605,7 +748,12 @@ VRcpIflagF32Vop3::VRcpIflagF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_iflag_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop3>(opcode);
 }
 } // namespace detail
@@ -622,7 +770,11 @@ VRsqF32Vop3::VRsqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rsq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -639,7 +791,11 @@ VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -656,7 +812,11 @@ VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rsq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -673,7 +833,11 @@ VSqrtF32Vop3::VSqrtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sqrt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -690,7 +854,11 @@ VSqrtF64Vop3::VSqrtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sqrt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -707,7 +875,11 @@ VSinF32Vop3::VSinF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sin_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop3>(opcode);
 }
 } // namespace detail
@@ -724,7 +896,11 @@ VCosF32Vop3::VCosF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cos_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop3>(opcode);
 }
 } // namespace detail
@@ -741,7 +917,11 @@ VNotB32Vop3::VNotB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_not_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop3>(opcode);
 }
 } // namespace detail
@@ -758,7 +938,11 @@ VBfrevB32Vop3::VBfrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfrev_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -775,7 +959,11 @@ VFfbhU32Vop3::VFfbhU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFfbhU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ffbh_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhU32Vop3>(opcode);
 }
 } // namespace detail
@@ -792,7 +980,11 @@ VFfblB32Vop3::VFfblB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfblB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFfblB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ffbl_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfblB32Vop3>(opcode);
 }
 } // namespace detail
@@ -809,7 +1001,11 @@ VFfbhI32Vop3::VFfbhI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFfbhI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ffbh_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhI32Vop3>(opcode);
 }
 } // namespace detail
@@ -826,7 +1022,12 @@ VFrexpExpI32F64Vop3::VFrexpExpI32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_exp_i32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -843,7 +1044,12 @@ VFrexpMantF64Vop3::VFrexpMantF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_mant_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF64Vop3>(opcode);
 }
 } // namespace detail
@@ -860,7 +1066,11 @@ VFractF64Vop3::VFractF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fract_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF64Vop3>(opcode);
 }
 } // namespace detail
@@ -877,7 +1087,12 @@ VFrexpExpI32F32Vop3::VFrexpExpI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_exp_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -894,7 +1109,12 @@ VFrexpMantF32Vop3::VFrexpMantF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_mant_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop3>(opcode);
 }
 } // namespace detail
@@ -907,7 +1127,11 @@ VClrexcpVop3::VClrexcpVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClrexcpVop3(const MachineInst *opcode) {
+DecodeResult decodeVClrexcpVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_clrexcp", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClrexcpVop3>(opcode);
 }
 } // namespace detail
@@ -924,7 +1148,12 @@ VScreenPartition4seB32Vop3::VScreenPartition4seB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVScreenPartition4seB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVScreenPartition4seB32Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_screen_partition_4se_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VScreenPartition4seB32Vop3>(opcode);
 }
 } // namespace detail
@@ -941,7 +1170,11 @@ VMovB64Vop3::VMovB64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mov_b64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB64Vop3>(opcode);
 }
 } // namespace detail
@@ -958,7 +1191,11 @@ VCvtF16U16Vop3::VCvtF16U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f16_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop3>(opcode);
 }
 } // namespace detail
@@ -981,7 +1218,11 @@ VCvtF16I16Vop3::VCvtF16I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f16_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop3>(opcode);
 }
 } // namespace detail
@@ -1004,7 +1245,11 @@ VCvtU16F16Vop3::VCvtU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_u16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1027,7 +1272,11 @@ VCvtI16F16Vop3::VCvtI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1050,7 +1299,11 @@ VRcpF16Vop3::VRcpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1073,7 +1326,11 @@ VSqrtF16Vop3::VSqrtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sqrt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1096,7 +1353,11 @@ VRsqF16Vop3::VRsqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rsq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1119,7 +1380,11 @@ VLogF16Vop3::VLogF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_log_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1142,7 +1407,11 @@ VExpF16Vop3::VExpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_exp_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1165,7 +1434,12 @@ VFrexpMantF16Vop3::VFrexpMantF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_mant_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1188,7 +1462,12 @@ VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_exp_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1211,7 +1490,11 @@ VFloorF16Vop3::VFloorF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_floor_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1234,7 +1517,11 @@ VCeilF16Vop3::VCeilF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ceil_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1257,7 +1544,11 @@ VTruncF16Vop3::VTruncF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trunc_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1280,7 +1571,11 @@ VRndneF16Vop3::VRndneF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rndne_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1303,7 +1598,11 @@ VFractF16Vop3::VFractF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fract_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1326,7 +1625,11 @@ VSinF16Vop3::VSinF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sin_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1349,7 +1652,11 @@ VCosF16Vop3::VCosF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cos_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1372,7 +1679,12 @@ VCvtNormI16F16Vop3::VCvtNormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_norm_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1395,7 +1707,12 @@ VCvtNormU16F16Vop3::VCvtNormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_norm_u16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1418,7 +1735,12 @@ VSatPkU8I16Vop3::VSatPkU8I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sat_pk_u8_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop3>(opcode);
 }
 } // namespace detail
@@ -1443,7 +1765,11 @@ VSwapB32Vop3::VSwapB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwapB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSwapB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_swap_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSwapB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1466,7 +1792,12 @@ VAccvgprMovB32Vop3::VAccvgprMovB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAccvgprMovB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAccvgprMovB32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_accvgpr_mov_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAccvgprMovB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1483,7 +1814,11 @@ VCvtF32Fp8Vop3::VCvtF32Fp8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Fp8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Fp8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_fp8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Fp8Vop3>(opcode);
 }
 } // namespace detail
@@ -1500,7 +1835,11 @@ VCvtF32Bf8Vop3::VCvtF32Bf8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Bf8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Bf8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_bf8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Bf8Vop3>(opcode);
 }
 } // namespace detail
@@ -1517,7 +1856,12 @@ VCvtPkF32Fp8Vop3::VCvtPkF32Fp8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF32Fp8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF32Fp8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_f32_fp8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkF32Fp8Vop3>(opcode);
 }
 } // namespace detail
@@ -1534,7 +1878,12 @@ VCvtPkF32Bf8Vop3::VCvtPkF32Bf8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF32Bf8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF32Bf8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_f32_bf8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkF32Bf8Vop3>(opcode);
 }
 } // namespace detail
@@ -1555,7 +1904,12 @@ VCndmaskB32Vop3::VCndmaskB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cndmask_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1574,7 +1928,11 @@ VAddF32Vop3::VAddF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1593,7 +1951,11 @@ VSubF32Vop3::VSubF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1612,7 +1974,11 @@ VSubrevF32Vop3::VSubrevF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1632,7 +1998,11 @@ VFmacF64Vop3::VFmacF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fmac_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1651,7 +2021,11 @@ VMulF32Vop3::VMulF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1670,7 +2044,11 @@ VMulI32I24Vop3::VMulI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_i32_i24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -1689,7 +2067,12 @@ VMulHiI32I24Vop3::VMulHiI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_i32_i24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -1708,7 +2091,11 @@ VMulU32U24Vop3::VMulU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_u32_u24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -1727,7 +2114,12 @@ VMulHiU32U24Vop3::VMulHiU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_u32_u24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -1746,7 +2138,11 @@ VMinF32Vop3::VMinF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1765,7 +2161,11 @@ VMaxF32Vop3::VMaxF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1784,7 +2184,11 @@ VMinI32Vop3::VMinI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop3>(opcode);
 }
 } // namespace detail
@@ -1803,7 +2207,11 @@ VMaxI32Vop3::VMaxI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop3>(opcode);
 }
 } // namespace detail
@@ -1822,7 +2230,11 @@ VMinU32Vop3::VMinU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop3>(opcode);
 }
 } // namespace detail
@@ -1841,7 +2253,11 @@ VMaxU32Vop3::VMaxU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop3>(opcode);
 }
 } // namespace detail
@@ -1860,7 +2276,12 @@ VLshrrevB32Vop3::VLshrrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshrrev_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1879,7 +2300,12 @@ VAshrrevI32Vop3::VAshrrevI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashrrev_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop3>(opcode);
 }
 } // namespace detail
@@ -1898,7 +2324,12 @@ VLshlrevB32Vop3::VLshlrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshlrev_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1917,7 +2348,11 @@ VAndB32Vop3::VAndB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_and_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1936,7 +2371,11 @@ VOrB32Vop3::VOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_or_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1955,7 +2394,11 @@ VXorB32Vop3::VXorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xor_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1974,7 +2417,11 @@ VAddF16Vop3::VAddF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1999,7 +2446,11 @@ VSubF16Vop3::VSubF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2024,7 +2475,11 @@ VSubrevF16Vop3::VSubrevF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2049,7 +2504,11 @@ VMulF16Vop3::VMulF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2075,7 +2534,11 @@ VMacF16Vop3::VMacF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMacF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mac_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMacF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2100,7 +2563,11 @@ VAddU16Vop3::VAddU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2125,7 +2592,11 @@ VSubU16Vop3::VSubU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2150,7 +2621,11 @@ VSubrevU16Vop3::VSubrevU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2175,7 +2650,11 @@ VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_lo_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2200,7 +2679,12 @@ VLshlrevB16Vop3::VLshlrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshlrev_b16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -2225,7 +2709,12 @@ VLshrrevB16Vop3::VLshrrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshrrev_b16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -2250,7 +2739,12 @@ VAshrrevI16Vop3::VAshrrevI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashrrev_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI16Vop3>(opcode);
 }
 } // namespace detail
@@ -2275,7 +2769,11 @@ VMaxF16Vop3::VMaxF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2300,7 +2798,11 @@ VMinF16Vop3::VMinF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2325,7 +2827,11 @@ VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2350,7 +2856,11 @@ VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI16Vop3>(opcode);
 }
 } // namespace detail
@@ -2375,7 +2885,11 @@ VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2400,7 +2914,11 @@ VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI16Vop3>(opcode);
 }
 } // namespace detail
@@ -2425,7 +2943,11 @@ VLdexpF16Vop3::VLdexpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ldexp_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2450,7 +2972,11 @@ VAddU32Vop3::VAddU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2469,7 +2995,11 @@ VSubU32Vop3::VSubU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2488,7 +3018,11 @@ VSubrevU32Vop3::VSubrevU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2508,7 +3042,12 @@ VDot2cF32F16Vop3::VDot2cF32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot2cF32F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot2c_f32_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2cF32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -2528,7 +3067,12 @@ VDot2cI32I16Vop3::VDot2cI32I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cI32I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot2cI32I16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot2c_i32_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2cI32I16Vop3>(opcode);
 }
 } // namespace detail
@@ -2548,7 +3092,12 @@ VDot4cI32I8Vop3::VDot4cI32I8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot4cI32I8Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot4c_i32_i8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot4cI32I8Vop3>(opcode);
 }
 } // namespace detail
@@ -2568,7 +3117,12 @@ VDot8cI32I4Vop3::VDot8cI32I4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8cI32I4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot8cI32I4Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot8c_i32_i4", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot8cI32I4Vop3>(opcode);
 }
 } // namespace detail
@@ -2588,7 +3142,11 @@ VFmacF32Vop3::VFmacF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fmac_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2608,7 +3166,11 @@ VPkFmacF16Vop3::VPkFmacF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPkFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_pk_fmac_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkFmacF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2627,7 +3189,11 @@ VXnorB32Vop3::VXnorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xnor_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2648,7 +3214,11 @@ VMadI32I24Vop3::VMadI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_i32_i24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -2669,7 +3239,11 @@ VMadU32U24Vop3::VMadU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_u32_u24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -2690,7 +3264,11 @@ VCubeidF32Vop3::VCubeidF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubeid_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubeidF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2711,7 +3289,11 @@ VCubescF32Vop3::VCubescF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubesc_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubescF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2732,7 +3314,11 @@ VCubetcF32Vop3::VCubetcF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubetc_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubetcF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2753,7 +3339,11 @@ VCubemaF32Vop3::VCubemaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubema_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubemaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2774,7 +3364,11 @@ VBfeU32Vop3::VBfeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfe_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2795,7 +3389,11 @@ VBfeI32Vop3::VBfeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfe_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -2816,7 +3414,11 @@ VBfiB32Vop3::VBfiB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfi_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfiB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2837,7 +3439,11 @@ VFmaF32Vop3::VFmaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2858,7 +3464,11 @@ VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF64Vop3>(opcode);
 }
 } // namespace detail
@@ -2879,7 +3489,11 @@ VLerpU8Vop3::VLerpU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lerp_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLerpU8Vop3>(opcode);
 }
 } // namespace detail
@@ -2900,7 +3514,12 @@ VAlignbitB32Vop3::VAlignbitB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_alignbit_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbitB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2921,7 +3540,12 @@ VAlignbyteB32Vop3::VAlignbyteB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_alignbyte_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbyteB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2942,7 +3566,11 @@ VMin3F32Vop3::VMin3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -2963,7 +3591,11 @@ VMin3I32Vop3::VMin3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -2984,7 +3616,11 @@ VMin3U32Vop3::VMin3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3005,7 +3641,11 @@ VMax3F32Vop3::VMax3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3026,7 +3666,11 @@ VMax3I32Vop3::VMax3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -3047,7 +3691,11 @@ VMax3U32Vop3::VMax3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3068,7 +3716,11 @@ VMed3F32Vop3::VMed3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3089,7 +3741,11 @@ VMed3I32Vop3::VMed3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -3110,7 +3766,11 @@ VMed3U32Vop3::VMed3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3131,7 +3791,11 @@ VSadU8Vop3::VSadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3152,7 +3816,11 @@ VSadHiU8Vop3::VSadHiU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_hi_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadHiU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3173,7 +3841,11 @@ VSadU16Vop3::VSadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -3194,7 +3866,11 @@ VSadU32Vop3::VSadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3215,7 +3891,12 @@ VCvtPkU8F32Vop3::VCvtPkU8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_u8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3236,7 +3917,12 @@ VDivFixupF32Vop3::VDivFixupF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3257,7 +3943,12 @@ VDivFixupF64Vop3::VDivFixupF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF64Vop3>(opcode);
 }
 } // namespace detail
@@ -3281,7 +3972,12 @@ VDivFmasF32Vop3::VDivFmasF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fmas_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFmasF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3305,7 +4001,12 @@ VDivFmasF64Vop3::VDivFmasF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fmas_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFmasF64Vop3>(opcode);
 }
 } // namespace detail
@@ -3326,7 +4027,11 @@ VMsadU8Vop3::VMsadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_msad_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMsadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3347,7 +4052,12 @@ VQsadPkU16U8Vop3::VQsadPkU16U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_qsad_pk_u16_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VQsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -3368,7 +4078,12 @@ VMqsadPkU16U8Vop3::VMqsadPkU16U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mqsad_pk_u16_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMqsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -3389,7 +4104,12 @@ VMqsadU32U8Vop3::VMqsadU32U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mqsad_u32_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMqsadU32U8Vop3>(opcode);
 }
 } // namespace detail
@@ -3410,7 +4130,12 @@ VMadLegacyF16Vop3::VMadLegacyF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadLegacyF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadLegacyF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_legacy_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadLegacyF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3437,7 +4162,12 @@ VMadLegacyU16Vop3::VMadLegacyU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadLegacyU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadLegacyU16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_legacy_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadLegacyU16Vop3>(opcode);
 }
 } // namespace detail
@@ -3464,7 +4194,12 @@ VMadLegacyI16Vop3::VMadLegacyI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadLegacyI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadLegacyI16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_legacy_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadLegacyI16Vop3>(opcode);
 }
 } // namespace detail
@@ -3491,7 +4226,11 @@ VPermB32Vop3::VPermB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_perm_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPermB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3512,7 +4251,12 @@ VFmaLegacyF16Vop3::VFmaLegacyF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaLegacyF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaLegacyF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_legacy_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaLegacyF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3539,7 +4283,12 @@ VDivFixupLegacyF16Vop3::VDivFixupLegacyF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupLegacyF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupLegacyF16Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_legacy_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupLegacyF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3565,7 +4314,12 @@ VCvtPkaccumU8F32Vop3::VCvtPkaccumU8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkaccumU8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkaccumU8F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pkaccum_u8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkaccumU8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3586,7 +4340,11 @@ VMadU32U16Vop3::VMadU32U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_u32_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3607,7 +4365,11 @@ VMadI32I16Vop3::VMadI32I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_i32_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3628,7 +4390,11 @@ VXadU32Vop3::VXadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xad_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3649,7 +4415,11 @@ VMin3F16Vop3::VMin3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3676,7 +4446,11 @@ VMin3I16Vop3::VMin3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3703,7 +4477,11 @@ VMin3U16Vop3::VMin3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3730,7 +4508,11 @@ VMax3F16Vop3::VMax3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3757,7 +4539,11 @@ VMax3I16Vop3::VMax3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3784,7 +4570,11 @@ VMax3U16Vop3::VMax3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3811,7 +4601,11 @@ VMed3F16Vop3::VMed3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3838,7 +4632,11 @@ VMed3I16Vop3::VMed3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3865,7 +4663,11 @@ VMed3U16Vop3::VMed3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3892,7 +4694,12 @@ VLshlAddU32Vop3::VLshlAddU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshl_add_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlAddU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3913,7 +4720,12 @@ VAddLshlU32Vop3::VAddLshlU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_lshl_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddLshlU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3934,7 +4746,11 @@ VAdd3U32Vop3::VAdd3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAdd3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3955,7 +4771,11 @@ VLshlOrB32Vop3::VLshlOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshl_or_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3976,7 +4796,11 @@ VAndOrB32Vop3::VAndOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_and_or_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3997,7 +4821,11 @@ VOr3B32Vop3::VOr3B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_or3_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOr3B32Vop3>(opcode);
 }
 } // namespace detail
@@ -4018,7 +4846,11 @@ VMadF16Vop3::VMadF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4045,7 +4877,11 @@ VMadU16Vop3::VMadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -4072,7 +4908,11 @@ VMadI16Vop3::VMadI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI16Vop3>(opcode);
 }
 } // namespace detail
@@ -4099,7 +4939,11 @@ VFmaF16Vop3::VFmaF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4126,7 +4970,12 @@ VDivFixupF16Vop3::VDivFixupF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4153,7 +5002,12 @@ VLshlAddU64Vop3::VLshlAddU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlAddU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlAddU64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshl_add_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlAddU64Vop3>(opcode);
 }
 } // namespace detail
@@ -4172,7 +5026,11 @@ VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4191,7 +5049,11 @@ VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4210,7 +5072,11 @@ VMinF64Vop3::VMinF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4229,7 +5095,11 @@ VMaxF64Vop3::VMaxF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4248,7 +5118,11 @@ VLdexpF64Vop3::VLdexpF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ldexp_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4267,7 +5141,11 @@ VMulLoU32Vop3::VMulLoU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_lo_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4286,7 +5164,11 @@ VMulHiU32Vop3::VMulHiU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4305,7 +5187,11 @@ VMulHiI32Vop3::VMulHiI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4324,7 +5210,11 @@ VLdexpF32Vop3::VLdexpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ldexp_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4343,7 +5233,12 @@ VReadlaneB32Vop3::VReadlaneB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_readlane_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VReadlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4363,7 +5258,12 @@ VWritelaneB32Vop3::VWritelaneB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_writelane_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VWritelaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4382,7 +5282,12 @@ VBcntU32B32Vop3::VBcntU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bcnt_u32_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBcntU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -4401,7 +5306,12 @@ VMbcntLoU32B32Vop3::VMbcntLoU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mbcnt_lo_u32_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntLoU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -4420,7 +5330,12 @@ VMbcntHiU32B32Vop3::VMbcntHiU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mbcnt_hi_u32_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntHiU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -4439,7 +5354,12 @@ VLshlrevB64Vop3::VLshlrevB64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshlrev_b64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -4458,7 +5378,12 @@ VLshrrevB64Vop3::VLshrrevB64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshrrev_b64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -4477,7 +5402,12 @@ VAshrrevI64Vop3::VAshrrevI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashrrev_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI64Vop3>(opcode);
 }
 } // namespace detail
@@ -4496,7 +5426,12 @@ VTrigPreopF64Vop3::VTrigPreopF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trig_preop_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTrigPreopF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4515,7 +5450,11 @@ VBfmB32Vop3::VBfmB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfm_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfmB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4534,7 +5473,12 @@ VCvtPknormI16F32Vop3::VCvtPknormI16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormI16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_i16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormI16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4553,7 +5497,12 @@ VCvtPknormU16F32Vop3::VCvtPknormU16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormU16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_u16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormU16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4572,7 +5521,12 @@ VCvtPkrtzF16F32Vop3::VCvtPkrtzF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pkrtz_f16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkrtzF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4591,7 +5545,12 @@ VCvtPkU16U32Vop3::VCvtPkU16U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_u16_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU16U32Vop3>(opcode);
 }
 } // namespace detail
@@ -4610,7 +5569,12 @@ VCvtPkI16I32Vop3::VCvtPkI16I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_i16_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkI16I32Vop3>(opcode);
 }
 } // namespace detail
@@ -4629,7 +5593,12 @@ VCvtPknormI16F16Vop3::VCvtPknormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4648,7 +5617,12 @@ VCvtPknormU16F16Vop3::VCvtPknormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_u16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4667,7 +5641,11 @@ VAddI32Vop3::VAddI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4686,7 +5664,11 @@ VSubI32Vop3::VSubI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4705,7 +5687,11 @@ VAddI16Vop3::VAddI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddI16Vop3>(opcode);
 }
 } // namespace detail
@@ -4730,7 +5716,11 @@ VSubI16Vop3::VSubI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubI16Vop3>(opcode);
 }
 } // namespace detail
@@ -4755,7 +5745,12 @@ VPackB32F16Vop3::VPackB32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_pack_b32_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPackB32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4774,7 +5769,12 @@ VMulLegacyF32Vop3::VMulLegacyF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLegacyF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_legacy_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLegacyF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4794,7 +5794,12 @@ VCvtPkFp8F32Vop3::VCvtPkFp8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkFp8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkFp8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_fp8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkFp8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4820,7 +5825,12 @@ VCvtPkBf8F32Vop3::VCvtPkBf8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkBf8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkBf8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_bf8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkBf8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4846,7 +5856,12 @@ VCvtSrFp8F32Vop3::VCvtSrFp8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtSrFp8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtSrFp8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_sr_fp8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtSrFp8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4872,7 +5887,12 @@ VCvtSrBf8F32Vop3::VCvtSrBf8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtSrBf8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtSrBf8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_sr_bf8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtSrBf8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4897,7 +5917,12 @@ VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_class_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4920,7 +5945,12 @@ VCmpxClassF32Vop3::VCmpxClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_class_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4939,7 +5969,12 @@ VCmpClassF64Vop3::VCmpClassF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_class_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4962,7 +5997,12 @@ VCmpxClassF64Vop3::VCmpxClassF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_class_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4981,7 +6021,12 @@ VCmpClassF16Vop3::VCmpClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_class_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5004,7 +6049,12 @@ VCmpxClassF16Vop3::VCmpxClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_class_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5023,7 +6073,11 @@ VCmpFF16Vop3::VCmpFF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5042,7 +6096,11 @@ VCmpLtF16Vop3::VCmpLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5061,7 +6119,11 @@ VCmpEqF16Vop3::VCmpEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5080,7 +6142,11 @@ VCmpLeF16Vop3::VCmpLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5099,7 +6165,11 @@ VCmpGtF16Vop3::VCmpGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5118,7 +6188,11 @@ VCmpLgF16Vop3::VCmpLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5137,7 +6211,11 @@ VCmpGeF16Vop3::VCmpGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5156,7 +6234,11 @@ VCmpOF16Vop3::VCmpOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_o_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5175,7 +6257,11 @@ VCmpUF16Vop3::VCmpUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_u_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5194,7 +6280,11 @@ VCmpNgeF16Vop3::VCmpNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5213,7 +6303,11 @@ VCmpNlgF16Vop3::VCmpNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5232,7 +6326,11 @@ VCmpNgtF16Vop3::VCmpNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ngt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5251,7 +6349,11 @@ VCmpNleF16Vop3::VCmpNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nle_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5270,7 +6372,11 @@ VCmpNeqF16Vop3::VCmpNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_neq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5289,7 +6395,11 @@ VCmpNltF16Vop3::VCmpNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5308,7 +6418,11 @@ VCmpTruF16Vop3::VCmpTruF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_tru_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTruF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5331,7 +6445,11 @@ VCmpxFF16Vop3::VCmpxFF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5354,7 +6472,11 @@ VCmpxLtF16Vop3::VCmpxLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5377,7 +6499,11 @@ VCmpxEqF16Vop3::VCmpxEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5400,7 +6526,11 @@ VCmpxLeF16Vop3::VCmpxLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5423,7 +6553,11 @@ VCmpxGtF16Vop3::VCmpxGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5446,7 +6580,11 @@ VCmpxLgF16Vop3::VCmpxLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5469,7 +6607,11 @@ VCmpxGeF16Vop3::VCmpxGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5492,7 +6634,11 @@ VCmpxOF16Vop3::VCmpxOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_o_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5515,7 +6661,11 @@ VCmpxUF16Vop3::VCmpxUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_u_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5538,7 +6688,12 @@ VCmpxNgeF16Vop3::VCmpxNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5561,7 +6716,12 @@ VCmpxNlgF16Vop3::VCmpxNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5584,7 +6744,12 @@ VCmpxNgtF16Vop3::VCmpxNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ngt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5607,7 +6772,12 @@ VCmpxNleF16Vop3::VCmpxNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nle_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5630,7 +6800,12 @@ VCmpxNeqF16Vop3::VCmpxNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_neq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5653,7 +6828,12 @@ VCmpxNltF16Vop3::VCmpxNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5676,7 +6856,12 @@ VCmpxTruF16Vop3::VCmpxTruF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_tru_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTruF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5695,7 +6880,11 @@ VCmpFF32Vop3::VCmpFF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5714,7 +6903,11 @@ VCmpLtF32Vop3::VCmpLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5733,7 +6926,11 @@ VCmpEqF32Vop3::VCmpEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5752,7 +6949,11 @@ VCmpLeF32Vop3::VCmpLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5771,7 +6972,11 @@ VCmpGtF32Vop3::VCmpGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5790,7 +6995,11 @@ VCmpLgF32Vop3::VCmpLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5809,7 +7018,11 @@ VCmpGeF32Vop3::VCmpGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5828,7 +7041,11 @@ VCmpOF32Vop3::VCmpOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_o_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5847,7 +7064,11 @@ VCmpUF32Vop3::VCmpUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_u_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5866,7 +7087,11 @@ VCmpNgeF32Vop3::VCmpNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5885,7 +7110,11 @@ VCmpNlgF32Vop3::VCmpNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5904,7 +7133,11 @@ VCmpNgtF32Vop3::VCmpNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ngt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5923,7 +7156,11 @@ VCmpNleF32Vop3::VCmpNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nle_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5942,7 +7179,11 @@ VCmpNeqF32Vop3::VCmpNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_neq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5961,7 +7202,11 @@ VCmpNltF32Vop3::VCmpNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5980,7 +7225,11 @@ VCmpTruF32Vop3::VCmpTruF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_tru_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTruF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6003,7 +7252,11 @@ VCmpxFF32Vop3::VCmpxFF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6026,7 +7279,11 @@ VCmpxLtF32Vop3::VCmpxLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6049,7 +7306,11 @@ VCmpxEqF32Vop3::VCmpxEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6072,7 +7333,11 @@ VCmpxLeF32Vop3::VCmpxLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6095,7 +7360,11 @@ VCmpxGtF32Vop3::VCmpxGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6118,7 +7387,11 @@ VCmpxLgF32Vop3::VCmpxLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6141,7 +7414,11 @@ VCmpxGeF32Vop3::VCmpxGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6164,7 +7441,11 @@ VCmpxOF32Vop3::VCmpxOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_o_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6187,7 +7468,11 @@ VCmpxUF32Vop3::VCmpxUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_u_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6210,7 +7495,12 @@ VCmpxNgeF32Vop3::VCmpxNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6233,7 +7523,12 @@ VCmpxNlgF32Vop3::VCmpxNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6256,7 +7551,12 @@ VCmpxNgtF32Vop3::VCmpxNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ngt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6279,7 +7579,12 @@ VCmpxNleF32Vop3::VCmpxNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nle_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6302,7 +7607,12 @@ VCmpxNeqF32Vop3::VCmpxNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_neq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6325,7 +7635,12 @@ VCmpxNltF32Vop3::VCmpxNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6348,7 +7663,12 @@ VCmpxTruF32Vop3::VCmpxTruF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_tru_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTruF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6367,7 +7687,11 @@ VCmpFF64Vop3::VCmpFF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6386,7 +7710,11 @@ VCmpLtF64Vop3::VCmpLtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6405,7 +7733,11 @@ VCmpEqF64Vop3::VCmpEqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6424,7 +7756,11 @@ VCmpLeF64Vop3::VCmpLeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6443,7 +7779,11 @@ VCmpGtF64Vop3::VCmpGtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6462,7 +7802,11 @@ VCmpLgF64Vop3::VCmpLgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6481,7 +7825,11 @@ VCmpGeF64Vop3::VCmpGeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6500,7 +7848,11 @@ VCmpOF64Vop3::VCmpOF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_o_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6519,7 +7871,11 @@ VCmpUF64Vop3::VCmpUF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_u_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6538,7 +7894,11 @@ VCmpNgeF64Vop3::VCmpNgeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6557,7 +7917,11 @@ VCmpNlgF64Vop3::VCmpNlgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6576,7 +7940,11 @@ VCmpNgtF64Vop3::VCmpNgtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ngt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6595,7 +7963,11 @@ VCmpNleF64Vop3::VCmpNleF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nle_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6614,7 +7986,11 @@ VCmpNeqF64Vop3::VCmpNeqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_neq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6633,7 +8009,11 @@ VCmpNltF64Vop3::VCmpNltF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6652,7 +8032,11 @@ VCmpTruF64Vop3::VCmpTruF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_tru_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTruF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6675,7 +8059,11 @@ VCmpxFF64Vop3::VCmpxFF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6698,7 +8086,11 @@ VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6721,7 +8113,11 @@ VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6744,7 +8140,11 @@ VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6767,7 +8167,11 @@ VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6790,7 +8194,11 @@ VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6813,7 +8221,11 @@ VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6836,7 +8248,11 @@ VCmpxOF64Vop3::VCmpxOF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_o_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6859,7 +8275,11 @@ VCmpxUF64Vop3::VCmpxUF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_u_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6882,7 +8302,12 @@ VCmpxNgeF64Vop3::VCmpxNgeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6905,7 +8330,12 @@ VCmpxNlgF64Vop3::VCmpxNlgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6928,7 +8358,12 @@ VCmpxNgtF64Vop3::VCmpxNgtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ngt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6951,7 +8386,12 @@ VCmpxNleF64Vop3::VCmpxNleF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nle_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6974,7 +8414,12 @@ VCmpxNeqF64Vop3::VCmpxNeqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_neq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6997,7 +8442,12 @@ VCmpxNltF64Vop3::VCmpxNltF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7020,7 +8470,12 @@ VCmpxTruF64Vop3::VCmpxTruF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_tru_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTruF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7039,7 +8494,11 @@ VCmpFI16Vop3::VCmpFI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7058,7 +8517,11 @@ VCmpLtI16Vop3::VCmpLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7077,7 +8540,11 @@ VCmpEqI16Vop3::VCmpEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7096,7 +8563,11 @@ VCmpLeI16Vop3::VCmpLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7115,7 +8586,11 @@ VCmpGtI16Vop3::VCmpGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7134,7 +8609,11 @@ VCmpNeI16Vop3::VCmpNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7153,7 +8632,11 @@ VCmpGeI16Vop3::VCmpGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7172,7 +8655,11 @@ VCmpTI16Vop3::VCmpTI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7191,7 +8678,11 @@ VCmpFU16Vop3::VCmpFU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7210,7 +8701,11 @@ VCmpLtU16Vop3::VCmpLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7229,7 +8724,11 @@ VCmpEqU16Vop3::VCmpEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7248,7 +8747,11 @@ VCmpLeU16Vop3::VCmpLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7267,7 +8770,11 @@ VCmpGtU16Vop3::VCmpGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7286,7 +8793,11 @@ VCmpNeU16Vop3::VCmpNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7305,7 +8816,11 @@ VCmpGeU16Vop3::VCmpGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7324,7 +8839,11 @@ VCmpTU16Vop3::VCmpTU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7347,7 +8866,11 @@ VCmpxFI16Vop3::VCmpxFI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7370,7 +8893,11 @@ VCmpxLtI16Vop3::VCmpxLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7393,7 +8920,11 @@ VCmpxEqI16Vop3::VCmpxEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7416,7 +8947,11 @@ VCmpxLeI16Vop3::VCmpxLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7439,7 +8974,11 @@ VCmpxGtI16Vop3::VCmpxGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7462,7 +9001,11 @@ VCmpxNeI16Vop3::VCmpxNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7485,7 +9028,11 @@ VCmpxGeI16Vop3::VCmpxGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7508,7 +9055,11 @@ VCmpxTI16Vop3::VCmpxTI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI16Vop3>(opcode);
 }
 } // namespace detail
@@ -7531,7 +9082,11 @@ VCmpxFU16Vop3::VCmpxFU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7554,7 +9109,11 @@ VCmpxLtU16Vop3::VCmpxLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7577,7 +9136,11 @@ VCmpxEqU16Vop3::VCmpxEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7600,7 +9163,11 @@ VCmpxLeU16Vop3::VCmpxLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7623,7 +9190,11 @@ VCmpxGtU16Vop3::VCmpxGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7646,7 +9217,11 @@ VCmpxNeU16Vop3::VCmpxNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7669,7 +9244,11 @@ VCmpxGeU16Vop3::VCmpxGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7692,7 +9271,11 @@ VCmpxTU16Vop3::VCmpxTU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7711,7 +9294,11 @@ VCmpFI32Vop3::VCmpFI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7730,7 +9317,11 @@ VCmpLtI32Vop3::VCmpLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7749,7 +9340,11 @@ VCmpEqI32Vop3::VCmpEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7768,7 +9363,11 @@ VCmpLeI32Vop3::VCmpLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7787,7 +9386,11 @@ VCmpGtI32Vop3::VCmpGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7806,7 +9409,11 @@ VCmpNeI32Vop3::VCmpNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7825,7 +9432,11 @@ VCmpGeI32Vop3::VCmpGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7844,7 +9455,11 @@ VCmpTI32Vop3::VCmpTI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7863,7 +9478,11 @@ VCmpFU32Vop3::VCmpFU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7882,7 +9501,11 @@ VCmpLtU32Vop3::VCmpLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7901,7 +9524,11 @@ VCmpEqU32Vop3::VCmpEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7920,7 +9547,11 @@ VCmpLeU32Vop3::VCmpLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7939,7 +9570,11 @@ VCmpGtU32Vop3::VCmpGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7958,7 +9593,11 @@ VCmpNeU32Vop3::VCmpNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7977,7 +9616,11 @@ VCmpGeU32Vop3::VCmpGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7996,7 +9639,11 @@ VCmpTU32Vop3::VCmpTU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8019,7 +9666,11 @@ VCmpxFI32Vop3::VCmpxFI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8042,7 +9693,11 @@ VCmpxLtI32Vop3::VCmpxLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8065,7 +9720,11 @@ VCmpxEqI32Vop3::VCmpxEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8088,7 +9747,11 @@ VCmpxLeI32Vop3::VCmpxLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8111,7 +9774,11 @@ VCmpxGtI32Vop3::VCmpxGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8134,7 +9801,11 @@ VCmpxNeI32Vop3::VCmpxNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8157,7 +9828,11 @@ VCmpxGeI32Vop3::VCmpxGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8180,7 +9855,11 @@ VCmpxTI32Vop3::VCmpxTI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8203,7 +9882,11 @@ VCmpxFU32Vop3::VCmpxFU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8226,7 +9909,11 @@ VCmpxLtU32Vop3::VCmpxLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8249,7 +9936,11 @@ VCmpxEqU32Vop3::VCmpxEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8272,7 +9963,11 @@ VCmpxLeU32Vop3::VCmpxLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8295,7 +9990,11 @@ VCmpxGtU32Vop3::VCmpxGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8318,7 +10017,11 @@ VCmpxNeU32Vop3::VCmpxNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8341,7 +10044,11 @@ VCmpxGeU32Vop3::VCmpxGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8364,7 +10071,11 @@ VCmpxTU32Vop3::VCmpxTU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8383,7 +10094,11 @@ VCmpFI64Vop3::VCmpFI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8402,7 +10117,11 @@ VCmpLtI64Vop3::VCmpLtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8421,7 +10140,11 @@ VCmpEqI64Vop3::VCmpEqI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8440,7 +10163,11 @@ VCmpLeI64Vop3::VCmpLeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8459,7 +10186,11 @@ VCmpGtI64Vop3::VCmpGtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8478,7 +10209,11 @@ VCmpNeI64Vop3::VCmpNeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8497,7 +10232,11 @@ VCmpGeI64Vop3::VCmpGeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8516,7 +10255,11 @@ VCmpTI64Vop3::VCmpTI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8535,7 +10278,11 @@ VCmpFU64Vop3::VCmpFU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8554,7 +10301,11 @@ VCmpLtU64Vop3::VCmpLtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8573,7 +10324,11 @@ VCmpEqU64Vop3::VCmpEqU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8592,7 +10347,11 @@ VCmpLeU64Vop3::VCmpLeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8611,7 +10370,11 @@ VCmpGtU64Vop3::VCmpGtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8630,7 +10393,11 @@ VCmpNeU64Vop3::VCmpNeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8649,7 +10416,11 @@ VCmpGeU64Vop3::VCmpGeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8668,7 +10439,11 @@ VCmpTU64Vop3::VCmpTU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8691,7 +10466,11 @@ VCmpxFI64Vop3::VCmpxFI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8714,7 +10493,11 @@ VCmpxLtI64Vop3::VCmpxLtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8737,7 +10520,11 @@ VCmpxEqI64Vop3::VCmpxEqI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8760,7 +10547,11 @@ VCmpxLeI64Vop3::VCmpxLeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8783,7 +10574,11 @@ VCmpxGtI64Vop3::VCmpxGtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8806,7 +10601,11 @@ VCmpxNeI64Vop3::VCmpxNeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8829,7 +10628,11 @@ VCmpxGeI64Vop3::VCmpxGeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8852,7 +10655,11 @@ VCmpxTI64Vop3::VCmpxTI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI64Vop3>(opcode);
 }
 } // namespace detail
@@ -8875,7 +10682,11 @@ VCmpxFU64Vop3::VCmpxFU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8898,7 +10709,11 @@ VCmpxLtU64Vop3::VCmpxLtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8921,7 +10736,11 @@ VCmpxEqU64Vop3::VCmpxEqU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8944,7 +10763,11 @@ VCmpxLeU64Vop3::VCmpxLeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8967,7 +10790,11 @@ VCmpxGtU64Vop3::VCmpxGtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -8990,7 +10817,11 @@ VCmpxNeU64Vop3::VCmpxNeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -9013,7 +10844,11 @@ VCmpxGeU64Vop3::VCmpxGeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -9036,7 +10871,11 @@ VCmpxTU64Vop3::VCmpxTU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU64Vop3>(opcode);
 }
 } // namespace detail
@@ -9057,7 +10896,12 @@ VAddCoU32Vop3SdstEnc::VAddCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_add_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9078,7 +10922,12 @@ VSubCoU32Vop3SdstEnc::VSubCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_sub_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9099,7 +10948,12 @@ VSubrevCoU32Vop3SdstEnc::VSubrevCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_subrev_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9122,7 +10976,12 @@ VAddcCoU32Vop3SdstEnc::VAddcCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddcCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddcCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_addc_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddcCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9145,7 +11004,12 @@ VSubbCoU32Vop3SdstEnc::VSubbCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubbCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubbCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_subb_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubbCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9168,7 +11032,12 @@ VSubbrevCoU32Vop3SdstEnc::VSubbrevCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubbrevCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubbrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_subbrev_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubbrevCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9191,7 +11060,12 @@ VDivScaleF32Vop3SdstEnc::VDivScaleF32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_div_scale_f32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivScaleF32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9214,7 +11088,12 @@ VDivScaleF64Vop3SdstEnc::VDivScaleF64Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_div_scale_f64", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivScaleF64Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9237,7 +11116,12 @@ VMadU64U32Vop3SdstEnc::VMadU64U32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_mad_u64_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU64U32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -9260,7 +11144,12 @@ VMadI64I32Vop3SdstEnc::VMadI64I32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_mad_i64_i32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI64I32Vop3SdstEnc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/vop3p.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -41,7 +40,11 @@ VPkMadI16Vop3p::VPkMadI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mad_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMadI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -66,7 +69,12 @@ VPkMulLoU16Vop3p::VPkMulLoU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mul_lo_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMulLoU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -91,7 +99,11 @@ VPkAddI16Vop3p::VPkAddI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -110,7 +122,11 @@ VPkSubI16Vop3p::VPkSubI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_sub_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkSubI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -129,7 +145,12 @@ VPkLshlrevB16Vop3p::VPkLshlrevB16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_lshlrev_b16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkLshlrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -148,7 +169,12 @@ VPkLshrrevB16Vop3p::VPkLshrrevB16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_lshrrev_b16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkLshrrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -167,7 +193,12 @@ VPkAshrrevI16Vop3p::VPkAshrrevI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_ashrrev_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAshrrevI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -186,7 +217,11 @@ VPkMaxI16Vop3p::VPkMaxI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_max_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaxI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -211,7 +246,11 @@ VPkMinI16Vop3p::VPkMinI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_min_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -238,7 +277,11 @@ VPkMadU16Vop3p::VPkMadU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mad_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMadU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -263,7 +306,11 @@ VPkAddU16Vop3p::VPkAddU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -282,7 +329,11 @@ VPkSubU16Vop3p::VPkSubU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_sub_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkSubU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -301,7 +352,11 @@ VPkMaxU16Vop3p::VPkMaxU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_max_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaxU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -326,7 +381,11 @@ VPkMinU16Vop3p::VPkMinU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_min_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -353,7 +412,11 @@ VPkFmaF16Vop3p::VPkFmaF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_fma_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkFmaF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -372,7 +435,11 @@ VPkAddF16Vop3p::VPkAddF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -391,7 +458,11 @@ VPkMulF16Vop3p::VPkMulF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mul_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMulF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -410,7 +481,11 @@ VPkMinF16Vop3p::VPkMinF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_min_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -435,7 +510,11 @@ VPkMaxF16Vop3p::VPkMaxF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_max_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaxF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -462,7 +541,12 @@ VMadMixF32Vop3p::VMadMixF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadMixF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVMadMixF32Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_mad_mix_f32", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadMixF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -484,7 +568,12 @@ VMadMixloF16Vop3p::VMadMixloF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadMixloF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVMadMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_mad_mixlo_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadMixloF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -512,7 +601,12 @@ VMadMixhiF16Vop3p::VMadMixhiF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadMixhiF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVMadMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_mad_mixhi_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadMixhiF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -539,7 +633,12 @@ VDot2F32F16Vop3p::VDot2F32F16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2F32F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2F32F16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_f32_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2F32F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -560,7 +659,12 @@ VDot2I32I16Vop3p::VDot2I32I16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2I32I16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2I32I16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_i32_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2I32I16Vop3p>(opcode);
 }
 } // namespace detail
@@ -581,7 +685,12 @@ VDot2U32U16Vop3p::VDot2U32U16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2U32U16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2U32U16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_u32_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2U32U16Vop3p>(opcode);
 }
 } // namespace detail
@@ -602,7 +711,12 @@ VDot4I32I8Vop3p::VDot4I32I8Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4I32I8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4I32I8Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot4_i32_i8", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot4I32I8Vop3p>(opcode);
 }
 } // namespace detail
@@ -623,7 +737,12 @@ VDot4U32U8Vop3p::VDot4U32U8Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot4_u32_u8", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot4U32U8Vop3p>(opcode);
 }
 } // namespace detail
@@ -644,7 +763,12 @@ VDot8I32I4Vop3p::VDot8I32I4Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8I32I4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8I32I4Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot8_i32_i4", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot8I32I4Vop3p>(opcode);
 }
 } // namespace detail
@@ -665,7 +789,12 @@ VDot8U32U4Vop3p::VDot8U32U4Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot8_u32_u4", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot8U32U4Vop3p>(opcode);
 }
 } // namespace detail
@@ -686,7 +815,11 @@ VPkFmaF32Vop3p::VPkFmaF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmaF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkFmaF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_fma_f32", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkFmaF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -705,7 +838,11 @@ VPkMulF32Vop3p::VPkMulF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mul_f32", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMulF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -724,7 +861,11 @@ VPkAddF32Vop3p::VPkAddF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_f32", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -743,7 +884,11 @@ VPkMovB32Vop3p::VPkMovB32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMovB32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMovB32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mov_b32", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMovB32Vop3p>(opcode);
 }
 } // namespace detail
@@ -764,7 +909,12 @@ VAccvgprReadVop3p::VAccvgprReadVop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAccvgprReadVop3p(const MachineInst *opcode) {
+DecodeResult decodeVAccvgprReadVop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_accvgpr_read", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAccvgprReadVop3p>(opcode);
 }
 } // namespace detail
@@ -782,7 +932,12 @@ VAccvgprWriteVop3p::VAccvgprWriteVop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAccvgprWriteVop3p(const MachineInst *opcode) {
+DecodeResult decodeVAccvgprWriteVop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_accvgpr_write", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAccvgprWriteVop3p>(opcode);
 }
 } // namespace detail
@@ -820,7 +975,13 @@ VMfmaF3216x16x8Xf32Vop3pMfma::VMfmaF3216x16x8Xf32Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x8Xf32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x8Xf32Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x8_xf32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x8Xf32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -858,7 +1019,13 @@ VMfmaF3232x32x4Xf32Vop3pMfma::VMfmaF3232x32x4Xf32Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x4Xf32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x4Xf32Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x4_xf32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x4Xf32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -896,7 +1063,13 @@ VMfmaF3232x32x12bF32Vop3pMfma::VMfmaF3232x32x12bF32Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x12bF32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x12bF32Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x1_2b_f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x12bF32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -934,7 +1107,13 @@ VMfmaF3216x16x14bF32Vop3pMfma::VMfmaF3216x16x14bF32Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x14bF32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x14bF32Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x1_4b_f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x14bF32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -972,7 +1151,13 @@ VMfmaF324x4x116bF32Vop3pMfma::VMfmaF324x4x116bF32Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF324x4x116bF32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF324x4x116bF32Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_4x4x1_16b_f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF324x4x116bF32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1010,7 +1195,13 @@ VMfmaF3232x32x2F32Vop3pMfma::VMfmaF3232x32x2F32Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x2F32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x2F32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x2_f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x2F32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1048,7 +1239,13 @@ VMfmaF3216x16x4F32Vop3pMfma::VMfmaF3216x16x4F32Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x4F32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x4F32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x4_f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x4F32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1086,7 +1283,13 @@ VMfmaF3232x32x42bF16Vop3pMfma::VMfmaF3232x32x42bF16Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x42bF16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x42bF16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x4_2b_f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x42bF16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1124,7 +1327,13 @@ VMfmaF3216x16x44bF16Vop3pMfma::VMfmaF3216x16x44bF16Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x44bF16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x44bF16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x4_4b_f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x44bF16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1162,7 +1371,13 @@ VMfmaF324x4x416bF16Vop3pMfma::VMfmaF324x4x416bF16Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF324x4x416bF16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF324x4x416bF16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_4x4x4_16b_f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF324x4x416bF16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1200,7 +1415,13 @@ VMfmaF3232x32x8F16Vop3pMfma::VMfmaF3232x32x8F16Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x8F16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x8F16Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x8_f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x8F16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1238,7 +1459,13 @@ VMfmaF3216x16x16F16Vop3pMfma::VMfmaF3216x16x16F16Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x16F16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x16F16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x16_f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x16F16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1276,7 +1503,13 @@ VMfmaI3232x32x42bI8Vop3pMfma::VMfmaI3232x32x42bI8Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI3232x32x42bI8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI3232x32x42bI8Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_32x32x4_2b_i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI3232x32x42bI8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1314,7 +1547,13 @@ VMfmaI3216x16x44bI8Vop3pMfma::VMfmaI3216x16x44bI8Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI3216x16x44bI8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI3216x16x44bI8Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_16x16x4_4b_i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI3216x16x44bI8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1352,7 +1591,13 @@ VMfmaI324x4x416bI8Vop3pMfma::VMfmaI324x4x416bI8Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI324x4x416bI8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI324x4x416bI8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_4x4x4_16b_i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI324x4x416bI8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1390,7 +1635,13 @@ VMfmaI3232x32x16I8Vop3pMfma::VMfmaI3232x32x16I8Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI3232x32x16I8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI3232x32x16I8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_32x32x16_i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI3232x32x16I8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1428,7 +1679,13 @@ VMfmaI3216x16x32I8Vop3pMfma::VMfmaI3216x16x32I8Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI3216x16x32I8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI3216x16x32I8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_16x16x32_i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI3216x16x32I8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1466,7 +1723,13 @@ VMfmaF3232x32x42bBf16Vop3pMfma::VMfmaF3232x32x42bBf16Vop3pMfma(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x42bBf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x42bBf16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x4_2b_bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x42bBf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1504,7 +1767,13 @@ VMfmaF3216x16x44bBf16Vop3pMfma::VMfmaF3216x16x44bBf16Vop3pMfma(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x44bBf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x44bBf16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x4_4b_bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x44bBf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1542,7 +1811,13 @@ VMfmaF324x4x416bBf16Vop3pMfma::VMfmaF324x4x416bBf16Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF324x4x416bBf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF324x4x416bBf16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_4x4x4_16b_bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF324x4x416bBf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1580,7 +1855,13 @@ VMfmaF3232x32x8Bf16Vop3pMfma::VMfmaF3232x32x8Bf16Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x8Bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x8Bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x8_bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x8Bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1618,7 +1899,13 @@ VMfmaF3216x16x16Bf16Vop3pMfma::VMfmaF3216x16x16Bf16Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x16Bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x16Bf16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x16_bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x16Bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1655,7 +1942,13 @@ VSmfmacF3216x16x32F16Vop3pMfma::VSmfmacF3216x16x32F16Vop3pMfma(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x32F16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3216x16x32F16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_16x16x32_f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3216x16x32F16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1692,7 +1985,13 @@ VSmfmacF3232x32x16F16Vop3pMfma::VSmfmacF3232x32x16F16Vop3pMfma(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x16F16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3232x32x16F16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_32x32x16_f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3232x32x16F16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1729,7 +2028,13 @@ VSmfmacF3216x16x32Bf16Vop3pMfma::VSmfmacF3216x16x32Bf16Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x32Bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3216x16x32Bf16Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_16x16x32_bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3216x16x32Bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1766,7 +2071,13 @@ VSmfmacF3232x32x16Bf16Vop3pMfma::VSmfmacF3232x32x16Bf16Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x16Bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3232x32x16Bf16Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_32x32x16_bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3232x32x16Bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1803,7 +2114,13 @@ VSmfmacI3216x16x64I8Vop3pMfma::VSmfmacI3216x16x64I8Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacI3216x16x64I8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacI3216x16x64I8Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_i32_16x16x64_i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacI3216x16x64I8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1840,7 +2157,13 @@ VSmfmacI3232x32x32I8Vop3pMfma::VSmfmacI3232x32x32I8Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacI3232x32x32I8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacI3232x32x32I8Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_i32_32x32x32_i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacI3232x32x32I8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1878,7 +2201,13 @@ VMfmaF6416x16x4F64Vop3pMfma::VMfmaF6416x16x4F64Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF6416x16x4F64Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF6416x16x4F64Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f64_16x16x4_f64", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF6416x16x4F64Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1916,7 +2245,13 @@ VMfmaF644x4x44bF64Vop3pMfma::VMfmaF644x4x44bF64Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF644x4x44bF64Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF644x4x44bF64Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f64_4x4x4_4b_f64", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF644x4x44bF64Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1954,7 +2289,13 @@ VMfmaF3216x16x32Bf8Bf8Vop3pMfma::VMfmaF3216x16x32Bf8Bf8Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32Bf8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x32Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x32_bf8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x32Bf8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1992,7 +2333,13 @@ VMfmaF3216x16x32Bf8Fp8Vop3pMfma::VMfmaF3216x16x32Bf8Fp8Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32Bf8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x32Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x32_bf8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x32Bf8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2030,7 +2377,13 @@ VMfmaF3216x16x32Fp8Bf8Vop3pMfma::VMfmaF3216x16x32Fp8Bf8Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32Fp8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x32Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x32_fp8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x32Fp8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2068,7 +2421,13 @@ VMfmaF3216x16x32Fp8Fp8Vop3pMfma::VMfmaF3216x16x32Fp8Fp8Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32Fp8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x32Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x32_fp8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x32Fp8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2106,7 +2465,13 @@ VMfmaF3232x32x16Bf8Bf8Vop3pMfma::VMfmaF3232x32x16Bf8Bf8Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16Bf8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x16Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x16_bf8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x16Bf8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2144,7 +2509,13 @@ VMfmaF3232x32x16Bf8Fp8Vop3pMfma::VMfmaF3232x32x16Bf8Fp8Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16Bf8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x16Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x16_bf8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x16Bf8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2182,7 +2553,13 @@ VMfmaF3232x32x16Fp8Bf8Vop3pMfma::VMfmaF3232x32x16Fp8Bf8Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16Fp8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x16Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x16_fp8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x16Fp8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2220,7 +2597,13 @@ VMfmaF3232x32x16Fp8Fp8Vop3pMfma::VMfmaF3232x32x16Fp8Fp8Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16Fp8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x16Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x16_fp8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x16Fp8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2257,7 +2640,13 @@ VSmfmacF3216x16x64Bf8Bf8Vop3pMfma::VSmfmacF3216x16x64Bf8Bf8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64Bf8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3216x16x64Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_16x16x64_bf8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3216x16x64Bf8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2294,7 +2683,13 @@ VSmfmacF3216x16x64Bf8Fp8Vop3pMfma::VSmfmacF3216x16x64Bf8Fp8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64Bf8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3216x16x64Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_16x16x64_bf8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3216x16x64Bf8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2331,7 +2726,13 @@ VSmfmacF3216x16x64Fp8Bf8Vop3pMfma::VSmfmacF3216x16x64Fp8Bf8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64Fp8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3216x16x64Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_16x16x64_fp8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3216x16x64Fp8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2368,7 +2769,13 @@ VSmfmacF3216x16x64Fp8Fp8Vop3pMfma::VSmfmacF3216x16x64Fp8Fp8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64Fp8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3216x16x64Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_16x16x64_fp8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3216x16x64Fp8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2405,7 +2812,13 @@ VSmfmacF3232x32x32Bf8Bf8Vop3pMfma::VSmfmacF3232x32x32Bf8Bf8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32Bf8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3232x32x32Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_32x32x32_bf8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3232x32x32Bf8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2442,7 +2855,13 @@ VSmfmacF3232x32x32Bf8Fp8Vop3pMfma::VSmfmacF3232x32x32Bf8Fp8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32Bf8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3232x32x32Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_32x32x32_bf8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3232x32x32Bf8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2479,7 +2898,13 @@ VSmfmacF3232x32x32Fp8Bf8Vop3pMfma::VSmfmacF3232x32x32Fp8Bf8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32Fp8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3232x32x32Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_32x32x32_fp8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3232x32x32Fp8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2516,7 +2941,13 @@ VSmfmacF3232x32x32Fp8Fp8Vop3pMfma::VSmfmacF3232x32x32Fp8Fp8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32Fp8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3232x32x32Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_32x32x32_fp8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3232x32x32Fp8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/vopc.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/vopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -31,8 +30,6 @@ VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_CLASS_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -60,7 +57,18 @@ VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_class_f32_sdwa"
+          : "v_cmp_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F32 does not support DPP";
   return std::make_unique<VCmpClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -85,8 +93,6 @@ VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_CLASS_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -116,7 +122,18 @@ VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_class_f32_sdwa"
+          : "v_cmpx_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F32 does not support DPP";
   return std::make_unique<VCmpxClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -137,15 +154,21 @@ VCmpClassF64Vopc::VCmpClassF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_class_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support SDWA";
   return std::make_unique<VCmpClassF64Vopc>(opcode);
 }
 } // namespace detail
@@ -168,17 +191,23 @@ VCmpxClassF64Vopc::VCmpxClassF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_class_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support SDWA";
   return std::make_unique<VCmpxClassF64Vopc>(opcode);
 }
 } // namespace detail
@@ -202,8 +231,6 @@ VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_CLASS_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -231,7 +258,18 @@ VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_class_f16_sdwa"
+          : "v_cmp_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F16 does not support DPP";
   return std::make_unique<VCmpClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -257,8 +295,6 @@ VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_CLASS_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -288,7 +324,18 @@ VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_class_f16_sdwa"
+          : "v_cmpx_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F16 does not support DPP";
   return std::make_unique<VCmpxClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -311,8 +358,6 @@ VCmpFF16Vopc::VCmpFF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -340,7 +385,17 @@ VCmpFF16Vopc::VCmpFF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_f16_sdwa"
+          : "v_cmp_f_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F16 does not support DPP";
   return std::make_unique<VCmpFF16Vopc>(opcode);
 }
 } // namespace detail
@@ -364,8 +419,6 @@ VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -393,7 +446,17 @@ VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_f16_sdwa"
+          : "v_cmp_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F16 does not support DPP";
   return std::make_unique<VCmpLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -417,8 +480,6 @@ VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -446,7 +507,17 @@ VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_f16_sdwa"
+          : "v_cmp_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F16 does not support DPP";
   return std::make_unique<VCmpEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -470,8 +541,6 @@ VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -499,7 +568,17 @@ VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_f16_sdwa"
+          : "v_cmp_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F16 does not support DPP";
   return std::make_unique<VCmpLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -523,8 +602,6 @@ VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -552,7 +629,17 @@ VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_f16_sdwa"
+          : "v_cmp_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F16 does not support DPP";
   return std::make_unique<VCmpGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -576,8 +663,6 @@ VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -605,7 +690,17 @@ VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lg_f16_sdwa"
+          : "v_cmp_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F16 does not support DPP";
   return std::make_unique<VCmpLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -629,8 +724,6 @@ VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -658,7 +751,17 @@ VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_f16_sdwa"
+          : "v_cmp_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F16 does not support DPP";
   return std::make_unique<VCmpGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -681,8 +784,6 @@ VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_O_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -710,7 +811,17 @@ VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_o_f16_sdwa"
+          : "v_cmp_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F16 does not support DPP";
   return std::make_unique<VCmpOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -733,8 +844,6 @@ VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_U_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -762,7 +871,17 @@ VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_u_f16_sdwa"
+          : "v_cmp_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F16 does not support DPP";
   return std::make_unique<VCmpUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -786,8 +905,6 @@ VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -815,7 +932,17 @@ VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nge_f16_sdwa"
+          : "v_cmp_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F16 does not support DPP";
   return std::make_unique<VCmpNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -839,8 +966,6 @@ VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -868,7 +993,17 @@ VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlg_f16_sdwa"
+          : "v_cmp_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F16 does not support DPP";
   return std::make_unique<VCmpNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -892,8 +1027,6 @@ VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -921,7 +1054,17 @@ VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ngt_f16_sdwa"
+          : "v_cmp_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F16 does not support DPP";
   return std::make_unique<VCmpNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -945,8 +1088,6 @@ VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -974,7 +1115,17 @@ VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nle_f16_sdwa"
+          : "v_cmp_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F16 does not support DPP";
   return std::make_unique<VCmpNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -998,8 +1149,6 @@ VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NEQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1027,7 +1176,17 @@ VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_neq_f16_sdwa"
+          : "v_cmp_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F16 does not support DPP";
   return std::make_unique<VCmpNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1051,8 +1210,6 @@ VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1080,7 +1237,17 @@ VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlt_f16_sdwa"
+          : "v_cmp_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F16 does not support DPP";
   return std::make_unique<VCmpNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1104,8 +1271,6 @@ VCmpTruF16Vopc::VCmpTruF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_TRU_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1133,7 +1298,17 @@ VCmpTruF16Vopc::VCmpTruF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_tru_f16_sdwa"
+          : "v_cmp_tru_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F16 does not support DPP";
   return std::make_unique<VCmpTruF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1159,8 +1334,6 @@ VCmpxFF16Vopc::VCmpxFF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1190,7 +1363,17 @@ VCmpxFF16Vopc::VCmpxFF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_f16_sdwa"
+          : "v_cmpx_f_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F16 does not support DPP";
   return std::make_unique<VCmpxFF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1216,8 +1399,6 @@ VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1247,7 +1428,17 @@ VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_f16_sdwa"
+          : "v_cmpx_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F16 does not support DPP";
   return std::make_unique<VCmpxLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1273,8 +1464,6 @@ VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1304,7 +1493,17 @@ VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_f16_sdwa"
+          : "v_cmpx_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F16 does not support DPP";
   return std::make_unique<VCmpxEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1330,8 +1529,6 @@ VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1361,7 +1558,17 @@ VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_f16_sdwa"
+          : "v_cmpx_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F16 does not support DPP";
   return std::make_unique<VCmpxLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1387,8 +1594,6 @@ VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1418,7 +1623,17 @@ VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_f16_sdwa"
+          : "v_cmpx_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F16 does not support DPP";
   return std::make_unique<VCmpxGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1444,8 +1659,6 @@ VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1475,7 +1688,17 @@ VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lg_f16_sdwa"
+          : "v_cmpx_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F16 does not support DPP";
   return std::make_unique<VCmpxLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1501,8 +1724,6 @@ VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1532,7 +1753,17 @@ VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_f16_sdwa"
+          : "v_cmpx_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F16 does not support DPP";
   return std::make_unique<VCmpxGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1558,8 +1789,6 @@ VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_O_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1589,7 +1818,17 @@ VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_o_f16_sdwa"
+          : "v_cmpx_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F16 does not support DPP";
   return std::make_unique<VCmpxOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1615,8 +1854,6 @@ VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_U_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1646,7 +1883,17 @@ VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_u_f16_sdwa"
+          : "v_cmpx_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F16 does not support DPP";
   return std::make_unique<VCmpxUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1672,8 +1919,6 @@ VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1703,7 +1948,18 @@ VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nge_f16_sdwa"
+          : "v_cmpx_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F16 does not support DPP";
   return std::make_unique<VCmpxNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1729,8 +1985,6 @@ VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1760,7 +2014,18 @@ VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlg_f16_sdwa"
+          : "v_cmpx_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F16 does not support DPP";
   return std::make_unique<VCmpxNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1786,8 +2051,6 @@ VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1817,7 +2080,18 @@ VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ngt_f16_sdwa"
+          : "v_cmpx_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F16 does not support DPP";
   return std::make_unique<VCmpxNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1843,8 +2117,6 @@ VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1874,7 +2146,18 @@ VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nle_f16_sdwa"
+          : "v_cmpx_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F16 does not support DPP";
   return std::make_unique<VCmpxNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1900,8 +2183,6 @@ VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NEQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1931,7 +2212,18 @@ VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_neq_f16_sdwa"
+          : "v_cmpx_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F16 does not support DPP";
   return std::make_unique<VCmpxNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1957,8 +2249,6 @@ VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1988,7 +2278,18 @@ VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlt_f16_sdwa"
+          : "v_cmpx_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F16 does not support DPP";
   return std::make_unique<VCmpxNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -2014,8 +2315,6 @@ VCmpxTruF16Vopc::VCmpxTruF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_TRU_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2045,7 +2344,18 @@ VCmpxTruF16Vopc::VCmpxTruF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_tru_f16_sdwa"
+          : "v_cmpx_tru_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F16 does not support DPP";
   return std::make_unique<VCmpxTruF16Vopc>(opcode);
 }
 } // namespace detail
@@ -2067,8 +2377,6 @@ VCmpFF32Vopc::VCmpFF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2096,7 +2404,17 @@ VCmpFF32Vopc::VCmpFF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_f32_sdwa"
+          : "v_cmp_f_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F32 does not support DPP";
   return std::make_unique<VCmpFF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2119,8 +2437,6 @@ VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2148,7 +2464,17 @@ VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_f32_sdwa"
+          : "v_cmp_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F32 does not support DPP";
   return std::make_unique<VCmpLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2171,8 +2497,6 @@ VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2200,7 +2524,17 @@ VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_f32_sdwa"
+          : "v_cmp_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F32 does not support DPP";
   return std::make_unique<VCmpEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2223,8 +2557,6 @@ VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2252,7 +2584,17 @@ VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_f32_sdwa"
+          : "v_cmp_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F32 does not support DPP";
   return std::make_unique<VCmpLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2275,8 +2617,6 @@ VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2304,7 +2644,17 @@ VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_f32_sdwa"
+          : "v_cmp_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F32 does not support DPP";
   return std::make_unique<VCmpGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2327,8 +2677,6 @@ VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2356,7 +2704,17 @@ VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lg_f32_sdwa"
+          : "v_cmp_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F32 does not support DPP";
   return std::make_unique<VCmpLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2379,8 +2737,6 @@ VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2408,7 +2764,17 @@ VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_f32_sdwa"
+          : "v_cmp_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F32 does not support DPP";
   return std::make_unique<VCmpGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2430,8 +2796,6 @@ VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_O_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2459,7 +2823,17 @@ VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_o_f32_sdwa"
+          : "v_cmp_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F32 does not support DPP";
   return std::make_unique<VCmpOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2481,8 +2855,6 @@ VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_U_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2510,7 +2882,17 @@ VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_u_f32_sdwa"
+          : "v_cmp_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F32 does not support DPP";
   return std::make_unique<VCmpUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2533,8 +2915,6 @@ VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2562,7 +2942,17 @@ VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nge_f32_sdwa"
+          : "v_cmp_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F32 does not support DPP";
   return std::make_unique<VCmpNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2585,8 +2975,6 @@ VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2614,7 +3002,17 @@ VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlg_f32_sdwa"
+          : "v_cmp_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F32 does not support DPP";
   return std::make_unique<VCmpNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2637,8 +3035,6 @@ VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2666,7 +3062,17 @@ VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ngt_f32_sdwa"
+          : "v_cmp_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F32 does not support DPP";
   return std::make_unique<VCmpNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2689,8 +3095,6 @@ VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2718,7 +3122,17 @@ VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nle_f32_sdwa"
+          : "v_cmp_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F32 does not support DPP";
   return std::make_unique<VCmpNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2741,8 +3155,6 @@ VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NEQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2770,7 +3182,17 @@ VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_neq_f32_sdwa"
+          : "v_cmp_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F32 does not support DPP";
   return std::make_unique<VCmpNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2793,8 +3215,6 @@ VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2822,7 +3242,17 @@ VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlt_f32_sdwa"
+          : "v_cmp_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F32 does not support DPP";
   return std::make_unique<VCmpNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2845,8 +3275,6 @@ VCmpTruF32Vopc::VCmpTruF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_TRU_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2874,7 +3302,17 @@ VCmpTruF32Vopc::VCmpTruF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_tru_f32_sdwa"
+          : "v_cmp_tru_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F32 does not support DPP";
   return std::make_unique<VCmpTruF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2899,8 +3337,6 @@ VCmpxFF32Vopc::VCmpxFF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2930,7 +3366,17 @@ VCmpxFF32Vopc::VCmpxFF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_f32_sdwa"
+          : "v_cmpx_f_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F32 does not support DPP";
   return std::make_unique<VCmpxFF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2955,8 +3401,6 @@ VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2986,7 +3430,17 @@ VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_f32_sdwa"
+          : "v_cmpx_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F32 does not support DPP";
   return std::make_unique<VCmpxLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3011,8 +3465,6 @@ VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3042,7 +3494,17 @@ VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_f32_sdwa"
+          : "v_cmpx_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F32 does not support DPP";
   return std::make_unique<VCmpxEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3067,8 +3529,6 @@ VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3098,7 +3558,17 @@ VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_f32_sdwa"
+          : "v_cmpx_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F32 does not support DPP";
   return std::make_unique<VCmpxLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3123,8 +3593,6 @@ VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3154,7 +3622,17 @@ VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_f32_sdwa"
+          : "v_cmpx_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F32 does not support DPP";
   return std::make_unique<VCmpxGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3179,8 +3657,6 @@ VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3210,7 +3686,17 @@ VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lg_f32_sdwa"
+          : "v_cmpx_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F32 does not support DPP";
   return std::make_unique<VCmpxLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3235,8 +3721,6 @@ VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3266,7 +3750,17 @@ VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_f32_sdwa"
+          : "v_cmpx_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F32 does not support DPP";
   return std::make_unique<VCmpxGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3291,8 +3785,6 @@ VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_O_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3322,7 +3814,17 @@ VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_o_f32_sdwa"
+          : "v_cmpx_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F32 does not support DPP";
   return std::make_unique<VCmpxOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3347,8 +3849,6 @@ VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_U_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3378,7 +3878,17 @@ VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_u_f32_sdwa"
+          : "v_cmpx_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F32 does not support DPP";
   return std::make_unique<VCmpxUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3403,8 +3913,6 @@ VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3434,7 +3942,18 @@ VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nge_f32_sdwa"
+          : "v_cmpx_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F32 does not support DPP";
   return std::make_unique<VCmpxNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3459,8 +3978,6 @@ VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3490,7 +4007,18 @@ VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlg_f32_sdwa"
+          : "v_cmpx_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F32 does not support DPP";
   return std::make_unique<VCmpxNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3515,8 +4043,6 @@ VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3546,7 +4072,18 @@ VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ngt_f32_sdwa"
+          : "v_cmpx_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F32 does not support DPP";
   return std::make_unique<VCmpxNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3571,8 +4108,6 @@ VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3602,7 +4137,18 @@ VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nle_f32_sdwa"
+          : "v_cmpx_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F32 does not support DPP";
   return std::make_unique<VCmpxNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3627,8 +4173,6 @@ VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NEQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3658,7 +4202,18 @@ VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_neq_f32_sdwa"
+          : "v_cmpx_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F32 does not support DPP";
   return std::make_unique<VCmpxNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3683,8 +4238,6 @@ VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3714,7 +4267,18 @@ VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlt_f32_sdwa"
+          : "v_cmpx_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F32 does not support DPP";
   return std::make_unique<VCmpxNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3739,8 +4303,6 @@ VCmpxTruF32Vopc::VCmpxTruF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_TRU_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3770,7 +4332,18 @@ VCmpxTruF32Vopc::VCmpxTruF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_tru_f32_sdwa"
+          : "v_cmpx_tru_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F32 does not support DPP";
   return std::make_unique<VCmpxTruF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3791,15 +4364,20 @@ VCmpFF64Vopc::VCmpFF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_F_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_f_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F64 does not support SDWA";
   return std::make_unique<VCmpFF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3820,15 +4398,20 @@ VCmpLtF64Vopc::VCmpLtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support SDWA";
   return std::make_unique<VCmpLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3849,15 +4432,20 @@ VCmpEqF64Vopc::VCmpEqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_eq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support SDWA";
   return std::make_unique<VCmpEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3878,15 +4466,20 @@ VCmpLeF64Vopc::VCmpLeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_le_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support SDWA";
   return std::make_unique<VCmpLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3907,15 +4500,20 @@ VCmpGtF64Vopc::VCmpGtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_gt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support SDWA";
   return std::make_unique<VCmpGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3936,15 +4534,20 @@ VCmpLgF64Vopc::VCmpLgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support SDWA";
   return std::make_unique<VCmpLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3965,15 +4568,20 @@ VCmpGeF64Vopc::VCmpGeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support SDWA";
   return std::make_unique<VCmpGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3994,15 +4602,20 @@ VCmpOF64Vopc::VCmpOF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_O_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_O_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_o_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support SDWA";
   return std::make_unique<VCmpOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4023,15 +4636,20 @@ VCmpUF64Vopc::VCmpUF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_U_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_U_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_u_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support SDWA";
   return std::make_unique<VCmpUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4052,15 +4670,20 @@ VCmpNgeF64Vopc::VCmpNgeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support SDWA";
   return std::make_unique<VCmpNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4081,15 +4704,20 @@ VCmpNlgF64Vopc::VCmpNlgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nlg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support SDWA";
   return std::make_unique<VCmpNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4110,15 +4738,20 @@ VCmpNgtF64Vopc::VCmpNgtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ngt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support SDWA";
   return std::make_unique<VCmpNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4139,15 +4772,20 @@ VCmpNleF64Vopc::VCmpNleF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nle_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support SDWA";
   return std::make_unique<VCmpNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4168,15 +4806,20 @@ VCmpNeqF64Vopc::VCmpNeqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_neq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support SDWA";
   return std::make_unique<VCmpNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4197,15 +4840,20 @@ VCmpNltF64Vopc::VCmpNltF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nlt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support SDWA";
   return std::make_unique<VCmpNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4226,15 +4874,20 @@ VCmpTruF64Vopc::VCmpTruF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_TRU_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_TRU_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_tru_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F64 does not support SDWA";
   return std::make_unique<VCmpTruF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4257,17 +4910,22 @@ VCmpxFF64Vopc::VCmpxFF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_F_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_f_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F64 does not support SDWA";
   return std::make_unique<VCmpxFF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4290,17 +4948,22 @@ VCmpxLtF64Vopc::VCmpxLtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support SDWA";
   return std::make_unique<VCmpxLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4323,17 +4986,22 @@ VCmpxEqF64Vopc::VCmpxEqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_eq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support SDWA";
   return std::make_unique<VCmpxEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4356,17 +5024,22 @@ VCmpxLeF64Vopc::VCmpxLeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_le_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support SDWA";
   return std::make_unique<VCmpxLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4389,17 +5062,22 @@ VCmpxGtF64Vopc::VCmpxGtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_gt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support SDWA";
   return std::make_unique<VCmpxGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4422,17 +5100,22 @@ VCmpxLgF64Vopc::VCmpxLgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support SDWA";
   return std::make_unique<VCmpxLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4455,17 +5138,22 @@ VCmpxGeF64Vopc::VCmpxGeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support SDWA";
   return std::make_unique<VCmpxGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4488,17 +5176,22 @@ VCmpxOF64Vopc::VCmpxOF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_O_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_O_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_o_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support SDWA";
   return std::make_unique<VCmpxOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4521,17 +5214,22 @@ VCmpxUF64Vopc::VCmpxUF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_U_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_U_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_u_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support SDWA";
   return std::make_unique<VCmpxUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4554,17 +5252,23 @@ VCmpxNgeF64Vopc::VCmpxNgeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support SDWA";
   return std::make_unique<VCmpxNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4587,17 +5291,23 @@ VCmpxNlgF64Vopc::VCmpxNlgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nlg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support SDWA";
   return std::make_unique<VCmpxNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4620,17 +5330,23 @@ VCmpxNgtF64Vopc::VCmpxNgtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ngt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support SDWA";
   return std::make_unique<VCmpxNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4653,17 +5369,23 @@ VCmpxNleF64Vopc::VCmpxNleF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nle_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support SDWA";
   return std::make_unique<VCmpxNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4686,17 +5408,23 @@ VCmpxNeqF64Vopc::VCmpxNeqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_neq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support SDWA";
   return std::make_unique<VCmpxNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4719,17 +5447,23 @@ VCmpxNltF64Vopc::VCmpxNltF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nlt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support SDWA";
   return std::make_unique<VCmpxNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4752,17 +5486,23 @@ VCmpxTruF64Vopc::VCmpxTruF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_TRU_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_TRU_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_tru_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F64 does not support SDWA";
   return std::make_unique<VCmpxTruF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4785,8 +5525,6 @@ VCmpFI16Vopc::VCmpFI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4814,7 +5552,17 @@ VCmpFI16Vopc::VCmpFI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_i16_sdwa"
+          : "v_cmp_f_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I16 does not support DPP";
   return std::make_unique<VCmpFI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4838,8 +5586,6 @@ VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4867,7 +5613,17 @@ VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_i16_sdwa"
+          : "v_cmp_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I16 does not support DPP";
   return std::make_unique<VCmpLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4891,8 +5647,6 @@ VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4920,7 +5674,17 @@ VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_i16_sdwa"
+          : "v_cmp_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I16 does not support DPP";
   return std::make_unique<VCmpEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4944,8 +5708,6 @@ VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4973,7 +5735,17 @@ VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_i16_sdwa"
+          : "v_cmp_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I16 does not support DPP";
   return std::make_unique<VCmpLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4997,8 +5769,6 @@ VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5026,7 +5796,17 @@ VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_i16_sdwa"
+          : "v_cmp_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I16 does not support DPP";
   return std::make_unique<VCmpGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5050,8 +5830,6 @@ VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5079,7 +5857,17 @@ VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_i16_sdwa"
+          : "v_cmp_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I16 does not support DPP";
   return std::make_unique<VCmpNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5103,8 +5891,6 @@ VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5132,7 +5918,17 @@ VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_i16_sdwa"
+          : "v_cmp_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I16 does not support DPP";
   return std::make_unique<VCmpGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5155,8 +5951,6 @@ VCmpTI16Vopc::VCmpTI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5184,7 +5978,17 @@ VCmpTI16Vopc::VCmpTI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_i16_sdwa"
+          : "v_cmp_t_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I16 does not support DPP";
   return std::make_unique<VCmpTI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5207,8 +6011,6 @@ VCmpFU16Vopc::VCmpFU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5236,7 +6038,17 @@ VCmpFU16Vopc::VCmpFU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_u16_sdwa"
+          : "v_cmp_f_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U16 does not support DPP";
   return std::make_unique<VCmpFU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5260,8 +6072,6 @@ VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5289,7 +6099,17 @@ VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_u16_sdwa"
+          : "v_cmp_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U16 does not support DPP";
   return std::make_unique<VCmpLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5313,8 +6133,6 @@ VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5342,7 +6160,17 @@ VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_u16_sdwa"
+          : "v_cmp_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U16 does not support DPP";
   return std::make_unique<VCmpEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5366,8 +6194,6 @@ VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5395,7 +6221,17 @@ VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_u16_sdwa"
+          : "v_cmp_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U16 does not support DPP";
   return std::make_unique<VCmpLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5419,8 +6255,6 @@ VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5448,7 +6282,17 @@ VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_u16_sdwa"
+          : "v_cmp_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U16 does not support DPP";
   return std::make_unique<VCmpGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5472,8 +6316,6 @@ VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5501,7 +6343,17 @@ VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_u16_sdwa"
+          : "v_cmp_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U16 does not support DPP";
   return std::make_unique<VCmpNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5525,8 +6377,6 @@ VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5554,7 +6404,17 @@ VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_u16_sdwa"
+          : "v_cmp_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U16 does not support DPP";
   return std::make_unique<VCmpGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5577,8 +6437,6 @@ VCmpTU16Vopc::VCmpTU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5606,7 +6464,17 @@ VCmpTU16Vopc::VCmpTU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_u16_sdwa"
+          : "v_cmp_t_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U16 does not support DPP";
   return std::make_unique<VCmpTU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5632,8 +6500,6 @@ VCmpxFI16Vopc::VCmpxFI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5663,7 +6529,17 @@ VCmpxFI16Vopc::VCmpxFI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_i16_sdwa"
+          : "v_cmpx_f_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I16 does not support DPP";
   return std::make_unique<VCmpxFI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5689,8 +6565,6 @@ VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5720,7 +6594,17 @@ VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_i16_sdwa"
+          : "v_cmpx_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I16 does not support DPP";
   return std::make_unique<VCmpxLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5746,8 +6630,6 @@ VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5777,7 +6659,17 @@ VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_i16_sdwa"
+          : "v_cmpx_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I16 does not support DPP";
   return std::make_unique<VCmpxEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5803,8 +6695,6 @@ VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5834,7 +6724,17 @@ VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_i16_sdwa"
+          : "v_cmpx_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I16 does not support DPP";
   return std::make_unique<VCmpxLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5860,8 +6760,6 @@ VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5891,7 +6789,17 @@ VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_i16_sdwa"
+          : "v_cmpx_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I16 does not support DPP";
   return std::make_unique<VCmpxGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5917,8 +6825,6 @@ VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5948,7 +6854,17 @@ VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_i16_sdwa"
+          : "v_cmpx_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I16 does not support DPP";
   return std::make_unique<VCmpxNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5974,8 +6890,6 @@ VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6005,7 +6919,17 @@ VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_i16_sdwa"
+          : "v_cmpx_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I16 does not support DPP";
   return std::make_unique<VCmpxGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6031,8 +6955,6 @@ VCmpxTI16Vopc::VCmpxTI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6062,7 +6984,17 @@ VCmpxTI16Vopc::VCmpxTI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_i16_sdwa"
+          : "v_cmpx_t_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I16 does not support DPP";
   return std::make_unique<VCmpxTI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6088,8 +7020,6 @@ VCmpxFU16Vopc::VCmpxFU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6119,7 +7049,17 @@ VCmpxFU16Vopc::VCmpxFU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_u16_sdwa"
+          : "v_cmpx_f_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U16 does not support DPP";
   return std::make_unique<VCmpxFU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6145,8 +7085,6 @@ VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6176,7 +7114,17 @@ VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_u16_sdwa"
+          : "v_cmpx_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U16 does not support DPP";
   return std::make_unique<VCmpxLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6202,8 +7150,6 @@ VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6233,7 +7179,17 @@ VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_u16_sdwa"
+          : "v_cmpx_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U16 does not support DPP";
   return std::make_unique<VCmpxEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6259,8 +7215,6 @@ VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6290,7 +7244,17 @@ VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_u16_sdwa"
+          : "v_cmpx_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U16 does not support DPP";
   return std::make_unique<VCmpxLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6316,8 +7280,6 @@ VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6347,7 +7309,17 @@ VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_u16_sdwa"
+          : "v_cmpx_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U16 does not support DPP";
   return std::make_unique<VCmpxGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6373,8 +7345,6 @@ VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6404,7 +7374,17 @@ VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_u16_sdwa"
+          : "v_cmpx_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U16 does not support DPP";
   return std::make_unique<VCmpxNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6430,8 +7410,6 @@ VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6461,7 +7439,17 @@ VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_u16_sdwa"
+          : "v_cmpx_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U16 does not support DPP";
   return std::make_unique<VCmpxGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6487,8 +7475,6 @@ VCmpxTU16Vopc::VCmpxTU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6518,7 +7504,17 @@ VCmpxTU16Vopc::VCmpxTU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_u16_sdwa"
+          : "v_cmpx_t_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U16 does not support DPP";
   return std::make_unique<VCmpxTU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6540,8 +7536,6 @@ VCmpFI32Vopc::VCmpFI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6569,7 +7563,17 @@ VCmpFI32Vopc::VCmpFI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_i32_sdwa"
+          : "v_cmp_f_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I32 does not support DPP";
   return std::make_unique<VCmpFI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6592,8 +7596,6 @@ VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6621,7 +7623,17 @@ VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_i32_sdwa"
+          : "v_cmp_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I32 does not support DPP";
   return std::make_unique<VCmpLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6644,8 +7656,6 @@ VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6673,7 +7683,17 @@ VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_i32_sdwa"
+          : "v_cmp_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I32 does not support DPP";
   return std::make_unique<VCmpEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6696,8 +7716,6 @@ VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6725,7 +7743,17 @@ VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_i32_sdwa"
+          : "v_cmp_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I32 does not support DPP";
   return std::make_unique<VCmpLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6748,8 +7776,6 @@ VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6777,7 +7803,17 @@ VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_i32_sdwa"
+          : "v_cmp_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I32 does not support DPP";
   return std::make_unique<VCmpGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6800,8 +7836,6 @@ VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6829,7 +7863,17 @@ VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_i32_sdwa"
+          : "v_cmp_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I32 does not support DPP";
   return std::make_unique<VCmpNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6852,8 +7896,6 @@ VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6881,7 +7923,17 @@ VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_i32_sdwa"
+          : "v_cmp_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I32 does not support DPP";
   return std::make_unique<VCmpGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6903,8 +7955,6 @@ VCmpTI32Vopc::VCmpTI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6932,7 +7982,17 @@ VCmpTI32Vopc::VCmpTI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_i32_sdwa"
+          : "v_cmp_t_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I32 does not support DPP";
   return std::make_unique<VCmpTI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6954,8 +8014,6 @@ VCmpFU32Vopc::VCmpFU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6983,7 +8041,17 @@ VCmpFU32Vopc::VCmpFU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_u32_sdwa"
+          : "v_cmp_f_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U32 does not support DPP";
   return std::make_unique<VCmpFU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7006,8 +8074,6 @@ VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7035,7 +8101,17 @@ VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_u32_sdwa"
+          : "v_cmp_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U32 does not support DPP";
   return std::make_unique<VCmpLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7058,8 +8134,6 @@ VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7087,7 +8161,17 @@ VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_u32_sdwa"
+          : "v_cmp_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U32 does not support DPP";
   return std::make_unique<VCmpEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7110,8 +8194,6 @@ VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7139,7 +8221,17 @@ VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_u32_sdwa"
+          : "v_cmp_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U32 does not support DPP";
   return std::make_unique<VCmpLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7162,8 +8254,6 @@ VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7191,7 +8281,17 @@ VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_u32_sdwa"
+          : "v_cmp_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U32 does not support DPP";
   return std::make_unique<VCmpGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7214,8 +8314,6 @@ VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7243,7 +8341,17 @@ VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_u32_sdwa"
+          : "v_cmp_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U32 does not support DPP";
   return std::make_unique<VCmpNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7266,8 +8374,6 @@ VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7295,7 +8401,17 @@ VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_u32_sdwa"
+          : "v_cmp_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U32 does not support DPP";
   return std::make_unique<VCmpGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7317,8 +8433,6 @@ VCmpTU32Vopc::VCmpTU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7346,7 +8460,17 @@ VCmpTU32Vopc::VCmpTU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_u32_sdwa"
+          : "v_cmp_t_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U32 does not support DPP";
   return std::make_unique<VCmpTU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7371,8 +8495,6 @@ VCmpxFI32Vopc::VCmpxFI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7402,7 +8524,17 @@ VCmpxFI32Vopc::VCmpxFI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_i32_sdwa"
+          : "v_cmpx_f_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I32 does not support DPP";
   return std::make_unique<VCmpxFI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7427,8 +8559,6 @@ VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7458,7 +8588,17 @@ VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_i32_sdwa"
+          : "v_cmpx_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I32 does not support DPP";
   return std::make_unique<VCmpxLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7483,8 +8623,6 @@ VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7514,7 +8652,17 @@ VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_i32_sdwa"
+          : "v_cmpx_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I32 does not support DPP";
   return std::make_unique<VCmpxEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7539,8 +8687,6 @@ VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7570,7 +8716,17 @@ VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_i32_sdwa"
+          : "v_cmpx_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I32 does not support DPP";
   return std::make_unique<VCmpxLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7595,8 +8751,6 @@ VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7626,7 +8780,17 @@ VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_i32_sdwa"
+          : "v_cmpx_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I32 does not support DPP";
   return std::make_unique<VCmpxGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7651,8 +8815,6 @@ VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7682,7 +8844,17 @@ VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_i32_sdwa"
+          : "v_cmpx_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I32 does not support DPP";
   return std::make_unique<VCmpxNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7707,8 +8879,6 @@ VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7738,7 +8908,17 @@ VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_i32_sdwa"
+          : "v_cmpx_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I32 does not support DPP";
   return std::make_unique<VCmpxGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7763,8 +8943,6 @@ VCmpxTI32Vopc::VCmpxTI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7794,7 +8972,17 @@ VCmpxTI32Vopc::VCmpxTI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_i32_sdwa"
+          : "v_cmpx_t_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I32 does not support DPP";
   return std::make_unique<VCmpxTI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7819,8 +9007,6 @@ VCmpxFU32Vopc::VCmpxFU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7850,7 +9036,17 @@ VCmpxFU32Vopc::VCmpxFU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_u32_sdwa"
+          : "v_cmpx_f_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U32 does not support DPP";
   return std::make_unique<VCmpxFU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7875,8 +9071,6 @@ VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7906,7 +9100,17 @@ VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_u32_sdwa"
+          : "v_cmpx_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U32 does not support DPP";
   return std::make_unique<VCmpxLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7931,8 +9135,6 @@ VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7962,7 +9164,17 @@ VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_u32_sdwa"
+          : "v_cmpx_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U32 does not support DPP";
   return std::make_unique<VCmpxEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7987,8 +9199,6 @@ VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8018,7 +9228,17 @@ VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_u32_sdwa"
+          : "v_cmpx_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U32 does not support DPP";
   return std::make_unique<VCmpxLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8043,8 +9263,6 @@ VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8074,7 +9292,17 @@ VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_u32_sdwa"
+          : "v_cmpx_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U32 does not support DPP";
   return std::make_unique<VCmpxGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8099,8 +9327,6 @@ VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8130,7 +9356,17 @@ VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_u32_sdwa"
+          : "v_cmpx_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U32 does not support DPP";
   return std::make_unique<VCmpxNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8155,8 +9391,6 @@ VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8186,7 +9420,17 @@ VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_u32_sdwa"
+          : "v_cmpx_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U32 does not support DPP";
   return std::make_unique<VCmpxGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8211,8 +9455,6 @@ VCmpxTU32Vopc::VCmpxTU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8242,7 +9484,17 @@ VCmpxTU32Vopc::VCmpxTU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_u32_sdwa"
+          : "v_cmpx_t_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U32 does not support DPP";
   return std::make_unique<VCmpxTU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8263,15 +9515,20 @@ VCmpFI64Vopc::VCmpFI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_F_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_f_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I64 does not support SDWA";
   return std::make_unique<VCmpFI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8292,15 +9549,20 @@ VCmpLtI64Vopc::VCmpLtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support SDWA";
   return std::make_unique<VCmpLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8321,15 +9583,20 @@ VCmpEqI64Vopc::VCmpEqI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_eq_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support SDWA";
   return std::make_unique<VCmpEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8350,15 +9617,20 @@ VCmpLeI64Vopc::VCmpLeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_le_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support SDWA";
   return std::make_unique<VCmpLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8379,15 +9651,20 @@ VCmpGtI64Vopc::VCmpGtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_gt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support SDWA";
   return std::make_unique<VCmpGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8408,15 +9685,20 @@ VCmpNeI64Vopc::VCmpNeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ne_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support SDWA";
   return std::make_unique<VCmpNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8437,15 +9719,20 @@ VCmpGeI64Vopc::VCmpGeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ge_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support SDWA";
   return std::make_unique<VCmpGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8466,15 +9753,20 @@ VCmpTI64Vopc::VCmpTI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_T_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_t_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I64 does not support SDWA";
   return std::make_unique<VCmpTI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8495,15 +9787,20 @@ VCmpFU64Vopc::VCmpFU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_F_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_f_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U64 does not support SDWA";
   return std::make_unique<VCmpFU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8524,15 +9821,20 @@ VCmpLtU64Vopc::VCmpLtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support SDWA";
   return std::make_unique<VCmpLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8553,15 +9855,20 @@ VCmpEqU64Vopc::VCmpEqU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_eq_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support SDWA";
   return std::make_unique<VCmpEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8582,15 +9889,20 @@ VCmpLeU64Vopc::VCmpLeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_le_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support SDWA";
   return std::make_unique<VCmpLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8611,15 +9923,20 @@ VCmpGtU64Vopc::VCmpGtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_gt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support SDWA";
   return std::make_unique<VCmpGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8640,15 +9957,20 @@ VCmpNeU64Vopc::VCmpNeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ne_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support SDWA";
   return std::make_unique<VCmpNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8669,15 +9991,20 @@ VCmpGeU64Vopc::VCmpGeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ge_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support SDWA";
   return std::make_unique<VCmpGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8698,15 +10025,20 @@ VCmpTU64Vopc::VCmpTU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_T_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_t_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U64 does not support SDWA";
   return std::make_unique<VCmpTU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8729,17 +10061,22 @@ VCmpxFI64Vopc::VCmpxFI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_F_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_f_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I64 does not support SDWA";
   return std::make_unique<VCmpxFI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8762,17 +10099,22 @@ VCmpxLtI64Vopc::VCmpxLtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support SDWA";
   return std::make_unique<VCmpxLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8795,17 +10137,22 @@ VCmpxEqI64Vopc::VCmpxEqI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_eq_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support SDWA";
   return std::make_unique<VCmpxEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8828,17 +10175,22 @@ VCmpxLeI64Vopc::VCmpxLeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_le_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support SDWA";
   return std::make_unique<VCmpxLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8861,17 +10213,22 @@ VCmpxGtI64Vopc::VCmpxGtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_gt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support SDWA";
   return std::make_unique<VCmpxGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8894,17 +10251,22 @@ VCmpxNeI64Vopc::VCmpxNeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ne_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support SDWA";
   return std::make_unique<VCmpxNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8927,17 +10289,22 @@ VCmpxGeI64Vopc::VCmpxGeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ge_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support SDWA";
   return std::make_unique<VCmpxGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8960,17 +10327,22 @@ VCmpxTI64Vopc::VCmpxTI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_T_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_t_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I64 does not support SDWA";
   return std::make_unique<VCmpxTI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8993,17 +10365,22 @@ VCmpxFU64Vopc::VCmpxFU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_F_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_f_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U64 does not support SDWA";
   return std::make_unique<VCmpxFU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9026,17 +10403,22 @@ VCmpxLtU64Vopc::VCmpxLtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support SDWA";
   return std::make_unique<VCmpxLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9059,17 +10441,22 @@ VCmpxEqU64Vopc::VCmpxEqU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_eq_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support SDWA";
   return std::make_unique<VCmpxEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9092,17 +10479,22 @@ VCmpxLeU64Vopc::VCmpxLeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_le_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support SDWA";
   return std::make_unique<VCmpxLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9125,17 +10517,22 @@ VCmpxGtU64Vopc::VCmpxGtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_gt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support SDWA";
   return std::make_unique<VCmpxGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9158,17 +10555,22 @@ VCmpxNeU64Vopc::VCmpxNeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ne_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support SDWA";
   return std::make_unique<VCmpxNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9191,17 +10593,22 @@ VCmpxGeU64Vopc::VCmpxGeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ge_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support SDWA";
   return std::make_unique<VCmpxGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9224,17 +10631,22 @@ VCmpxTU64Vopc::VCmpxTU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_T_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_t_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U64 does not support SDWA";
   return std::make_unique<VCmpxTU64Vopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/decoder.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/decoder.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/opcodes.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/vop3p.h"
-#include "util/except.h"
 #include <array>
 #include <bit>
 #include <format>
@@ -16,1524 +15,2067 @@ namespace rocjitsu {
 namespace cdna4 {
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddF64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxF64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinF64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicPkAddBf16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicPkAddF16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSminMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUminMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferInvMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSbyteMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadShortD16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSshortMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUbyteMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUshortMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreByteMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreShortMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferWbl2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAppendDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsBpermuteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsConsumeDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsNopDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPermuteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPkAddBf16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPkAddF16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPkAddRtnBf16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPkAddRtnF16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2st64B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2st64B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadAddtidB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB128Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB64TrB16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB64TrB4Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB64TrB8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB96Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB96TrB6Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI8D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU16D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU16D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU8D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSwizzleB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrapRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2st64B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2st64B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteAddtidB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB128Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB16D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB96Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddF32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddF64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxF64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinF64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicPkAddBf16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicPkAddF16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSminFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSminX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUminFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUminX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordx2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordx3Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordx4Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSbyteFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadShortD16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadShortD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSshortFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUbyteFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUshortFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreByteD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreByteFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordx2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordx3Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordx4Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreShortD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreShortFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddcU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn1WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtcProbeBufferSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtcProbeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicAddSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicAddX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicAndSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicAndX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicCmpswapSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicCmpswapX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicDecSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicDecX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicIncSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicIncX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicOrSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicOrX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSmaxSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSmaxX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSminSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSminX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSubSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSubX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSwapSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicSwapX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicUmaxSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicUmaxX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicUminSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicUminX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicXorSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtomicXorX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBarrierSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicAddSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicAddX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicAndSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicAndX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicCmpswapSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicCmpswapX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicDecSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicDecX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicIncSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicIncX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicOrSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicOrX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSmaxSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSmaxX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSminSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSminX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSubSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSubX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSwapSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicSwapX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicUmaxSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicUmaxX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicUminSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicUminX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicXorSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferAtomicXorX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferStoreDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferStoreDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferStoreDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCallB64Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbguserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchGForkSop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchIForkSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchJoinSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkEqI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkEqU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGeI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGeU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGtI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGtU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLeI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLeU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLgI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLgU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLtI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLtU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheDiscardSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheDiscardX2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheInvVolSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheWbSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheWbVolSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf0I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf0I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf1I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf1I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32I64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetpcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMemrealtimeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMemtimeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRfeB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRfeRestoreB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchLoadDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchStoreDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchStoreDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchStoreDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetGprIdxIdxSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetGprIdxModeSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetGprIdxOffSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetGprIdxOnSopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetValuCoexecModeSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetkillSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetpcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetvskipSopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSStoreDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSStoreDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSStoreDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubbU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSwappcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAccvgprMovB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAccvgprMovB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAccvgprReadVop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAccvgprWriteVop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddcCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddcCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrPkI8I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrPkU8I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBitop3B16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBitop3B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClrexcpVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClrexcpVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Bf16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Bf8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Bf8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Fp8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Fp8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkBf16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkBf8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF32Bf8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF32Bf8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF32Fp8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF32Fp8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkFp8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkaccumU8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormI16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormU16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef322xpk16Bf6F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef322xpk16Fp6F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32F16Bf8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32F16Fp8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32F32Bf8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32F32Fp8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32Bf16Bf6Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32Bf16Fp6Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32Bf6Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32Bf6F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32F16Bf6Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32F16Fp6Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32F32Bf6Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32F32Fp6Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32Fp6Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32Fp6F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32PkBf16Bf8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32PkBf16Fp4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32PkBf16Fp8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32PkBf8Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32PkBf8F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32PkBf8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32PkF16Bf8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32PkF16Fp4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32PkF16Fp8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32PkF32Bf8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32PkF32Fp4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32PkF32Fp8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32PkFp4Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32PkFp4F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32PkFp4F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32PkFp8Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32PkFp8F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32PkFp8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrBf8Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrBf8F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrBf8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrFp8Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrFp8F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrFp8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk32Bf6Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk32Bf6F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk32Bf6F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk32Fp6Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk32Fp6F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk32Fp6F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPkFp4Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPkFp4F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPkFp4F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtSrBf16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtSrBf8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtSrF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtSrFp8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupLegacyF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2F32Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2F32F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2I32I16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2U32U16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cF32Bf16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cF32Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cI32I16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cI32I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4I32I8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8I32I4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8cI32I4Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8cI32I4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpLegacyF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpLegacyF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhI32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhU32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfblB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfblB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaLegacyF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaakF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmamkF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogLegacyF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogLegacyF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlAddU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMacF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadLegacyF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadLegacyI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadLegacyU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadMixF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadMixhiF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadMixloF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadakF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadmkF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaximum3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x128F8f6f4Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x14bF32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x16Bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x16F16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32Bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32Bf8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32Bf8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32F16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32Fp8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32Fp8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x44bBf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x44bF16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x4F32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x12bF32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16Bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16Bf8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16Bf8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16F16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16Fp8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16Fp8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x2F32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x42bBf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x42bF16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x64F8f6f4Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x8Bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x8F16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF324x4x116bF32Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF324x4x416bBf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF324x4x416bF16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF6416x16x4F64Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaF644x4x44bF64Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI3216x16x32I8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI3216x16x44bI8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI3216x16x64I8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI3232x32x16I8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI3232x32x32I8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI3232x32x42bI8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMfmaI324x4x416bI8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinimum3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLegacyF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlane16SwapB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlane16SwapB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlane32SwapB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlane32SwapB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmaF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaximum3F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinimum3F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMovB32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPrngB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPrngB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVScreenPartition4seB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVScreenPartition4seB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x128Bf8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x128Bf8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x128Fp8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x128Fp8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x32Bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x32F16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64Bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64Bf8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64Bf8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64F16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64Fp8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64Fp8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x16Bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x16F16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32Bf16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32Bf8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32Bf8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32F16Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32Fp8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32Fp8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x64Bf8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x64Bf8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x64Fp8Bf8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x64Fp8Fp8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacI3216x16x128I8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacI3216x16x64I8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacI3232x32x32I8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSmfmacI3232x32x64I8Vop3pMfma(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubbCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubbCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubbrevCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubbrevCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevU16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwapB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode);
+DecodeResult decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddF64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxF64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinF64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrMubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicPkAddBf16Mubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicPkAddF16Mubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferInvMubuf(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXMubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadShortD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreByteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreShortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferWbl2Mubuf(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAppendDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsBpermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsConsumeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsNopDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPkAddBf16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPkAddF16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPkAddRtnBf16Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPkAddRtnF16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2st64B32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2st64B64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadAddtidB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB64TrB16Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB64TrB4Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB64TrB8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB96TrB6Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI8D16HiDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU16D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU16D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU8D16HiDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSwizzleB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrapRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2st64B32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2st64B64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteAddtidB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB16D16HiDs(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB8D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchgRtnB32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchgRtnB64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddF32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddF64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapFlat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxF64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinF64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrX2Flat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicPkAddBf16Flat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicPkAddF16Flat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordx2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordx3Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordx4Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadShortD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadShortD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreByteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreByteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordx2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordx3Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordx4Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreShortD16HiFlat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreShortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddcU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn1WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtcProbeBufferSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtcProbeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicAddSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicAddX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicAndSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicAndX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicCmpswapSmem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicCmpswapX2Smem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicDecSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicDecX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicIncSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicIncX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicOrSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicOrX2Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSmaxSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSmaxX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSminSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSminX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSubSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSubX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSwapSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicSwapX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicUmaxSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicUmaxX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicUminSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicUminX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicXorSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtomicXorX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBarrierSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicAddSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicAddX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicAndSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicAndX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicCmpswapSmem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicCmpswapX2Smem(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicDecSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicDecX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicIncSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicIncX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicOrSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicOrX2Smem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSmaxSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSmaxX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSminSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSminX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSubSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSubX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSwapSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicSwapX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicUmaxSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicUmaxX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicUminSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicUminX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicXorSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferAtomicXorX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx16Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx4Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx8Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferStoreDwordSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferStoreDwordx2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferStoreDwordx4Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCallB64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysSopp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbguserSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchGForkSop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchIForkSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchJoinSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkEqI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkEqU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLgI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLgU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheDiscardSmem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheDiscardX2Smem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheInvVolSmem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheWbSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheWbVolSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf0I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf0I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf1I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf1I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32I64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx16Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx4Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx8Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMemrealtimeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMemtimeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRfeB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRfeRestoreB64Sop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchLoadDwordSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchLoadDwordx2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchLoadDwordx4Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchStoreDwordSmem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchStoreDwordx2Smem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchStoreDwordx4Smem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetGprIdxIdxSop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetGprIdxModeSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetGprIdxOffSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetGprIdxOnSopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetValuCoexecModeSopp(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetkillSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetvskipSopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSStoreDwordSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSStoreDwordx2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSStoreDwordx4Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubbU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSwappcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAccvgprMovB32Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAccvgprMovB32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAccvgprReadVop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAccvgprWriteVop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddcCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddcCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrPkI8I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrPkU8I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBitop3B16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBitop3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClrexcpVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClrexcpVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Bf16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Bf16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Bf8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Bf8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Fp8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Fp8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFlrI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFlrI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkBf16F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkBf8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF32Bf8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF32Bf8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF32Fp8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF32Fp8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkFp8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkaccumU8F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtRpiI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtRpiI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef322xpk16Bf6F32Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef322xpk16Fp6F32Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32F16Bf8Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32F16Fp8Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32F32Bf8Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32F32Fp8Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk32Bf16Bf6Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk32Bf16Fp6Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk32Bf6Bf16Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk32Bf6F16Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk32F16Bf6Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk32F16Fp6Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk32F32Bf6Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk32F32Fp6Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk32Fp6Bf16Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk32Fp6F16Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32PkBf16Bf8Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32PkBf16Fp4Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32PkBf16Fp8Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32PkBf8Bf16Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32PkBf8F16Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32PkBf8F32Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32PkF16Bf8Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32PkF16Fp4Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32PkF16Fp8Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32PkF32Bf8Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32PkF32Fp4Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32PkF32Fp8Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32PkFp4Bf16Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32PkFp4F16Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32PkFp4F32Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32PkFp8Bf16Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32PkFp8F16Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32PkFp8F32Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrBf8Bf16Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrBf8F16Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrBf8F32Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrFp8Bf16Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrFp8F16Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrFp8F32Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk32Bf6Bf16Vop3(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk32Bf6F16Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk32Bf6F32Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk32Fp6Bf16Vop3(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk32Fp6F16Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk32Fp6F32Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPkFp4Bf16Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPkFp4F16Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPkFp4F32Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtSrBf16F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtSrBf8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtSrF16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtSrFp8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupLegacyF16Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2F32Bf16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2F32F16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2I32I16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2U32U16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cF32Bf16Vop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cF32Bf16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cF32F16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cF32F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cI32I16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cI32I16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4I32I8Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4cI32I8Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4cI32I8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8I32I4Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8cI32I4Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8cI32I4Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpLegacyF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhU32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfblB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfblB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaLegacyF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmamkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogLegacyF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlAddU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadLegacyF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadLegacyI16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadLegacyU16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadMixF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadmkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaximum3F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x128F8f6f4Vop3pMfma(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x14bF32Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x16Bf16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x16F16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x32Bf16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x32Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x32Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x32F16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x32Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x32Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x44bBf16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x44bF16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3216x16x4F32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x12bF32Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x16Bf16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x16Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x16Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x16F16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x16Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x16Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x2F32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x42bBf16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x42bF16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x64F8f6f4Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x8Bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF3232x32x8F16Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF324x4x116bF32Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF324x4x416bBf16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF324x4x416bF16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF6416x16x4F64Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaF644x4x44bF64Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI3216x16x32I8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI3216x16x44bI8Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI3216x16x64I8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI3232x32x16I8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI3232x32x32I8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI3232x32x42bI8Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMfmaI324x4x416bI8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinimum3F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlane16SwapB32Vop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlane16SwapB32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlane32SwapB32Vop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlane32SwapB32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmaF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaximum3F16Vop3p(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinimum3F16Vop3p(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMovB32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPrngB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPrngB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVScreenPartition4seB32Vop1(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVScreenPartition4seB32Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3216x16x128Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3216x16x128Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3216x16x128Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3216x16x128Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3216x16x32Bf16Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3216x16x32F16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3216x16x64Bf16Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3216x16x64Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3216x16x64Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3216x16x64F16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3216x16x64Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3216x16x64Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3232x32x16Bf16Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3232x32x16F16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3232x32x32Bf16Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3232x32x32Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3232x32x32Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3232x32x32F16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3232x32x32Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3232x32x32Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3232x32x64Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3232x32x64Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3232x32x64Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacF3232x32x64Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacI3216x16x128I8Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacI3216x16x64I8Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacI3232x32x32I8Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSmfmacI3232x32x64I8Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubbCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubbCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubbrevCoU32Vop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubbrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwapB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 } // namespace detail
 
 struct DecoderImpl {
 public:
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 
 private:
-  using DecodeFunc = std::unique_ptr<Instruction> (*)(const MachineInst *);
-  static std::unique_ptr<Instruction> decodeInvalid(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopp(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSmem(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3p(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> decodeVop3pX2Prefix(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeDs(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeFlat(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMubuf(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMtbuf(const MachineInst *opcode);
+  using DecodeFunc = DecodeResult (*)(const MachineInst *, const DecodeErrorEmitter &);
+  static DecodeResult decodeInvalid(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult decodeVop3pX2Prefix(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMtbuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
   static const std::array<DecodeFunc, 512> primary_decode_table;
   static const std::array<DecodeFunc, 256> sub_decode_vopc;
   static const std::array<DecodeFunc, 256> sub_decode_vop1;
@@ -1549,90 +2091,103 @@ private:
   static const std::array<DecodeFunc, 16> sub_decode_mtbuf;
 };
 
-std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
-  return DecoderImpl::decode(opcode);
+DecodeResult Decoder::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  return DecoderImpl::decode(opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decode(const MachineInst *opcode) {
+DecodeResult DecoderImpl::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
   Sop1MachineInst op = std::bit_cast<decltype(op)>(*opcode);
-  return primary_decode_table[op.encoding](opcode);
+  return primary_decode_table[op.encoding](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decodeInvalid(const MachineInst *opcode) {
-  throw util::InvalidInst(std::format("{:X}", *opcode));
-  return nullptr;
+DecodeResult DecoderImpl::decodeInvalid(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  return emit_error.emit() << "Invalid instruction opcode: " << std::format("{:X}", *opcode);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vopc[op.op](opcode);
+  return sub_decode_vopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop1[op.op](opcode);
+  return sub_decode_vop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sop1[op.op](opcode);
+  return sub_decode_sop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopc[op.op](opcode);
+  return sub_decode_sopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopp(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopp::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopp[op.op](opcode);
+  return sub_decode_sopp[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSmem(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Smem::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_smem[op.op](opcode);
+  return sub_decode_smem[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop3::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3[op.op](opcode);
+  return sub_decode_vop3[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3p(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3p(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Vop3p::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3p[op.op](opcode);
+  return sub_decode_vop3p[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decodeVop3pX2Prefix(const MachineInst *opcode) {
+DecodeResult DecoderImpl::decodeVop3pX2Prefix(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
   const uint32_t suffix_encoding = (opcode[2] >> 23) & 0x1FFu;
   const uint32_t suffix_opcode = (opcode[2] >> 16) & 0x7Fu;
   if (suffix_encoding != encoding::kVop3pMfma ||
       (suffix_opcode != kVMfmaF3216x16x128F8f6f4Vop3pMfma &&
        suffix_opcode != kVMfmaF3232x32x64F8f6f4Vop3pMfma))
-    return decodeInvalid(opcode);
+    return decodeInvalid(opcode, emit_error);
   if (suffix_opcode == kVMfmaF3216x16x128F8f6f4Vop3pMfma)
     return std::make_unique<VMfmaF3216x16x128F8f6f4Vop3pMfma>(opcode + 2, true);
   return std::make_unique<VMfmaF3232x32x64F8f6f4Vop3pMfma>(opcode + 2, true);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeDs(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeDs(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
   Ds::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_ds[op.op](opcode);
+  return sub_decode_ds[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeFlat(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeFlat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Flat::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_flat[op.op](opcode);
+  return sub_decode_flat[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMubuf(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Mubuf::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mubuf[op.op](opcode);
+  return sub_decode_mubuf[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMtbuf(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMtbuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Mtbuf::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mtbuf[op.op](opcode);
+  return sub_decode_mtbuf[op.op](opcode, emit_error);
 }
 
 const std::array<DecoderImpl::DecodeFunc, 512> DecoderImpl::primary_decode_table = {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/decoder.h
@@ -8,6 +8,7 @@
 #define ROCJITSU_ISA_ARCH_AMDGPU_CDNA4_DECODER_H_
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/machine_insts.h"
+#include "rocjitsu/isa/decode_result.h"
 #include <array>
 #include <cstddef>
 #include <memory>
@@ -21,7 +22,7 @@ namespace cdna4 {
 class Decoder {
 public:
   static constexpr std::size_t kMaxInstructionWords = 4;
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 };
 
 } // namespace cdna4

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/ds.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/ds.cpp
@@ -8,7 +8,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -36,7 +35,11 @@ DsAddU32Ds::DsAddU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU32Ds>(opcode);
 }
 } // namespace detail
@@ -63,7 +66,11 @@ DsSubU32Ds::DsSubU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU32Ds>(opcode);
 }
 } // namespace detail
@@ -90,7 +97,11 @@ DsRsubU32Ds::DsRsubU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU32Ds>(opcode);
 }
 } // namespace detail
@@ -117,7 +128,11 @@ DsIncU32Ds::DsIncU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU32Ds>(opcode);
 }
 } // namespace detail
@@ -144,7 +159,11 @@ DsDecU32Ds::DsDecU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU32Ds>(opcode);
 }
 } // namespace detail
@@ -171,7 +190,11 @@ DsMinI32Ds::DsMinI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI32Ds>(opcode);
 }
 } // namespace detail
@@ -198,7 +221,11 @@ DsMaxI32Ds::DsMaxI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI32Ds>(opcode);
 }
 } // namespace detail
@@ -225,7 +252,11 @@ DsMinU32Ds::DsMinU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU32Ds>(opcode);
 }
 } // namespace detail
@@ -252,7 +283,11 @@ DsMaxU32Ds::DsMaxU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU32Ds>(opcode);
 }
 } // namespace detail
@@ -279,7 +314,11 @@ DsAndB32Ds::DsAndB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB32Ds>(opcode);
 }
 } // namespace detail
@@ -306,7 +345,11 @@ DsOrB32Ds::DsOrB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB32Ds>(opcode);
 }
 } // namespace detail
@@ -333,7 +376,11 @@ DsXorB32Ds::DsXorB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB32Ds>(opcode);
 }
 } // namespace detail
@@ -366,7 +413,11 @@ DsMskorB32Ds::DsMskorB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB32Ds>(opcode);
 }
 } // namespace detail
@@ -391,7 +442,11 @@ DsWriteB32Ds::DsWriteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB32Ds>(opcode);
 }
 } // namespace detail
@@ -422,7 +477,11 @@ DsWrite2B32Ds::DsWrite2B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2B32Ds>(opcode);
 }
 } // namespace detail
@@ -453,7 +512,12 @@ DsWrite2st64B32Ds::DsWrite2st64B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2st64B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2st64B32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2st64_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2st64B32Ds>(opcode);
 }
 } // namespace detail
@@ -486,7 +550,11 @@ DsCmpstB32Ds::DsCmpstB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstB32Ds>(opcode);
 }
 } // namespace detail
@@ -519,7 +587,11 @@ DsCmpstF32Ds::DsCmpstF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstF32Ds>(opcode);
 }
 } // namespace detail
@@ -546,7 +618,11 @@ DsMinF32Ds::DsMinF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinF32Ds>(opcode);
 }
 } // namespace detail
@@ -573,7 +649,11 @@ DsMaxF32Ds::DsMaxF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxF32Ds>(opcode);
 }
 } // namespace detail
@@ -586,7 +666,11 @@ DsNopDs::DsNopDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsNopDs(const MachineInst *opcode) {
+DecodeResult decodeDsNopDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Ds::validate_encoding("ds_nop", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsNopDs>(opcode);
 }
 } // namespace detail
@@ -613,7 +697,11 @@ DsAddF32Ds::DsAddF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddF32Ds>(opcode);
 }
 } // namespace detail
@@ -640,7 +728,11 @@ DsPkAddF16Ds::DsPkAddF16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPkAddF16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsPkAddF16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_pk_add_f16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPkAddF16Ds>(opcode);
 }
 } // namespace detail
@@ -667,7 +759,11 @@ DsPkAddBf16Ds::DsPkAddBf16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPkAddBf16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsPkAddBf16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_pk_add_bf16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPkAddBf16Ds>(opcode);
 }
 } // namespace detail
@@ -692,7 +788,12 @@ DsWriteAddtidB32Ds::DsWriteAddtidB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteAddtidB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteAddtidB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_addtid_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteAddtidB32Ds>(opcode);
 }
 } // namespace detail
@@ -717,7 +818,11 @@ DsWriteB8Ds::DsWriteB8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB8Ds>(opcode);
 }
 } // namespace detail
@@ -742,7 +847,11 @@ DsWriteB16Ds::DsWriteB16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB16Ds>(opcode);
 }
 } // namespace detail
@@ -775,7 +884,11 @@ DsAddRtnU32Ds::DsAddRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -808,7 +921,11 @@ DsSubRtnU32Ds::DsSubRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -841,7 +958,11 @@ DsRsubRtnU32Ds::DsRsubRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -874,7 +995,11 @@ DsIncRtnU32Ds::DsIncRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -907,7 +1032,11 @@ DsDecRtnU32Ds::DsDecRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -940,7 +1069,11 @@ DsMinRtnI32Ds::DsMinRtnI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI32Ds>(opcode);
 }
 } // namespace detail
@@ -973,7 +1106,11 @@ DsMaxRtnI32Ds::DsMaxRtnI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI32Ds>(opcode);
 }
 } // namespace detail
@@ -1006,7 +1143,11 @@ DsMinRtnU32Ds::DsMinRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -1039,7 +1180,11 @@ DsMaxRtnU32Ds::DsMaxRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -1072,7 +1217,11 @@ DsAndRtnB32Ds::DsAndRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1105,7 +1254,11 @@ DsOrRtnB32Ds::DsOrRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1138,7 +1291,11 @@ DsXorRtnB32Ds::DsXorRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1177,7 +1334,12 @@ DsMskorRtnB32Ds::DsMskorRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1210,7 +1372,12 @@ DsWrxchgRtnB32Ds::DsWrxchgRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchgRtnB32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchgRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1249,7 +1416,12 @@ DsWrxchg2RtnB32Ds::DsWrxchg2RtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2RtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1288,7 +1460,12 @@ DsWrxchg2st64RtnB32Ds::DsWrxchg2st64RtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2st64_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2st64RtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1327,7 +1504,12 @@ DsCmpstRtnB32Ds::DsCmpstRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1366,7 +1548,12 @@ DsCmpstRtnF32Ds::DsCmpstRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnF32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1399,7 +1586,11 @@ DsMinRtnF32Ds::DsMinRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1432,7 +1623,11 @@ DsMaxRtnF32Ds::DsMaxRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1470,7 +1665,11 @@ DsWrapRtnB32Ds::DsWrapRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrapRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrapRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrap_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrapRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1503,7 +1702,11 @@ DsAddRtnF32Ds::DsAddRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1528,7 +1731,11 @@ DsReadB32Ds::DsReadB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB32Ds>(opcode);
 }
 } // namespace detail
@@ -1553,7 +1760,11 @@ DsRead2B32Ds::DsRead2B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2B32Ds>(opcode);
 }
 } // namespace detail
@@ -1578,7 +1789,12 @@ DsRead2st64B32Ds::DsRead2st64B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2st64B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2st64B32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2st64_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2st64B32Ds>(opcode);
 }
 } // namespace detail
@@ -1603,7 +1819,11 @@ DsReadI8Ds::DsReadI8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadI8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI8Ds>(opcode);
 }
 } // namespace detail
@@ -1628,7 +1848,11 @@ DsReadU8Ds::DsReadU8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU8Ds>(opcode);
 }
 } // namespace detail
@@ -1653,7 +1877,11 @@ DsReadI16Ds::DsReadI16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadI16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI16Ds>(opcode);
 }
 } // namespace detail
@@ -1678,7 +1906,11 @@ DsReadU16Ds::DsReadU16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU16Ds>(opcode);
 }
 } // namespace detail
@@ -1699,7 +1931,11 @@ DsSwizzleB32Ds::DsSwizzleB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSwizzleB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSwizzleB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_swizzle_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSwizzleB32Ds>(opcode);
 }
 } // namespace detail
@@ -1726,7 +1962,11 @@ DsPermuteB32Ds::DsPermuteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPermuteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsPermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_permute_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPermuteB32Ds>(opcode);
 }
 } // namespace detail
@@ -1753,7 +1993,12 @@ DsBpermuteB32Ds::DsBpermuteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsBpermuteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsBpermuteB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_bpermute_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsBpermuteB32Ds>(opcode);
 }
 } // namespace detail
@@ -1780,7 +2025,11 @@ DsAddU64Ds::DsAddU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU64Ds>(opcode);
 }
 } // namespace detail
@@ -1807,7 +2056,11 @@ DsSubU64Ds::DsSubU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU64Ds>(opcode);
 }
 } // namespace detail
@@ -1834,7 +2087,11 @@ DsRsubU64Ds::DsRsubU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU64Ds>(opcode);
 }
 } // namespace detail
@@ -1861,7 +2118,11 @@ DsIncU64Ds::DsIncU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU64Ds>(opcode);
 }
 } // namespace detail
@@ -1888,7 +2149,11 @@ DsDecU64Ds::DsDecU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU64Ds>(opcode);
 }
 } // namespace detail
@@ -1915,7 +2180,11 @@ DsMinI64Ds::DsMinI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI64Ds>(opcode);
 }
 } // namespace detail
@@ -1942,7 +2211,11 @@ DsMaxI64Ds::DsMaxI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI64Ds>(opcode);
 }
 } // namespace detail
@@ -1969,7 +2242,11 @@ DsMinU64Ds::DsMinU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU64Ds>(opcode);
 }
 } // namespace detail
@@ -1996,7 +2273,11 @@ DsMaxU64Ds::DsMaxU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU64Ds>(opcode);
 }
 } // namespace detail
@@ -2023,7 +2304,11 @@ DsAndB64Ds::DsAndB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB64Ds>(opcode);
 }
 } // namespace detail
@@ -2050,7 +2335,11 @@ DsOrB64Ds::DsOrB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB64Ds>(opcode);
 }
 } // namespace detail
@@ -2077,7 +2366,11 @@ DsXorB64Ds::DsXorB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB64Ds>(opcode);
 }
 } // namespace detail
@@ -2110,7 +2403,11 @@ DsMskorB64Ds::DsMskorB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB64Ds>(opcode);
 }
 } // namespace detail
@@ -2135,7 +2432,11 @@ DsWriteB64Ds::DsWriteB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB64Ds>(opcode);
 }
 } // namespace detail
@@ -2166,7 +2467,11 @@ DsWrite2B64Ds::DsWrite2B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2B64Ds>(opcode);
 }
 } // namespace detail
@@ -2197,7 +2502,12 @@ DsWrite2st64B64Ds::DsWrite2st64B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2st64B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2st64B64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2st64_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2st64B64Ds>(opcode);
 }
 } // namespace detail
@@ -2230,7 +2540,11 @@ DsCmpstB64Ds::DsCmpstB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstB64Ds>(opcode);
 }
 } // namespace detail
@@ -2263,7 +2577,11 @@ DsCmpstF64Ds::DsCmpstF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstF64Ds>(opcode);
 }
 } // namespace detail
@@ -2290,7 +2608,11 @@ DsMinF64Ds::DsMinF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinF64Ds>(opcode);
 }
 } // namespace detail
@@ -2317,7 +2639,11 @@ DsMaxF64Ds::DsMaxF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxF64Ds>(opcode);
 }
 } // namespace detail
@@ -2342,7 +2668,12 @@ DsWriteB8D16HiDs::DsWriteB8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB8D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2367,7 +2698,12 @@ DsWriteB16D16HiDs::DsWriteB16D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB16D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB16D16HiDs(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b16_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB16D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2392,7 +2728,11 @@ DsReadU8D16Ds::DsReadU8D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU8D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u8_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU8D16Ds>(opcode);
 }
 } // namespace detail
@@ -2423,7 +2763,12 @@ DsReadU8D16HiDs::DsReadU8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsReadU8D16HiDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2454,7 +2799,11 @@ DsReadI8D16Ds::DsReadI8D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI8D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i8_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI8D16Ds>(opcode);
 }
 } // namespace detail
@@ -2485,7 +2834,12 @@ DsReadI8D16HiDs::DsReadI8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsReadI8D16HiDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2516,7 +2870,11 @@ DsReadU16D16Ds::DsReadU16D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU16D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU16D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u16_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU16D16Ds>(opcode);
 }
 } // namespace detail
@@ -2547,7 +2905,12 @@ DsReadU16D16HiDs::DsReadU16D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU16D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsReadU16D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u16_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU16D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2580,7 +2943,11 @@ DsAddF64Ds::DsAddF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddF64Ds>(opcode);
 }
 } // namespace detail
@@ -2613,7 +2980,11 @@ DsAddRtnU64Ds::DsAddRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2646,7 +3017,11 @@ DsSubRtnU64Ds::DsSubRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2679,7 +3054,11 @@ DsRsubRtnU64Ds::DsRsubRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2712,7 +3091,11 @@ DsIncRtnU64Ds::DsIncRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2745,7 +3128,11 @@ DsDecRtnU64Ds::DsDecRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2778,7 +3165,11 @@ DsMinRtnI64Ds::DsMinRtnI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI64Ds>(opcode);
 }
 } // namespace detail
@@ -2811,7 +3202,11 @@ DsMaxRtnI64Ds::DsMaxRtnI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI64Ds>(opcode);
 }
 } // namespace detail
@@ -2844,7 +3239,11 @@ DsMinRtnU64Ds::DsMinRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2877,7 +3276,11 @@ DsMaxRtnU64Ds::DsMaxRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2910,7 +3313,11 @@ DsAndRtnB64Ds::DsAndRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2943,7 +3350,11 @@ DsOrRtnB64Ds::DsOrRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2976,7 +3387,11 @@ DsXorRtnB64Ds::DsXorRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3015,7 +3430,12 @@ DsMskorRtnB64Ds::DsMskorRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3048,7 +3468,12 @@ DsWrxchgRtnB64Ds::DsWrxchgRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchgRtnB64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchgRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3087,7 +3512,12 @@ DsWrxchg2RtnB64Ds::DsWrxchg2RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3126,7 +3556,12 @@ DsWrxchg2st64RtnB64Ds::DsWrxchg2st64RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2st64_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2st64RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3165,7 +3600,12 @@ DsCmpstRtnB64Ds::DsCmpstRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnB64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3204,7 +3644,12 @@ DsCmpstRtnF64Ds::DsCmpstRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnF64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -3237,7 +3682,11 @@ DsMinRtnF64Ds::DsMinRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -3270,7 +3719,11 @@ DsMaxRtnF64Ds::DsMaxRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -3295,7 +3748,11 @@ DsReadB64Ds::DsReadB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB64Ds>(opcode);
 }
 } // namespace detail
@@ -3320,7 +3777,11 @@ DsRead2B64Ds::DsRead2B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2B64Ds>(opcode);
 }
 } // namespace detail
@@ -3345,7 +3806,12 @@ DsRead2st64B64Ds::DsRead2st64B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2st64B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2st64B64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2st64_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2st64B64Ds>(opcode);
 }
 } // namespace detail
@@ -3378,7 +3844,11 @@ DsAddRtnF64Ds::DsAddRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -3411,7 +3881,12 @@ DsCondxchg32RtnB64Ds::DsCondxchg32RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_condxchg32_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCondxchg32RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -3436,7 +3911,12 @@ DsReadAddtidB32Ds::DsReadAddtidB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadAddtidB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadAddtidB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_addtid_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadAddtidB32Ds>(opcode);
 }
 } // namespace detail
@@ -3469,7 +3949,12 @@ DsPkAddRtnF16Ds::DsPkAddRtnF16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPkAddRtnF16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsPkAddRtnF16Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_pk_add_rtn_f16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPkAddRtnF16Ds>(opcode);
 }
 } // namespace detail
@@ -3502,7 +3987,12 @@ DsPkAddRtnBf16Ds::DsPkAddRtnBf16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPkAddRtnBf16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsPkAddRtnBf16Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_pk_add_rtn_bf16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPkAddRtnBf16Ds>(opcode);
 }
 } // namespace detail
@@ -3527,7 +4017,11 @@ DsConsumeDs::DsConsumeDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsConsumeDs(const MachineInst *opcode) {
+DecodeResult decodeDsConsumeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_consume", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsConsumeDs>(opcode);
 }
 } // namespace detail
@@ -3552,7 +4046,11 @@ DsAppendDs::DsAppendDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAppendDs(const MachineInst *opcode) {
+DecodeResult decodeDsAppendDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_append", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAppendDs>(opcode);
 }
 } // namespace detail
@@ -3577,7 +4075,11 @@ DsWriteB96Ds::DsWriteB96Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB96Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b96", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB96Ds>(opcode);
 }
 } // namespace detail
@@ -3602,7 +4104,11 @@ DsWriteB128Ds::DsWriteB128Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB128Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b128", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB128Ds>(opcode);
 }
 } // namespace detail
@@ -3627,7 +4133,12 @@ DsReadB64TrB4Ds::DsReadB64TrB4Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB64TrB4Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB64TrB4Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b64_tr_b4", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB64TrB4Ds>(opcode);
 }
 } // namespace detail
@@ -3652,7 +4163,12 @@ DsReadB96TrB6Ds::DsReadB96TrB6Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB96TrB6Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB96TrB6Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b96_tr_b6", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB96TrB6Ds>(opcode);
 }
 } // namespace detail
@@ -3677,7 +4193,12 @@ DsReadB64TrB8Ds::DsReadB64TrB8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB64TrB8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB64TrB8Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b64_tr_b8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB64TrB8Ds>(opcode);
 }
 } // namespace detail
@@ -3702,7 +4223,12 @@ DsReadB64TrB16Ds::DsReadB64TrB16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB64TrB16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB64TrB16Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b64_tr_b16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB64TrB16Ds>(opcode);
 }
 } // namespace detail
@@ -3727,7 +4253,11 @@ DsReadB96Ds::DsReadB96Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB96Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b96", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB96Ds>(opcode);
 }
 } // namespace detail
@@ -3752,7 +4282,11 @@ DsReadB128Ds::DsReadB128Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB128Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b128", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB128Ds>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/encodings.h
@@ -10,6 +10,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna4/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
+#include "rocjitsu/isa/decode_result.h"
 #include "rocjitsu/isa/instruction.h"
 #include <array>
 #include <cstdint>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/flat.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/flat.cpp
@@ -8,7 +8,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -50,7 +49,12 @@ FlatLoadUbyteFlat::FlatLoadUbyteFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUbyteFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ubyte", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUbyteFlat>(opcode);
 }
 } // namespace detail
@@ -91,7 +95,12 @@ FlatLoadSbyteFlat::FlatLoadSbyteFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSbyteFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sbyte", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSbyteFlat>(opcode);
 }
 } // namespace detail
@@ -132,7 +141,12 @@ FlatLoadUshortFlat::FlatLoadUshortFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUshortFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ushort", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUshortFlat>(opcode);
 }
 } // namespace detail
@@ -173,7 +187,12 @@ FlatLoadSshortFlat::FlatLoadSshortFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSshortFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sshort", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSshortFlat>(opcode);
 }
 } // namespace detail
@@ -214,7 +233,12 @@ FlatLoadDwordFlat::FlatLoadDwordFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dword", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordFlat>(opcode);
 }
 } // namespace detail
@@ -255,7 +279,12 @@ FlatLoadDwordx2Flat::FlatLoadDwordx2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordx2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordx2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dwordx2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordx2Flat>(opcode);
 }
 } // namespace detail
@@ -296,7 +325,12 @@ FlatLoadDwordx3Flat::FlatLoadDwordx3Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordx3Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordx3Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dwordx3", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordx3Flat>(opcode);
 }
 } // namespace detail
@@ -337,7 +371,12 @@ FlatLoadDwordx4Flat::FlatLoadDwordx4Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordx4Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordx4Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dwordx4", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordx4Flat>(opcode);
 }
 } // namespace detail
@@ -378,7 +417,12 @@ FlatStoreByteFlat::FlatStoreByteFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreByteFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreByteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_byte", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreByteFlat>(opcode);
 }
 } // namespace detail
@@ -419,7 +463,12 @@ FlatStoreByteD16HiFlat::FlatStoreByteD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreByteD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreByteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_byte_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreByteD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -460,7 +509,12 @@ FlatStoreShortFlat::FlatStoreShortFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreShortFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreShortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_short", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreShortFlat>(opcode);
 }
 } // namespace detail
@@ -501,7 +555,12 @@ FlatStoreShortD16HiFlat::FlatStoreShortD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreShortD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreShortD16HiFlat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_short_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreShortD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -542,7 +601,12 @@ FlatStoreDwordFlat::FlatStoreDwordFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dword", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordFlat>(opcode);
 }
 } // namespace detail
@@ -583,7 +647,12 @@ FlatStoreDwordx2Flat::FlatStoreDwordx2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordx2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordx2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dwordx2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordx2Flat>(opcode);
 }
 } // namespace detail
@@ -624,7 +693,12 @@ FlatStoreDwordx3Flat::FlatStoreDwordx3Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordx3Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordx3Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dwordx3", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordx3Flat>(opcode);
 }
 } // namespace detail
@@ -665,7 +739,12 @@ FlatStoreDwordx4Flat::FlatStoreDwordx4Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordx4Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordx4Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dwordx4", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordx4Flat>(opcode);
 }
 } // namespace detail
@@ -706,7 +785,12 @@ FlatLoadUbyteD16Flat::FlatLoadUbyteD16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ubyte_d16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUbyteD16Flat>(opcode);
 }
 } // namespace detail
@@ -754,7 +838,12 @@ FlatLoadUbyteD16HiFlat::FlatLoadUbyteD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ubyte_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUbyteD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -802,7 +891,12 @@ FlatLoadSbyteD16Flat::FlatLoadSbyteD16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sbyte_d16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSbyteD16Flat>(opcode);
 }
 } // namespace detail
@@ -850,7 +944,12 @@ FlatLoadSbyteD16HiFlat::FlatLoadSbyteD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sbyte_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSbyteD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -898,7 +997,12 @@ FlatLoadShortD16Flat::FlatLoadShortD16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadShortD16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadShortD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_short_d16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadShortD16Flat>(opcode);
 }
 } // namespace detail
@@ -946,7 +1050,12 @@ FlatLoadShortD16HiFlat::FlatLoadShortD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadShortD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadShortD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_short_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadShortD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -1004,7 +1113,12 @@ FlatAtomicSwapFlat::FlatAtomicSwapFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_swap", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapFlat>(opcode);
 }
 } // namespace detail
@@ -1055,7 +1169,12 @@ FlatAtomicCmpswapFlat::FlatAtomicCmpswapFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapFlat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_cmpswap", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapFlat>(opcode);
 }
 } // namespace detail
@@ -1106,7 +1225,12 @@ FlatAtomicAddFlat::FlatAtomicAddFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddFlat>(opcode);
 }
 } // namespace detail
@@ -1157,7 +1281,12 @@ FlatAtomicSubFlat::FlatAtomicSubFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_sub", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubFlat>(opcode);
 }
 } // namespace detail
@@ -1208,7 +1337,12 @@ FlatAtomicSminFlat::FlatAtomicSminFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSminFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smin", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSminFlat>(opcode);
 }
 } // namespace detail
@@ -1259,7 +1393,12 @@ FlatAtomicUminFlat::FlatAtomicUminFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUminFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umin", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUminFlat>(opcode);
 }
 } // namespace detail
@@ -1310,7 +1449,12 @@ FlatAtomicSmaxFlat::FlatAtomicSmaxFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smax", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSmaxFlat>(opcode);
 }
 } // namespace detail
@@ -1361,7 +1505,12 @@ FlatAtomicUmaxFlat::FlatAtomicUmaxFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umax", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUmaxFlat>(opcode);
 }
 } // namespace detail
@@ -1412,7 +1561,12 @@ FlatAtomicAndFlat::FlatAtomicAndFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_and", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndFlat>(opcode);
 }
 } // namespace detail
@@ -1463,7 +1617,12 @@ FlatAtomicOrFlat::FlatAtomicOrFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_or", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrFlat>(opcode);
 }
 } // namespace detail
@@ -1514,7 +1673,12 @@ FlatAtomicXorFlat::FlatAtomicXorFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_xor", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorFlat>(opcode);
 }
 } // namespace detail
@@ -1565,7 +1729,12 @@ FlatAtomicIncFlat::FlatAtomicIncFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_inc", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncFlat>(opcode);
 }
 } // namespace detail
@@ -1616,7 +1785,12 @@ FlatAtomicDecFlat::FlatAtomicDecFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_dec", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecFlat>(opcode);
 }
 } // namespace detail
@@ -1667,7 +1841,12 @@ FlatAtomicAddF32Flat::FlatAtomicAddF32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddF32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddF32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add_f32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddF32Flat>(opcode);
 }
 } // namespace detail
@@ -1718,7 +1897,12 @@ FlatAtomicPkAddF16Flat::FlatAtomicPkAddF16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicPkAddF16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicPkAddF16Flat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_pk_add_f16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicPkAddF16Flat>(opcode);
 }
 } // namespace detail
@@ -1769,7 +1953,12 @@ FlatAtomicAddF64Flat::FlatAtomicAddF64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddF64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddF64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add_f64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddF64Flat>(opcode);
 }
 } // namespace detail
@@ -1820,7 +2009,12 @@ FlatAtomicMinF64Flat::FlatAtomicMinF64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinF64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinF64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_min_f64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinF64Flat>(opcode);
 }
 } // namespace detail
@@ -1871,7 +2065,12 @@ FlatAtomicMaxF64Flat::FlatAtomicMaxF64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxF64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxF64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_max_f64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxF64Flat>(opcode);
 }
 } // namespace detail
@@ -1922,7 +2121,12 @@ FlatAtomicPkAddBf16Flat::FlatAtomicPkAddBf16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicPkAddBf16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicPkAddBf16Flat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_pk_add_bf16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicPkAddBf16Flat>(opcode);
 }
 } // namespace detail
@@ -1973,7 +2177,12 @@ FlatAtomicSwapX2Flat::FlatAtomicSwapX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_swap_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapX2Flat>(opcode);
 }
 } // namespace detail
@@ -2024,7 +2233,12 @@ FlatAtomicCmpswapX2Flat::FlatAtomicCmpswapX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_cmpswap_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapX2Flat>(opcode);
 }
 } // namespace detail
@@ -2075,7 +2289,12 @@ FlatAtomicAddX2Flat::FlatAtomicAddX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddX2Flat>(opcode);
 }
 } // namespace detail
@@ -2126,7 +2345,12 @@ FlatAtomicSubX2Flat::FlatAtomicSubX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_sub_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubX2Flat>(opcode);
 }
 } // namespace detail
@@ -2177,7 +2401,12 @@ FlatAtomicSminX2Flat::FlatAtomicSminX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSminX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smin_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSminX2Flat>(opcode);
 }
 } // namespace detail
@@ -2228,7 +2457,12 @@ FlatAtomicUminX2Flat::FlatAtomicUminX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUminX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umin_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUminX2Flat>(opcode);
 }
 } // namespace detail
@@ -2279,7 +2513,12 @@ FlatAtomicSmaxX2Flat::FlatAtomicSmaxX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smax_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSmaxX2Flat>(opcode);
 }
 } // namespace detail
@@ -2330,7 +2569,12 @@ FlatAtomicUmaxX2Flat::FlatAtomicUmaxX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umax_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUmaxX2Flat>(opcode);
 }
 } // namespace detail
@@ -2381,7 +2625,12 @@ FlatAtomicAndX2Flat::FlatAtomicAndX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_and_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndX2Flat>(opcode);
 }
 } // namespace detail
@@ -2432,7 +2681,12 @@ FlatAtomicOrX2Flat::FlatAtomicOrX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrX2Flat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_or_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrX2Flat>(opcode);
 }
 } // namespace detail
@@ -2483,7 +2737,12 @@ FlatAtomicXorX2Flat::FlatAtomicXorX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_xor_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorX2Flat>(opcode);
 }
 } // namespace detail
@@ -2534,7 +2793,12 @@ FlatAtomicIncX2Flat::FlatAtomicIncX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_inc_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncX2Flat>(opcode);
 }
 } // namespace detail
@@ -2585,7 +2849,12 @@ FlatAtomicDecX2Flat::FlatAtomicDecX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_dec_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecX2Flat>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/mtbuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/mtbuf.cpp
@@ -8,7 +8,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -49,7 +48,12 @@ TbufferLoadFormatXMtbuf::TbufferLoadFormatXMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -79,7 +83,12 @@ TbufferLoadFormatXyMtbuf::TbufferLoadFormatXyMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xy", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -109,7 +118,12 @@ TbufferLoadFormatXyzMtbuf::TbufferLoadFormatXyzMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xyz", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -139,7 +153,12 @@ TbufferLoadFormatXyzwMtbuf::TbufferLoadFormatXyzwMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xyzw", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -169,7 +188,12 @@ TbufferStoreFormatXMtbuf::TbufferStoreFormatXMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -199,7 +223,12 @@ TbufferStoreFormatXyMtbuf::TbufferStoreFormatXyMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xy", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -229,7 +258,12 @@ TbufferStoreFormatXyzMtbuf::TbufferStoreFormatXyzMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xyz", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -259,7 +293,12 @@ TbufferStoreFormatXyzwMtbuf::TbufferStoreFormatXyzwMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xyzw", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -289,7 +328,12 @@ TbufferLoadFormatD16XMtbuf::TbufferLoadFormatD16XMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_d16_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XMtbuf>(opcode);
 }
 } // namespace detail
@@ -325,7 +369,13 @@ TbufferLoadFormatD16XyMtbuf::TbufferLoadFormatD16XyMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_format_d16_xy",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XyMtbuf>(opcode);
 }
 } // namespace detail
@@ -355,7 +405,13 @@ TbufferLoadFormatD16XyzMtbuf::TbufferLoadFormatD16XyzMtbuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_format_d16_xyz",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -391,7 +447,13 @@ TbufferLoadFormatD16XyzwMtbuf::TbufferLoadFormatD16XyzwMtbuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_format_d16_xyzw",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -421,7 +483,13 @@ TbufferStoreFormatD16XMtbuf::TbufferStoreFormatD16XMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_x",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XMtbuf>(opcode);
 }
 } // namespace detail
@@ -451,7 +519,13 @@ TbufferStoreFormatD16XyMtbuf::TbufferStoreFormatD16XyMtbuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_xy",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XyMtbuf>(opcode);
 }
 } // namespace detail
@@ -481,7 +555,13 @@ TbufferStoreFormatD16XyzMtbuf::TbufferStoreFormatD16XyzMtbuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_xyz",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -511,7 +591,13 @@ TbufferStoreFormatD16XyzwMtbuf::TbufferStoreFormatD16XyzwMtbuf(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_xyzw",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XyzwMtbuf>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/mubuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/mubuf.cpp
@@ -8,7 +8,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -49,7 +48,12 @@ BufferLoadFormatXMubuf::BufferLoadFormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXMubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -79,7 +83,12 @@ BufferLoadFormatXyMubuf::BufferLoadFormatXyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -109,7 +118,12 @@ BufferLoadFormatXyzMubuf::BufferLoadFormatXyzMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xyz", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -139,7 +153,12 @@ BufferLoadFormatXyzwMubuf::BufferLoadFormatXyzwMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xyzw", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -169,7 +188,12 @@ BufferStoreFormatXMubuf::BufferStoreFormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -199,7 +223,12 @@ BufferStoreFormatXyMubuf::BufferStoreFormatXyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -229,7 +258,12 @@ BufferStoreFormatXyzMubuf::BufferStoreFormatXyzMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xyz", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -259,7 +293,12 @@ BufferStoreFormatXyzwMubuf::BufferStoreFormatXyzwMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xyzw", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -289,7 +328,12 @@ BufferLoadFormatD16XMubuf::BufferLoadFormatD16XMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_d16_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XMubuf>(opcode);
 }
 } // namespace detail
@@ -326,7 +370,12 @@ BufferLoadFormatD16XyMubuf::BufferLoadFormatD16XyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_d16_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XyMubuf>(opcode);
 }
 } // namespace detail
@@ -356,7 +405,13 @@ BufferLoadFormatD16XyzMubuf::BufferLoadFormatD16XyzMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_format_d16_xyz",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XyzMubuf>(opcode);
 }
 } // namespace detail
@@ -393,7 +448,13 @@ BufferLoadFormatD16XyzwMubuf::BufferLoadFormatD16XyzwMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_format_d16_xyzw",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -423,7 +484,12 @@ BufferStoreFormatD16XMubuf::BufferStoreFormatD16XMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_d16_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XMubuf>(opcode);
 }
 } // namespace detail
@@ -453,7 +519,13 @@ BufferStoreFormatD16XyMubuf::BufferStoreFormatD16XyMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_xy",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XyMubuf>(opcode);
 }
 } // namespace detail
@@ -483,7 +555,13 @@ BufferStoreFormatD16XyzMubuf::BufferStoreFormatD16XyzMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_xyz",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XyzMubuf>(opcode);
 }
 } // namespace detail
@@ -513,7 +591,13 @@ BufferStoreFormatD16XyzwMubuf::BufferStoreFormatD16XyzwMubuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_xyzw",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -543,7 +627,12 @@ BufferLoadUbyteMubuf::BufferLoadUbyteMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUbyteMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ubyte", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUbyteMubuf>(opcode);
 }
 } // namespace detail
@@ -573,7 +662,12 @@ BufferLoadSbyteMubuf::BufferLoadSbyteMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSbyteMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sbyte", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSbyteMubuf>(opcode);
 }
 } // namespace detail
@@ -603,7 +697,12 @@ BufferLoadUshortMubuf::BufferLoadUshortMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUshortMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ushort", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUshortMubuf>(opcode);
 }
 } // namespace detail
@@ -633,7 +732,12 @@ BufferLoadSshortMubuf::BufferLoadSshortMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSshortMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sshort", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSshortMubuf>(opcode);
 }
 } // namespace detail
@@ -663,7 +767,12 @@ BufferLoadDwordMubuf::BufferLoadDwordMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dword", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordMubuf>(opcode);
 }
 } // namespace detail
@@ -693,7 +802,12 @@ BufferLoadDwordx2Mubuf::BufferLoadDwordx2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dwordx2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordx2Mubuf>(opcode);
 }
 } // namespace detail
@@ -723,7 +837,12 @@ BufferLoadDwordx3Mubuf::BufferLoadDwordx3Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dwordx3", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordx3Mubuf>(opcode);
 }
 } // namespace detail
@@ -753,7 +872,12 @@ BufferLoadDwordx4Mubuf::BufferLoadDwordx4Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dwordx4", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordx4Mubuf>(opcode);
 }
 } // namespace detail
@@ -783,7 +907,12 @@ BufferStoreByteMubuf::BufferStoreByteMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreByteMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreByteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_byte", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreByteMubuf>(opcode);
 }
 } // namespace detail
@@ -813,7 +942,12 @@ BufferStoreByteD16HiMubuf::BufferStoreByteD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_byte_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreByteD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -843,7 +977,12 @@ BufferStoreShortMubuf::BufferStoreShortMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreShortMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreShortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_short", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreShortMubuf>(opcode);
 }
 } // namespace detail
@@ -873,7 +1012,12 @@ BufferStoreShortD16HiMubuf::BufferStoreShortD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_short_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreShortD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -903,7 +1047,12 @@ BufferStoreDwordMubuf::BufferStoreDwordMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dword", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordMubuf>(opcode);
 }
 } // namespace detail
@@ -933,7 +1082,12 @@ BufferStoreDwordx2Mubuf::BufferStoreDwordx2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dwordx2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordx2Mubuf>(opcode);
 }
 } // namespace detail
@@ -963,7 +1117,12 @@ BufferStoreDwordx3Mubuf::BufferStoreDwordx3Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dwordx3", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordx3Mubuf>(opcode);
 }
 } // namespace detail
@@ -993,7 +1152,12 @@ BufferStoreDwordx4Mubuf::BufferStoreDwordx4Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dwordx4", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordx4Mubuf>(opcode);
 }
 } // namespace detail
@@ -1023,7 +1187,12 @@ BufferLoadUbyteD16Mubuf::BufferLoadUbyteD16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ubyte_d16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUbyteD16Mubuf>(opcode);
 }
 } // namespace detail
@@ -1060,7 +1229,12 @@ BufferLoadUbyteD16HiMubuf::BufferLoadUbyteD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ubyte_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUbyteD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -1097,7 +1271,12 @@ BufferLoadSbyteD16Mubuf::BufferLoadSbyteD16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sbyte_d16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSbyteD16Mubuf>(opcode);
 }
 } // namespace detail
@@ -1134,7 +1313,12 @@ BufferLoadSbyteD16HiMubuf::BufferLoadSbyteD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sbyte_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSbyteD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -1171,7 +1355,12 @@ BufferLoadShortD16Mubuf::BufferLoadShortD16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadShortD16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadShortD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_short_d16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadShortD16Mubuf>(opcode);
 }
 } // namespace detail
@@ -1208,7 +1397,12 @@ BufferLoadShortD16HiMubuf::BufferLoadShortD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_short_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadShortD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -1245,7 +1439,13 @@ BufferLoadFormatD16HiXMubuf::BufferLoadFormatD16HiXMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_format_d16_hi_x",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16HiXMubuf>(opcode);
 }
 } // namespace detail
@@ -1282,7 +1482,13 @@ BufferStoreFormatD16HiXMubuf::BufferStoreFormatD16HiXMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_hi_x",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16HiXMubuf>(opcode);
 }
 } // namespace detail
@@ -1295,7 +1501,12 @@ BufferWbl2Mubuf::BufferWbl2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferWbl2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferWbl2Mubuf(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_wbl2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferWbl2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1308,7 +1519,11 @@ BufferInvMubuf::BufferInvMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferInvMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferInvMubuf(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_inv", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferInvMubuf>(opcode);
 }
 } // namespace detail
@@ -1342,7 +1557,12 @@ BufferAtomicSwapMubuf::BufferAtomicSwapMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_swap", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapMubuf>(opcode);
 }
 } // namespace detail
@@ -1381,7 +1601,12 @@ BufferAtomicCmpswapMubuf::BufferAtomicCmpswapMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_cmpswap", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapMubuf>(opcode);
 }
 } // namespace detail
@@ -1415,7 +1640,12 @@ BufferAtomicAddMubuf::BufferAtomicAddMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddMubuf>(opcode);
 }
 } // namespace detail
@@ -1449,7 +1679,12 @@ BufferAtomicSubMubuf::BufferAtomicSubMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_sub", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubMubuf>(opcode);
 }
 } // namespace detail
@@ -1483,7 +1718,12 @@ BufferAtomicSminMubuf::BufferAtomicSminMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSminMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smin", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSminMubuf>(opcode);
 }
 } // namespace detail
@@ -1517,7 +1757,12 @@ BufferAtomicUminMubuf::BufferAtomicUminMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUminMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umin", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUminMubuf>(opcode);
 }
 } // namespace detail
@@ -1551,7 +1796,12 @@ BufferAtomicSmaxMubuf::BufferAtomicSmaxMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smax", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSmaxMubuf>(opcode);
 }
 } // namespace detail
@@ -1585,7 +1835,12 @@ BufferAtomicUmaxMubuf::BufferAtomicUmaxMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umax", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUmaxMubuf>(opcode);
 }
 } // namespace detail
@@ -1619,7 +1874,12 @@ BufferAtomicAndMubuf::BufferAtomicAndMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_and", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndMubuf>(opcode);
 }
 } // namespace detail
@@ -1653,7 +1913,12 @@ BufferAtomicOrMubuf::BufferAtomicOrMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrMubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_or", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrMubuf>(opcode);
 }
 } // namespace detail
@@ -1687,7 +1952,12 @@ BufferAtomicXorMubuf::BufferAtomicXorMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_xor", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorMubuf>(opcode);
 }
 } // namespace detail
@@ -1721,7 +1991,12 @@ BufferAtomicIncMubuf::BufferAtomicIncMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_inc", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncMubuf>(opcode);
 }
 } // namespace detail
@@ -1755,7 +2030,12 @@ BufferAtomicDecMubuf::BufferAtomicDecMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_dec", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecMubuf>(opcode);
 }
 } // namespace detail
@@ -1789,7 +2069,12 @@ BufferAtomicAddF32Mubuf::BufferAtomicAddF32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_f32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddF32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1823,7 +2108,12 @@ BufferAtomicPkAddF16Mubuf::BufferAtomicPkAddF16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicPkAddF16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicPkAddF16Mubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_pk_add_f16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicPkAddF16Mubuf>(opcode);
 }
 } // namespace detail
@@ -1857,7 +2147,12 @@ BufferAtomicAddF64Mubuf::BufferAtomicAddF64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddF64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_f64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddF64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1891,7 +2186,12 @@ BufferAtomicMinF64Mubuf::BufferAtomicMinF64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinF64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinF64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_min_f64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinF64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1925,7 +2225,12 @@ BufferAtomicMaxF64Mubuf::BufferAtomicMaxF64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxF64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxF64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_max_f64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxF64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1959,7 +2264,12 @@ BufferAtomicPkAddBf16Mubuf::BufferAtomicPkAddBf16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicPkAddBf16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicPkAddBf16Mubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_pk_add_bf16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicPkAddBf16Mubuf>(opcode);
 }
 } // namespace detail
@@ -1993,7 +2303,12 @@ BufferAtomicSwapX2Mubuf::BufferAtomicSwapX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_swap_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2032,7 +2347,12 @@ BufferAtomicCmpswapX2Mubuf::BufferAtomicCmpswapX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_cmpswap_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2066,7 +2386,12 @@ BufferAtomicAddX2Mubuf::BufferAtomicAddX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2100,7 +2425,12 @@ BufferAtomicSubX2Mubuf::BufferAtomicSubX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_sub_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2134,7 +2464,12 @@ BufferAtomicSminX2Mubuf::BufferAtomicSminX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smin_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSminX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2168,7 +2503,12 @@ BufferAtomicUminX2Mubuf::BufferAtomicUminX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umin_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUminX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2202,7 +2542,12 @@ BufferAtomicSmaxX2Mubuf::BufferAtomicSmaxX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smax_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSmaxX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2236,7 +2581,12 @@ BufferAtomicUmaxX2Mubuf::BufferAtomicUmaxX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umax_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUmaxX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2270,7 +2620,12 @@ BufferAtomicAndX2Mubuf::BufferAtomicAndX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_and_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2304,7 +2659,12 @@ BufferAtomicOrX2Mubuf::BufferAtomicOrX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_or_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2338,7 +2698,12 @@ BufferAtomicXorX2Mubuf::BufferAtomicXorX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_xor_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2372,7 +2737,12 @@ BufferAtomicIncX2Mubuf::BufferAtomicIncX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_inc_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -2406,7 +2776,12 @@ BufferAtomicDecX2Mubuf::BufferAtomicDecX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_dec_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecX2Mubuf>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/operand.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/operand.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/scalar_static_resolve.h"
-#include "util/except.h"
 #include <format>
 #include <optional>
 #include <stdexcept>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/smem.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/smem.cpp
@@ -8,7 +8,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -47,7 +46,11 @@ SLoadDwordSmem::SLoadDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordSmem>(opcode);
 }
 } // namespace detail
@@ -70,7 +73,12 @@ SLoadDwordx2Smem::SLoadDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -93,7 +101,12 @@ SLoadDwordx4Smem::SLoadDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx4Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -116,7 +129,12 @@ SLoadDwordx8Smem::SLoadDwordx8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx8Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx8Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx8Smem>(opcode);
 }
 } // namespace detail
@@ -139,7 +157,12 @@ SLoadDwordx16Smem::SLoadDwordx16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx16Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx16Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx16Smem>(opcode);
 }
 } // namespace detail
@@ -162,7 +185,12 @@ SScratchLoadDwordSmem::SScratchLoadDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchLoadDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSScratchLoadDwordSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_load_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchLoadDwordSmem>(opcode);
 }
 } // namespace detail
@@ -185,7 +213,12 @@ SScratchLoadDwordx2Smem::SScratchLoadDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSScratchLoadDwordx2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_load_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchLoadDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -208,7 +241,12 @@ SScratchLoadDwordx4Smem::SScratchLoadDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSScratchLoadDwordx4Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_load_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchLoadDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -231,7 +269,12 @@ SBufferLoadDwordSmem::SBufferLoadDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordSmem>(opcode);
 }
 } // namespace detail
@@ -254,7 +297,12 @@ SBufferLoadDwordx2Smem::SBufferLoadDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -277,7 +325,12 @@ SBufferLoadDwordx4Smem::SBufferLoadDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx4Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -300,7 +353,12 @@ SBufferLoadDwordx8Smem::SBufferLoadDwordx8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx8Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx8Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx8Smem>(opcode);
 }
 } // namespace detail
@@ -323,7 +381,12 @@ SBufferLoadDwordx16Smem::SBufferLoadDwordx16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx16Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx16Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx16Smem>(opcode);
 }
 } // namespace detail
@@ -346,7 +409,12 @@ SStoreDwordSmem::SStoreDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSStoreDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSStoreDwordSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_store_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SStoreDwordSmem>(opcode);
 }
 } // namespace detail
@@ -369,7 +437,12 @@ SStoreDwordx2Smem::SStoreDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSStoreDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSStoreDwordx2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_store_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SStoreDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -392,7 +465,12 @@ SStoreDwordx4Smem::SStoreDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSStoreDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSStoreDwordx4Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_store_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SStoreDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -415,7 +493,12 @@ SScratchStoreDwordSmem::SScratchStoreDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchStoreDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSScratchStoreDwordSmem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_store_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchStoreDwordSmem>(opcode);
 }
 } // namespace detail
@@ -438,7 +521,12 @@ SScratchStoreDwordx2Smem::SScratchStoreDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchStoreDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSScratchStoreDwordx2Smem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_store_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchStoreDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -461,7 +549,12 @@ SScratchStoreDwordx4Smem::SScratchStoreDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchStoreDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSScratchStoreDwordx4Smem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_store_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchStoreDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -484,7 +577,12 @@ SBufferStoreDwordSmem::SBufferStoreDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferStoreDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferStoreDwordSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_store_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferStoreDwordSmem>(opcode);
 }
 } // namespace detail
@@ -507,7 +605,12 @@ SBufferStoreDwordx2Smem::SBufferStoreDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferStoreDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferStoreDwordx2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_store_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferStoreDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -530,7 +633,12 @@ SBufferStoreDwordx4Smem::SBufferStoreDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferStoreDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferStoreDwordx4Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_store_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferStoreDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -543,7 +651,11 @@ SDcacheInvSmem::SDcacheInvSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_inv", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheInvSmem>(opcode);
 }
 } // namespace detail
@@ -556,7 +668,11 @@ SDcacheWbSmem::SDcacheWbSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheWbSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheWbSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_wb", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheWbSmem>(opcode);
 }
 } // namespace detail
@@ -569,7 +685,12 @@ SDcacheInvVolSmem::SDcacheInvVolSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheInvVolSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheInvVolSmem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_inv_vol", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheInvVolSmem>(opcode);
 }
 } // namespace detail
@@ -582,7 +703,12 @@ SDcacheWbVolSmem::SDcacheWbVolSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheWbVolSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheWbVolSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_wb_vol", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheWbVolSmem>(opcode);
 }
 } // namespace detail
@@ -597,7 +723,11 @@ SMemtimeSmem::SMemtimeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMemtimeSmem(const MachineInst *opcode) {
+DecodeResult decodeSMemtimeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_memtime", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMemtimeSmem>(opcode);
 }
 } // namespace detail
@@ -612,7 +742,12 @@ SMemrealtimeSmem::SMemrealtimeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMemrealtimeSmem(const MachineInst *opcode) {
+DecodeResult decodeSMemrealtimeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_memrealtime", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMemrealtimeSmem>(opcode);
 }
 } // namespace detail
@@ -631,7 +766,11 @@ SAtcProbeSmem::SAtcProbeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtcProbeSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtcProbeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atc_probe", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtcProbeSmem>(opcode);
 }
 } // namespace detail
@@ -650,7 +789,12 @@ SAtcProbeBufferSmem::SAtcProbeBufferSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtcProbeBufferSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtcProbeBufferSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atc_probe_buffer", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtcProbeBufferSmem>(opcode);
 }
 } // namespace detail
@@ -667,7 +811,12 @@ SDcacheDiscardSmem::SDcacheDiscardSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheDiscardSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheDiscardSmem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_discard", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheDiscardSmem>(opcode);
 }
 } // namespace detail
@@ -684,7 +833,12 @@ SDcacheDiscardX2Smem::SDcacheDiscardX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheDiscardX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheDiscardX2Smem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_discard_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheDiscardX2Smem>(opcode);
 }
 } // namespace detail
@@ -704,7 +858,12 @@ SBufferAtomicSwapSmem::SBufferAtomicSwapSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSwapSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSwapSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_swap", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSwapSmem>(opcode);
 }
 } // namespace detail
@@ -724,7 +883,12 @@ SBufferAtomicCmpswapSmem::SBufferAtomicCmpswapSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicCmpswapSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicCmpswapSmem(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_cmpswap", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicCmpswapSmem>(opcode);
 }
 } // namespace detail
@@ -744,7 +908,12 @@ SBufferAtomicAddSmem::SBufferAtomicAddSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicAddSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicAddSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_add", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicAddSmem>(opcode);
 }
 } // namespace detail
@@ -764,7 +933,12 @@ SBufferAtomicSubSmem::SBufferAtomicSubSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSubSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSubSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_sub", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSubSmem>(opcode);
 }
 } // namespace detail
@@ -784,7 +958,12 @@ SBufferAtomicSminSmem::SBufferAtomicSminSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSminSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSminSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_smin", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSminSmem>(opcode);
 }
 } // namespace detail
@@ -804,7 +983,12 @@ SBufferAtomicUminSmem::SBufferAtomicUminSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicUminSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicUminSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_umin", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicUminSmem>(opcode);
 }
 } // namespace detail
@@ -824,7 +1008,12 @@ SBufferAtomicSmaxSmem::SBufferAtomicSmaxSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSmaxSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSmaxSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_smax", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSmaxSmem>(opcode);
 }
 } // namespace detail
@@ -844,7 +1033,12 @@ SBufferAtomicUmaxSmem::SBufferAtomicUmaxSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicUmaxSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicUmaxSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_umax", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicUmaxSmem>(opcode);
 }
 } // namespace detail
@@ -864,7 +1058,12 @@ SBufferAtomicAndSmem::SBufferAtomicAndSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicAndSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicAndSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_and", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicAndSmem>(opcode);
 }
 } // namespace detail
@@ -884,7 +1083,12 @@ SBufferAtomicOrSmem::SBufferAtomicOrSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicOrSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicOrSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_or", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicOrSmem>(opcode);
 }
 } // namespace detail
@@ -904,7 +1108,12 @@ SBufferAtomicXorSmem::SBufferAtomicXorSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicXorSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicXorSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_xor", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicXorSmem>(opcode);
 }
 } // namespace detail
@@ -924,7 +1133,12 @@ SBufferAtomicIncSmem::SBufferAtomicIncSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicIncSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicIncSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_inc", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicIncSmem>(opcode);
 }
 } // namespace detail
@@ -944,7 +1158,12 @@ SBufferAtomicDecSmem::SBufferAtomicDecSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicDecSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicDecSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_dec", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicDecSmem>(opcode);
 }
 } // namespace detail
@@ -964,7 +1183,12 @@ SBufferAtomicSwapX2Smem::SBufferAtomicSwapX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSwapX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSwapX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_swap_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSwapX2Smem>(opcode);
 }
 } // namespace detail
@@ -984,7 +1208,12 @@ SBufferAtomicCmpswapX2Smem::SBufferAtomicCmpswapX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicCmpswapX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicCmpswapX2Smem(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_cmpswap_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicCmpswapX2Smem>(opcode);
 }
 } // namespace detail
@@ -1004,7 +1233,12 @@ SBufferAtomicAddX2Smem::SBufferAtomicAddX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicAddX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicAddX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_add_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicAddX2Smem>(opcode);
 }
 } // namespace detail
@@ -1024,7 +1258,12 @@ SBufferAtomicSubX2Smem::SBufferAtomicSubX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSubX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSubX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_sub_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSubX2Smem>(opcode);
 }
 } // namespace detail
@@ -1044,7 +1283,12 @@ SBufferAtomicSminX2Smem::SBufferAtomicSminX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSminX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSminX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_smin_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSminX2Smem>(opcode);
 }
 } // namespace detail
@@ -1064,7 +1308,12 @@ SBufferAtomicUminX2Smem::SBufferAtomicUminX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicUminX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicUminX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_umin_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicUminX2Smem>(opcode);
 }
 } // namespace detail
@@ -1084,7 +1333,12 @@ SBufferAtomicSmaxX2Smem::SBufferAtomicSmaxX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicSmaxX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicSmaxX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_smax_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicSmaxX2Smem>(opcode);
 }
 } // namespace detail
@@ -1104,7 +1358,12 @@ SBufferAtomicUmaxX2Smem::SBufferAtomicUmaxX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicUmaxX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicUmaxX2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_umax_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicUmaxX2Smem>(opcode);
 }
 } // namespace detail
@@ -1124,7 +1383,12 @@ SBufferAtomicAndX2Smem::SBufferAtomicAndX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicAndX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicAndX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_and_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicAndX2Smem>(opcode);
 }
 } // namespace detail
@@ -1144,7 +1408,12 @@ SBufferAtomicOrX2Smem::SBufferAtomicOrX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicOrX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicOrX2Smem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_or_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicOrX2Smem>(opcode);
 }
 } // namespace detail
@@ -1164,7 +1433,12 @@ SBufferAtomicXorX2Smem::SBufferAtomicXorX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicXorX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicXorX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_xor_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicXorX2Smem>(opcode);
 }
 } // namespace detail
@@ -1184,7 +1458,12 @@ SBufferAtomicIncX2Smem::SBufferAtomicIncX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicIncX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicIncX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_inc_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicIncX2Smem>(opcode);
 }
 } // namespace detail
@@ -1204,7 +1483,12 @@ SBufferAtomicDecX2Smem::SBufferAtomicDecX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferAtomicDecX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferAtomicDecX2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_atomic_dec_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferAtomicDecX2Smem>(opcode);
 }
 } // namespace detail
@@ -1224,7 +1508,12 @@ SAtomicSwapSmem::SAtomicSwapSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSwapSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSwapSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_swap", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSwapSmem>(opcode);
 }
 } // namespace detail
@@ -1244,7 +1533,12 @@ SAtomicCmpswapSmem::SAtomicCmpswapSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicCmpswapSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicCmpswapSmem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_cmpswap", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicCmpswapSmem>(opcode);
 }
 } // namespace detail
@@ -1264,7 +1558,11 @@ SAtomicAddSmem::SAtomicAddSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicAddSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicAddSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_add", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicAddSmem>(opcode);
 }
 } // namespace detail
@@ -1284,7 +1582,11 @@ SAtomicSubSmem::SAtomicSubSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSubSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSubSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_sub", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSubSmem>(opcode);
 }
 } // namespace detail
@@ -1304,7 +1606,12 @@ SAtomicSminSmem::SAtomicSminSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSminSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSminSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_smin", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSminSmem>(opcode);
 }
 } // namespace detail
@@ -1324,7 +1631,12 @@ SAtomicUminSmem::SAtomicUminSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicUminSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicUminSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_umin", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicUminSmem>(opcode);
 }
 } // namespace detail
@@ -1344,7 +1656,12 @@ SAtomicSmaxSmem::SAtomicSmaxSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSmaxSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSmaxSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_smax", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSmaxSmem>(opcode);
 }
 } // namespace detail
@@ -1364,7 +1681,12 @@ SAtomicUmaxSmem::SAtomicUmaxSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicUmaxSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicUmaxSmem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_umax", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicUmaxSmem>(opcode);
 }
 } // namespace detail
@@ -1384,7 +1706,11 @@ SAtomicAndSmem::SAtomicAndSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicAndSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicAndSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_and", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicAndSmem>(opcode);
 }
 } // namespace detail
@@ -1404,7 +1730,11 @@ SAtomicOrSmem::SAtomicOrSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicOrSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicOrSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_or", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicOrSmem>(opcode);
 }
 } // namespace detail
@@ -1424,7 +1754,11 @@ SAtomicXorSmem::SAtomicXorSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicXorSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicXorSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_xor", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicXorSmem>(opcode);
 }
 } // namespace detail
@@ -1444,7 +1778,11 @@ SAtomicIncSmem::SAtomicIncSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicIncSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicIncSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_inc", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicIncSmem>(opcode);
 }
 } // namespace detail
@@ -1464,7 +1802,11 @@ SAtomicDecSmem::SAtomicDecSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicDecSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicDecSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_dec", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicDecSmem>(opcode);
 }
 } // namespace detail
@@ -1484,7 +1826,12 @@ SAtomicSwapX2Smem::SAtomicSwapX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSwapX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSwapX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_swap_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSwapX2Smem>(opcode);
 }
 } // namespace detail
@@ -1504,7 +1851,12 @@ SAtomicCmpswapX2Smem::SAtomicCmpswapX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicCmpswapX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicCmpswapX2Smem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_cmpswap_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicCmpswapX2Smem>(opcode);
 }
 } // namespace detail
@@ -1524,7 +1876,12 @@ SAtomicAddX2Smem::SAtomicAddX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicAddX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicAddX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_add_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicAddX2Smem>(opcode);
 }
 } // namespace detail
@@ -1544,7 +1901,12 @@ SAtomicSubX2Smem::SAtomicSubX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSubX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSubX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_sub_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSubX2Smem>(opcode);
 }
 } // namespace detail
@@ -1564,7 +1926,12 @@ SAtomicSminX2Smem::SAtomicSminX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSminX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSminX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_smin_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSminX2Smem>(opcode);
 }
 } // namespace detail
@@ -1584,7 +1951,12 @@ SAtomicUminX2Smem::SAtomicUminX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicUminX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicUminX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_umin_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicUminX2Smem>(opcode);
 }
 } // namespace detail
@@ -1604,7 +1976,12 @@ SAtomicSmaxX2Smem::SAtomicSmaxX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicSmaxX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicSmaxX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_smax_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicSmaxX2Smem>(opcode);
 }
 } // namespace detail
@@ -1624,7 +2001,12 @@ SAtomicUmaxX2Smem::SAtomicUmaxX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicUmaxX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicUmaxX2Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_umax_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicUmaxX2Smem>(opcode);
 }
 } // namespace detail
@@ -1644,7 +2026,12 @@ SAtomicAndX2Smem::SAtomicAndX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicAndX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicAndX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_and_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicAndX2Smem>(opcode);
 }
 } // namespace detail
@@ -1664,7 +2051,12 @@ SAtomicOrX2Smem::SAtomicOrX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicOrX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicOrX2Smem(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_or_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicOrX2Smem>(opcode);
 }
 } // namespace detail
@@ -1684,7 +2076,12 @@ SAtomicXorX2Smem::SAtomicXorX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicXorX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicXorX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_xor_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicXorX2Smem>(opcode);
 }
 } // namespace detail
@@ -1704,7 +2101,12 @@ SAtomicIncX2Smem::SAtomicIncX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicIncX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicIncX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_inc_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicIncX2Smem>(opcode);
 }
 } // namespace detail
@@ -1724,7 +2126,12 @@ SAtomicDecX2Smem::SAtomicDecX2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtomicDecX2Smem(const MachineInst *opcode) {
+DecodeResult decodeSAtomicDecX2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atomic_dec_x2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtomicDecX2Smem>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/sop1.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/sop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -29,7 +28,11 @@ SMovB32Sop1::SMovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -52,7 +55,11 @@ SMovB64Sop1::SMovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -78,7 +85,11 @@ SCmovB32Sop1::SCmovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -105,7 +116,11 @@ SCmovB64Sop1::SCmovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -129,7 +144,11 @@ SNotB32Sop1::SNotB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB32Sop1>(opcode);
 }
 } // namespace detail
@@ -154,7 +173,11 @@ SNotB64Sop1::SNotB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB64Sop1>(opcode);
 }
 } // namespace detail
@@ -178,7 +201,11 @@ SWqmB32Sop1::SWqmB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB32Sop1>(opcode);
 }
 } // namespace detail
@@ -203,7 +230,11 @@ SWqmB64Sop1::SWqmB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB64Sop1>(opcode);
 }
 } // namespace detail
@@ -224,7 +255,11 @@ SBrevB32Sop1::SBrevB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB32Sop1>(opcode);
 }
 } // namespace detail
@@ -246,7 +281,11 @@ SBrevB64Sop1::SBrevB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB64Sop1>(opcode);
 }
 } // namespace detail
@@ -270,7 +309,12 @@ SBcnt0I32B32Sop1::SBcnt0I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -295,7 +339,12 @@ SBcnt0I32B64Sop1::SBcnt0I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -319,7 +368,12 @@ SBcnt1I32B32Sop1::SBcnt1I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -344,7 +398,12 @@ SBcnt1I32B64Sop1::SBcnt1I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -365,7 +424,11 @@ SFf0I32B32Sop1::SFf0I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf0I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf0I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff0_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf0I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -387,7 +450,11 @@ SFf0I32B64Sop1::SFf0I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf0I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf0I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff0_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf0I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -408,7 +475,11 @@ SFf1I32B32Sop1::SFf1I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf1I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf1I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff1_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf1I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -430,7 +501,11 @@ SFf1I32B64Sop1::SFf1I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf1I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf1I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff1_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf1I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -451,7 +526,12 @@ SFlbitI32B32Sop1::SFlbitI32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -473,7 +553,12 @@ SFlbitI32B64Sop1::SFlbitI32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -494,7 +579,11 @@ SFlbitI32Sop1::SFlbitI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32Sop1>(opcode);
 }
 } // namespace detail
@@ -516,7 +605,12 @@ SFlbitI32I64Sop1::SFlbitI32I64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32I64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32I64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32_i64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32I64Sop1>(opcode);
 }
 } // namespace detail
@@ -537,7 +631,11 @@ SSextI32I8Sop1::SSextI32I8Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i8", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I8Sop1>(opcode);
 }
 } // namespace detail
@@ -559,7 +657,12 @@ SSextI32I16Sop1::SSextI32I16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I16Sop1>(opcode);
 }
 } // namespace detail
@@ -581,7 +684,12 @@ SBitset0B32Sop1::SBitset0B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B32Sop1>(opcode);
 }
 } // namespace detail
@@ -603,7 +711,12 @@ SBitset0B64Sop1::SBitset0B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B64Sop1>(opcode);
 }
 } // namespace detail
@@ -625,7 +738,12 @@ SBitset1B32Sop1::SBitset1B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B32Sop1>(opcode);
 }
 } // namespace detail
@@ -647,7 +765,12 @@ SBitset1B64Sop1::SBitset1B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B64Sop1>(opcode);
 }
 } // namespace detail
@@ -665,7 +788,11 @@ SGetpcB64Sop1::SGetpcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetpcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSGetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_getpc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetpcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -684,7 +811,11 @@ SSetpcB64Sop1::SSetpcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetpcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_setpc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetpcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -707,7 +838,11 @@ SSwappcB64Sop1::SSwappcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSwappcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSwappcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_swappc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSwappcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -725,7 +860,11 @@ SRfeB64Sop1::SRfeB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRfeB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSRfeB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_rfe_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRfeB64Sop1>(opcode);
 }
 } // namespace detail
@@ -757,7 +896,12 @@ SAndSaveexecB64Sop1::SAndSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -790,7 +934,12 @@ SOrSaveexecB64Sop1::SOrSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -822,7 +971,12 @@ SXorSaveexecB64Sop1::SXorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -854,7 +1008,12 @@ SAndn2SaveexecB64Sop1::SAndn2SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn2_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -886,7 +1045,12 @@ SOrn2SaveexecB64Sop1::SOrn2SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_orn2_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -918,7 +1082,12 @@ SNandSaveexecB64Sop1::SNandSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nand_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -950,7 +1119,12 @@ SNorSaveexecB64Sop1::SNorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -982,7 +1156,12 @@ SXnorSaveexecB64Sop1::SXnorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xnor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1006,7 +1185,12 @@ SQuadmaskB32Sop1::SQuadmaskB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1031,7 +1215,12 @@ SQuadmaskB64Sop1::SQuadmaskB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1051,7 +1240,12 @@ SMovrelsB32Sop1::SMovrelsB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrels_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1071,7 +1265,12 @@ SMovrelsB64Sop1::SMovrelsB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrels_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1095,7 +1294,12 @@ SMovreldB32Sop1::SMovreldB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1120,7 +1324,12 @@ SMovreldB64Sop1::SMovreldB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1140,7 +1349,12 @@ SCbranchJoinSop1::SCbranchJoinSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchJoinSop1(const MachineInst *opcode) {
+DecodeResult decodeSCbranchJoinSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cbranch_join", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchJoinSop1>(opcode);
 }
 } // namespace detail
@@ -1164,7 +1378,11 @@ SAbsI32Sop1::SAbsI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_abs_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsI32Sop1>(opcode);
 }
 } // namespace detail
@@ -1188,7 +1406,12 @@ SSetGprIdxIdxSop1::SSetGprIdxIdxSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetGprIdxIdxSop1(const MachineInst *opcode) {
+DecodeResult decodeSSetGprIdxIdxSop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_set_gpr_idx_idx", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetGprIdxIdxSop1>(opcode);
 }
 } // namespace detail
@@ -1220,7 +1443,12 @@ SAndn1SaveexecB64Sop1::SAndn1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1252,7 +1480,12 @@ SOrn1SaveexecB64Sop1::SOrn1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_orn1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1284,7 +1517,12 @@ SAndn1WrexecB64Sop1::SAndn1WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn1WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn1WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn1_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn1WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1316,7 +1554,12 @@ SAndn2WrexecB64Sop1::SAndn2WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn2WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn2_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1337,7 +1580,12 @@ SBitreplicateB64B32Sop1::SBitreplicateB64B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitreplicate_b64_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitreplicateB64B32Sop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/sop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/sop2.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/sop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -37,7 +36,11 @@ SAddU32Sop2::SAddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -67,7 +70,11 @@ SSubU32Sop2::SSubU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubU32Sop2>(opcode);
 }
 } // namespace detail
@@ -97,7 +104,11 @@ SAddI32Sop2::SAddI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddI32Sop2>(opcode);
 }
 } // namespace detail
@@ -127,7 +138,11 @@ SSubI32Sop2::SSubI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubI32Sop2>(opcode);
 }
 } // namespace detail
@@ -160,7 +175,11 @@ SAddcU32Sop2::SAddcU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddcU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddcU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_addc_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddcU32Sop2>(opcode);
 }
 } // namespace detail
@@ -193,7 +212,11 @@ SSubbU32Sop2::SSubbU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubbU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubbU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_subb_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubbU32Sop2>(opcode);
 }
 } // namespace detail
@@ -223,7 +246,11 @@ SMinI32Sop2::SMinI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinI32Sop2>(opcode);
 }
 } // namespace detail
@@ -253,7 +280,11 @@ SMinU32Sop2::SMinU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinU32Sop2>(opcode);
 }
 } // namespace detail
@@ -283,7 +314,11 @@ SMaxI32Sop2::SMaxI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxI32Sop2>(opcode);
 }
 } // namespace detail
@@ -313,7 +348,11 @@ SMaxU32Sop2::SMaxU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxU32Sop2>(opcode);
 }
 } // namespace detail
@@ -343,7 +382,12 @@ SCselectB32Sop2::SCselectB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCselectB32Sop2>(opcode);
 }
 } // namespace detail
@@ -375,7 +419,12 @@ SCselectB64Sop2::SCselectB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCselectB64Sop2>(opcode);
 }
 } // namespace detail
@@ -405,7 +454,11 @@ SAndB32Sop2::SAndB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndB32Sop2>(opcode);
 }
 } // namespace detail
@@ -437,7 +490,11 @@ SAndB64Sop2::SAndB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndB64Sop2>(opcode);
 }
 } // namespace detail
@@ -468,7 +525,11 @@ SOrB32Sop2::SOrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -501,7 +562,11 @@ SOrB64Sop2::SOrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -531,7 +596,11 @@ SXorB32Sop2::SXorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -563,7 +632,11 @@ SXorB64Sop2::SXorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -593,7 +666,11 @@ SAndn2B32Sop2::SAndn2B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_andn2_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2B32Sop2>(opcode);
 }
 } // namespace detail
@@ -625,7 +702,11 @@ SAndn2B64Sop2::SAndn2B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_andn2_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2B64Sop2>(opcode);
 }
 } // namespace detail
@@ -655,7 +736,11 @@ SOrn2B32Sop2::SOrn2B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_orn2_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2B32Sop2>(opcode);
 }
 } // namespace detail
@@ -687,7 +772,11 @@ SOrn2B64Sop2::SOrn2B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_orn2_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2B64Sop2>(opcode);
 }
 } // namespace detail
@@ -717,7 +806,11 @@ SNandB32Sop2::SNandB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandB32Sop2>(opcode);
 }
 } // namespace detail
@@ -749,7 +842,11 @@ SNandB64Sop2::SNandB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandB64Sop2>(opcode);
 }
 } // namespace detail
@@ -779,7 +876,11 @@ SNorB32Sop2::SNorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -811,7 +912,11 @@ SNorB64Sop2::SNorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -841,7 +946,11 @@ SXnorB32Sop2::SXnorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -873,7 +982,11 @@ SXnorB64Sop2::SXnorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -903,7 +1016,11 @@ SLshlB32Sop2::SLshlB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshlB32Sop2>(opcode);
 }
 } // namespace detail
@@ -934,7 +1051,11 @@ SLshlB64Sop2::SLshlB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshlB64Sop2>(opcode);
 }
 } // namespace detail
@@ -964,7 +1085,11 @@ SLshrB32Sop2::SLshrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -995,7 +1120,11 @@ SLshrB64Sop2::SLshrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1025,7 +1154,11 @@ SAshrI32Sop2::SAshrI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAshrI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1056,7 +1189,11 @@ SAshrI64Sop2::SAshrI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAshrI64Sop2>(opcode);
 }
 } // namespace detail
@@ -1083,7 +1220,11 @@ SBfmB32Sop2::SBfmB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfmB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1110,7 +1251,11 @@ SBfmB64Sop2::SBfmB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfmB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1137,7 +1282,11 @@ SMulI32Sop2::SMulI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1167,7 +1316,11 @@ SBfeU32Sop2::SBfeU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1197,7 +1350,11 @@ SBfeI32Sop2::SBfeI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1228,7 +1385,11 @@ SBfeU64Sop2::SBfeU64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeU64Sop2>(opcode);
 }
 } // namespace detail
@@ -1259,7 +1420,11 @@ SBfeI64Sop2::SBfeI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeI64Sop2>(opcode);
 }
 } // namespace detail
@@ -1279,7 +1444,12 @@ SCbranchGForkSop2::SCbranchGForkSop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchGForkSop2(const MachineInst *opcode) {
+DecodeResult decodeSCbranchGForkSop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cbranch_g_fork", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchGForkSop2>(opcode);
 }
 } // namespace detail
@@ -1309,7 +1479,12 @@ SAbsdiffI32Sop2::SAbsdiffI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_absdiff_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsdiffI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1338,7 +1513,12 @@ SRfeRestoreB64Sop2::SRfeRestoreB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRfeRestoreB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSRfeRestoreB64Sop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_rfe_restore_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRfeRestoreB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1365,7 +1545,11 @@ SMulHiU32Sop2::SMulHiU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulHiU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1392,7 +1576,11 @@ SMulHiI32Sop2::SMulHiI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulHiI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1422,7 +1610,12 @@ SLshl1AddU32Sop2::SLshl1AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl1_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl1AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1452,7 +1645,12 @@ SLshl2AddU32Sop2::SLshl2AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl2_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl2AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1482,7 +1680,12 @@ SLshl3AddU32Sop2::SLshl3AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl3_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl3AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1512,7 +1715,12 @@ SLshl4AddU32Sop2::SLshl4AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl4_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl4AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1541,7 +1749,12 @@ SPackLlB32B16Sop2::SPackLlB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_ll_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackLlB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1569,7 +1782,12 @@ SPackLhB32B16Sop2::SPackLhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_lh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackLhB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1596,7 +1814,12 @@ SPackHhB32B16Sop2::SPackHhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_hh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackHhB32B16Sop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/sopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/sopc.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/sopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -35,7 +34,11 @@ SCmpEqI32Sopc::SCmpEqI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqI32Sopc>(opcode);
 }
 } // namespace detail
@@ -63,7 +66,11 @@ SCmpLgI32Sopc::SCmpLgI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgI32Sopc>(opcode);
 }
 } // namespace detail
@@ -91,7 +98,11 @@ SCmpGtI32Sopc::SCmpGtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -119,7 +130,11 @@ SCmpGeI32Sopc::SCmpGeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -147,7 +162,11 @@ SCmpLtI32Sopc::SCmpLtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -175,7 +194,11 @@ SCmpLeI32Sopc::SCmpLeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -203,7 +226,11 @@ SCmpEqU32Sopc::SCmpEqU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqU32Sopc>(opcode);
 }
 } // namespace detail
@@ -231,7 +258,11 @@ SCmpLgU32Sopc::SCmpLgU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgU32Sopc>(opcode);
 }
 } // namespace detail
@@ -259,7 +290,11 @@ SCmpGtU32Sopc::SCmpGtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -287,7 +322,11 @@ SCmpGeU32Sopc::SCmpGeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -315,7 +354,11 @@ SCmpLtU32Sopc::SCmpLtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -343,7 +386,11 @@ SCmpLeU32Sopc::SCmpLeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -371,7 +418,12 @@ SBitcmp0B32Sopc::SBitcmp0B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp0B32Sopc>(opcode);
 }
 } // namespace detail
@@ -399,7 +451,12 @@ SBitcmp1B32Sopc::SBitcmp1B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp1B32Sopc>(opcode);
 }
 } // namespace detail
@@ -428,7 +485,12 @@ SBitcmp0B64Sopc::SBitcmp0B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp0B64Sopc>(opcode);
 }
 } // namespace detail
@@ -457,7 +519,12 @@ SBitcmp1B64Sopc::SBitcmp1B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp1B64Sopc>(opcode);
 }
 } // namespace detail
@@ -482,7 +549,11 @@ SSetvskipSopc::SSetvskipSopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetvskipSopc(const MachineInst *opcode) {
+DecodeResult decodeSSetvskipSopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_setvskip", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetvskipSopc>(opcode);
 }
 } // namespace detail
@@ -508,7 +579,12 @@ SSetGprIdxOnSopc::SSetGprIdxOnSopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetGprIdxOnSopc(const MachineInst *opcode) {
+DecodeResult decodeSSetGprIdxOnSopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_set_gpr_idx_on", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetGprIdxOnSopc>(opcode);
 }
 } // namespace detail
@@ -538,7 +614,11 @@ SCmpEqU64Sopc::SCmpEqU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqU64Sopc>(opcode);
 }
 } // namespace detail
@@ -568,7 +648,11 @@ SCmpLgU64Sopc::SCmpLgU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgU64Sopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/sopk.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -24,7 +23,11 @@ SMovkI32Sopk::SMovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_movk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -46,7 +49,11 @@ SCmovkI32Sopk::SCmovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmovk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -66,7 +73,11 @@ SCmpkEqI32Sopk::SCmpkEqI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkEqI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkEqI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_eq_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkEqI32Sopk>(opcode);
 }
 } // namespace detail
@@ -86,7 +97,11 @@ SCmpkLgI32Sopk::SCmpkLgI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLgI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLgI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lg_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLgI32Sopk>(opcode);
 }
 } // namespace detail
@@ -106,7 +121,11 @@ SCmpkGtI32Sopk::SCmpkGtI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGtI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_gt_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGtI32Sopk>(opcode);
 }
 } // namespace detail
@@ -126,7 +145,11 @@ SCmpkGeI32Sopk::SCmpkGeI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGeI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_ge_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGeI32Sopk>(opcode);
 }
 } // namespace detail
@@ -146,7 +169,11 @@ SCmpkLtI32Sopk::SCmpkLtI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLtI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lt_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLtI32Sopk>(opcode);
 }
 } // namespace detail
@@ -166,7 +193,11 @@ SCmpkLeI32Sopk::SCmpkLeI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLeI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_le_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLeI32Sopk>(opcode);
 }
 } // namespace detail
@@ -186,7 +217,11 @@ SCmpkEqU32Sopk::SCmpkEqU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkEqU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkEqU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_eq_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkEqU32Sopk>(opcode);
 }
 } // namespace detail
@@ -206,7 +241,11 @@ SCmpkLgU32Sopk::SCmpkLgU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLgU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLgU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lg_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLgU32Sopk>(opcode);
 }
 } // namespace detail
@@ -226,7 +265,11 @@ SCmpkGtU32Sopk::SCmpkGtU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGtU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_gt_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGtU32Sopk>(opcode);
 }
 } // namespace detail
@@ -246,7 +289,11 @@ SCmpkGeU32Sopk::SCmpkGeU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGeU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_ge_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGeU32Sopk>(opcode);
 }
 } // namespace detail
@@ -266,7 +313,11 @@ SCmpkLtU32Sopk::SCmpkLtU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLtU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lt_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLtU32Sopk>(opcode);
 }
 } // namespace detail
@@ -286,7 +337,11 @@ SCmpkLeU32Sopk::SCmpkLeU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLeU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_le_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLeU32Sopk>(opcode);
 }
 } // namespace detail
@@ -307,7 +362,11 @@ SAddkI32Sopk::SAddkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSAddkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_addk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -325,7 +384,11 @@ SMulkI32Sopk::SMulkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_mulk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -342,7 +405,12 @@ SCbranchIForkSopk::SCbranchIForkSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchIForkSopk(const MachineInst *opcode) {
+DecodeResult decodeSCbranchIForkSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cbranch_i_fork", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchIForkSopk>(opcode);
 }
 } // namespace detail
@@ -359,7 +427,11 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_getreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -376,7 +448,11 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -401,7 +477,12 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_imm32_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregImm32B32Sopk>(opcode);
 }
 } // namespace detail
@@ -430,7 +511,11 @@ SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCallB64Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCallB64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_call_b64", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCallB64Sopk>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/sopp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/sopp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/sopp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -22,7 +21,11 @@ SNopSopp::SNopSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode) {
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_nop", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNopSopp>(opcode);
 }
 } // namespace detail
@@ -36,7 +39,11 @@ SEndpgmSopp::SEndpgmSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSopp>(opcode);
 }
 } // namespace detail
@@ -53,7 +60,11 @@ SBranchSopp::SBranchSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode) {
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_branch", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBranchSopp>(opcode);
 }
 } // namespace detail
@@ -71,7 +82,11 @@ SWakeupSopp::SWakeupSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode) {
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wakeup", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWakeupSopp>(opcode);
 }
 } // namespace detail
@@ -91,7 +106,12 @@ SCbranchScc0Sopp::SCbranchScc0Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc0", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc0Sopp>(opcode);
 }
 } // namespace detail
@@ -116,7 +136,12 @@ SCbranchScc1Sopp::SCbranchScc1Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc1", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc1Sopp>(opcode);
 }
 } // namespace detail
@@ -141,7 +166,12 @@ SCbranchVcczSopp::SCbranchVcczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVcczSopp>(opcode);
 }
 } // namespace detail
@@ -166,7 +196,12 @@ SCbranchVccnzSopp::SCbranchVccnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVccnzSopp>(opcode);
 }
 } // namespace detail
@@ -191,7 +226,12 @@ SCbranchExeczSopp::SCbranchExeczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExeczSopp>(opcode);
 }
 } // namespace detail
@@ -216,7 +256,12 @@ SCbranchExecnzSopp::SCbranchExecnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExecnzSopp>(opcode);
 }
 } // namespace detail
@@ -235,7 +280,11 @@ SBarrierSopp::SBarrierSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBarrierSopp(const MachineInst *opcode) {
+DecodeResult decodeSBarrierSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_barrier", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBarrierSopp>(opcode);
 }
 } // namespace detail
@@ -250,7 +299,11 @@ SSetkillSopp::SSetkillSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetkillSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetkillSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setkill", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetkillSopp>(opcode);
 }
 } // namespace detail
@@ -266,7 +319,11 @@ SWaitcntSopp::SWaitcntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_waitcnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntSopp>(opcode);
 }
 } // namespace detail
@@ -281,7 +338,11 @@ SSethaltSopp::SSethaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sethalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSethaltSopp>(opcode);
 }
 } // namespace detail
@@ -296,7 +357,11 @@ SSleepSopp::SSleepSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode) {
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sleep", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSleepSopp>(opcode);
 }
 } // namespace detail
@@ -311,7 +376,11 @@ SSetprioSopp::SSetprioSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setprio", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetprioSopp>(opcode);
 }
 } // namespace detail
@@ -329,7 +398,11 @@ SSendmsgSopp::SSendmsgSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsg", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsgSopp>(opcode);
 }
 } // namespace detail
@@ -347,7 +420,12 @@ SSendmsghaltSopp::SSendmsghaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsghalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsghaltSopp>(opcode);
 }
 } // namespace detail
@@ -362,7 +440,11 @@ STrapSopp::STrapSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode) {
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_trap", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STrapSopp>(opcode);
 }
 } // namespace detail
@@ -375,7 +457,11 @@ SIcacheInvSopp::SIcacheInvSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode) {
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_icache_inv", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIcacheInvSopp>(opcode);
 }
 } // namespace detail
@@ -390,7 +476,12 @@ SIncperflevelSopp::SIncperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_incperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIncperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -405,7 +496,12 @@ SDecperflevelSopp::SDecperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_decperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDecperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -421,7 +517,12 @@ STtracedataSopp::STtracedataSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode) {
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_ttracedata", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STtracedataSopp>(opcode);
 }
 } // namespace detail
@@ -436,7 +537,12 @@ SCbranchCdbgsysSopp::SCbranchCdbgsysSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysSopp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysSopp>(opcode);
 }
 } // namespace detail
@@ -451,7 +557,12 @@ SCbranchCdbguserSopp::SCbranchCdbguserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbguserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbguserSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbguser", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbguserSopp>(opcode);
 }
 } // namespace detail
@@ -466,7 +577,12 @@ SCbranchCdbgsysOrUserSopp::SCbranchCdbgsysOrUserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys_or_user", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysOrUserSopp>(opcode);
 }
 } // namespace detail
@@ -481,7 +597,12 @@ SCbranchCdbgsysAndUserSopp::SCbranchCdbgsysAndUserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys_and_user", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysAndUserSopp>(opcode);
 }
 } // namespace detail
@@ -495,7 +616,12 @@ SEndpgmSavedSopp::SEndpgmSavedSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm_saved", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSavedSopp>(opcode);
 }
 } // namespace detail
@@ -508,7 +634,12 @@ SSetGprIdxOffSopp::SSetGprIdxOffSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetGprIdxOffSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetGprIdxOffSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_set_gpr_idx_off", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetGprIdxOffSopp>(opcode);
 }
 } // namespace detail
@@ -528,7 +659,12 @@ SSetGprIdxModeSopp::SSetGprIdxModeSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetGprIdxModeSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetGprIdxModeSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_set_gpr_idx_mode", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetGprIdxModeSopp>(opcode);
 }
 } // namespace detail
@@ -542,7 +678,12 @@ SEndpgmOrderedPsDoneSopp::SEndpgmOrderedPsDoneSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm_ordered_ps_done", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmOrderedPsDoneSopp>(opcode);
 }
 } // namespace detail
@@ -557,7 +698,12 @@ SSetValuCoexecModeSopp::SSetValuCoexecModeSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetValuCoexecModeSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetValuCoexecModeSopp(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_set_valu_coexec_mode", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetValuCoexecModeSopp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vop1.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/vop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -23,7 +22,14 @@ VNopVop1::VNopVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode) {
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_nop_sdwa"
+                                                                                 : "v_nop_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop1>(opcode);
 }
 } // namespace detail
@@ -72,7 +78,14 @@ VMovB32Vop1::VMovB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mov_b32_sdwa"
+                                                                                 : "v_mov_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop1>(opcode);
 }
 } // namespace detail
@@ -86,14 +99,20 @@ VReadfirstlaneB32Vop1::VReadfirstlaneB32Vop1(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_readfirstlane_b32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support SDWA";
   return std::make_unique<VReadfirstlaneB32Vop1>(opcode);
 }
 } // namespace detail
@@ -120,12 +139,17 @@ VCvtI32F64Vop1::VCvtI32F64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_I32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_i32_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_I32_F64 does not support SDWA";
   return std::make_unique<VCvtI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -151,12 +175,17 @@ VCvtF64I32Vop1::VCvtF64I32Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F64_I32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_f64_i32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_I32 does not support SDWA";
   return std::make_unique<VCvtF64I32Vop1>(opcode);
 }
 } // namespace detail
@@ -206,7 +235,15 @@ VCvtF32I32Vop1::VCvtF32I32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_i32_sdwa"
+          : "v_cvt_f32_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop1>(opcode);
 }
 } // namespace detail
@@ -256,7 +293,15 @@ VCvtF32U32Vop1::VCvtF32U32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_u32_sdwa"
+          : "v_cvt_f32_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop1>(opcode);
 }
 } // namespace detail
@@ -306,7 +351,15 @@ VCvtU32F32Vop1::VCvtU32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_u32_f32_sdwa"
+          : "v_cvt_u32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -356,7 +409,15 @@ VCvtI32F32Vop1::VCvtI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_i32_f32_sdwa"
+          : "v_cvt_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -406,7 +467,15 @@ VCvtF16F32Vop1::VCvtF16F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f16_f32_sdwa"
+          : "v_cvt_f16_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop1>(opcode);
 }
 } // namespace detail
@@ -463,7 +532,15 @@ VCvtF32F16Vop1::VCvtF32F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_f16_sdwa"
+          : "v_cvt_f32_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop1>(opcode);
 }
 } // namespace detail
@@ -513,7 +590,16 @@ VCvtRpiI32F32Vop1::VCvtRpiI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtRpiI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_rpi_i32_f32_sdwa"
+          : "v_cvt_rpi_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtRpiI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -563,7 +649,16 @@ VCvtFlrI32F32Vop1::VCvtFlrI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtFlrI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_flr_i32_f32_sdwa"
+          : "v_cvt_flr_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFlrI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -613,7 +708,16 @@ VCvtOffF32I4Vop1::VCvtOffF32I4Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_off_f32_i4_sdwa"
+          : "v_cvt_off_f32_i4_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop1>(opcode);
 }
 } // namespace detail
@@ -640,12 +744,17 @@ VCvtF32F64Vop1::VCvtF32F64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_f32_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F32_F64 does not support SDWA";
   return std::make_unique<VCvtF32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -663,14 +772,19 @@ VCvtF64F32Vop1::VCvtF64F32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CVT_F64_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F64_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_f64_f32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support SDWA";
   return std::make_unique<VCvtF64F32Vop1>(opcode);
 }
 } // namespace detail
@@ -720,7 +834,16 @@ VCvtF32Ubyte0Vop1::VCvtF32Ubyte0Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte0_sdwa"
+          : "v_cvt_f32_ubyte0_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop1>(opcode);
 }
 } // namespace detail
@@ -770,7 +893,16 @@ VCvtF32Ubyte1Vop1::VCvtF32Ubyte1Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte1_sdwa"
+          : "v_cvt_f32_ubyte1_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop1>(opcode);
 }
 } // namespace detail
@@ -820,7 +952,16 @@ VCvtF32Ubyte2Vop1::VCvtF32Ubyte2Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte2_sdwa"
+          : "v_cvt_f32_ubyte2_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop1>(opcode);
 }
 } // namespace detail
@@ -870,7 +1011,16 @@ VCvtF32Ubyte3Vop1::VCvtF32Ubyte3Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte3_sdwa"
+          : "v_cvt_f32_ubyte3_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop1>(opcode);
 }
 } // namespace detail
@@ -897,12 +1047,17 @@ VCvtU32F64Vop1::VCvtU32F64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_U32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_u32_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_U32_F64 does not support SDWA";
   return std::make_unique<VCvtU32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -928,12 +1083,17 @@ VCvtF64U32Vop1::VCvtF64U32Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F64_U32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_cvt_f64_u32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_U32 does not support SDWA";
   return std::make_unique<VCvtF64U32Vop1>(opcode);
 }
 } // namespace detail
@@ -960,12 +1120,17 @@ VTruncF64Vop1::VTruncF64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_TRUNC_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_trunc_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_TRUNC_F64 does not support SDWA";
   return std::make_unique<VTruncF64Vop1>(opcode);
 }
 } // namespace detail
@@ -992,12 +1157,17 @@ VCeilF64Vop1::VCeilF64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CEIL_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_ceil_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CEIL_F64 does not support SDWA";
   return std::make_unique<VCeilF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1016,14 +1186,19 @@ VRndneF64Vop1::VRndneF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_RNDNE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_RNDNE_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_rndne_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support SDWA";
   return std::make_unique<VRndneF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1050,12 +1225,17 @@ VFloorF64Vop1::VFloorF64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FLOOR_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_floor_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FLOOR_F64 does not support SDWA";
   return std::make_unique<VFloorF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1104,7 +1284,15 @@ VFractF32Vop1::VFractF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_fract_f32_sdwa"
+          : "v_fract_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1153,7 +1341,15 @@ VTruncF32Vop1::VTruncF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_trunc_f32_sdwa"
+          : "v_trunc_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1202,7 +1398,14 @@ VCeilF32Vop1::VCeilF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ceil_f32_sdwa"
+                                                                                 : "v_ceil_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1251,7 +1454,15 @@ VRndneF32Vop1::VRndneF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_rndne_f32_sdwa"
+          : "v_rndne_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1300,7 +1511,15 @@ VFloorF32Vop1::VFloorF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_floor_f32_sdwa"
+          : "v_floor_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1349,7 +1568,14 @@ VExpF32Vop1::VExpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_exp_f32_sdwa"
+                                                                                 : "v_exp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1398,7 +1624,14 @@ VLogF32Vop1::VLogF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_log_f32_sdwa"
+                                                                                 : "v_log_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1447,7 +1680,14 @@ VRcpF32Vop1::VRcpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rcp_f32_sdwa"
+                                                                                 : "v_rcp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1497,7 +1737,16 @@ VRcpIflagF32Vop1::VRcpIflagF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_rcp_iflag_f32_sdwa"
+          : "v_rcp_iflag_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1546,7 +1795,14 @@ VRsqF32Vop1::VRsqF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rsq_f32_sdwa"
+                                                                                 : "v_rsq_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1565,14 +1821,19 @@ VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_RCP_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_RCP_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_rcp_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support SDWA";
   return std::make_unique<VRcpF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1591,14 +1852,19 @@ VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_RSQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_RSQ_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_rsq_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support SDWA";
   return std::make_unique<VRsqF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1647,7 +1913,14 @@ VSqrtF32Vop1::VSqrtF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sqrt_f32_sdwa"
+                                                                                 : "v_sqrt_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1666,14 +1939,19 @@ VSqrtF64Vop1::VSqrtF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_SQRT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_SQRT_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_sqrt_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support SDWA";
   return std::make_unique<VSqrtF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1722,7 +2000,14 @@ VSinF32Vop1::VSinF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sin_f32_sdwa"
+                                                                                 : "v_sin_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1771,7 +2056,14 @@ VCosF32Vop1::VCosF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_cos_f32_sdwa"
+                                                                                 : "v_cos_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1820,7 +2112,14 @@ VNotB32Vop1::VNotB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_not_b32_sdwa"
+                                                                                 : "v_not_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop1>(opcode);
 }
 } // namespace detail
@@ -1869,7 +2168,15 @@ VBfrevB32Vop1::VBfrevB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_bfrev_b32_sdwa"
+          : "v_bfrev_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop1>(opcode);
 }
 } // namespace detail
@@ -1918,7 +2225,14 @@ VFfbhU32Vop1::VFfbhU32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhU32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFfbhU32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ffbh_u32_sdwa"
+                                                                                 : "v_ffbh_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhU32Vop1>(opcode);
 }
 } // namespace detail
@@ -1967,7 +2281,14 @@ VFfblB32Vop1::VFfblB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfblB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFfblB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ffbl_b32_sdwa"
+                                                                                 : "v_ffbl_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfblB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2016,7 +2337,14 @@ VFfbhI32Vop1::VFfbhI32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhI32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFfbhI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ffbh_i32_sdwa"
+                                                                                 : "v_ffbh_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhI32Vop1>(opcode);
 }
 } // namespace detail
@@ -2043,12 +2371,18 @@ VFrexpExpI32F64Vop1::VFrexpExpI32F64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FREXP_EXP_I32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_frexp_exp_i32_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_EXP_I32_F64 does not support SDWA";
   return std::make_unique<VFrexpExpI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -2075,12 +2409,18 @@ VFrexpMantF64Vop1::VFrexpMantF64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FREXP_MANT_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_frexp_mant_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_MANT_F64 does not support SDWA";
   return std::make_unique<VFrexpMantF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2107,12 +2447,17 @@ VFractF64Vop1::VFractF64Vop1(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FRACT_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_fract_f64_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FRACT_F64 does not support SDWA";
   return std::make_unique<VFractF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2162,7 +2507,16 @@ VFrexpExpI32F32Vop1::VFrexpExpI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_exp_i32_f32_sdwa"
+          : "v_frexp_exp_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -2212,7 +2566,16 @@ VFrexpMantF32Vop1::VFrexpMantF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_mant_f32_sdwa"
+          : "v_frexp_mant_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop1>(opcode);
 }
 } // namespace detail
@@ -2225,7 +2588,11 @@ VClrexcpVop1::VClrexcpVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClrexcpVop1(const MachineInst *opcode) {
+DecodeResult decodeVClrexcpVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop1::validate_encoding(
+      "v_clrexcp_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClrexcpVop1>(opcode);
 }
 } // namespace detail
@@ -2275,7 +2642,16 @@ VScreenPartition4seB32Vop1::VScreenPartition4seB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVScreenPartition4seB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVScreenPartition4seB32Vop1(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_screen_partition_4se_b32_sdwa"
+          : "v_screen_partition_4se_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VScreenPartition4seB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2325,7 +2701,14 @@ VMovB64Vop1::VMovB64Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovB64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mov_b64_sdwa"
+                                                                                 : "v_mov_b64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB64Vop1>(opcode);
 }
 } // namespace detail
@@ -2376,7 +2759,15 @@ VCvtF16U16Vop1::VCvtF16U16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f16_u16_sdwa"
+          : "v_cvt_f16_u16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop1>(opcode);
 }
 } // namespace detail
@@ -2433,7 +2824,15 @@ VCvtF16I16Vop1::VCvtF16I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f16_i16_sdwa"
+          : "v_cvt_f16_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop1>(opcode);
 }
 } // namespace detail
@@ -2490,7 +2889,15 @@ VCvtU16F16Vop1::VCvtU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_u16_f16_sdwa"
+          : "v_cvt_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2547,7 +2954,15 @@ VCvtI16F16Vop1::VCvtI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_i16_f16_sdwa"
+          : "v_cvt_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2603,7 +3018,14 @@ VRcpF16Vop1::VRcpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rcp_f16_sdwa"
+                                                                                 : "v_rcp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2659,7 +3081,14 @@ VSqrtF16Vop1::VSqrtF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sqrt_f16_sdwa"
+                                                                                 : "v_sqrt_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2715,7 +3144,14 @@ VRsqF16Vop1::VRsqF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rsq_f16_sdwa"
+                                                                                 : "v_rsq_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2771,7 +3207,14 @@ VLogF16Vop1::VLogF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_log_f16_sdwa"
+                                                                                 : "v_log_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2827,7 +3270,14 @@ VExpF16Vop1::VExpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_exp_f16_sdwa"
+                                                                                 : "v_exp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2884,7 +3334,16 @@ VFrexpMantF16Vop1::VFrexpMantF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_mant_f16_sdwa"
+          : "v_frexp_mant_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2941,7 +3400,16 @@ VFrexpExpI16F16Vop1::VFrexpExpI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_exp_i16_f16_sdwa"
+          : "v_frexp_exp_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2997,7 +3465,15 @@ VFloorF16Vop1::VFloorF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_floor_f16_sdwa"
+          : "v_floor_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3053,7 +3529,14 @@ VCeilF16Vop1::VCeilF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ceil_f16_sdwa"
+                                                                                 : "v_ceil_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3109,7 +3592,15 @@ VTruncF16Vop1::VTruncF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_trunc_f16_sdwa"
+          : "v_trunc_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3165,7 +3656,15 @@ VRndneF16Vop1::VRndneF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_rndne_f16_sdwa"
+          : "v_rndne_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3221,7 +3720,15 @@ VFractF16Vop1::VFractF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_fract_f16_sdwa"
+          : "v_fract_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3277,7 +3784,14 @@ VSinF16Vop1::VSinF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sin_f16_sdwa"
+                                                                                 : "v_sin_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3333,7 +3847,14 @@ VCosF16Vop1::VCosF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_cos_f16_sdwa"
+                                                                                 : "v_cos_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3389,7 +3910,16 @@ VExpLegacyF32Vop1::VExpLegacyF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpLegacyF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpLegacyF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_exp_legacy_f32_sdwa"
+          : "v_exp_legacy_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpLegacyF32Vop1>(opcode);
 }
 } // namespace detail
@@ -3439,7 +3969,16 @@ VLogLegacyF32Vop1::VLogLegacyF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogLegacyF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogLegacyF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_log_legacy_f32_sdwa"
+          : "v_log_legacy_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogLegacyF32Vop1>(opcode);
 }
 } // namespace detail
@@ -3490,7 +4029,16 @@ VCvtNormI16F16Vop1::VCvtNormI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_norm_i16_f16_sdwa"
+          : "v_cvt_norm_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3547,7 +4095,16 @@ VCvtNormU16F16Vop1::VCvtNormU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_norm_u16_f16_sdwa"
+          : "v_cvt_norm_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3603,7 +4160,16 @@ VSatPkU8I16Vop1::VSatPkU8I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_sat_pk_u8_i16_sdwa"
+          : "v_sat_pk_u8_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop1>(opcode);
 }
 } // namespace detail
@@ -3625,14 +4191,19 @@ VSwapB32Vop1::VSwapB32Vop1(const MachineInst *inst)
   src_operands_[1] = &src0;
   num_src_ = 2;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_SWAP_B32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_SWAP_B32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_swap_b32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B32 does not support SDWA";
   return std::make_unique<VSwapB32Vop1>(opcode);
 }
 } // namespace detail
@@ -3684,7 +4255,16 @@ VAccvgprMovB32Vop1::VAccvgprMovB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAccvgprMovB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVAccvgprMovB32Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_accvgpr_mov_b32_sdwa"
+          : "v_accvgpr_mov_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAccvgprMovB32Vop1>(opcode);
 }
 } // namespace detail
@@ -3734,7 +4314,15 @@ VCvtF32Fp8Vop1::VCvtF32Fp8Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Fp8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Fp8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_fp8_sdwa"
+          : "v_cvt_f32_fp8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Fp8Vop1>(opcode);
 }
 } // namespace detail
@@ -3784,7 +4372,15 @@ VCvtF32Bf8Vop1::VCvtF32Bf8Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Bf8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Bf8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_bf8_sdwa"
+          : "v_cvt_f32_bf8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Bf8Vop1>(opcode);
 }
 } // namespace detail
@@ -3835,7 +4431,16 @@ VCvtPkF32Fp8Vop1::VCvtPkF32Fp8Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF32Fp8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF32Fp8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_pk_f32_fp8_sdwa"
+          : "v_cvt_pk_f32_fp8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkF32Fp8Vop1>(opcode);
 }
 } // namespace detail
@@ -3886,7 +4491,16 @@ VCvtPkF32Bf8Vop1::VCvtPkF32Bf8Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF32Bf8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF32Bf8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_pk_f32_bf8_sdwa"
+          : "v_cvt_pk_f32_bf8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkF32Bf8Vop1>(opcode);
 }
 } // namespace detail
@@ -3935,7 +4549,14 @@ VPrngB32Vop1::VPrngB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPrngB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVPrngB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_prng_b32_sdwa"
+                                                                                 : "v_prng_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPrngB32Vop1>(opcode);
 }
 } // namespace detail
@@ -3951,14 +4572,20 @@ VPermlane16SwapB32Vop1::VPermlane16SwapB32Vop1(const MachineInst *inst)
   src_operands_[1] = &src0;
   num_src_ = 2;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_PERMLANE16_SWAP_B32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_PERMLANE16_SWAP_B32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlane16SwapB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVPermlane16SwapB32Vop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_permlane16_swap_b32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE16_SWAP_B32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE16_SWAP_B32 does not support SDWA";
   return std::make_unique<VPermlane16SwapB32Vop1>(opcode);
 }
 } // namespace detail
@@ -3974,14 +4601,20 @@ VPermlane32SwapB32Vop1::VPermlane32SwapB32Vop1(const MachineInst *inst)
   src_operands_[1] = &src0;
   num_src_ = 2;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_PERMLANE32_SWAP_B32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_PERMLANE32_SWAP_B32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlane32SwapB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVPermlane32SwapB32Vop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      "v_permlane32_swap_b32_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE32_SWAP_B32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE32_SWAP_B32 does not support SDWA";
   return std::make_unique<VPermlane32SwapB32Vop1>(opcode);
 }
 } // namespace detail
@@ -4032,7 +4665,16 @@ VCvtF32Bf16Vop1::VCvtF32Bf16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Bf16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Bf16Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_bf16_sdwa"
+          : "v_cvt_f32_bf16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Bf16Vop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vop2.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/vop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -67,7 +66,16 @@ VCndmaskB32Vop2::VCndmaskB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cndmask_b32_sdwa"
+          : "v_cndmask_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop2>(opcode);
 }
 } // namespace detail
@@ -122,7 +130,14 @@ VAddF32Vop2::VAddF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_f32_sdwa"
+                                                                                 : "v_add_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop2>(opcode);
 }
 } // namespace detail
@@ -177,7 +192,14 @@ VSubF32Vop2::VSubF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_f32_sdwa"
+                                                                                 : "v_sub_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop2>(opcode);
 }
 } // namespace detail
@@ -233,7 +255,15 @@ VSubrevF32Vop2::VSubrevF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_f32_sdwa"
+          : "v_subrev_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop2>(opcode);
 }
 } // namespace detail
@@ -263,12 +293,17 @@ VFmacF64Vop2::VFmacF64Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAC_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_fmac_f64_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_F64 does not support SDWA";
   return std::make_unique<VFmacF64Vop2>(opcode);
 }
 } // namespace detail
@@ -323,7 +358,14 @@ VMulF32Vop2::VMulF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mul_f32_sdwa"
+                                                                                 : "v_mul_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop2>(opcode);
 }
 } // namespace detail
@@ -379,7 +421,15 @@ VMulI32I24Vop2::VMulI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_i32_i24_sdwa"
+          : "v_mul_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -435,7 +485,16 @@ VMulHiI32I24Vop2::VMulHiI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_hi_i32_i24_sdwa"
+          : "v_mul_hi_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -491,7 +550,15 @@ VMulU32U24Vop2::VMulU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_u32_u24_sdwa"
+          : "v_mul_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -547,7 +614,16 @@ VMulHiU32U24Vop2::VMulHiU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_hi_u32_u24_sdwa"
+          : "v_mul_hi_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -602,7 +678,14 @@ VMinF32Vop2::VMinF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_f32_sdwa"
+                                                                                 : "v_min_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF32Vop2>(opcode);
 }
 } // namespace detail
@@ -657,7 +740,14 @@ VMaxF32Vop2::VMaxF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_f32_sdwa"
+                                                                                 : "v_max_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF32Vop2>(opcode);
 }
 } // namespace detail
@@ -712,7 +802,14 @@ VMinI32Vop2::VMinI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_i32_sdwa"
+                                                                                 : "v_min_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop2>(opcode);
 }
 } // namespace detail
@@ -767,7 +864,14 @@ VMaxI32Vop2::VMaxI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_i32_sdwa"
+                                                                                 : "v_max_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop2>(opcode);
 }
 } // namespace detail
@@ -822,7 +926,14 @@ VMinU32Vop2::VMinU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_u32_sdwa"
+                                                                                 : "v_min_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop2>(opcode);
 }
 } // namespace detail
@@ -877,7 +988,14 @@ VMaxU32Vop2::VMaxU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_u32_sdwa"
+                                                                                 : "v_max_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop2>(opcode);
 }
 } // namespace detail
@@ -933,7 +1051,16 @@ VLshrrevB32Vop2::VLshrrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshrrev_b32_sdwa"
+          : "v_lshrrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -989,7 +1116,16 @@ VAshrrevI32Vop2::VAshrrevI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_ashrrev_i32_sdwa"
+          : "v_ashrrev_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop2>(opcode);
 }
 } // namespace detail
@@ -1045,7 +1181,16 @@ VLshlrevB32Vop2::VLshlrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshlrev_b32_sdwa"
+          : "v_lshlrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1100,7 +1245,14 @@ VAndB32Vop2::VAndB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_and_b32_sdwa"
+                                                                                 : "v_and_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1155,7 +1307,14 @@ VOrB32Vop2::VOrB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_or_b32_sdwa"
+                                                                                 : "v_or_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1210,7 +1369,14 @@ VXorB32Vop2::VXorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_xor_b32_sdwa"
+                                                                                 : "v_xor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1239,12 +1405,18 @@ VDot2cF32Bf16Vop2::VDot2cF32Bf16Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT2C_F32_BF16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cF32Bf16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot2cF32Bf16Vop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_dot2c_f32_bf16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT2C_F32_BF16 does not support SDWA";
   return std::make_unique<VDot2cF32Bf16Vop2>(opcode);
 }
 } // namespace detail
@@ -1269,15 +1441,20 @@ VFmamkF32Vop2::VFmamkF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_FMAMK_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAMK_F32 does not support SDWA", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmamkF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmamkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_fmamk_f32_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F32 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F32 does not support SDWA";
   return std::make_unique<VFmamkF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1302,15 +1479,20 @@ VFmaakF32Vop2::VFmaakF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_FMAAK_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAAK_F32 does not support SDWA", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaakF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmaakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_fmaak_f32_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F32 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F32 does not support SDWA";
   return std::make_unique<VFmaakF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1369,7 +1551,15 @@ VAddCoU32Vop2::VAddCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_add_co_u32_sdwa"
+          : "v_add_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1428,7 +1618,15 @@ VSubCoU32Vop2::VSubCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_sub_co_u32_sdwa"
+          : "v_sub_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1487,7 +1685,16 @@ VSubrevCoU32Vop2::VSubrevCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_co_u32_sdwa"
+          : "v_subrev_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1549,7 +1756,15 @@ VAddcCoU32Vop2::VAddcCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddcCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddcCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_addc_co_u32_sdwa"
+          : "v_addc_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddcCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1611,7 +1826,15 @@ VSubbCoU32Vop2::VSubbCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubbCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubbCoU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subb_co_u32_sdwa"
+          : "v_subb_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubbCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1673,7 +1896,16 @@ VSubbrevCoU32Vop2::VSubbrevCoU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubbrevCoU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubbrevCoU32Vop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subbrev_co_u32_sdwa"
+          : "v_subbrev_co_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubbrevCoU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1729,7 +1961,14 @@ VAddF16Vop2::VAddF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_f16_sdwa"
+                                                                                 : "v_add_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1791,7 +2030,14 @@ VSubF16Vop2::VSubF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_f16_sdwa"
+                                                                                 : "v_sub_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1854,7 +2100,15 @@ VSubrevF16Vop2::VSubrevF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_f16_sdwa"
+          : "v_subrev_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1916,7 +2170,14 @@ VMulF16Vop2::VMulF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mul_f16_sdwa"
+                                                                                 : "v_mul_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1952,12 +2213,17 @@ VMacF16Vop2::VMacF16Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MAC_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_mac_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MAC_F16 does not support SDWA";
   return std::make_unique<VMacF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1990,15 +2256,20 @@ VMadmkF16Vop2::VMadmkF16Vop2(const MachineInst *inst)
       Operand(16, OperandType::OPR_SIMM32,
               static_cast<int>(
                   (reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_MADMK_F16 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MADMK_F16 does not support SDWA", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadmkF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMadmkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_madmk_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_MADMK_F16 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MADMK_F16 does not support SDWA";
   return std::make_unique<VMadmkF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2031,15 +2302,20 @@ VMadakF16Vop2::VMadakF16Vop2(const MachineInst *inst)
       Operand(16, OperandType::OPR_SIMM32,
               static_cast<int>(
                   (reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_MADAK_F16 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MADAK_F16 does not support SDWA", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadakF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMadakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_madak_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_MADAK_F16 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MADAK_F16 does not support SDWA";
   return std::make_unique<VMadakF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2101,7 +2377,14 @@ VAddU16Vop2::VAddU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_u16_sdwa"
+                                                                                 : "v_add_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2163,7 +2446,14 @@ VSubU16Vop2::VSubU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_u16_sdwa"
+                                                                                 : "v_sub_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2226,7 +2516,15 @@ VSubrevU16Vop2::VSubrevU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_u16_sdwa"
+          : "v_subrev_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2289,7 +2587,15 @@ VMulLoU16Vop2::VMulLoU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_lo_u16_sdwa"
+          : "v_mul_lo_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2352,7 +2658,16 @@ VLshlrevB16Vop2::VLshlrevB16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB16Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshlrev_b16_sdwa"
+          : "v_lshlrev_b16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB16Vop2>(opcode);
 }
 } // namespace detail
@@ -2415,7 +2730,16 @@ VLshrrevB16Vop2::VLshrrevB16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB16Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshrrev_b16_sdwa"
+          : "v_lshrrev_b16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB16Vop2>(opcode);
 }
 } // namespace detail
@@ -2478,7 +2802,16 @@ VAshrrevI16Vop2::VAshrrevI16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI16Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_ashrrev_i16_sdwa"
+          : "v_ashrrev_i16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI16Vop2>(opcode);
 }
 } // namespace detail
@@ -2540,7 +2873,14 @@ VMaxF16Vop2::VMaxF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_f16_sdwa"
+                                                                                 : "v_max_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2602,7 +2942,14 @@ VMinF16Vop2::VMinF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_f16_sdwa"
+                                                                                 : "v_min_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2664,7 +3011,14 @@ VMaxU16Vop2::VMaxU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_u16_sdwa"
+                                                                                 : "v_max_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2726,7 +3080,14 @@ VMaxI16Vop2::VMaxI16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_i16_sdwa"
+                                                                                 : "v_max_i16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI16Vop2>(opcode);
 }
 } // namespace detail
@@ -2788,7 +3149,14 @@ VMinU16Vop2::VMinU16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinU16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_u16_sdwa"
+                                                                                 : "v_min_u16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU16Vop2>(opcode);
 }
 } // namespace detail
@@ -2850,7 +3218,14 @@ VMinI16Vop2::VMinI16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinI16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_i16_sdwa"
+                                                                                 : "v_min_i16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI16Vop2>(opcode);
 }
 } // namespace detail
@@ -2912,7 +3287,15 @@ VLdexpF16Vop2::VLdexpF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_ldexp_f16_sdwa"
+          : "v_ldexp_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2973,7 +3356,14 @@ VAddU32Vop2::VAddU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_u32_sdwa"
+                                                                                 : "v_add_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddU32Vop2>(opcode);
 }
 } // namespace detail
@@ -3028,7 +3418,14 @@ VSubU32Vop2::VSubU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_u32_sdwa"
+                                                                                 : "v_sub_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubU32Vop2>(opcode);
 }
 } // namespace detail
@@ -3084,7 +3481,15 @@ VSubrevU32Vop2::VSubrevU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_u32_sdwa"
+          : "v_subrev_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevU32Vop2>(opcode);
 }
 } // namespace detail
@@ -3113,12 +3518,18 @@ VDot2cF32F16Vop2::VDot2cF32F16Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT2C_F32_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot2cF32F16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_dot2c_f32_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT2C_F32_F16 does not support SDWA";
   return std::make_unique<VDot2cF32F16Vop2>(opcode);
 }
 } // namespace detail
@@ -3147,12 +3558,18 @@ VDot2cI32I16Vop2::VDot2cI32I16Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT2C_I32_I16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cI32I16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot2cI32I16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_dot2c_i32_i16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT2C_I32_I16 does not support SDWA";
   return std::make_unique<VDot2cI32I16Vop2>(opcode);
 }
 } // namespace detail
@@ -3181,12 +3598,18 @@ VDot4cI32I8Vop2::VDot4cI32I8Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT4C_I32_I8 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot4cI32I8Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_dot4c_i32_i8_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT4C_I32_I8 does not support SDWA";
   return std::make_unique<VDot4cI32I8Vop2>(opcode);
 }
 } // namespace detail
@@ -3215,12 +3638,18 @@ VDot8cI32I4Vop2::VDot8cI32I4Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT8C_I32_I4 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8cI32I4Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot8cI32I4Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_dot8c_i32_i4_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT8C_I32_I4 does not support SDWA";
   return std::make_unique<VDot8cI32I4Vop2>(opcode);
 }
 } // namespace detail
@@ -3249,12 +3678,17 @@ VFmacF32Vop2::VFmacF32Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAC_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_fmac_f32_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_F32 does not support SDWA";
   return std::make_unique<VFmacF32Vop2>(opcode);
 }
 } // namespace detail
@@ -3283,12 +3717,17 @@ VPkFmacF16Vop2::VPkFmacF16Vop2(const MachineInst *inst)
     dpp_bank_mask_ = dp->bank_mask;
     dpp_bound_ctrl_ = dp->bound_ctrl;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_PK_FMAC_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      "v_pk_fmac_f16_e32", reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_PK_FMAC_F16 does not support SDWA";
   return std::make_unique<VPkFmacF16Vop2>(opcode);
 }
 } // namespace detail
@@ -3343,7 +3782,14 @@ VXnorB32Vop2::VXnorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_xnor_b32_sdwa"
+                                                                                 : "v_xnor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vop3.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/vop3.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -21,7 +20,11 @@ VNopVop3::VNopVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode) {
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_nop", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop3>(opcode);
 }
 } // namespace detail
@@ -38,7 +41,11 @@ VMovB32Vop3::VMovB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mov_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop3>(opcode);
 }
 } // namespace detail
@@ -55,7 +62,12 @@ VReadfirstlaneB32Vop3::VReadfirstlaneB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_readfirstlane_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VReadfirstlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -72,7 +84,11 @@ VCvtI32F64Vop3::VCvtI32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_i32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -89,7 +105,11 @@ VCvtF64I32Vop3::VCvtF64I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f64_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF64I32Vop3>(opcode);
 }
 } // namespace detail
@@ -106,7 +126,11 @@ VCvtF32I32Vop3::VCvtF32I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop3>(opcode);
 }
 } // namespace detail
@@ -123,7 +147,11 @@ VCvtF32U32Vop3::VCvtF32U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop3>(opcode);
 }
 } // namespace detail
@@ -140,7 +168,11 @@ VCvtU32F32Vop3::VCvtU32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_u32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -157,7 +189,11 @@ VCvtI32F32Vop3::VCvtI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -174,7 +210,11 @@ VCvtF16F32Vop3::VCvtF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -197,7 +237,11 @@ VCvtF32F16Vop3::VCvtF32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -214,7 +258,12 @@ VCvtRpiI32F32Vop3::VCvtRpiI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtRpiI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_rpi_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtRpiI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -231,7 +280,12 @@ VCvtFlrI32F32Vop3::VCvtFlrI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtFlrI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_flr_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFlrI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -248,7 +302,12 @@ VCvtOffF32I4Vop3::VCvtOffF32I4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_off_f32_i4", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop3>(opcode);
 }
 } // namespace detail
@@ -265,7 +324,11 @@ VCvtF32F64Vop3::VCvtF32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -282,7 +345,11 @@ VCvtF64F32Vop3::VCvtF64F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f64_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF64F32Vop3>(opcode);
 }
 } // namespace detail
@@ -299,7 +366,12 @@ VCvtF32Ubyte0Vop3::VCvtF32Ubyte0Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte0", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop3>(opcode);
 }
 } // namespace detail
@@ -316,7 +388,12 @@ VCvtF32Ubyte1Vop3::VCvtF32Ubyte1Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte1", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop3>(opcode);
 }
 } // namespace detail
@@ -333,7 +410,12 @@ VCvtF32Ubyte2Vop3::VCvtF32Ubyte2Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte2", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop3>(opcode);
 }
 } // namespace detail
@@ -350,7 +432,12 @@ VCvtF32Ubyte3Vop3::VCvtF32Ubyte3Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte3", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop3>(opcode);
 }
 } // namespace detail
@@ -367,7 +454,11 @@ VCvtU32F64Vop3::VCvtU32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_u32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -384,7 +475,11 @@ VCvtF64U32Vop3::VCvtF64U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f64_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF64U32Vop3>(opcode);
 }
 } // namespace detail
@@ -401,7 +496,11 @@ VTruncF64Vop3::VTruncF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trunc_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF64Vop3>(opcode);
 }
 } // namespace detail
@@ -418,7 +517,11 @@ VCeilF64Vop3::VCeilF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ceil_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF64Vop3>(opcode);
 }
 } // namespace detail
@@ -435,7 +538,11 @@ VRndneF64Vop3::VRndneF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rndne_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF64Vop3>(opcode);
 }
 } // namespace detail
@@ -452,7 +559,11 @@ VFloorF64Vop3::VFloorF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_floor_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF64Vop3>(opcode);
 }
 } // namespace detail
@@ -469,7 +580,11 @@ VFractF32Vop3::VFractF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fract_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop3>(opcode);
 }
 } // namespace detail
@@ -486,7 +601,11 @@ VTruncF32Vop3::VTruncF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trunc_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop3>(opcode);
 }
 } // namespace detail
@@ -503,7 +622,11 @@ VCeilF32Vop3::VCeilF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ceil_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop3>(opcode);
 }
 } // namespace detail
@@ -520,7 +643,11 @@ VRndneF32Vop3::VRndneF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rndne_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop3>(opcode);
 }
 } // namespace detail
@@ -537,7 +664,11 @@ VFloorF32Vop3::VFloorF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_floor_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop3>(opcode);
 }
 } // namespace detail
@@ -554,7 +685,11 @@ VExpF32Vop3::VExpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_exp_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -571,7 +706,11 @@ VLogF32Vop3::VLogF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_log_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop3>(opcode);
 }
 } // namespace detail
@@ -588,7 +727,11 @@ VRcpF32Vop3::VRcpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -605,7 +748,12 @@ VRcpIflagF32Vop3::VRcpIflagF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_iflag_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop3>(opcode);
 }
 } // namespace detail
@@ -622,7 +770,11 @@ VRsqF32Vop3::VRsqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rsq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -639,7 +791,11 @@ VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -656,7 +812,11 @@ VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rsq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -673,7 +833,11 @@ VSqrtF32Vop3::VSqrtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sqrt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -690,7 +854,11 @@ VSqrtF64Vop3::VSqrtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sqrt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -707,7 +875,11 @@ VSinF32Vop3::VSinF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sin_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop3>(opcode);
 }
 } // namespace detail
@@ -724,7 +896,11 @@ VCosF32Vop3::VCosF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cos_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop3>(opcode);
 }
 } // namespace detail
@@ -741,7 +917,11 @@ VNotB32Vop3::VNotB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_not_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop3>(opcode);
 }
 } // namespace detail
@@ -758,7 +938,11 @@ VBfrevB32Vop3::VBfrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfrev_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -775,7 +959,11 @@ VFfbhU32Vop3::VFfbhU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFfbhU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ffbh_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhU32Vop3>(opcode);
 }
 } // namespace detail
@@ -792,7 +980,11 @@ VFfblB32Vop3::VFfblB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfblB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFfblB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ffbl_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfblB32Vop3>(opcode);
 }
 } // namespace detail
@@ -809,7 +1001,11 @@ VFfbhI32Vop3::VFfbhI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFfbhI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ffbh_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhI32Vop3>(opcode);
 }
 } // namespace detail
@@ -826,7 +1022,12 @@ VFrexpExpI32F64Vop3::VFrexpExpI32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_exp_i32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -843,7 +1044,12 @@ VFrexpMantF64Vop3::VFrexpMantF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_mant_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF64Vop3>(opcode);
 }
 } // namespace detail
@@ -860,7 +1066,11 @@ VFractF64Vop3::VFractF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fract_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF64Vop3>(opcode);
 }
 } // namespace detail
@@ -877,7 +1087,12 @@ VFrexpExpI32F32Vop3::VFrexpExpI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_exp_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -894,7 +1109,12 @@ VFrexpMantF32Vop3::VFrexpMantF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_mant_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop3>(opcode);
 }
 } // namespace detail
@@ -907,7 +1127,11 @@ VClrexcpVop3::VClrexcpVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClrexcpVop3(const MachineInst *opcode) {
+DecodeResult decodeVClrexcpVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_clrexcp", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClrexcpVop3>(opcode);
 }
 } // namespace detail
@@ -924,7 +1148,12 @@ VScreenPartition4seB32Vop3::VScreenPartition4seB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVScreenPartition4seB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVScreenPartition4seB32Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_screen_partition_4se_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VScreenPartition4seB32Vop3>(opcode);
 }
 } // namespace detail
@@ -941,7 +1170,11 @@ VMovB64Vop3::VMovB64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mov_b64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB64Vop3>(opcode);
 }
 } // namespace detail
@@ -958,7 +1191,11 @@ VCvtF16U16Vop3::VCvtF16U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f16_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop3>(opcode);
 }
 } // namespace detail
@@ -981,7 +1218,11 @@ VCvtF16I16Vop3::VCvtF16I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f16_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop3>(opcode);
 }
 } // namespace detail
@@ -1004,7 +1245,11 @@ VCvtU16F16Vop3::VCvtU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_u16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1027,7 +1272,11 @@ VCvtI16F16Vop3::VCvtI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1050,7 +1299,11 @@ VRcpF16Vop3::VRcpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1073,7 +1326,11 @@ VSqrtF16Vop3::VSqrtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sqrt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1096,7 +1353,11 @@ VRsqF16Vop3::VRsqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rsq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1119,7 +1380,11 @@ VLogF16Vop3::VLogF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_log_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1142,7 +1407,11 @@ VExpF16Vop3::VExpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_exp_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1165,7 +1434,12 @@ VFrexpMantF16Vop3::VFrexpMantF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_mant_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1188,7 +1462,12 @@ VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_exp_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1211,7 +1490,11 @@ VFloorF16Vop3::VFloorF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_floor_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1234,7 +1517,11 @@ VCeilF16Vop3::VCeilF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ceil_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1257,7 +1544,11 @@ VTruncF16Vop3::VTruncF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trunc_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1280,7 +1571,11 @@ VRndneF16Vop3::VRndneF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rndne_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1303,7 +1598,11 @@ VFractF16Vop3::VFractF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fract_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1326,7 +1625,11 @@ VSinF16Vop3::VSinF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sin_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1349,7 +1652,11 @@ VCosF16Vop3::VCosF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cos_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1372,7 +1679,12 @@ VExpLegacyF32Vop3::VExpLegacyF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpLegacyF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_exp_legacy_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpLegacyF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1389,7 +1701,12 @@ VLogLegacyF32Vop3::VLogLegacyF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogLegacyF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_log_legacy_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogLegacyF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1406,7 +1723,12 @@ VCvtNormI16F16Vop3::VCvtNormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_norm_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1429,7 +1751,12 @@ VCvtNormU16F16Vop3::VCvtNormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_norm_u16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1452,7 +1779,12 @@ VSatPkU8I16Vop3::VSatPkU8I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sat_pk_u8_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop3>(opcode);
 }
 } // namespace detail
@@ -1477,7 +1809,11 @@ VSwapB32Vop3::VSwapB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwapB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSwapB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_swap_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSwapB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1500,7 +1836,12 @@ VAccvgprMovB32Vop3::VAccvgprMovB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAccvgprMovB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAccvgprMovB32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_accvgpr_mov_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAccvgprMovB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1517,7 +1858,11 @@ VCvtF32Fp8Vop3::VCvtF32Fp8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Fp8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Fp8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_fp8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Fp8Vop3>(opcode);
 }
 } // namespace detail
@@ -1534,7 +1879,11 @@ VCvtF32Bf8Vop3::VCvtF32Bf8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Bf8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Bf8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_bf8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Bf8Vop3>(opcode);
 }
 } // namespace detail
@@ -1551,7 +1900,12 @@ VCvtPkF32Fp8Vop3::VCvtPkF32Fp8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF32Fp8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF32Fp8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_f32_fp8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkF32Fp8Vop3>(opcode);
 }
 } // namespace detail
@@ -1568,7 +1922,12 @@ VCvtPkF32Bf8Vop3::VCvtPkF32Bf8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF32Bf8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF32Bf8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_f32_bf8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkF32Bf8Vop3>(opcode);
 }
 } // namespace detail
@@ -1585,7 +1944,11 @@ VPrngB32Vop3::VPrngB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPrngB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPrngB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_prng_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPrngB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1604,7 +1967,12 @@ VPermlane16SwapB32Vop3::VPermlane16SwapB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlane16SwapB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlane16SwapB32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_permlane16_swap_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPermlane16SwapB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1623,7 +1991,12 @@ VPermlane32SwapB32Vop3::VPermlane32SwapB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlane32SwapB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlane32SwapB32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_permlane32_swap_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPermlane32SwapB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1640,7 +2013,12 @@ VCvtF32Bf16Vop3::VCvtF32Bf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Bf16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_bf16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -1661,7 +2039,12 @@ VCndmaskB32Vop3::VCndmaskB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cndmask_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1680,7 +2063,11 @@ VAddF32Vop3::VAddF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1699,7 +2086,11 @@ VSubF32Vop3::VSubF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1718,7 +2109,11 @@ VSubrevF32Vop3::VSubrevF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1738,7 +2133,11 @@ VFmacF64Vop3::VFmacF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fmac_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1757,7 +2156,11 @@ VMulF32Vop3::VMulF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1776,7 +2179,11 @@ VMulI32I24Vop3::VMulI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_i32_i24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -1795,7 +2202,12 @@ VMulHiI32I24Vop3::VMulHiI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_i32_i24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -1814,7 +2226,11 @@ VMulU32U24Vop3::VMulU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_u32_u24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -1833,7 +2249,12 @@ VMulHiU32U24Vop3::VMulHiU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_u32_u24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -1852,7 +2273,11 @@ VMinF32Vop3::VMinF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1871,7 +2296,11 @@ VMaxF32Vop3::VMaxF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1890,7 +2319,11 @@ VMinI32Vop3::VMinI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop3>(opcode);
 }
 } // namespace detail
@@ -1909,7 +2342,11 @@ VMaxI32Vop3::VMaxI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop3>(opcode);
 }
 } // namespace detail
@@ -1928,7 +2365,11 @@ VMinU32Vop3::VMinU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop3>(opcode);
 }
 } // namespace detail
@@ -1947,7 +2388,11 @@ VMaxU32Vop3::VMaxU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop3>(opcode);
 }
 } // namespace detail
@@ -1966,7 +2411,12 @@ VLshrrevB32Vop3::VLshrrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshrrev_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1985,7 +2435,12 @@ VAshrrevI32Vop3::VAshrrevI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashrrev_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop3>(opcode);
 }
 } // namespace detail
@@ -2004,7 +2459,12 @@ VLshlrevB32Vop3::VLshlrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshlrev_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2023,7 +2483,11 @@ VAndB32Vop3::VAndB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_and_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2042,7 +2506,11 @@ VOrB32Vop3::VOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_or_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2061,7 +2529,11 @@ VXorB32Vop3::VXorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xor_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2081,7 +2553,12 @@ VDot2cF32Bf16Vop3::VDot2cF32Bf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cF32Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot2cF32Bf16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot2c_f32_bf16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2cF32Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -2100,7 +2577,11 @@ VAddF16Vop3::VAddF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2125,7 +2606,11 @@ VSubF16Vop3::VSubF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2150,7 +2635,11 @@ VSubrevF16Vop3::VSubrevF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2175,7 +2664,11 @@ VMulF16Vop3::VMulF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2201,7 +2694,11 @@ VMacF16Vop3::VMacF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMacF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mac_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMacF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2226,7 +2723,11 @@ VAddU16Vop3::VAddU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2251,7 +2752,11 @@ VSubU16Vop3::VSubU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2276,7 +2781,11 @@ VSubrevU16Vop3::VSubrevU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2301,7 +2810,11 @@ VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_lo_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2326,7 +2839,12 @@ VLshlrevB16Vop3::VLshlrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshlrev_b16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -2351,7 +2869,12 @@ VLshrrevB16Vop3::VLshrrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshrrev_b16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -2376,7 +2899,12 @@ VAshrrevI16Vop3::VAshrrevI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashrrev_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI16Vop3>(opcode);
 }
 } // namespace detail
@@ -2401,7 +2929,11 @@ VMaxF16Vop3::VMaxF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2426,7 +2958,11 @@ VMinF16Vop3::VMinF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2451,7 +2987,11 @@ VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2476,7 +3016,11 @@ VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI16Vop3>(opcode);
 }
 } // namespace detail
@@ -2501,7 +3045,11 @@ VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2526,7 +3074,11 @@ VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI16Vop3>(opcode);
 }
 } // namespace detail
@@ -2551,7 +3103,11 @@ VLdexpF16Vop3::VLdexpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ldexp_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2576,7 +3132,11 @@ VAddU32Vop3::VAddU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2595,7 +3155,11 @@ VSubU32Vop3::VSubU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2614,7 +3178,11 @@ VSubrevU32Vop3::VSubrevU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2634,7 +3202,12 @@ VDot2cF32F16Vop3::VDot2cF32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot2cF32F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot2c_f32_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2cF32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -2654,7 +3227,12 @@ VDot2cI32I16Vop3::VDot2cI32I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cI32I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot2cI32I16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot2c_i32_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2cI32I16Vop3>(opcode);
 }
 } // namespace detail
@@ -2674,7 +3252,12 @@ VDot4cI32I8Vop3::VDot4cI32I8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot4cI32I8Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot4c_i32_i8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot4cI32I8Vop3>(opcode);
 }
 } // namespace detail
@@ -2694,7 +3277,12 @@ VDot8cI32I4Vop3::VDot8cI32I4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8cI32I4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot8cI32I4Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot8c_i32_i4", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot8cI32I4Vop3>(opcode);
 }
 } // namespace detail
@@ -2714,7 +3302,11 @@ VFmacF32Vop3::VFmacF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fmac_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2734,7 +3326,11 @@ VPkFmacF16Vop3::VPkFmacF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPkFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_pk_fmac_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkFmacF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2753,7 +3349,11 @@ VXnorB32Vop3::VXnorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xnor_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2774,7 +3374,11 @@ VMadI32I24Vop3::VMadI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_i32_i24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -2795,7 +3399,11 @@ VMadU32U24Vop3::VMadU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_u32_u24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -2816,7 +3424,11 @@ VCubeidF32Vop3::VCubeidF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubeid_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubeidF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2837,7 +3449,11 @@ VCubescF32Vop3::VCubescF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubesc_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubescF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2858,7 +3474,11 @@ VCubetcF32Vop3::VCubetcF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubetc_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubetcF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2879,7 +3499,11 @@ VCubemaF32Vop3::VCubemaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubema_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubemaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2900,7 +3524,11 @@ VBfeU32Vop3::VBfeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfe_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2921,7 +3549,11 @@ VBfeI32Vop3::VBfeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfe_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -2942,7 +3574,11 @@ VBfiB32Vop3::VBfiB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfi_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfiB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2963,7 +3599,11 @@ VFmaF32Vop3::VFmaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2984,7 +3624,11 @@ VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF64Vop3>(opcode);
 }
 } // namespace detail
@@ -3005,7 +3649,11 @@ VLerpU8Vop3::VLerpU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lerp_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLerpU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3026,7 +3674,12 @@ VAlignbitB32Vop3::VAlignbitB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_alignbit_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbitB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3047,7 +3700,12 @@ VAlignbyteB32Vop3::VAlignbyteB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_alignbyte_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbyteB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3068,7 +3726,11 @@ VMin3F32Vop3::VMin3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3089,7 +3751,11 @@ VMin3I32Vop3::VMin3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -3110,7 +3776,11 @@ VMin3U32Vop3::VMin3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3131,7 +3801,11 @@ VMax3F32Vop3::VMax3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3152,7 +3826,11 @@ VMax3I32Vop3::VMax3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -3173,7 +3851,11 @@ VMax3U32Vop3::VMax3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3194,7 +3876,11 @@ VMed3F32Vop3::VMed3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3215,7 +3901,11 @@ VMed3I32Vop3::VMed3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -3236,7 +3926,11 @@ VMed3U32Vop3::VMed3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3257,7 +3951,11 @@ VSadU8Vop3::VSadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3278,7 +3976,11 @@ VSadHiU8Vop3::VSadHiU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_hi_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadHiU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3299,7 +4001,11 @@ VSadU16Vop3::VSadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -3320,7 +4026,11 @@ VSadU32Vop3::VSadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3341,7 +4051,12 @@ VCvtPkU8F32Vop3::VCvtPkU8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_u8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3362,7 +4077,12 @@ VDivFixupF32Vop3::VDivFixupF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3383,7 +4103,12 @@ VDivFixupF64Vop3::VDivFixupF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF64Vop3>(opcode);
 }
 } // namespace detail
@@ -3407,7 +4132,12 @@ VDivFmasF32Vop3::VDivFmasF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fmas_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFmasF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3431,7 +4161,12 @@ VDivFmasF64Vop3::VDivFmasF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fmas_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFmasF64Vop3>(opcode);
 }
 } // namespace detail
@@ -3452,7 +4187,11 @@ VMsadU8Vop3::VMsadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_msad_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMsadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3473,7 +4212,12 @@ VQsadPkU16U8Vop3::VQsadPkU16U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_qsad_pk_u16_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VQsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -3494,7 +4238,12 @@ VMqsadPkU16U8Vop3::VMqsadPkU16U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mqsad_pk_u16_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMqsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -3515,7 +4264,12 @@ VMqsadU32U8Vop3::VMqsadU32U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mqsad_u32_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMqsadU32U8Vop3>(opcode);
 }
 } // namespace detail
@@ -3536,7 +4290,12 @@ VMadLegacyF16Vop3::VMadLegacyF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadLegacyF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadLegacyF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_legacy_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadLegacyF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3563,7 +4322,12 @@ VMadLegacyU16Vop3::VMadLegacyU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadLegacyU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadLegacyU16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_legacy_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadLegacyU16Vop3>(opcode);
 }
 } // namespace detail
@@ -3590,7 +4354,12 @@ VMadLegacyI16Vop3::VMadLegacyI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadLegacyI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadLegacyI16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_legacy_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadLegacyI16Vop3>(opcode);
 }
 } // namespace detail
@@ -3617,7 +4386,11 @@ VPermB32Vop3::VPermB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_perm_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPermB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3638,7 +4411,12 @@ VFmaLegacyF16Vop3::VFmaLegacyF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaLegacyF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaLegacyF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_legacy_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaLegacyF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3665,7 +4443,12 @@ VDivFixupLegacyF16Vop3::VDivFixupLegacyF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupLegacyF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupLegacyF16Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_legacy_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupLegacyF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3691,7 +4474,12 @@ VCvtPkaccumU8F32Vop3::VCvtPkaccumU8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkaccumU8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkaccumU8F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pkaccum_u8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkaccumU8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3712,7 +4500,11 @@ VMadU32U16Vop3::VMadU32U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_u32_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3733,7 +4525,11 @@ VMadI32I16Vop3::VMadI32I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_i32_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3754,7 +4550,11 @@ VXadU32Vop3::VXadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xad_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3775,7 +4575,11 @@ VMin3F16Vop3::VMin3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3802,7 +4606,11 @@ VMin3I16Vop3::VMin3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3829,7 +4637,11 @@ VMin3U16Vop3::VMin3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3856,7 +4668,11 @@ VMax3F16Vop3::VMax3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3883,7 +4699,11 @@ VMax3I16Vop3::VMax3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3910,7 +4730,11 @@ VMax3U16Vop3::VMax3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3937,7 +4761,11 @@ VMed3F16Vop3::VMed3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3964,7 +4792,11 @@ VMed3I16Vop3::VMed3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3991,7 +4823,11 @@ VMed3U16Vop3::VMed3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -4018,7 +4854,12 @@ VLshlAddU32Vop3::VLshlAddU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshl_add_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlAddU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4039,7 +4880,12 @@ VAddLshlU32Vop3::VAddLshlU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_lshl_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddLshlU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4060,7 +4906,11 @@ VAdd3U32Vop3::VAdd3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAdd3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -4081,7 +4931,11 @@ VLshlOrB32Vop3::VLshlOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshl_or_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4102,7 +4956,11 @@ VAndOrB32Vop3::VAndOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_and_or_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4123,7 +4981,11 @@ VOr3B32Vop3::VOr3B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_or3_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOr3B32Vop3>(opcode);
 }
 } // namespace detail
@@ -4144,7 +5006,11 @@ VMadF16Vop3::VMadF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4171,7 +5037,11 @@ VMadU16Vop3::VMadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -4198,7 +5068,11 @@ VMadI16Vop3::VMadI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI16Vop3>(opcode);
 }
 } // namespace detail
@@ -4225,7 +5099,11 @@ VFmaF16Vop3::VFmaF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4252,7 +5130,12 @@ VDivFixupF16Vop3::VDivFixupF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4279,7 +5162,12 @@ VLshlAddU64Vop3::VLshlAddU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlAddU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlAddU64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshl_add_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlAddU64Vop3>(opcode);
 }
 } // namespace detail
@@ -4300,7 +5188,11 @@ VBitop3B16Vop3::VBitop3B16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBitop3B16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBitop3B16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bitop3_b16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBitop3B16Vop3>(opcode);
 }
 } // namespace detail
@@ -4327,7 +5219,11 @@ VBitop3B32Vop3::VBitop3B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBitop3B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBitop3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bitop3_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBitop3B32Vop3>(opcode);
 }
 } // namespace detail
@@ -4348,7 +5244,12 @@ VCvtScalef32PkFp8F32Vop3::VCvtScalef32PkFp8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32PkFp8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32PkFp8F32Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_pk_fp8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32PkFp8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4375,7 +5276,12 @@ VCvtScalef32PkBf8F32Vop3::VCvtScalef32PkBf8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32PkBf8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32PkBf8F32Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_pk_bf8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32PkBf8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4402,7 +5308,12 @@ VCvtScalef32SrFp8F32Vop3::VCvtScalef32SrFp8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrFp8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrFp8F32Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_sr_fp8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32SrFp8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4429,7 +5340,12 @@ VCvtScalef32SrBf8F32Vop3::VCvtScalef32SrBf8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrBf8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrBf8F32Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_sr_bf8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32SrBf8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4454,7 +5370,12 @@ VCvtScalef32PkF32Fp8Vop3::VCvtScalef32PkF32Fp8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32PkF32Fp8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32PkF32Fp8Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_pk_f32_fp8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32PkF32Fp8Vop3>(opcode);
 }
 } // namespace detail
@@ -4473,7 +5394,12 @@ VCvtScalef32PkF32Bf8Vop3::VCvtScalef32PkF32Bf8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32PkF32Bf8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32PkF32Bf8Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_pk_f32_bf8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32PkF32Bf8Vop3>(opcode);
 }
 } // namespace detail
@@ -4492,7 +5418,12 @@ VCvtScalef32F32Fp8Vop3::VCvtScalef32F32Fp8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32F32Fp8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32F32Fp8Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_f32_fp8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32F32Fp8Vop3>(opcode);
 }
 } // namespace detail
@@ -4511,7 +5442,12 @@ VCvtScalef32F32Bf8Vop3::VCvtScalef32F32Bf8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32F32Bf8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32F32Bf8Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_f32_bf8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32F32Bf8Vop3>(opcode);
 }
 } // namespace detail
@@ -4532,7 +5468,12 @@ VCvtScalef32PkFp4F32Vop3::VCvtScalef32PkFp4F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32PkFp4F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32PkFp4F32Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_pk_fp4_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32PkFp4F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4559,7 +5500,13 @@ VCvtScalef32SrPkFp4F32Vop3::VCvtScalef32SrPkFp4F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPkFp4F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPkFp4F32Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_sr_pk_fp4_f32",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32SrPkFp4F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4584,7 +5531,12 @@ VCvtScalef32PkF32Fp4Vop3::VCvtScalef32PkF32Fp4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32PkF32Fp4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32PkF32Fp4Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_pk_f32_fp4", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32PkF32Fp4Vop3>(opcode);
 }
 } // namespace detail
@@ -4603,7 +5555,12 @@ VCvtScalef32PkFp8F16Vop3::VCvtScalef32PkFp8F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32PkFp8F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32PkFp8F16Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_pk_fp8_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32PkFp8F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4628,7 +5585,12 @@ VCvtScalef32PkBf8F16Vop3::VCvtScalef32PkBf8F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32PkBf8F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32PkBf8F16Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_pk_bf8_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32PkBf8F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4655,7 +5617,12 @@ VCvtScalef32SrFp8F16Vop3::VCvtScalef32SrFp8F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrFp8F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrFp8F16Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_sr_fp8_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32SrFp8F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4682,7 +5649,12 @@ VCvtScalef32SrBf8F16Vop3::VCvtScalef32SrBf8F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrBf8F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrBf8F16Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_sr_bf8_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32SrBf8F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4707,7 +5679,12 @@ VCvtScalef32PkFp8Bf16Vop3::VCvtScalef32PkFp8Bf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32PkFp8Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32PkFp8Bf16Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_pk_fp8_bf16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32PkFp8Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -4732,7 +5709,12 @@ VCvtScalef32PkBf8Bf16Vop3::VCvtScalef32PkBf8Bf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32PkBf8Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32PkBf8Bf16Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_pk_bf8_bf16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32PkBf8Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -4759,7 +5741,12 @@ VCvtScalef32SrFp8Bf16Vop3::VCvtScalef32SrFp8Bf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrFp8Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrFp8Bf16Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_sr_fp8_bf16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32SrFp8Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -4786,7 +5773,12 @@ VCvtScalef32SrBf8Bf16Vop3::VCvtScalef32SrBf8Bf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrBf8Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrBf8Bf16Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_sr_bf8_bf16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32SrBf8Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -4811,7 +5803,12 @@ VCvtScalef32PkF16Fp8Vop3::VCvtScalef32PkF16Fp8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32PkF16Fp8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32PkF16Fp8Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_pk_f16_fp8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32PkF16Fp8Vop3>(opcode);
 }
 } // namespace detail
@@ -4830,7 +5827,12 @@ VCvtScalef32PkF16Bf8Vop3::VCvtScalef32PkF16Bf8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32PkF16Bf8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32PkF16Bf8Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_pk_f16_bf8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32PkF16Bf8Vop3>(opcode);
 }
 } // namespace detail
@@ -4849,7 +5851,12 @@ VCvtScalef32F16Fp8Vop3::VCvtScalef32F16Fp8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32F16Fp8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32F16Fp8Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_f16_fp8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32F16Fp8Vop3>(opcode);
 }
 } // namespace detail
@@ -4874,7 +5881,12 @@ VCvtScalef32F16Bf8Vop3::VCvtScalef32F16Bf8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32F16Bf8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32F16Bf8Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_f16_bf8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32F16Bf8Vop3>(opcode);
 }
 } // namespace detail
@@ -4899,7 +5911,12 @@ VCvtScalef32PkFp4F16Vop3::VCvtScalef32PkFp4F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32PkFp4F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32PkFp4F16Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_pk_fp4_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32PkFp4F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4924,7 +5941,12 @@ VCvtScalef32PkFp4Bf16Vop3::VCvtScalef32PkFp4Bf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32PkFp4Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32PkFp4Bf16Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_pk_fp4_bf16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32PkFp4Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -4951,7 +5973,13 @@ VCvtScalef32SrPkFp4F16Vop3::VCvtScalef32SrPkFp4F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPkFp4F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPkFp4F16Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_sr_pk_fp4_f16",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32SrPkFp4F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4978,7 +6006,13 @@ VCvtScalef32SrPkFp4Bf16Vop3::VCvtScalef32SrPkFp4Bf16Vop3(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPkFp4Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPkFp4Bf16Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_sr_pk_fp4_bf16",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32SrPkFp4Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -5003,7 +6037,12 @@ VCvtScalef32PkF16Fp4Vop3::VCvtScalef32PkF16Fp4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32PkF16Fp4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32PkF16Fp4Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_pk_f16_fp4", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32PkF16Fp4Vop3>(opcode);
 }
 } // namespace detail
@@ -5022,7 +6061,12 @@ VCvtScalef32PkBf16Fp4Vop3::VCvtScalef32PkBf16Fp4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32PkBf16Fp4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32PkBf16Fp4Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_pk_bf16_fp4", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32PkBf16Fp4Vop3>(opcode);
 }
 } // namespace detail
@@ -5043,7 +6087,13 @@ VCvtScalef322xpk16Fp6F32Vop3::VCvtScalef322xpk16Fp6F32Vop3(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef322xpk16Fp6F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef322xpk16Fp6F32Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_2xpk16_fp6_f32",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef322xpk16Fp6F32Vop3>(opcode);
 }
 } // namespace detail
@@ -5064,7 +6114,13 @@ VCvtScalef322xpk16Bf6F32Vop3::VCvtScalef322xpk16Bf6F32Vop3(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef322xpk16Bf6F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef322xpk16Bf6F32Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_2xpk16_bf6_f32",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef322xpk16Bf6F32Vop3>(opcode);
 }
 } // namespace detail
@@ -5085,7 +6141,13 @@ VCvtScalef32SrPk32Fp6F32Vop3::VCvtScalef32SrPk32Fp6F32Vop3(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk32Fp6F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk32Fp6F32Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_sr_pk32_fp6_f32",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32SrPk32Fp6F32Vop3>(opcode);
 }
 } // namespace detail
@@ -5106,7 +6168,13 @@ VCvtScalef32SrPk32Bf6F32Vop3::VCvtScalef32SrPk32Bf6F32Vop3(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk32Bf6F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk32Bf6F32Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_sr_pk32_bf6_f32",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32SrPk32Bf6F32Vop3>(opcode);
 }
 } // namespace detail
@@ -5125,7 +6193,13 @@ VCvtScalef32Pk32F32Fp6Vop3::VCvtScalef32Pk32F32Fp6Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32F32Fp6Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk32F32Fp6Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_pk32_f32_fp6",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32Pk32F32Fp6Vop3>(opcode);
 }
 } // namespace detail
@@ -5144,7 +6218,13 @@ VCvtScalef32Pk32F32Bf6Vop3::VCvtScalef32Pk32F32Bf6Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32F32Bf6Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk32F32Bf6Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_pk32_f32_bf6",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32Pk32F32Bf6Vop3>(opcode);
 }
 } // namespace detail
@@ -5163,7 +6243,13 @@ VCvtScalef32Pk32Fp6F16Vop3::VCvtScalef32Pk32Fp6F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32Fp6F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk32Fp6F16Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_pk32_fp6_f16",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32Pk32Fp6F16Vop3>(opcode);
 }
 } // namespace detail
@@ -5182,7 +6268,13 @@ VCvtScalef32Pk32Fp6Bf16Vop3::VCvtScalef32Pk32Fp6Bf16Vop3(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32Fp6Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk32Fp6Bf16Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_pk32_fp6_bf16",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32Pk32Fp6Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -5201,7 +6293,13 @@ VCvtScalef32Pk32Bf6F16Vop3::VCvtScalef32Pk32Bf6F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32Bf6F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk32Bf6F16Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_pk32_bf6_f16",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32Pk32Bf6F16Vop3>(opcode);
 }
 } // namespace detail
@@ -5220,7 +6318,13 @@ VCvtScalef32Pk32Bf6Bf16Vop3::VCvtScalef32Pk32Bf6Bf16Vop3(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32Bf6Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk32Bf6Bf16Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_pk32_bf6_bf16",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32Pk32Bf6Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -5241,7 +6345,13 @@ VCvtScalef32SrPk32Fp6F16Vop3::VCvtScalef32SrPk32Fp6F16Vop3(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk32Fp6F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk32Fp6F16Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_sr_pk32_fp6_f16",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32SrPk32Fp6F16Vop3>(opcode);
 }
 } // namespace detail
@@ -5262,7 +6372,13 @@ VCvtScalef32SrPk32Fp6Bf16Vop3::VCvtScalef32SrPk32Fp6Bf16Vop3(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk32Fp6Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk32Fp6Bf16Vop3(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_sr_pk32_fp6_bf16",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32SrPk32Fp6Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -5283,7 +6399,13 @@ VCvtScalef32SrPk32Bf6F16Vop3::VCvtScalef32SrPk32Bf6F16Vop3(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk32Bf6F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk32Bf6F16Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_sr_pk32_bf6_f16",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32SrPk32Bf6F16Vop3>(opcode);
 }
 } // namespace detail
@@ -5304,7 +6426,13 @@ VCvtScalef32SrPk32Bf6Bf16Vop3::VCvtScalef32SrPk32Bf6Bf16Vop3(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk32Bf6Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk32Bf6Bf16Vop3(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_sr_pk32_bf6_bf16",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32SrPk32Bf6Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -5323,7 +6451,13 @@ VCvtScalef32Pk32F16Fp6Vop3::VCvtScalef32Pk32F16Fp6Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32F16Fp6Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk32F16Fp6Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_pk32_f16_fp6",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32Pk32F16Fp6Vop3>(opcode);
 }
 } // namespace detail
@@ -5342,7 +6476,13 @@ VCvtScalef32Pk32Bf16Fp6Vop3::VCvtScalef32Pk32Bf16Fp6Vop3(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32Bf16Fp6Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk32Bf16Fp6Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_pk32_bf16_fp6",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32Pk32Bf16Fp6Vop3>(opcode);
 }
 } // namespace detail
@@ -5361,7 +6501,13 @@ VCvtScalef32Pk32F16Bf6Vop3::VCvtScalef32Pk32F16Bf6Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32F16Bf6Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk32F16Bf6Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_pk32_f16_bf6",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32Pk32F16Bf6Vop3>(opcode);
 }
 } // namespace detail
@@ -5380,7 +6526,13 @@ VCvtScalef32Pk32Bf16Bf6Vop3::VCvtScalef32Pk32Bf16Bf6Vop3(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk32Bf16Bf6Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk32Bf16Bf6Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vop3::validate_encoding("v_cvt_scalef32_pk32_bf16_bf6",
+                              reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32Pk32Bf16Bf6Vop3>(opcode);
 }
 } // namespace detail
@@ -5401,7 +6553,12 @@ VAshrPkI8I32Vop3::VAshrPkI8I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrPkI8I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrPkI8I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashr_pk_i8_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrPkI8I32Vop3>(opcode);
 }
 } // namespace detail
@@ -5428,7 +6585,12 @@ VAshrPkU8I32Vop3::VAshrPkU8I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrPkU8I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrPkU8I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashr_pk_u8_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrPkU8I32Vop3>(opcode);
 }
 } // namespace detail
@@ -5453,7 +6615,12 @@ VCvtPkF16F32Vop3::VCvtPkF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_f16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -5472,7 +6639,12 @@ VCvtPkBf16F32Vop3::VCvtPkBf16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkBf16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkBf16F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_bf16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkBf16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -5491,7 +6663,12 @@ VCvtScalef32PkBf16Fp8Vop3::VCvtScalef32PkBf16Fp8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32PkBf16Fp8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32PkBf16Fp8Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_pk_bf16_fp8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32PkBf16Fp8Vop3>(opcode);
 }
 } // namespace detail
@@ -5510,7 +6687,12 @@ VCvtScalef32PkBf16Bf8Vop3::VCvtScalef32PkBf16Bf8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32PkBf16Bf8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32PkBf16Bf8Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_scalef32_pk_bf16_bf8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtScalef32PkBf16Bf8Vop3>(opcode);
 }
 } // namespace detail
@@ -5529,7 +6711,11 @@ VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5548,7 +6734,11 @@ VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5567,7 +6757,11 @@ VMinF64Vop3::VMinF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5586,7 +6780,11 @@ VMaxF64Vop3::VMaxF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5605,7 +6803,11 @@ VLdexpF64Vop3::VLdexpF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ldexp_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5624,7 +6826,11 @@ VMulLoU32Vop3::VMulLoU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_lo_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU32Vop3>(opcode);
 }
 } // namespace detail
@@ -5643,7 +6849,11 @@ VMulHiU32Vop3::VMulHiU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32Vop3>(opcode);
 }
 } // namespace detail
@@ -5662,7 +6872,11 @@ VMulHiI32Vop3::VMulHiI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32Vop3>(opcode);
 }
 } // namespace detail
@@ -5681,7 +6895,11 @@ VLdexpF32Vop3::VLdexpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ldexp_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5700,7 +6918,12 @@ VReadlaneB32Vop3::VReadlaneB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_readlane_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VReadlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -5720,7 +6943,12 @@ VWritelaneB32Vop3::VWritelaneB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_writelane_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VWritelaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -5745,7 +6973,12 @@ VBcntU32B32Vop3::VBcntU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bcnt_u32_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBcntU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -5764,7 +6997,12 @@ VMbcntLoU32B32Vop3::VMbcntLoU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mbcnt_lo_u32_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntLoU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -5783,7 +7021,12 @@ VMbcntHiU32B32Vop3::VMbcntHiU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mbcnt_hi_u32_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntHiU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -5802,7 +7045,12 @@ VLshlrevB64Vop3::VLshlrevB64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshlrev_b64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -5821,7 +7069,12 @@ VLshrrevB64Vop3::VLshrrevB64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshrrev_b64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -5840,7 +7093,12 @@ VAshrrevI64Vop3::VAshrrevI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashrrev_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI64Vop3>(opcode);
 }
 } // namespace detail
@@ -5859,7 +7117,12 @@ VTrigPreopF64Vop3::VTrigPreopF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trig_preop_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTrigPreopF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5878,7 +7141,11 @@ VBfmB32Vop3::VBfmB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfm_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfmB32Vop3>(opcode);
 }
 } // namespace detail
@@ -5897,7 +7164,12 @@ VCvtPknormI16F32Vop3::VCvtPknormI16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormI16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_i16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormI16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -5916,7 +7188,12 @@ VCvtPknormU16F32Vop3::VCvtPknormU16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormU16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_u16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormU16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -5935,7 +7212,12 @@ VCvtPkrtzF16F32Vop3::VCvtPkrtzF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pkrtz_f16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkrtzF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -5954,7 +7236,12 @@ VCvtPkU16U32Vop3::VCvtPkU16U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_u16_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU16U32Vop3>(opcode);
 }
 } // namespace detail
@@ -5973,7 +7260,12 @@ VCvtPkI16I32Vop3::VCvtPkI16I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_i16_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkI16I32Vop3>(opcode);
 }
 } // namespace detail
@@ -5992,7 +7284,12 @@ VCvtPknormI16F16Vop3::VCvtPknormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -6011,7 +7308,12 @@ VCvtPknormU16F16Vop3::VCvtPknormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_u16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -6030,7 +7332,11 @@ VAddI32Vop3::VAddI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddI32Vop3>(opcode);
 }
 } // namespace detail
@@ -6049,7 +7355,11 @@ VSubI32Vop3::VSubI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubI32Vop3>(opcode);
 }
 } // namespace detail
@@ -6068,7 +7378,11 @@ VAddI16Vop3::VAddI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddI16Vop3>(opcode);
 }
 } // namespace detail
@@ -6093,7 +7407,11 @@ VSubI16Vop3::VSubI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubI16Vop3>(opcode);
 }
 } // namespace detail
@@ -6118,7 +7436,12 @@ VPackB32F16Vop3::VPackB32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_pack_b32_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPackB32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -6137,7 +7460,12 @@ VMulLegacyF32Vop3::VMulLegacyF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLegacyF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_legacy_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLegacyF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6156,7 +7484,12 @@ VCvtPkFp8F32Vop3::VCvtPkFp8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkFp8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkFp8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_fp8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkFp8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6181,7 +7514,12 @@ VCvtPkBf8F32Vop3::VCvtPkBf8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkBf8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkBf8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_bf8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkBf8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6206,7 +7544,12 @@ VCvtSrFp8F32Vop3::VCvtSrFp8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtSrFp8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtSrFp8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_sr_fp8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtSrFp8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6231,7 +7574,12 @@ VCvtSrBf8F32Vop3::VCvtSrBf8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtSrBf8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtSrBf8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_sr_bf8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtSrBf8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6256,7 +7604,12 @@ VCvtSrF16F32Vop3::VCvtSrF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtSrF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtSrF16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_sr_f16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtSrF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6281,7 +7634,12 @@ VCvtSrBf16F32Vop3::VCvtSrBf16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtSrBf16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtSrBf16F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_sr_bf16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtSrBf16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6308,7 +7666,12 @@ VMinimum3F32Vop3::VMinimum3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinimum3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinimum3F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_minimum3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinimum3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6329,7 +7692,12 @@ VMaximum3F32Vop3::VMaximum3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaximum3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaximum3F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_maximum3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaximum3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6348,7 +7716,12 @@ VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_class_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6371,7 +7744,12 @@ VCmpxClassF32Vop3::VCmpxClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_class_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6390,7 +7768,12 @@ VCmpClassF64Vop3::VCmpClassF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_class_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6413,7 +7796,12 @@ VCmpxClassF64Vop3::VCmpxClassF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_class_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6432,7 +7820,12 @@ VCmpClassF16Vop3::VCmpClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_class_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6455,7 +7848,12 @@ VCmpxClassF16Vop3::VCmpxClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_class_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6474,7 +7872,11 @@ VCmpFF16Vop3::VCmpFF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6493,7 +7895,11 @@ VCmpLtF16Vop3::VCmpLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6512,7 +7918,11 @@ VCmpEqF16Vop3::VCmpEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6531,7 +7941,11 @@ VCmpLeF16Vop3::VCmpLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6550,7 +7964,11 @@ VCmpGtF16Vop3::VCmpGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6569,7 +7987,11 @@ VCmpLgF16Vop3::VCmpLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6588,7 +8010,11 @@ VCmpGeF16Vop3::VCmpGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6607,7 +8033,11 @@ VCmpOF16Vop3::VCmpOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_o_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6626,7 +8056,11 @@ VCmpUF16Vop3::VCmpUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_u_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6645,7 +8079,11 @@ VCmpNgeF16Vop3::VCmpNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6664,7 +8102,11 @@ VCmpNlgF16Vop3::VCmpNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6683,7 +8125,11 @@ VCmpNgtF16Vop3::VCmpNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ngt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6702,7 +8148,11 @@ VCmpNleF16Vop3::VCmpNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nle_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6721,7 +8171,11 @@ VCmpNeqF16Vop3::VCmpNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_neq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6740,7 +8194,11 @@ VCmpNltF16Vop3::VCmpNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6759,7 +8217,11 @@ VCmpTruF16Vop3::VCmpTruF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_tru_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTruF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6782,7 +8244,11 @@ VCmpxFF16Vop3::VCmpxFF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6805,7 +8271,11 @@ VCmpxLtF16Vop3::VCmpxLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6828,7 +8298,11 @@ VCmpxEqF16Vop3::VCmpxEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6851,7 +8325,11 @@ VCmpxLeF16Vop3::VCmpxLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6874,7 +8352,11 @@ VCmpxGtF16Vop3::VCmpxGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6897,7 +8379,11 @@ VCmpxLgF16Vop3::VCmpxLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6920,7 +8406,11 @@ VCmpxGeF16Vop3::VCmpxGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6943,7 +8433,11 @@ VCmpxOF16Vop3::VCmpxOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_o_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6966,7 +8460,11 @@ VCmpxUF16Vop3::VCmpxUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_u_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -6989,7 +8487,12 @@ VCmpxNgeF16Vop3::VCmpxNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -7012,7 +8515,12 @@ VCmpxNlgF16Vop3::VCmpxNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -7035,7 +8543,12 @@ VCmpxNgtF16Vop3::VCmpxNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ngt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -7058,7 +8571,12 @@ VCmpxNleF16Vop3::VCmpxNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nle_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -7081,7 +8599,12 @@ VCmpxNeqF16Vop3::VCmpxNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_neq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -7104,7 +8627,12 @@ VCmpxNltF16Vop3::VCmpxNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -7127,7 +8655,12 @@ VCmpxTruF16Vop3::VCmpxTruF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_tru_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTruF16Vop3>(opcode);
 }
 } // namespace detail
@@ -7146,7 +8679,11 @@ VCmpFF32Vop3::VCmpFF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7165,7 +8702,11 @@ VCmpLtF32Vop3::VCmpLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7184,7 +8725,11 @@ VCmpEqF32Vop3::VCmpEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7203,7 +8748,11 @@ VCmpLeF32Vop3::VCmpLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7222,7 +8771,11 @@ VCmpGtF32Vop3::VCmpGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7241,7 +8794,11 @@ VCmpLgF32Vop3::VCmpLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7260,7 +8817,11 @@ VCmpGeF32Vop3::VCmpGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7279,7 +8840,11 @@ VCmpOF32Vop3::VCmpOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_o_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7298,7 +8863,11 @@ VCmpUF32Vop3::VCmpUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_u_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7317,7 +8886,11 @@ VCmpNgeF32Vop3::VCmpNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7336,7 +8909,11 @@ VCmpNlgF32Vop3::VCmpNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7355,7 +8932,11 @@ VCmpNgtF32Vop3::VCmpNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ngt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7374,7 +8955,11 @@ VCmpNleF32Vop3::VCmpNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nle_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7393,7 +8978,11 @@ VCmpNeqF32Vop3::VCmpNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_neq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7412,7 +9001,11 @@ VCmpNltF32Vop3::VCmpNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7431,7 +9024,11 @@ VCmpTruF32Vop3::VCmpTruF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_tru_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTruF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7454,7 +9051,11 @@ VCmpxFF32Vop3::VCmpxFF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7477,7 +9078,11 @@ VCmpxLtF32Vop3::VCmpxLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7500,7 +9105,11 @@ VCmpxEqF32Vop3::VCmpxEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7523,7 +9132,11 @@ VCmpxLeF32Vop3::VCmpxLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7546,7 +9159,11 @@ VCmpxGtF32Vop3::VCmpxGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7569,7 +9186,11 @@ VCmpxLgF32Vop3::VCmpxLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7592,7 +9213,11 @@ VCmpxGeF32Vop3::VCmpxGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7615,7 +9240,11 @@ VCmpxOF32Vop3::VCmpxOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_o_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7638,7 +9267,11 @@ VCmpxUF32Vop3::VCmpxUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_u_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7661,7 +9294,12 @@ VCmpxNgeF32Vop3::VCmpxNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7684,7 +9322,12 @@ VCmpxNlgF32Vop3::VCmpxNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7707,7 +9350,12 @@ VCmpxNgtF32Vop3::VCmpxNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ngt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7730,7 +9378,12 @@ VCmpxNleF32Vop3::VCmpxNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nle_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7753,7 +9406,12 @@ VCmpxNeqF32Vop3::VCmpxNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_neq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7776,7 +9434,12 @@ VCmpxNltF32Vop3::VCmpxNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7799,7 +9462,12 @@ VCmpxTruF32Vop3::VCmpxTruF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_tru_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTruF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7818,7 +9486,11 @@ VCmpFF64Vop3::VCmpFF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7837,7 +9509,11 @@ VCmpLtF64Vop3::VCmpLtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7856,7 +9532,11 @@ VCmpEqF64Vop3::VCmpEqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7875,7 +9555,11 @@ VCmpLeF64Vop3::VCmpLeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7894,7 +9578,11 @@ VCmpGtF64Vop3::VCmpGtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7913,7 +9601,11 @@ VCmpLgF64Vop3::VCmpLgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7932,7 +9624,11 @@ VCmpGeF64Vop3::VCmpGeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7951,7 +9647,11 @@ VCmpOF64Vop3::VCmpOF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_o_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7970,7 +9670,11 @@ VCmpUF64Vop3::VCmpUF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_u_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7989,7 +9693,11 @@ VCmpNgeF64Vop3::VCmpNgeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8008,7 +9716,11 @@ VCmpNlgF64Vop3::VCmpNlgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8027,7 +9739,11 @@ VCmpNgtF64Vop3::VCmpNgtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ngt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8046,7 +9762,11 @@ VCmpNleF64Vop3::VCmpNleF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nle_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8065,7 +9785,11 @@ VCmpNeqF64Vop3::VCmpNeqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_neq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8084,7 +9808,11 @@ VCmpNltF64Vop3::VCmpNltF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8103,7 +9831,11 @@ VCmpTruF64Vop3::VCmpTruF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_tru_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTruF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8126,7 +9858,11 @@ VCmpxFF64Vop3::VCmpxFF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8149,7 +9885,11 @@ VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8172,7 +9912,11 @@ VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8195,7 +9939,11 @@ VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8218,7 +9966,11 @@ VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8241,7 +9993,11 @@ VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8264,7 +10020,11 @@ VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8287,7 +10047,11 @@ VCmpxOF64Vop3::VCmpxOF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_o_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8310,7 +10074,11 @@ VCmpxUF64Vop3::VCmpxUF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_u_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8333,7 +10101,12 @@ VCmpxNgeF64Vop3::VCmpxNgeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8356,7 +10129,12 @@ VCmpxNlgF64Vop3::VCmpxNlgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8379,7 +10157,12 @@ VCmpxNgtF64Vop3::VCmpxNgtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ngt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8402,7 +10185,12 @@ VCmpxNleF64Vop3::VCmpxNleF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nle_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8425,7 +10213,12 @@ VCmpxNeqF64Vop3::VCmpxNeqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_neq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8448,7 +10241,12 @@ VCmpxNltF64Vop3::VCmpxNltF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8471,7 +10269,12 @@ VCmpxTruF64Vop3::VCmpxTruF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_tru_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTruF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8490,7 +10293,11 @@ VCmpFI16Vop3::VCmpFI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8509,7 +10316,11 @@ VCmpLtI16Vop3::VCmpLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8528,7 +10339,11 @@ VCmpEqI16Vop3::VCmpEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8547,7 +10362,11 @@ VCmpLeI16Vop3::VCmpLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8566,7 +10385,11 @@ VCmpGtI16Vop3::VCmpGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8585,7 +10408,11 @@ VCmpNeI16Vop3::VCmpNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8604,7 +10431,11 @@ VCmpGeI16Vop3::VCmpGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8623,7 +10454,11 @@ VCmpTI16Vop3::VCmpTI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8642,7 +10477,11 @@ VCmpFU16Vop3::VCmpFU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU16Vop3>(opcode);
 }
 } // namespace detail
@@ -8661,7 +10500,11 @@ VCmpLtU16Vop3::VCmpLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -8680,7 +10523,11 @@ VCmpEqU16Vop3::VCmpEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -8699,7 +10546,11 @@ VCmpLeU16Vop3::VCmpLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -8718,7 +10569,11 @@ VCmpGtU16Vop3::VCmpGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -8737,7 +10592,11 @@ VCmpNeU16Vop3::VCmpNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -8756,7 +10615,11 @@ VCmpGeU16Vop3::VCmpGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -8775,7 +10638,11 @@ VCmpTU16Vop3::VCmpTU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU16Vop3>(opcode);
 }
 } // namespace detail
@@ -8798,7 +10665,11 @@ VCmpxFI16Vop3::VCmpxFI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8821,7 +10692,11 @@ VCmpxLtI16Vop3::VCmpxLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8844,7 +10719,11 @@ VCmpxEqI16Vop3::VCmpxEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8867,7 +10746,11 @@ VCmpxLeI16Vop3::VCmpxLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8890,7 +10773,11 @@ VCmpxGtI16Vop3::VCmpxGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8913,7 +10800,11 @@ VCmpxNeI16Vop3::VCmpxNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8936,7 +10827,11 @@ VCmpxGeI16Vop3::VCmpxGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8959,7 +10854,11 @@ VCmpxTI16Vop3::VCmpxTI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8982,7 +10881,11 @@ VCmpxFU16Vop3::VCmpxFU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9005,7 +10908,11 @@ VCmpxLtU16Vop3::VCmpxLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9028,7 +10935,11 @@ VCmpxEqU16Vop3::VCmpxEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9051,7 +10962,11 @@ VCmpxLeU16Vop3::VCmpxLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9074,7 +10989,11 @@ VCmpxGtU16Vop3::VCmpxGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9097,7 +11016,11 @@ VCmpxNeU16Vop3::VCmpxNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9120,7 +11043,11 @@ VCmpxGeU16Vop3::VCmpxGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9143,7 +11070,11 @@ VCmpxTU16Vop3::VCmpxTU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9162,7 +11093,11 @@ VCmpFI32Vop3::VCmpFI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9181,7 +11116,11 @@ VCmpLtI32Vop3::VCmpLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9200,7 +11139,11 @@ VCmpEqI32Vop3::VCmpEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9219,7 +11162,11 @@ VCmpLeI32Vop3::VCmpLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9238,7 +11185,11 @@ VCmpGtI32Vop3::VCmpGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9257,7 +11208,11 @@ VCmpNeI32Vop3::VCmpNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9276,7 +11231,11 @@ VCmpGeI32Vop3::VCmpGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9295,7 +11254,11 @@ VCmpTI32Vop3::VCmpTI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9314,7 +11277,11 @@ VCmpFU32Vop3::VCmpFU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9333,7 +11300,11 @@ VCmpLtU32Vop3::VCmpLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9352,7 +11323,11 @@ VCmpEqU32Vop3::VCmpEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9371,7 +11346,11 @@ VCmpLeU32Vop3::VCmpLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9390,7 +11369,11 @@ VCmpGtU32Vop3::VCmpGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9409,7 +11392,11 @@ VCmpNeU32Vop3::VCmpNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9428,7 +11415,11 @@ VCmpGeU32Vop3::VCmpGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9447,7 +11438,11 @@ VCmpTU32Vop3::VCmpTU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9470,7 +11465,11 @@ VCmpxFI32Vop3::VCmpxFI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9493,7 +11492,11 @@ VCmpxLtI32Vop3::VCmpxLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9516,7 +11519,11 @@ VCmpxEqI32Vop3::VCmpxEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9539,7 +11546,11 @@ VCmpxLeI32Vop3::VCmpxLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9562,7 +11573,11 @@ VCmpxGtI32Vop3::VCmpxGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9585,7 +11600,11 @@ VCmpxNeI32Vop3::VCmpxNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9608,7 +11627,11 @@ VCmpxGeI32Vop3::VCmpxGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9631,7 +11654,11 @@ VCmpxTI32Vop3::VCmpxTI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9654,7 +11681,11 @@ VCmpxFU32Vop3::VCmpxFU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9677,7 +11708,11 @@ VCmpxLtU32Vop3::VCmpxLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9700,7 +11735,11 @@ VCmpxEqU32Vop3::VCmpxEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9723,7 +11762,11 @@ VCmpxLeU32Vop3::VCmpxLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9746,7 +11789,11 @@ VCmpxGtU32Vop3::VCmpxGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9769,7 +11816,11 @@ VCmpxNeU32Vop3::VCmpxNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9792,7 +11843,11 @@ VCmpxGeU32Vop3::VCmpxGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9815,7 +11870,11 @@ VCmpxTU32Vop3::VCmpxTU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9834,7 +11893,11 @@ VCmpFI64Vop3::VCmpFI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9853,7 +11916,11 @@ VCmpLtI64Vop3::VCmpLtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9872,7 +11939,11 @@ VCmpEqI64Vop3::VCmpEqI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9891,7 +11962,11 @@ VCmpLeI64Vop3::VCmpLeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9910,7 +11985,11 @@ VCmpGtI64Vop3::VCmpGtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9929,7 +12008,11 @@ VCmpNeI64Vop3::VCmpNeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9948,7 +12031,11 @@ VCmpGeI64Vop3::VCmpGeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9967,7 +12054,11 @@ VCmpTI64Vop3::VCmpTI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9986,7 +12077,11 @@ VCmpFU64Vop3::VCmpFU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU64Vop3>(opcode);
 }
 } // namespace detail
@@ -10005,7 +12100,11 @@ VCmpLtU64Vop3::VCmpLtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -10024,7 +12123,11 @@ VCmpEqU64Vop3::VCmpEqU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -10043,7 +12146,11 @@ VCmpLeU64Vop3::VCmpLeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -10062,7 +12169,11 @@ VCmpGtU64Vop3::VCmpGtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -10081,7 +12192,11 @@ VCmpNeU64Vop3::VCmpNeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -10100,7 +12215,11 @@ VCmpGeU64Vop3::VCmpGeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -10119,7 +12238,11 @@ VCmpTU64Vop3::VCmpTU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU64Vop3>(opcode);
 }
 } // namespace detail
@@ -10142,7 +12265,11 @@ VCmpxFI64Vop3::VCmpxFI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI64Vop3>(opcode);
 }
 } // namespace detail
@@ -10165,7 +12292,11 @@ VCmpxLtI64Vop3::VCmpxLtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -10188,7 +12319,11 @@ VCmpxEqI64Vop3::VCmpxEqI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -10211,7 +12346,11 @@ VCmpxLeI64Vop3::VCmpxLeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -10234,7 +12373,11 @@ VCmpxGtI64Vop3::VCmpxGtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -10257,7 +12400,11 @@ VCmpxNeI64Vop3::VCmpxNeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -10280,7 +12427,11 @@ VCmpxGeI64Vop3::VCmpxGeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -10303,7 +12454,11 @@ VCmpxTI64Vop3::VCmpxTI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI64Vop3>(opcode);
 }
 } // namespace detail
@@ -10326,7 +12481,11 @@ VCmpxFU64Vop3::VCmpxFU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU64Vop3>(opcode);
 }
 } // namespace detail
@@ -10349,7 +12508,11 @@ VCmpxLtU64Vop3::VCmpxLtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -10372,7 +12535,11 @@ VCmpxEqU64Vop3::VCmpxEqU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -10395,7 +12562,11 @@ VCmpxLeU64Vop3::VCmpxLeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -10418,7 +12589,11 @@ VCmpxGtU64Vop3::VCmpxGtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -10441,7 +12616,11 @@ VCmpxNeU64Vop3::VCmpxNeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -10464,7 +12643,11 @@ VCmpxGeU64Vop3::VCmpxGeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -10487,7 +12670,11 @@ VCmpxTU64Vop3::VCmpxTU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU64Vop3>(opcode);
 }
 } // namespace detail
@@ -10508,7 +12695,12 @@ VAddCoU32Vop3SdstEnc::VAddCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_add_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -10529,7 +12721,12 @@ VSubCoU32Vop3SdstEnc::VSubCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_sub_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -10550,7 +12747,12 @@ VSubrevCoU32Vop3SdstEnc::VSubrevCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_subrev_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -10573,7 +12775,12 @@ VAddcCoU32Vop3SdstEnc::VAddcCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddcCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddcCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_addc_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddcCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -10596,7 +12803,12 @@ VSubbCoU32Vop3SdstEnc::VSubbCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubbCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubbCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_subb_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubbCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -10619,7 +12831,12 @@ VSubbrevCoU32Vop3SdstEnc::VSubbrevCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubbrevCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubbrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_subbrev_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubbrevCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -10642,7 +12859,12 @@ VDivScaleF32Vop3SdstEnc::VDivScaleF32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_div_scale_f32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivScaleF32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -10665,7 +12887,12 @@ VDivScaleF64Vop3SdstEnc::VDivScaleF64Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_div_scale_f64", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivScaleF64Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -10688,7 +12915,12 @@ VMadU64U32Vop3SdstEnc::VMadU64U32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_mad_u64_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU64U32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -10711,7 +12943,12 @@ VMadI64I32Vop3SdstEnc::VMadI64I32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_mad_i64_i32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI64I32Vop3SdstEnc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vop3p.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -59,7 +58,11 @@ VPkMadI16Vop3p::VPkMadI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mad_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMadI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -78,7 +81,12 @@ VPkMulLoU16Vop3p::VPkMulLoU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mul_lo_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMulLoU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -97,7 +105,11 @@ VPkAddI16Vop3p::VPkAddI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -116,7 +128,11 @@ VPkSubI16Vop3p::VPkSubI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_sub_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkSubI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -135,7 +151,12 @@ VPkLshlrevB16Vop3p::VPkLshlrevB16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_lshlrev_b16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkLshlrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -154,7 +175,12 @@ VPkLshrrevB16Vop3p::VPkLshrrevB16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_lshrrev_b16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkLshrrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -173,7 +199,12 @@ VPkAshrrevI16Vop3p::VPkAshrrevI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_ashrrev_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAshrrevI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -192,7 +223,11 @@ VPkMaxI16Vop3p::VPkMaxI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_max_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaxI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -211,7 +246,11 @@ VPkMinI16Vop3p::VPkMinI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_min_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -232,7 +271,11 @@ VPkMadU16Vop3p::VPkMadU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mad_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMadU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -251,7 +294,11 @@ VPkAddU16Vop3p::VPkAddU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -270,7 +317,11 @@ VPkSubU16Vop3p::VPkSubU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_sub_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkSubU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -289,7 +340,11 @@ VPkMaxU16Vop3p::VPkMaxU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_max_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaxU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -308,7 +363,11 @@ VPkMinU16Vop3p::VPkMinU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_min_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -329,7 +388,11 @@ VPkFmaF16Vop3p::VPkFmaF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_fma_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkFmaF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -348,7 +411,11 @@ VPkAddF16Vop3p::VPkAddF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -367,7 +434,11 @@ VPkMulF16Vop3p::VPkMulF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mul_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMulF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -386,7 +457,11 @@ VPkMinF16Vop3p::VPkMinF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_min_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -405,7 +480,11 @@ VPkMaxF16Vop3p::VPkMaxF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_max_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaxF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -426,7 +505,12 @@ VDot2F32Bf16Vop3p::VDot2F32Bf16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2F32Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2F32Bf16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_f32_bf16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2F32Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -447,7 +531,12 @@ VPkMinimum3F16Vop3p::VPkMinimum3F16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinimum3F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinimum3F16Vop3p(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_minimum3_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinimum3F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -468,7 +557,12 @@ VPkMaximum3F16Vop3p::VPkMaximum3F16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaximum3F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaximum3F16Vop3p(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_maximum3_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaximum3F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -489,7 +583,12 @@ VMadMixF32Vop3p::VMadMixF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadMixF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVMadMixF32Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_mad_mix_f32", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadMixF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -511,7 +610,12 @@ VMadMixloF16Vop3p::VMadMixloF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadMixloF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVMadMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_mad_mixlo_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadMixloF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -539,7 +643,12 @@ VMadMixhiF16Vop3p::VMadMixhiF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadMixhiF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVMadMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_mad_mixhi_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadMixhiF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -566,7 +675,12 @@ VDot2F32F16Vop3p::VDot2F32F16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2F32F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2F32F16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_f32_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2F32F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -587,7 +701,12 @@ VDot2I32I16Vop3p::VDot2I32I16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2I32I16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2I32I16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_i32_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2I32I16Vop3p>(opcode);
 }
 } // namespace detail
@@ -608,7 +727,12 @@ VDot2U32U16Vop3p::VDot2U32U16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2U32U16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2U32U16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_u32_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2U32U16Vop3p>(opcode);
 }
 } // namespace detail
@@ -629,7 +753,12 @@ VDot4I32I8Vop3p::VDot4I32I8Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4I32I8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4I32I8Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot4_i32_i8", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot4I32I8Vop3p>(opcode);
 }
 } // namespace detail
@@ -650,7 +779,12 @@ VDot4U32U8Vop3p::VDot4U32U8Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot4_u32_u8", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot4U32U8Vop3p>(opcode);
 }
 } // namespace detail
@@ -671,7 +805,12 @@ VDot8I32I4Vop3p::VDot8I32I4Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8I32I4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8I32I4Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot8_i32_i4", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot8I32I4Vop3p>(opcode);
 }
 } // namespace detail
@@ -692,7 +831,12 @@ VDot8U32U4Vop3p::VDot8U32U4Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot8_u32_u4", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot8U32U4Vop3p>(opcode);
 }
 } // namespace detail
@@ -713,7 +857,11 @@ VPkFmaF32Vop3p::VPkFmaF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmaF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkFmaF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_fma_f32", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkFmaF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -732,7 +880,11 @@ VPkMulF32Vop3p::VPkMulF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mul_f32", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMulF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -751,7 +903,11 @@ VPkAddF32Vop3p::VPkAddF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_f32", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -770,7 +926,11 @@ VPkMovB32Vop3p::VPkMovB32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMovB32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMovB32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mov_b32", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMovB32Vop3p>(opcode);
 }
 } // namespace detail
@@ -791,7 +951,12 @@ VAccvgprReadVop3p::VAccvgprReadVop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAccvgprReadVop3p(const MachineInst *opcode) {
+DecodeResult decodeVAccvgprReadVop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_accvgpr_read", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAccvgprReadVop3p>(opcode);
 }
 } // namespace detail
@@ -809,7 +974,12 @@ VAccvgprWriteVop3p::VAccvgprWriteVop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAccvgprWriteVop3p(const MachineInst *opcode) {
+DecodeResult decodeVAccvgprWriteVop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_accvgpr_write", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAccvgprWriteVop3p>(opcode);
 }
 } // namespace detail
@@ -857,7 +1027,13 @@ VMfmaF3216x16x128F8f6f4Vop3pMfma::VMfmaF3216x16x128F8f6f4Vop3pMfma(const Machine
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x128F8f6f4Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x128F8f6f4Vop3pMfma(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x128_f8f6f4", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x128F8f6f4Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -905,7 +1081,13 @@ VMfmaF3232x32x64F8f6f4Vop3pMfma::VMfmaF3232x32x64F8f6f4Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x64F8f6f4Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x64F8f6f4Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x64_f8f6f4", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x64F8f6f4Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -943,7 +1125,13 @@ VMfmaF3216x16x32Bf16Vop3pMfma::VMfmaF3216x16x32Bf16Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32Bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x32Bf16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x32_bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x32Bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -981,7 +1169,13 @@ VMfmaI3216x16x64I8Vop3pMfma::VMfmaI3216x16x64I8Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI3216x16x64I8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI3216x16x64I8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_16x16x64_i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI3216x16x64I8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1019,7 +1213,13 @@ VMfmaF3232x32x16Bf16Vop3pMfma::VMfmaF3232x32x16Bf16Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16Bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x16Bf16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x16_bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x16Bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1057,7 +1257,13 @@ VMfmaI3232x32x32I8Vop3pMfma::VMfmaI3232x32x32I8Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI3232x32x32I8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI3232x32x32I8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_32x32x32_i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI3232x32x32I8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1094,7 +1300,13 @@ VSmfmacF3216x16x64Bf16Vop3pMfma::VSmfmacF3216x16x64Bf16Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64Bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3216x16x64Bf16Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_16x16x64_bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3216x16x64Bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1131,7 +1343,13 @@ VSmfmacI3216x16x128I8Vop3pMfma::VSmfmacI3216x16x128I8Vop3pMfma(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacI3216x16x128I8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacI3216x16x128I8Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_i32_16x16x128_i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacI3216x16x128I8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1168,7 +1386,13 @@ VSmfmacF3216x16x128Bf8Bf8Vop3pMfma::VSmfmacF3216x16x128Bf8Bf8Vop3pMfma(const Mac
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x128Bf8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3216x16x128Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_16x16x128_bf8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3216x16x128Bf8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1205,7 +1429,13 @@ VSmfmacF3216x16x128Bf8Fp8Vop3pMfma::VSmfmacF3216x16x128Bf8Fp8Vop3pMfma(const Mac
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x128Bf8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3216x16x128Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_16x16x128_bf8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3216x16x128Bf8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1242,7 +1472,13 @@ VSmfmacF3216x16x128Fp8Bf8Vop3pMfma::VSmfmacF3216x16x128Fp8Bf8Vop3pMfma(const Mac
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x128Fp8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3216x16x128Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_16x16x128_fp8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3216x16x128Fp8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1280,7 +1516,13 @@ VMfmaF3232x32x12bF32Vop3pMfma::VMfmaF3232x32x12bF32Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x12bF32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x12bF32Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x1_2b_f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x12bF32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1318,7 +1560,13 @@ VMfmaF3216x16x14bF32Vop3pMfma::VMfmaF3216x16x14bF32Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x14bF32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x14bF32Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x1_4b_f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x14bF32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1356,7 +1604,13 @@ VMfmaF324x4x116bF32Vop3pMfma::VMfmaF324x4x116bF32Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF324x4x116bF32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF324x4x116bF32Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_4x4x1_16b_f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF324x4x116bF32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1393,7 +1647,13 @@ VSmfmacF3216x16x128Fp8Fp8Vop3pMfma::VSmfmacF3216x16x128Fp8Fp8Vop3pMfma(const Mac
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x128Fp8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3216x16x128Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_16x16x128_fp8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3216x16x128Fp8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1431,7 +1691,13 @@ VMfmaF3232x32x2F32Vop3pMfma::VMfmaF3232x32x2F32Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x2F32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x2F32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x2_f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x2F32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1469,7 +1735,13 @@ VMfmaF3216x16x4F32Vop3pMfma::VMfmaF3216x16x4F32Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x4F32Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x4F32Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x4_f32", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x4F32Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1506,7 +1778,13 @@ VSmfmacF3232x32x32Bf16Vop3pMfma::VSmfmacF3232x32x32Bf16Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32Bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3232x32x32Bf16Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_32x32x32_bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3232x32x32Bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1543,7 +1821,13 @@ VSmfmacI3232x32x64I8Vop3pMfma::VSmfmacI3232x32x64I8Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacI3232x32x64I8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacI3232x32x64I8Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_i32_32x32x64_i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacI3232x32x64I8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1581,7 +1865,13 @@ VMfmaF3232x32x42bF16Vop3pMfma::VMfmaF3232x32x42bF16Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x42bF16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x42bF16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x4_2b_f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x42bF16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1619,7 +1909,13 @@ VMfmaF3216x16x44bF16Vop3pMfma::VMfmaF3216x16x44bF16Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x44bF16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x44bF16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x4_4b_f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x44bF16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1657,7 +1953,13 @@ VMfmaF324x4x416bF16Vop3pMfma::VMfmaF324x4x416bF16Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF324x4x416bF16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF324x4x416bF16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_4x4x4_16b_f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF324x4x416bF16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1694,7 +1996,13 @@ VSmfmacF3232x32x64Bf8Bf8Vop3pMfma::VSmfmacF3232x32x64Bf8Bf8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x64Bf8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3232x32x64Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_32x32x64_bf8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3232x32x64Bf8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1732,7 +2040,13 @@ VMfmaF3232x32x8F16Vop3pMfma::VMfmaF3232x32x8F16Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x8F16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x8F16Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x8_f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x8F16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1770,7 +2084,13 @@ VMfmaF3216x16x16F16Vop3pMfma::VMfmaF3216x16x16F16Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x16F16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x16F16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x16_f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x16F16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1807,7 +2127,13 @@ VSmfmacF3232x32x64Bf8Fp8Vop3pMfma::VSmfmacF3232x32x64Bf8Fp8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x64Bf8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3232x32x64Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_32x32x64_bf8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3232x32x64Bf8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1844,7 +2170,13 @@ VSmfmacF3232x32x64Fp8Bf8Vop3pMfma::VSmfmacF3232x32x64Fp8Bf8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x64Fp8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3232x32x64Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_32x32x64_fp8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3232x32x64Fp8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1882,7 +2214,13 @@ VMfmaI3232x32x42bI8Vop3pMfma::VMfmaI3232x32x42bI8Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI3232x32x42bI8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI3232x32x42bI8Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_32x32x4_2b_i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI3232x32x42bI8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1920,7 +2258,13 @@ VMfmaI3216x16x44bI8Vop3pMfma::VMfmaI3216x16x44bI8Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI3216x16x44bI8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI3216x16x44bI8Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_16x16x4_4b_i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI3216x16x44bI8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1958,7 +2302,13 @@ VMfmaI324x4x416bI8Vop3pMfma::VMfmaI324x4x416bI8Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI324x4x416bI8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI324x4x416bI8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_4x4x4_16b_i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI324x4x416bI8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -1995,7 +2345,13 @@ VSmfmacF3232x32x64Fp8Fp8Vop3pMfma::VSmfmacF3232x32x64Fp8Fp8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x64Fp8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3232x32x64Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_32x32x64_fp8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3232x32x64Fp8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2033,7 +2389,13 @@ VMfmaF3216x16x32F16Vop3pMfma::VMfmaF3216x16x32F16Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32F16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x32F16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x32_f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x32F16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2071,7 +2433,13 @@ VMfmaF3232x32x16F16Vop3pMfma::VMfmaF3232x32x16F16Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16F16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x16F16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x16_f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x16F16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2109,7 +2477,13 @@ VMfmaI3232x32x16I8Vop3pMfma::VMfmaI3232x32x16I8Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI3232x32x16I8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI3232x32x16I8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_32x32x16_i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI3232x32x16I8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2147,7 +2521,13 @@ VMfmaI3216x16x32I8Vop3pMfma::VMfmaI3216x16x32I8Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaI3216x16x32I8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaI3216x16x32I8Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_i32_16x16x32_i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaI3216x16x32I8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2184,7 +2564,13 @@ VSmfmacF3216x16x64F16Vop3pMfma::VSmfmacF3216x16x64F16Vop3pMfma(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64F16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3216x16x64F16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_16x16x64_f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3216x16x64F16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2221,7 +2607,13 @@ VSmfmacF3232x32x32F16Vop3pMfma::VSmfmacF3232x32x32F16Vop3pMfma(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32F16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3232x32x32F16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_32x32x32_f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3232x32x32F16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2259,7 +2651,13 @@ VMfmaF3232x32x42bBf16Vop3pMfma::VMfmaF3232x32x42bBf16Vop3pMfma(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x42bBf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x42bBf16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x4_2b_bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x42bBf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2297,7 +2695,13 @@ VMfmaF3216x16x44bBf16Vop3pMfma::VMfmaF3216x16x44bBf16Vop3pMfma(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x44bBf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x44bBf16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x4_4b_bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x44bBf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2335,7 +2739,13 @@ VMfmaF324x4x416bBf16Vop3pMfma::VMfmaF324x4x416bBf16Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF324x4x416bBf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF324x4x416bBf16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_4x4x4_16b_bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF324x4x416bBf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2373,7 +2783,13 @@ VMfmaF3232x32x8Bf16Vop3pMfma::VMfmaF3232x32x8Bf16Vop3pMfma(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x8Bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x8Bf16Vop3pMfma(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x8_bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x8Bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2411,7 +2827,13 @@ VMfmaF3216x16x16Bf16Vop3pMfma::VMfmaF3216x16x16Bf16Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x16Bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x16Bf16Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x16_bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x16Bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2448,7 +2870,13 @@ VSmfmacF3216x16x32F16Vop3pMfma::VSmfmacF3216x16x32F16Vop3pMfma(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x32F16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3216x16x32F16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_16x16x32_f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3216x16x32F16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2485,7 +2913,13 @@ VSmfmacF3232x32x16F16Vop3pMfma::VSmfmacF3232x32x16F16Vop3pMfma(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x16F16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3232x32x16F16Vop3pMfma(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_32x32x16_f16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3232x32x16F16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2522,7 +2956,13 @@ VSmfmacF3216x16x32Bf16Vop3pMfma::VSmfmacF3216x16x32Bf16Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x32Bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3216x16x32Bf16Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_16x16x32_bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3216x16x32Bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2559,7 +2999,13 @@ VSmfmacF3232x32x16Bf16Vop3pMfma::VSmfmacF3232x32x16Bf16Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x16Bf16Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3232x32x16Bf16Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_32x32x16_bf16", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3232x32x16Bf16Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2596,7 +3042,13 @@ VSmfmacI3216x16x64I8Vop3pMfma::VSmfmacI3216x16x64I8Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacI3216x16x64I8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacI3216x16x64I8Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_i32_16x16x64_i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacI3216x16x64I8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2633,7 +3085,13 @@ VSmfmacI3232x32x32I8Vop3pMfma::VSmfmacI3232x32x32I8Vop3pMfma(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacI3232x32x32I8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacI3232x32x32I8Vop3pMfma(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_i32_32x32x32_i8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacI3232x32x32I8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2671,7 +3129,13 @@ VMfmaF6416x16x4F64Vop3pMfma::VMfmaF6416x16x4F64Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF6416x16x4F64Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF6416x16x4F64Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f64_16x16x4_f64", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF6416x16x4F64Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2709,7 +3173,13 @@ VMfmaF644x4x44bF64Vop3pMfma::VMfmaF644x4x44bF64Vop3pMfma(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF644x4x44bF64Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF644x4x44bF64Vop3pMfma(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f64_4x4x4_4b_f64", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF644x4x44bF64Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2747,7 +3217,13 @@ VMfmaF3216x16x32Bf8Bf8Vop3pMfma::VMfmaF3216x16x32Bf8Bf8Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32Bf8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x32Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x32_bf8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x32Bf8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2785,7 +3261,13 @@ VMfmaF3216x16x32Bf8Fp8Vop3pMfma::VMfmaF3216x16x32Bf8Fp8Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32Bf8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x32Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x32_bf8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x32Bf8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2823,7 +3305,13 @@ VMfmaF3216x16x32Fp8Bf8Vop3pMfma::VMfmaF3216x16x32Fp8Bf8Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32Fp8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x32Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x32_fp8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x32Fp8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2861,7 +3349,13 @@ VMfmaF3216x16x32Fp8Fp8Vop3pMfma::VMfmaF3216x16x32Fp8Fp8Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3216x16x32Fp8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3216x16x32Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_16x16x32_fp8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3216x16x32Fp8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2899,7 +3393,13 @@ VMfmaF3232x32x16Bf8Bf8Vop3pMfma::VMfmaF3232x32x16Bf8Bf8Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16Bf8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x16Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x16_bf8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x16Bf8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2937,7 +3437,13 @@ VMfmaF3232x32x16Bf8Fp8Vop3pMfma::VMfmaF3232x32x16Bf8Fp8Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16Bf8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x16Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x16_bf8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x16Bf8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -2975,7 +3481,13 @@ VMfmaF3232x32x16Fp8Bf8Vop3pMfma::VMfmaF3232x32x16Fp8Bf8Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16Fp8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x16Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x16_fp8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x16Fp8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -3013,7 +3525,13 @@ VMfmaF3232x32x16Fp8Fp8Vop3pMfma::VMfmaF3232x32x16Fp8Fp8Vop3pMfma(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMfmaF3232x32x16Fp8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVMfmaF3232x32x16Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_mfma_f32_32x32x16_fp8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMfmaF3232x32x16Fp8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -3050,7 +3568,13 @@ VSmfmacF3216x16x64Bf8Bf8Vop3pMfma::VSmfmacF3216x16x64Bf8Bf8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64Bf8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3216x16x64Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_16x16x64_bf8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3216x16x64Bf8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -3087,7 +3611,13 @@ VSmfmacF3216x16x64Bf8Fp8Vop3pMfma::VSmfmacF3216x16x64Bf8Fp8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64Bf8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3216x16x64Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_16x16x64_bf8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3216x16x64Bf8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -3124,7 +3654,13 @@ VSmfmacF3216x16x64Fp8Bf8Vop3pMfma::VSmfmacF3216x16x64Fp8Bf8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64Fp8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3216x16x64Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_16x16x64_fp8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3216x16x64Fp8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -3161,7 +3697,13 @@ VSmfmacF3216x16x64Fp8Fp8Vop3pMfma::VSmfmacF3216x16x64Fp8Fp8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3216x16x64Fp8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3216x16x64Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_16x16x64_fp8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3216x16x64Fp8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -3198,7 +3740,13 @@ VSmfmacF3232x32x32Bf8Bf8Vop3pMfma::VSmfmacF3232x32x32Bf8Bf8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32Bf8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3232x32x32Bf8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_32x32x32_bf8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3232x32x32Bf8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -3235,7 +3783,13 @@ VSmfmacF3232x32x32Bf8Fp8Vop3pMfma::VSmfmacF3232x32x32Bf8Fp8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32Bf8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3232x32x32Bf8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_32x32x32_bf8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3232x32x32Bf8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -3272,7 +3826,13 @@ VSmfmacF3232x32x32Fp8Bf8Vop3pMfma::VSmfmacF3232x32x32Fp8Bf8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32Fp8Bf8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3232x32x32Fp8Bf8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_32x32x32_fp8_bf8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3232x32x32Fp8Bf8Vop3pMfma>(opcode);
 }
 } // namespace detail
@@ -3309,7 +3869,13 @@ VSmfmacF3232x32x32Fp8Fp8Vop3pMfma::VSmfmacF3232x32x32Fp8Fp8Vop3pMfma(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSmfmacF3232x32x32Fp8Fp8Vop3pMfma(const MachineInst *opcode) {
+DecodeResult decodeVSmfmacF3232x32x32Fp8Fp8Vop3pMfma(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3pMfma::validate_encoding(
+      "v_smfmac_f32_32x32x32_fp8_fp8", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSmfmacF3232x32x32Fp8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vopc.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/vopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -31,8 +30,6 @@ VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_CLASS_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -60,7 +57,18 @@ VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_class_f32_sdwa"
+          : "v_cmp_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F32 does not support DPP";
   return std::make_unique<VCmpClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -85,8 +93,6 @@ VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_CLASS_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -116,7 +122,18 @@ VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_class_f32_sdwa"
+          : "v_cmpx_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F32 does not support DPP";
   return std::make_unique<VCmpxClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -137,15 +154,21 @@ VCmpClassF64Vopc::VCmpClassF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_class_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support SDWA";
   return std::make_unique<VCmpClassF64Vopc>(opcode);
 }
 } // namespace detail
@@ -168,17 +191,23 @@ VCmpxClassF64Vopc::VCmpxClassF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_class_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support SDWA";
   return std::make_unique<VCmpxClassF64Vopc>(opcode);
 }
 } // namespace detail
@@ -202,8 +231,6 @@ VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_CLASS_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -231,7 +258,18 @@ VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_class_f16_sdwa"
+          : "v_cmp_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F16 does not support DPP";
   return std::make_unique<VCmpClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -257,8 +295,6 @@ VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_CLASS_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -288,7 +324,18 @@ VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_class_f16_sdwa"
+          : "v_cmpx_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F16 does not support DPP";
   return std::make_unique<VCmpxClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -311,8 +358,6 @@ VCmpFF16Vopc::VCmpFF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -340,7 +385,17 @@ VCmpFF16Vopc::VCmpFF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_f16_sdwa"
+          : "v_cmp_f_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F16 does not support DPP";
   return std::make_unique<VCmpFF16Vopc>(opcode);
 }
 } // namespace detail
@@ -364,8 +419,6 @@ VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -393,7 +446,17 @@ VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_f16_sdwa"
+          : "v_cmp_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F16 does not support DPP";
   return std::make_unique<VCmpLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -417,8 +480,6 @@ VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -446,7 +507,17 @@ VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_f16_sdwa"
+          : "v_cmp_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F16 does not support DPP";
   return std::make_unique<VCmpEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -470,8 +541,6 @@ VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -499,7 +568,17 @@ VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_f16_sdwa"
+          : "v_cmp_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F16 does not support DPP";
   return std::make_unique<VCmpLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -523,8 +602,6 @@ VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -552,7 +629,17 @@ VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_f16_sdwa"
+          : "v_cmp_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F16 does not support DPP";
   return std::make_unique<VCmpGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -576,8 +663,6 @@ VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -605,7 +690,17 @@ VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lg_f16_sdwa"
+          : "v_cmp_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F16 does not support DPP";
   return std::make_unique<VCmpLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -629,8 +724,6 @@ VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -658,7 +751,17 @@ VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_f16_sdwa"
+          : "v_cmp_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F16 does not support DPP";
   return std::make_unique<VCmpGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -681,8 +784,6 @@ VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_O_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -710,7 +811,17 @@ VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_o_f16_sdwa"
+          : "v_cmp_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F16 does not support DPP";
   return std::make_unique<VCmpOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -733,8 +844,6 @@ VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_U_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -762,7 +871,17 @@ VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_u_f16_sdwa"
+          : "v_cmp_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F16 does not support DPP";
   return std::make_unique<VCmpUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -786,8 +905,6 @@ VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -815,7 +932,17 @@ VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nge_f16_sdwa"
+          : "v_cmp_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F16 does not support DPP";
   return std::make_unique<VCmpNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -839,8 +966,6 @@ VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -868,7 +993,17 @@ VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlg_f16_sdwa"
+          : "v_cmp_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F16 does not support DPP";
   return std::make_unique<VCmpNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -892,8 +1027,6 @@ VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -921,7 +1054,17 @@ VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ngt_f16_sdwa"
+          : "v_cmp_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F16 does not support DPP";
   return std::make_unique<VCmpNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -945,8 +1088,6 @@ VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -974,7 +1115,17 @@ VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nle_f16_sdwa"
+          : "v_cmp_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F16 does not support DPP";
   return std::make_unique<VCmpNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -998,8 +1149,6 @@ VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NEQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1027,7 +1176,17 @@ VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_neq_f16_sdwa"
+          : "v_cmp_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F16 does not support DPP";
   return std::make_unique<VCmpNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1051,8 +1210,6 @@ VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1080,7 +1237,17 @@ VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlt_f16_sdwa"
+          : "v_cmp_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F16 does not support DPP";
   return std::make_unique<VCmpNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1104,8 +1271,6 @@ VCmpTruF16Vopc::VCmpTruF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_TRU_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1133,7 +1298,17 @@ VCmpTruF16Vopc::VCmpTruF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_tru_f16_sdwa"
+          : "v_cmp_tru_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F16 does not support DPP";
   return std::make_unique<VCmpTruF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1159,8 +1334,6 @@ VCmpxFF16Vopc::VCmpxFF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1190,7 +1363,17 @@ VCmpxFF16Vopc::VCmpxFF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_f16_sdwa"
+          : "v_cmpx_f_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F16 does not support DPP";
   return std::make_unique<VCmpxFF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1216,8 +1399,6 @@ VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1247,7 +1428,17 @@ VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_f16_sdwa"
+          : "v_cmpx_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F16 does not support DPP";
   return std::make_unique<VCmpxLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1273,8 +1464,6 @@ VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1304,7 +1493,17 @@ VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_f16_sdwa"
+          : "v_cmpx_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F16 does not support DPP";
   return std::make_unique<VCmpxEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1330,8 +1529,6 @@ VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1361,7 +1558,17 @@ VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_f16_sdwa"
+          : "v_cmpx_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F16 does not support DPP";
   return std::make_unique<VCmpxLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1387,8 +1594,6 @@ VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1418,7 +1623,17 @@ VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_f16_sdwa"
+          : "v_cmpx_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F16 does not support DPP";
   return std::make_unique<VCmpxGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1444,8 +1659,6 @@ VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1475,7 +1688,17 @@ VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lg_f16_sdwa"
+          : "v_cmpx_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F16 does not support DPP";
   return std::make_unique<VCmpxLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1501,8 +1724,6 @@ VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1532,7 +1753,17 @@ VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_f16_sdwa"
+          : "v_cmpx_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F16 does not support DPP";
   return std::make_unique<VCmpxGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1558,8 +1789,6 @@ VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_O_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1589,7 +1818,17 @@ VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_o_f16_sdwa"
+          : "v_cmpx_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F16 does not support DPP";
   return std::make_unique<VCmpxOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1615,8 +1854,6 @@ VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_U_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1646,7 +1883,17 @@ VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_u_f16_sdwa"
+          : "v_cmpx_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F16 does not support DPP";
   return std::make_unique<VCmpxUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1672,8 +1919,6 @@ VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1703,7 +1948,18 @@ VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nge_f16_sdwa"
+          : "v_cmpx_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F16 does not support DPP";
   return std::make_unique<VCmpxNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1729,8 +1985,6 @@ VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1760,7 +2014,18 @@ VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlg_f16_sdwa"
+          : "v_cmpx_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F16 does not support DPP";
   return std::make_unique<VCmpxNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1786,8 +2051,6 @@ VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1817,7 +2080,18 @@ VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ngt_f16_sdwa"
+          : "v_cmpx_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F16 does not support DPP";
   return std::make_unique<VCmpxNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1843,8 +2117,6 @@ VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1874,7 +2146,18 @@ VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nle_f16_sdwa"
+          : "v_cmpx_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F16 does not support DPP";
   return std::make_unique<VCmpxNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1900,8 +2183,6 @@ VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NEQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1931,7 +2212,18 @@ VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_neq_f16_sdwa"
+          : "v_cmpx_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F16 does not support DPP";
   return std::make_unique<VCmpxNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -1957,8 +2249,6 @@ VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1988,7 +2278,18 @@ VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlt_f16_sdwa"
+          : "v_cmpx_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F16 does not support DPP";
   return std::make_unique<VCmpxNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -2014,8 +2315,6 @@ VCmpxTruF16Vopc::VCmpxTruF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_TRU_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2045,7 +2344,18 @@ VCmpxTruF16Vopc::VCmpxTruF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_tru_f16_sdwa"
+          : "v_cmpx_tru_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F16 does not support DPP";
   return std::make_unique<VCmpxTruF16Vopc>(opcode);
 }
 } // namespace detail
@@ -2067,8 +2377,6 @@ VCmpFF32Vopc::VCmpFF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2096,7 +2404,17 @@ VCmpFF32Vopc::VCmpFF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_f32_sdwa"
+          : "v_cmp_f_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F32 does not support DPP";
   return std::make_unique<VCmpFF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2119,8 +2437,6 @@ VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2148,7 +2464,17 @@ VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_f32_sdwa"
+          : "v_cmp_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F32 does not support DPP";
   return std::make_unique<VCmpLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2171,8 +2497,6 @@ VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2200,7 +2524,17 @@ VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_f32_sdwa"
+          : "v_cmp_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F32 does not support DPP";
   return std::make_unique<VCmpEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2223,8 +2557,6 @@ VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2252,7 +2584,17 @@ VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_f32_sdwa"
+          : "v_cmp_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F32 does not support DPP";
   return std::make_unique<VCmpLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2275,8 +2617,6 @@ VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2304,7 +2644,17 @@ VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_f32_sdwa"
+          : "v_cmp_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F32 does not support DPP";
   return std::make_unique<VCmpGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2327,8 +2677,6 @@ VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2356,7 +2704,17 @@ VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lg_f32_sdwa"
+          : "v_cmp_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F32 does not support DPP";
   return std::make_unique<VCmpLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2379,8 +2737,6 @@ VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2408,7 +2764,17 @@ VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_f32_sdwa"
+          : "v_cmp_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F32 does not support DPP";
   return std::make_unique<VCmpGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2430,8 +2796,6 @@ VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_O_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2459,7 +2823,17 @@ VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_o_f32_sdwa"
+          : "v_cmp_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F32 does not support DPP";
   return std::make_unique<VCmpOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2481,8 +2855,6 @@ VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_U_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2510,7 +2882,17 @@ VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_u_f32_sdwa"
+          : "v_cmp_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F32 does not support DPP";
   return std::make_unique<VCmpUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2533,8 +2915,6 @@ VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2562,7 +2942,17 @@ VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nge_f32_sdwa"
+          : "v_cmp_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F32 does not support DPP";
   return std::make_unique<VCmpNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2585,8 +2975,6 @@ VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2614,7 +3002,17 @@ VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlg_f32_sdwa"
+          : "v_cmp_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F32 does not support DPP";
   return std::make_unique<VCmpNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2637,8 +3035,6 @@ VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2666,7 +3062,17 @@ VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ngt_f32_sdwa"
+          : "v_cmp_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F32 does not support DPP";
   return std::make_unique<VCmpNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2689,8 +3095,6 @@ VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2718,7 +3122,17 @@ VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nle_f32_sdwa"
+          : "v_cmp_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F32 does not support DPP";
   return std::make_unique<VCmpNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2741,8 +3155,6 @@ VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NEQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2770,7 +3182,17 @@ VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_neq_f32_sdwa"
+          : "v_cmp_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F32 does not support DPP";
   return std::make_unique<VCmpNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2793,8 +3215,6 @@ VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2822,7 +3242,17 @@ VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlt_f32_sdwa"
+          : "v_cmp_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F32 does not support DPP";
   return std::make_unique<VCmpNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2845,8 +3275,6 @@ VCmpTruF32Vopc::VCmpTruF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_TRU_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2874,7 +3302,17 @@ VCmpTruF32Vopc::VCmpTruF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_tru_f32_sdwa"
+          : "v_cmp_tru_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F32 does not support DPP";
   return std::make_unique<VCmpTruF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2899,8 +3337,6 @@ VCmpxFF32Vopc::VCmpxFF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2930,7 +3366,17 @@ VCmpxFF32Vopc::VCmpxFF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_f32_sdwa"
+          : "v_cmpx_f_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F32 does not support DPP";
   return std::make_unique<VCmpxFF32Vopc>(opcode);
 }
 } // namespace detail
@@ -2955,8 +3401,6 @@ VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2986,7 +3430,17 @@ VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_f32_sdwa"
+          : "v_cmpx_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F32 does not support DPP";
   return std::make_unique<VCmpxLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3011,8 +3465,6 @@ VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3042,7 +3494,17 @@ VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_f32_sdwa"
+          : "v_cmpx_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F32 does not support DPP";
   return std::make_unique<VCmpxEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3067,8 +3529,6 @@ VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3098,7 +3558,17 @@ VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_f32_sdwa"
+          : "v_cmpx_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F32 does not support DPP";
   return std::make_unique<VCmpxLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3123,8 +3593,6 @@ VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3154,7 +3622,17 @@ VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_f32_sdwa"
+          : "v_cmpx_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F32 does not support DPP";
   return std::make_unique<VCmpxGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3179,8 +3657,6 @@ VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3210,7 +3686,17 @@ VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lg_f32_sdwa"
+          : "v_cmpx_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F32 does not support DPP";
   return std::make_unique<VCmpxLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3235,8 +3721,6 @@ VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3266,7 +3750,17 @@ VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_f32_sdwa"
+          : "v_cmpx_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F32 does not support DPP";
   return std::make_unique<VCmpxGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3291,8 +3785,6 @@ VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_O_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3322,7 +3814,17 @@ VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_o_f32_sdwa"
+          : "v_cmpx_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F32 does not support DPP";
   return std::make_unique<VCmpxOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3347,8 +3849,6 @@ VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_U_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3378,7 +3878,17 @@ VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_u_f32_sdwa"
+          : "v_cmpx_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F32 does not support DPP";
   return std::make_unique<VCmpxUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3403,8 +3913,6 @@ VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3434,7 +3942,18 @@ VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nge_f32_sdwa"
+          : "v_cmpx_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F32 does not support DPP";
   return std::make_unique<VCmpxNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3459,8 +3978,6 @@ VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3490,7 +4007,18 @@ VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlg_f32_sdwa"
+          : "v_cmpx_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F32 does not support DPP";
   return std::make_unique<VCmpxNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3515,8 +4043,6 @@ VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3546,7 +4072,18 @@ VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ngt_f32_sdwa"
+          : "v_cmpx_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F32 does not support DPP";
   return std::make_unique<VCmpxNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3571,8 +4108,6 @@ VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3602,7 +4137,18 @@ VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nle_f32_sdwa"
+          : "v_cmpx_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F32 does not support DPP";
   return std::make_unique<VCmpxNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3627,8 +4173,6 @@ VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NEQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3658,7 +4202,18 @@ VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_neq_f32_sdwa"
+          : "v_cmpx_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F32 does not support DPP";
   return std::make_unique<VCmpxNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3683,8 +4238,6 @@ VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3714,7 +4267,18 @@ VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlt_f32_sdwa"
+          : "v_cmpx_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F32 does not support DPP";
   return std::make_unique<VCmpxNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3739,8 +4303,6 @@ VCmpxTruF32Vopc::VCmpxTruF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_TRU_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3770,7 +4332,18 @@ VCmpxTruF32Vopc::VCmpxTruF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_tru_f32_sdwa"
+          : "v_cmpx_tru_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F32 does not support DPP";
   return std::make_unique<VCmpxTruF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3791,15 +4364,20 @@ VCmpFF64Vopc::VCmpFF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_F_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_f_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F64 does not support SDWA";
   return std::make_unique<VCmpFF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3820,15 +4398,20 @@ VCmpLtF64Vopc::VCmpLtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support SDWA";
   return std::make_unique<VCmpLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3849,15 +4432,20 @@ VCmpEqF64Vopc::VCmpEqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_eq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support SDWA";
   return std::make_unique<VCmpEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3878,15 +4466,20 @@ VCmpLeF64Vopc::VCmpLeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_le_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support SDWA";
   return std::make_unique<VCmpLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3907,15 +4500,20 @@ VCmpGtF64Vopc::VCmpGtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_gt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support SDWA";
   return std::make_unique<VCmpGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3936,15 +4534,20 @@ VCmpLgF64Vopc::VCmpLgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support SDWA";
   return std::make_unique<VCmpLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3965,15 +4568,20 @@ VCmpGeF64Vopc::VCmpGeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support SDWA";
   return std::make_unique<VCmpGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3994,15 +4602,20 @@ VCmpOF64Vopc::VCmpOF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_O_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_O_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_o_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support SDWA";
   return std::make_unique<VCmpOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4023,15 +4636,20 @@ VCmpUF64Vopc::VCmpUF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_U_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_U_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_u_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support SDWA";
   return std::make_unique<VCmpUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4052,15 +4670,20 @@ VCmpNgeF64Vopc::VCmpNgeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support SDWA";
   return std::make_unique<VCmpNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4081,15 +4704,20 @@ VCmpNlgF64Vopc::VCmpNlgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nlg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support SDWA";
   return std::make_unique<VCmpNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4110,15 +4738,20 @@ VCmpNgtF64Vopc::VCmpNgtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ngt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support SDWA";
   return std::make_unique<VCmpNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4139,15 +4772,20 @@ VCmpNleF64Vopc::VCmpNleF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nle_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support SDWA";
   return std::make_unique<VCmpNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4168,15 +4806,20 @@ VCmpNeqF64Vopc::VCmpNeqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_neq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support SDWA";
   return std::make_unique<VCmpNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4197,15 +4840,20 @@ VCmpNltF64Vopc::VCmpNltF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nlt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support SDWA";
   return std::make_unique<VCmpNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4226,15 +4874,20 @@ VCmpTruF64Vopc::VCmpTruF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_TRU_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_TRU_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_tru_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F64 does not support SDWA";
   return std::make_unique<VCmpTruF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4257,17 +4910,22 @@ VCmpxFF64Vopc::VCmpxFF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_F_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_f_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F64 does not support SDWA";
   return std::make_unique<VCmpxFF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4290,17 +4948,22 @@ VCmpxLtF64Vopc::VCmpxLtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support SDWA";
   return std::make_unique<VCmpxLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4323,17 +4986,22 @@ VCmpxEqF64Vopc::VCmpxEqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_eq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support SDWA";
   return std::make_unique<VCmpxEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4356,17 +5024,22 @@ VCmpxLeF64Vopc::VCmpxLeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_le_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support SDWA";
   return std::make_unique<VCmpxLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4389,17 +5062,22 @@ VCmpxGtF64Vopc::VCmpxGtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_gt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support SDWA";
   return std::make_unique<VCmpxGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4422,17 +5100,22 @@ VCmpxLgF64Vopc::VCmpxLgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support SDWA";
   return std::make_unique<VCmpxLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4455,17 +5138,22 @@ VCmpxGeF64Vopc::VCmpxGeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support SDWA";
   return std::make_unique<VCmpxGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4488,17 +5176,22 @@ VCmpxOF64Vopc::VCmpxOF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_O_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_O_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_o_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support SDWA";
   return std::make_unique<VCmpxOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4521,17 +5214,22 @@ VCmpxUF64Vopc::VCmpxUF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_U_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_U_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_u_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support SDWA";
   return std::make_unique<VCmpxUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4554,17 +5252,23 @@ VCmpxNgeF64Vopc::VCmpxNgeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support SDWA";
   return std::make_unique<VCmpxNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4587,17 +5291,23 @@ VCmpxNlgF64Vopc::VCmpxNlgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nlg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support SDWA";
   return std::make_unique<VCmpxNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4620,17 +5330,23 @@ VCmpxNgtF64Vopc::VCmpxNgtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ngt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support SDWA";
   return std::make_unique<VCmpxNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4653,17 +5369,23 @@ VCmpxNleF64Vopc::VCmpxNleF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nle_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support SDWA";
   return std::make_unique<VCmpxNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4686,17 +5408,23 @@ VCmpxNeqF64Vopc::VCmpxNeqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_neq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support SDWA";
   return std::make_unique<VCmpxNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4719,17 +5447,23 @@ VCmpxNltF64Vopc::VCmpxNltF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nlt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support SDWA";
   return std::make_unique<VCmpxNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4752,17 +5486,23 @@ VCmpxTruF64Vopc::VCmpxTruF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_TRU_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_TRU_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_tru_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F64 does not support SDWA";
   return std::make_unique<VCmpxTruF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4785,8 +5525,6 @@ VCmpFI16Vopc::VCmpFI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4814,7 +5552,17 @@ VCmpFI16Vopc::VCmpFI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_i16_sdwa"
+          : "v_cmp_f_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I16 does not support DPP";
   return std::make_unique<VCmpFI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4838,8 +5586,6 @@ VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4867,7 +5613,17 @@ VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_i16_sdwa"
+          : "v_cmp_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I16 does not support DPP";
   return std::make_unique<VCmpLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4891,8 +5647,6 @@ VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4920,7 +5674,17 @@ VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_i16_sdwa"
+          : "v_cmp_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I16 does not support DPP";
   return std::make_unique<VCmpEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4944,8 +5708,6 @@ VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4973,7 +5735,17 @@ VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_i16_sdwa"
+          : "v_cmp_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I16 does not support DPP";
   return std::make_unique<VCmpLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4997,8 +5769,6 @@ VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5026,7 +5796,17 @@ VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_i16_sdwa"
+          : "v_cmp_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I16 does not support DPP";
   return std::make_unique<VCmpGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5050,8 +5830,6 @@ VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5079,7 +5857,17 @@ VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_i16_sdwa"
+          : "v_cmp_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I16 does not support DPP";
   return std::make_unique<VCmpNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5103,8 +5891,6 @@ VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5132,7 +5918,17 @@ VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_i16_sdwa"
+          : "v_cmp_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I16 does not support DPP";
   return std::make_unique<VCmpGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5155,8 +5951,6 @@ VCmpTI16Vopc::VCmpTI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5184,7 +5978,17 @@ VCmpTI16Vopc::VCmpTI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_i16_sdwa"
+          : "v_cmp_t_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I16 does not support DPP";
   return std::make_unique<VCmpTI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5207,8 +6011,6 @@ VCmpFU16Vopc::VCmpFU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5236,7 +6038,17 @@ VCmpFU16Vopc::VCmpFU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_u16_sdwa"
+          : "v_cmp_f_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U16 does not support DPP";
   return std::make_unique<VCmpFU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5260,8 +6072,6 @@ VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5289,7 +6099,17 @@ VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_u16_sdwa"
+          : "v_cmp_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U16 does not support DPP";
   return std::make_unique<VCmpLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5313,8 +6133,6 @@ VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5342,7 +6160,17 @@ VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_u16_sdwa"
+          : "v_cmp_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U16 does not support DPP";
   return std::make_unique<VCmpEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5366,8 +6194,6 @@ VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5395,7 +6221,17 @@ VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_u16_sdwa"
+          : "v_cmp_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U16 does not support DPP";
   return std::make_unique<VCmpLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5419,8 +6255,6 @@ VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5448,7 +6282,17 @@ VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_u16_sdwa"
+          : "v_cmp_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U16 does not support DPP";
   return std::make_unique<VCmpGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5472,8 +6316,6 @@ VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5501,7 +6343,17 @@ VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_u16_sdwa"
+          : "v_cmp_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U16 does not support DPP";
   return std::make_unique<VCmpNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5525,8 +6377,6 @@ VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5554,7 +6404,17 @@ VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_u16_sdwa"
+          : "v_cmp_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U16 does not support DPP";
   return std::make_unique<VCmpGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5577,8 +6437,6 @@ VCmpTU16Vopc::VCmpTU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5606,7 +6464,17 @@ VCmpTU16Vopc::VCmpTU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_u16_sdwa"
+          : "v_cmp_t_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U16 does not support DPP";
   return std::make_unique<VCmpTU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5632,8 +6500,6 @@ VCmpxFI16Vopc::VCmpxFI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5663,7 +6529,17 @@ VCmpxFI16Vopc::VCmpxFI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_i16_sdwa"
+          : "v_cmpx_f_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I16 does not support DPP";
   return std::make_unique<VCmpxFI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5689,8 +6565,6 @@ VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5720,7 +6594,17 @@ VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_i16_sdwa"
+          : "v_cmpx_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I16 does not support DPP";
   return std::make_unique<VCmpxLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5746,8 +6630,6 @@ VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5777,7 +6659,17 @@ VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_i16_sdwa"
+          : "v_cmpx_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I16 does not support DPP";
   return std::make_unique<VCmpxEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5803,8 +6695,6 @@ VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5834,7 +6724,17 @@ VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_i16_sdwa"
+          : "v_cmpx_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I16 does not support DPP";
   return std::make_unique<VCmpxLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5860,8 +6760,6 @@ VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5891,7 +6789,17 @@ VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_i16_sdwa"
+          : "v_cmpx_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I16 does not support DPP";
   return std::make_unique<VCmpxGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5917,8 +6825,6 @@ VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5948,7 +6854,17 @@ VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_i16_sdwa"
+          : "v_cmpx_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I16 does not support DPP";
   return std::make_unique<VCmpxNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5974,8 +6890,6 @@ VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6005,7 +6919,17 @@ VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_i16_sdwa"
+          : "v_cmpx_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I16 does not support DPP";
   return std::make_unique<VCmpxGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6031,8 +6955,6 @@ VCmpxTI16Vopc::VCmpxTI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6062,7 +6984,17 @@ VCmpxTI16Vopc::VCmpxTI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_i16_sdwa"
+          : "v_cmpx_t_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I16 does not support DPP";
   return std::make_unique<VCmpxTI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6088,8 +7020,6 @@ VCmpxFU16Vopc::VCmpxFU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6119,7 +7049,17 @@ VCmpxFU16Vopc::VCmpxFU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_u16_sdwa"
+          : "v_cmpx_f_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U16 does not support DPP";
   return std::make_unique<VCmpxFU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6145,8 +7085,6 @@ VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6176,7 +7114,17 @@ VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_u16_sdwa"
+          : "v_cmpx_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U16 does not support DPP";
   return std::make_unique<VCmpxLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6202,8 +7150,6 @@ VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6233,7 +7179,17 @@ VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_u16_sdwa"
+          : "v_cmpx_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U16 does not support DPP";
   return std::make_unique<VCmpxEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6259,8 +7215,6 @@ VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6290,7 +7244,17 @@ VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_u16_sdwa"
+          : "v_cmpx_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U16 does not support DPP";
   return std::make_unique<VCmpxLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6316,8 +7280,6 @@ VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6347,7 +7309,17 @@ VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_u16_sdwa"
+          : "v_cmpx_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U16 does not support DPP";
   return std::make_unique<VCmpxGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6373,8 +7345,6 @@ VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6404,7 +7374,17 @@ VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_u16_sdwa"
+          : "v_cmpx_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U16 does not support DPP";
   return std::make_unique<VCmpxNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6430,8 +7410,6 @@ VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6461,7 +7439,17 @@ VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_u16_sdwa"
+          : "v_cmpx_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U16 does not support DPP";
   return std::make_unique<VCmpxGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6487,8 +7475,6 @@ VCmpxTU16Vopc::VCmpxTU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6518,7 +7504,17 @@ VCmpxTU16Vopc::VCmpxTU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_u16_sdwa"
+          : "v_cmpx_t_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U16 does not support DPP";
   return std::make_unique<VCmpxTU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6540,8 +7536,6 @@ VCmpFI32Vopc::VCmpFI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6569,7 +7563,17 @@ VCmpFI32Vopc::VCmpFI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_i32_sdwa"
+          : "v_cmp_f_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I32 does not support DPP";
   return std::make_unique<VCmpFI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6592,8 +7596,6 @@ VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6621,7 +7623,17 @@ VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_i32_sdwa"
+          : "v_cmp_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I32 does not support DPP";
   return std::make_unique<VCmpLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6644,8 +7656,6 @@ VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6673,7 +7683,17 @@ VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_i32_sdwa"
+          : "v_cmp_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I32 does not support DPP";
   return std::make_unique<VCmpEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6696,8 +7716,6 @@ VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6725,7 +7743,17 @@ VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_i32_sdwa"
+          : "v_cmp_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I32 does not support DPP";
   return std::make_unique<VCmpLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6748,8 +7776,6 @@ VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6777,7 +7803,17 @@ VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_i32_sdwa"
+          : "v_cmp_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I32 does not support DPP";
   return std::make_unique<VCmpGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6800,8 +7836,6 @@ VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6829,7 +7863,17 @@ VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_i32_sdwa"
+          : "v_cmp_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I32 does not support DPP";
   return std::make_unique<VCmpNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6852,8 +7896,6 @@ VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6881,7 +7923,17 @@ VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_i32_sdwa"
+          : "v_cmp_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I32 does not support DPP";
   return std::make_unique<VCmpGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6903,8 +7955,6 @@ VCmpTI32Vopc::VCmpTI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6932,7 +7982,17 @@ VCmpTI32Vopc::VCmpTI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_i32_sdwa"
+          : "v_cmp_t_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I32 does not support DPP";
   return std::make_unique<VCmpTI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6954,8 +8014,6 @@ VCmpFU32Vopc::VCmpFU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6983,7 +8041,17 @@ VCmpFU32Vopc::VCmpFU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_u32_sdwa"
+          : "v_cmp_f_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U32 does not support DPP";
   return std::make_unique<VCmpFU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7006,8 +8074,6 @@ VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7035,7 +8101,17 @@ VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_u32_sdwa"
+          : "v_cmp_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U32 does not support DPP";
   return std::make_unique<VCmpLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7058,8 +8134,6 @@ VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7087,7 +8161,17 @@ VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_u32_sdwa"
+          : "v_cmp_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U32 does not support DPP";
   return std::make_unique<VCmpEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7110,8 +8194,6 @@ VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7139,7 +8221,17 @@ VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_u32_sdwa"
+          : "v_cmp_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U32 does not support DPP";
   return std::make_unique<VCmpLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7162,8 +8254,6 @@ VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7191,7 +8281,17 @@ VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_u32_sdwa"
+          : "v_cmp_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U32 does not support DPP";
   return std::make_unique<VCmpGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7214,8 +8314,6 @@ VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7243,7 +8341,17 @@ VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_u32_sdwa"
+          : "v_cmp_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U32 does not support DPP";
   return std::make_unique<VCmpNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7266,8 +8374,6 @@ VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7295,7 +8401,17 @@ VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_u32_sdwa"
+          : "v_cmp_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U32 does not support DPP";
   return std::make_unique<VCmpGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7317,8 +8433,6 @@ VCmpTU32Vopc::VCmpTU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7346,7 +8460,17 @@ VCmpTU32Vopc::VCmpTU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_u32_sdwa"
+          : "v_cmp_t_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U32 does not support DPP";
   return std::make_unique<VCmpTU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7371,8 +8495,6 @@ VCmpxFI32Vopc::VCmpxFI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7402,7 +8524,17 @@ VCmpxFI32Vopc::VCmpxFI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_i32_sdwa"
+          : "v_cmpx_f_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I32 does not support DPP";
   return std::make_unique<VCmpxFI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7427,8 +8559,6 @@ VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7458,7 +8588,17 @@ VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_i32_sdwa"
+          : "v_cmpx_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I32 does not support DPP";
   return std::make_unique<VCmpxLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7483,8 +8623,6 @@ VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7514,7 +8652,17 @@ VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_i32_sdwa"
+          : "v_cmpx_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I32 does not support DPP";
   return std::make_unique<VCmpxEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7539,8 +8687,6 @@ VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7570,7 +8716,17 @@ VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_i32_sdwa"
+          : "v_cmpx_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I32 does not support DPP";
   return std::make_unique<VCmpxLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7595,8 +8751,6 @@ VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7626,7 +8780,17 @@ VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_i32_sdwa"
+          : "v_cmpx_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I32 does not support DPP";
   return std::make_unique<VCmpxGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7651,8 +8815,6 @@ VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7682,7 +8844,17 @@ VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_i32_sdwa"
+          : "v_cmpx_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I32 does not support DPP";
   return std::make_unique<VCmpxNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7707,8 +8879,6 @@ VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7738,7 +8908,17 @@ VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_i32_sdwa"
+          : "v_cmpx_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I32 does not support DPP";
   return std::make_unique<VCmpxGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7763,8 +8943,6 @@ VCmpxTI32Vopc::VCmpxTI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7794,7 +8972,17 @@ VCmpxTI32Vopc::VCmpxTI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_i32_sdwa"
+          : "v_cmpx_t_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I32 does not support DPP";
   return std::make_unique<VCmpxTI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7819,8 +9007,6 @@ VCmpxFU32Vopc::VCmpxFU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7850,7 +9036,17 @@ VCmpxFU32Vopc::VCmpxFU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_u32_sdwa"
+          : "v_cmpx_f_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U32 does not support DPP";
   return std::make_unique<VCmpxFU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7875,8 +9071,6 @@ VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7906,7 +9100,17 @@ VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_u32_sdwa"
+          : "v_cmpx_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U32 does not support DPP";
   return std::make_unique<VCmpxLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7931,8 +9135,6 @@ VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7962,7 +9164,17 @@ VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_u32_sdwa"
+          : "v_cmpx_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U32 does not support DPP";
   return std::make_unique<VCmpxEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7987,8 +9199,6 @@ VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8018,7 +9228,17 @@ VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_u32_sdwa"
+          : "v_cmpx_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U32 does not support DPP";
   return std::make_unique<VCmpxLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8043,8 +9263,6 @@ VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8074,7 +9292,17 @@ VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_u32_sdwa"
+          : "v_cmpx_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U32 does not support DPP";
   return std::make_unique<VCmpxGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8099,8 +9327,6 @@ VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8130,7 +9356,17 @@ VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_u32_sdwa"
+          : "v_cmpx_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U32 does not support DPP";
   return std::make_unique<VCmpxNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8155,8 +9391,6 @@ VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8186,7 +9420,17 @@ VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_u32_sdwa"
+          : "v_cmpx_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U32 does not support DPP";
   return std::make_unique<VCmpxGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8211,8 +9455,6 @@ VCmpxTU32Vopc::VCmpxTU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8242,7 +9484,17 @@ VCmpxTU32Vopc::VCmpxTU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_u32_sdwa"
+          : "v_cmpx_t_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U32 does not support DPP";
   return std::make_unique<VCmpxTU32Vopc>(opcode);
 }
 } // namespace detail
@@ -8263,15 +9515,20 @@ VCmpFI64Vopc::VCmpFI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_F_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_f_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I64 does not support SDWA";
   return std::make_unique<VCmpFI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8292,15 +9549,20 @@ VCmpLtI64Vopc::VCmpLtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support SDWA";
   return std::make_unique<VCmpLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8321,15 +9583,20 @@ VCmpEqI64Vopc::VCmpEqI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_eq_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support SDWA";
   return std::make_unique<VCmpEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8350,15 +9617,20 @@ VCmpLeI64Vopc::VCmpLeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_le_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support SDWA";
   return std::make_unique<VCmpLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8379,15 +9651,20 @@ VCmpGtI64Vopc::VCmpGtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_gt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support SDWA";
   return std::make_unique<VCmpGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8408,15 +9685,20 @@ VCmpNeI64Vopc::VCmpNeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ne_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support SDWA";
   return std::make_unique<VCmpNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8437,15 +9719,20 @@ VCmpGeI64Vopc::VCmpGeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ge_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support SDWA";
   return std::make_unique<VCmpGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8466,15 +9753,20 @@ VCmpTI64Vopc::VCmpTI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_T_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_t_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I64 does not support SDWA";
   return std::make_unique<VCmpTI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8495,15 +9787,20 @@ VCmpFU64Vopc::VCmpFU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_F_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_F_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_f_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U64 does not support SDWA";
   return std::make_unique<VCmpFU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8524,15 +9821,20 @@ VCmpLtU64Vopc::VCmpLtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support SDWA";
   return std::make_unique<VCmpLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8553,15 +9855,20 @@ VCmpEqU64Vopc::VCmpEqU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_eq_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support SDWA";
   return std::make_unique<VCmpEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8582,15 +9889,20 @@ VCmpLeU64Vopc::VCmpLeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_LE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_le_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support SDWA";
   return std::make_unique<VCmpLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8611,15 +9923,20 @@ VCmpGtU64Vopc::VCmpGtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_gt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support SDWA";
   return std::make_unique<VCmpGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8640,15 +9957,20 @@ VCmpNeU64Vopc::VCmpNeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_NE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ne_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support SDWA";
   return std::make_unique<VCmpNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8669,15 +9991,20 @@ VCmpGeU64Vopc::VCmpGeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_GE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ge_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support SDWA";
   return std::make_unique<VCmpGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8698,15 +10025,20 @@ VCmpTU64Vopc::VCmpTU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMP_T_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_T_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_t_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U64 does not support SDWA";
   return std::make_unique<VCmpTU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8729,17 +10061,22 @@ VCmpxFI64Vopc::VCmpxFI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_F_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_f_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I64 does not support SDWA";
   return std::make_unique<VCmpxFI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8762,17 +10099,22 @@ VCmpxLtI64Vopc::VCmpxLtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support SDWA";
   return std::make_unique<VCmpxLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8795,17 +10137,22 @@ VCmpxEqI64Vopc::VCmpxEqI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_eq_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support SDWA";
   return std::make_unique<VCmpxEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8828,17 +10175,22 @@ VCmpxLeI64Vopc::VCmpxLeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_le_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support SDWA";
   return std::make_unique<VCmpxLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8861,17 +10213,22 @@ VCmpxGtI64Vopc::VCmpxGtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_gt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support SDWA";
   return std::make_unique<VCmpxGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8894,17 +10251,22 @@ VCmpxNeI64Vopc::VCmpxNeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ne_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support SDWA";
   return std::make_unique<VCmpxNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8927,17 +10289,22 @@ VCmpxGeI64Vopc::VCmpxGeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ge_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support SDWA";
   return std::make_unique<VCmpxGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8960,17 +10327,22 @@ VCmpxTI64Vopc::VCmpxTI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_T_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_t_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I64 does not support SDWA";
   return std::make_unique<VCmpxTI64Vopc>(opcode);
 }
 } // namespace detail
@@ -8993,17 +10365,22 @@ VCmpxFU64Vopc::VCmpxFU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_F_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_F_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_f_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U64 does not support SDWA";
   return std::make_unique<VCmpxFU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9026,17 +10403,22 @@ VCmpxLtU64Vopc::VCmpxLtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support SDWA";
   return std::make_unique<VCmpxLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9059,17 +10441,22 @@ VCmpxEqU64Vopc::VCmpxEqU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_eq_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support SDWA";
   return std::make_unique<VCmpxEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9092,17 +10479,22 @@ VCmpxLeU64Vopc::VCmpxLeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_le_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support SDWA";
   return std::make_unique<VCmpxLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9125,17 +10517,22 @@ VCmpxGtU64Vopc::VCmpxGtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_gt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support SDWA";
   return std::make_unique<VCmpxGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9158,17 +10555,22 @@ VCmpxNeU64Vopc::VCmpxNeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ne_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support SDWA";
   return std::make_unique<VCmpxNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9191,17 +10593,22 @@ VCmpxGeU64Vopc::VCmpxGeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ge_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support SDWA";
   return std::make_unique<VCmpxGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -9224,17 +10631,22 @@ VCmpxTU64Vopc::VCmpxTU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP)
-    throw util::InvalidInst("V_CMPX_T_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_T_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_t_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U64 does not support SDWA";
   return std::make_unique<VCmpxTU64Vopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/decoder.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/decoder.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vopd.h"
-#include "util/except.h"
 #include <array>
 #include <bit>
 #include <format>
@@ -16,1642 +15,2270 @@ namespace rocjitsu {
 namespace cdna5 {
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddF64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddU32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddU64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndB32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndB64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapB32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapB64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCondSubU32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecU32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecU64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncU32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncU64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxI32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxI64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxNumF32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxNumF64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxU32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxU64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinI32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinI64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinNumF32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinNumF64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinU32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinU64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrB32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrB64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicPkAddBf16Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicPkAddF16Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubClampU32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubU32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubU64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapB32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapB64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorB32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorB64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadB128Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadB32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadB64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadB96Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16B16Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16HiB16Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16HiI8Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16HiU8Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16I8Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16U8Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadI16Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadI8Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadU16Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadU8Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB128Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB16Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB8Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB96Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16HiB16Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16HiB8Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeClusterLoadAsyncToLdsB128Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeClusterLoadAsyncToLdsB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeClusterLoadAsyncToLdsB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeClusterLoadAsyncToLdsB8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeClusterLoadB128Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeClusterLoadB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeClusterLoadB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddF32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddF64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnF32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnF64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAppendVds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAtomicAsyncBarrierArriveB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAtomicBarrierArriveRtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsBpermuteB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsBpermuteFiB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCondSubRtnU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCondSubU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsConsumeVds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoad2addrB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoad2addrB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoad2addrStride64B32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoad2addrStride64B64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadAddtidB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadB128Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadB96Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadI16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadI8D16HiVds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadI8D16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadI8Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadTr16B128Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadTr4B64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadTr6B96Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadTr8B64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU16D16HiVds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU16D16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU8D16HiVds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU8D16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU8Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxNumF32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxNumF64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxNumRtnF32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxNumRtnF64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinNumF32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinNumF64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinNumRtnF32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinNumRtnF64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsNopVds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPermuteB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPkAddBf16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPkAddF16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPkAddRtnBf16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPkAddRtnF16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStore2addrB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStore2addrB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStore2addrStride64B32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStore2addrStride64B64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreAddtidB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB128Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB16D16HiVds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB8D16HiVds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB8Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB96Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchg2addrRtnB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchg2addrRtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchg2addrStride64RtnB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchg2addrStride64RtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchgRtnB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchgRtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubClampRtnU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubClampU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSwizzleB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddF32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddF64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddU32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddU64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndB32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndB64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapB32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapB64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCondSubU32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecU32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecU64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncU32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncU64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxI32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxI64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxNumF32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxNumF64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxU32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxU64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinI32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinI64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinNumF32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinNumF64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinU32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinU64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrB32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrB64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicPkAddBf16Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicPkAddF16Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubClampU32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubU32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubU64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapB32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapB64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorB32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorB64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadB128Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadB32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadB64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadB96Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16B16Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16HiB16Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16HiI8Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16HiU8Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16I8Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16U8Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadI16Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadI8Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadMonitorB128Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadMonitorB32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadMonitorB64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadU16Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadU8Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatPrefetchB8Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB128Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB16Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB8Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB96Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreD16HiB16Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreD16HiB8Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicAddF32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicAddF64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicAddU32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicAddU64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicAndB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicAndB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicCmpswapB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicCmpswapB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicCondSubU32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicDecU32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicDecU64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicIncU32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicIncU64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxI32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxI64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxNumF32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxNumF64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxU32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxU64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMinI32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMinI64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMinNumF32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMinNumF64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMinU32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMinU64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicOrB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicOrB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicPkAddBf16Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicPkAddF16Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicSubClampU32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicSubU32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicSubU64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicSwapB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicSwapB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicXorB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicXorB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalInvVglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadAddtidB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadAsyncToLdsB128Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadAsyncToLdsB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadAsyncToLdsB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadAsyncToLdsB8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadB128Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadB96Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadBlockVglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadD16B16Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadD16HiB16Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadD16HiI8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadD16HiU8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadD16I8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadD16U8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadI16Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadI8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadMonitorB128Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadMonitorB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadMonitorB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadTr16B128Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadTr4B64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadTr6B96Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadTr8B64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadU16Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadU8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalPrefetchB8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreAddtidB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreAsyncFromLdsB128Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreAsyncFromLdsB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreAsyncFromLdsB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreAsyncFromLdsB8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreB128Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreB16Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreB8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreB96Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreBlockVglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreD16HiB16Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreD16HiB8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalWbVglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalWbinvVglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddCoCiU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddCoI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddCoU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddNcU64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddPcI64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddkCoI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAllocVgprSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot0SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot0SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot0WrexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot0WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1WrexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtcProbeBufferSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtcProbeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBarrierInitSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBarrierJoinSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBarrierLeaveSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBarrierSignalIsfirstSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBarrierSignalSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBarrierWaitSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB128Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB256Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB32Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB512Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB64Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB96Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadI16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadI8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadU16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadU8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferPrefetchDataSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCallI64Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCeilF16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCeilF32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClauseSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClsI32I64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClsI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClzI32U32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClzI32U64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNeqF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNeqF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNgeF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNgeF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNgtF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNgtF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNleF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNleF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNlgF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNlgF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNltF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNltF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpOF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpOF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpUF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpUF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCodeEndSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCtzI32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCtzI32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtF16F32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtF32F16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtF32I32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtF32U32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtHiF32F16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtI32F32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtPkRtzF16F32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtU32F32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDelayAluSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDenormModeSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFloorF16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFloorF32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFmaakF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFmacF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFmacF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFmamkF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetBarrierStateSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetPcI64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetShaderCyclesU64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB128Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB256Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB32Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB512Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB64Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB96Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadI16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadI8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadU16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadU8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxNumF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxNumF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaximumF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaximumF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinNumF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinNumF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinimumF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinimumF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMonitorSleepSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsd2B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulU64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot0SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot0SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot1B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot1B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot1SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackHlB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPrefetchDataPcRelSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPrefetchDataSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPrefetchInstPcRelSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPrefetchInstSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRfeI64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRndneF16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRndneF32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRoundModeSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsgRtnB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsgRtnB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetPcI64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetVgprMsbSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetprioIncWgSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSleepVarSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubCoCiU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubCoI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubCoU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubNcU64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSwapPcI64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTruncF16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTruncF32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTtracedataImmSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSVersionSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitAluSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitAsynccntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitDscntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitIdleSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitKmcntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitLoadcntDscntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitLoadcntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitStorecntDscntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitStorecntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitTensorcntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitXcntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWakeupBarrierSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadB128Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadB32Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadB64Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadB96Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadBlockVscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadD16B16Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadD16HiB16Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadD16HiI8Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadD16HiU8Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadD16I8Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadD16U8Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadI16Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadI8Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadU16Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadU8Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchStoreB128Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchStoreB16Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchStoreB32Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchStoreB64Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchStoreB8Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchStoreB96Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchStoreBlockVscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchStoreD16HiB16Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchStoreD16HiB8Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTensorLoadToLdsVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTensorStoreFromLdsVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddMaxI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddMaxU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddMinI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddMinU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrPkI8I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrPkU8I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBitop3B16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBitop3B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClsI32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClsI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClzI32U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClzI32U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosBf16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosBf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCtzI32B32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCtzI32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16Bf8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16Bf8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16Fp8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16Fp8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Bf16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Bf8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Bf8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Fp8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Fp8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFloorI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFloorI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNearestI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNearestI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkBf16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkBf8F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkBf8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF16Bf8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF16Bf8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF16Fp8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF16Fp8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF32Bf8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF32Bf8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF32Fp8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF32Fp8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkFp8F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkFp8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkI16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkNormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkNormI16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkNormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkNormU16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkRtzF16F32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkRtzF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalePk16Bf16Bf6Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalePk16Bf16Fp6Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalePk16F16Bf6Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalePk16F16Fp6Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalePk16F32Bf6Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalePk16F32Fp6Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalePk8Bf16Bf8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalePk8Bf16Fp4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalePk8Bf16Fp8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalePk8F16Bf8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalePk8F16Fp4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalePk8F16Fp8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalePk8F32Bf8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalePk8F32Fp4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalePk8F32Fp8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk16Bf6Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk16Bf6F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk16Bf6F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk16Fp6Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk16Fp6F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk16Fp6F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk8Bf8Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk8Bf8F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk8Bf8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk8Fp4Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk8Fp4F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk8Fp4F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk8Fp8Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk8Fp8F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk8Fp8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk16Bf6Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk16Bf6F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk16Bf6F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk16Fp6Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk16Fp6F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk16Fp6F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk8Bf8Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk8Bf8F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk8Bf8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk8Fp4Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk8Fp4F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk8Fp4F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk8Fp8Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk8Fp8F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk8Fp8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtSrBf8F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtSrBf8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtSrFp8F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtSrFp8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtSrPkBf16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtSrPkF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32U16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4I32Iu8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8I32Iu4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpBf16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpBf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaDx9ZeroF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixF32Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixhiBf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixhiF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixloBf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixloF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaakF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaakF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaakF64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmamkF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmamkF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmamkF64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogBf16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogBf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlAddU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadCoI64I32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadCoU64U32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadNcI64I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadNcU64U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3NumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3NumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxNumF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxNumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxNumF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxNumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxNumF64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxNumF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaximum3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaximum3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaximumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaximumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaximumF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaximumminimumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaximumminimumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxminI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxminNumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxminNumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxminU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3NumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3NumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3NumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3NumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinNumF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinNumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinNumF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinNumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinNumF64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinNumF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinimum3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinimum3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinimumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinimumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinimumF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinimummaximumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinimummaximumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinmaxI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinmaxNumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinmaxNumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinmaxU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovreldB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovreldB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulDx9ZeroF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulDx9ZeroF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMullitF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermPk16B4U4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermPk16B6U4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermPk16B8U4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlane16B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlane16SwapB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlane16SwapB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlane16VarB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlaneBcastB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlaneDownB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlaneIdxGenB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlaneUpB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlaneXorB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlanex16B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlanex16VarB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPipeflushVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPipeflushVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddBf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddMaxI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddMaxU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddMinI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddMinU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmaBf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmaF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMax3I16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMax3NumF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMax3U16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxNumBf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxNumF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaximum3F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaximumF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMin3I16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMin3NumF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMin3U16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinNumBf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinNumF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinimum3F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinimumF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulBf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPrngB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPrngB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpBf16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpBf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqBf16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqBf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSExpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSExpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSLogF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSLogF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSRcpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSRcpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSRsqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSRsqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSSqrtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSSqrtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPk4I4I8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPk4I4I8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPk4U4U8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPk4U4U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinBf16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinBf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtBf16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtBf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwapB16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwaprelB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacBf1616x16x64Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacBf16f3216x16x64Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacF1616x16x128Bf8Bf8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacF1616x16x128Bf8Fp8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacF1616x16x128Fp8Bf8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacF1616x16x128Fp8Fp8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacF1616x16x64F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x128Bf8Bf8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x128Bf8Fp8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x128Fp8Bf8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x128Fp8Fp8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x64Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x64F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacI3216x16x128Iu8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTanhBf16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTanhBf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTanhF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTanhF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTanhF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTanhF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaBf1616x16x32Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaBf16f3216x16x32Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x128Bf8Bf8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x128Bf8Fp8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x128Fp8Bf8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x128Fp8Fp8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x32F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x64Bf8Bf8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x64Bf8Fp8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x64Fp8Bf8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x64Fp8Fp8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x128Bf8Bf8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x128Bf8Fp8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x128F8f6f4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x128Fp8Bf8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x128Fp8Fp8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x32Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x32F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x4F32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x64Bf8Bf8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x64Bf8Fp8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x64Fp8Bf8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x64Fp8Fp8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3232x16x128F4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaI3216x16x64Iu8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXor3B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode);
+DecodeResult decodeBufferAtomicAddF32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddF64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndB32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndB64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapB32Vbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapB64Vbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCondSubU32Vbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxI32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxI64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxNumF32Vbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxNumF64Vbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinI32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinI64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinNumF32Vbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinNumF64Vbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrB32Vbuffer(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrB64Vbuffer(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicPkAddBf16Vbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicPkAddF16Vbuffer(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubClampU32Vbuffer(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapB32Vbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapB64Vbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorB32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorB64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadB128Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadB32Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadB64Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadB96Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16B16Vbuffer(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16HiB16Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16HiI8Vbuffer(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16HiU8Vbuffer(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16I8Vbuffer(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16U8Vbuffer(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadI16Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadI8Vbuffer(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadU16Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadU8Vbuffer(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB128Vbuffer(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB16Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB32Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB64Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB8Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB96Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16HiB16Vbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16HiB8Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeClusterLoadAsyncToLdsB128Vglobal(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeClusterLoadAsyncToLdsB32Vglobal(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeClusterLoadAsyncToLdsB64Vglobal(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeClusterLoadAsyncToLdsB8Vglobal(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeClusterLoadB128Vglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeClusterLoadB32Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeClusterLoadB64Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddF32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddF64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnF32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnF64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAppendVds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAtomicAsyncBarrierArriveB64Vds(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAtomicBarrierArriveRtnB64Vds(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsBpermuteB32Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsBpermuteFiB32Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreB32Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreB64Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreRtnB32Vds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreRtnB64Vds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCondSubRtnU32Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCondSubU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCondxchg32RtnB64Vds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsConsumeVds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoad2addrB32Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoad2addrB64Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoad2addrStride64B32Vds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoad2addrStride64B64Vds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadAddtidB32Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadB128Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadB96Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadI16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadI8D16HiVds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadI8D16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadI8Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadTr16B128Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadTr4B64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadTr6B96Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadTr8B64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU16D16HiVds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU16D16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU8D16HiVds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU8D16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU8Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxNumF32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxNumF64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxNumRtnF32Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxNumRtnF64Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinNumF32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinNumF64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinNumRtnF32Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinNumRtnF64Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB32Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB64Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsNopVds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPermuteB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPkAddBf16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPkAddF16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPkAddRtnBf16Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPkAddRtnF16Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStore2addrB32Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStore2addrB64Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStore2addrStride64B32Vds(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStore2addrStride64B64Vds(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreAddtidB32Vds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB128Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB16D16HiVds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB8D16HiVds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB8Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB96Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchg2addrRtnB32Vds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchg2addrRtnB64Vds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchg2addrStride64RtnB32Vds(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchg2addrStride64RtnB64Vds(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchgRtnB32Vds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchgRtnB64Vds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubClampRtnU32Vds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubClampU32Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSwizzleB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddF32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddF64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndB32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndB64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapB32Vflat(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapB64Vflat(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCondSubU32Vflat(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxI32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxI64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxNumF32Vflat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxNumF64Vflat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinI32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinI64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinNumF32Vflat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinNumF64Vflat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrB32Vflat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrB64Vflat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicPkAddBf16Vflat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicPkAddF16Vflat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubClampU32Vflat(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapB32Vflat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapB64Vflat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorB32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorB64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadB128Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadB32Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadB64Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadB96Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16B16Vflat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16HiB16Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16HiI8Vflat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16HiU8Vflat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16I8Vflat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16U8Vflat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadI16Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadI8Vflat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadMonitorB128Vflat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadMonitorB32Vflat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadMonitorB64Vflat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadU16Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadU8Vflat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatPrefetchB8Vflat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB128Vflat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB16Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB32Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB64Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB8Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB96Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreD16HiB16Vflat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreD16HiB8Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicAddF32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicAddF64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicAddU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicAddU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicAndB32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicAndB64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicCmpswapB32Vglobal(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicCmpswapB64Vglobal(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicCondSubU32Vglobal(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicDecU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicDecU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicIncU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicIncU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMaxI32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMaxI64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMaxNumF32Vglobal(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMaxNumF64Vglobal(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMaxU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMaxU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMinI32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMinI64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMinNumF32Vglobal(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMinNumF64Vglobal(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMinU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMinU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicOrB32Vglobal(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicOrB64Vglobal(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicPkAddBf16Vglobal(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicPkAddF16Vglobal(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicSubClampU32Vglobal(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicSubU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicSubU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicSwapB32Vglobal(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicSwapB64Vglobal(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicXorB32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicXorB64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalInvVglobal(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadAddtidB32Vglobal(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadAsyncToLdsB128Vglobal(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadAsyncToLdsB32Vglobal(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadAsyncToLdsB64Vglobal(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadAsyncToLdsB8Vglobal(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadB128Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadB32Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadB64Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadB96Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadBlockVglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadD16B16Vglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadD16HiB16Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadD16HiI8Vglobal(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadD16HiU8Vglobal(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadD16I8Vglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadD16U8Vglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadI16Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadI8Vglobal(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadMonitorB128Vglobal(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadMonitorB32Vglobal(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadMonitorB64Vglobal(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadTr16B128Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadTr4B64Vglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadTr6B96Vglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadTr8B64Vglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadU16Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadU8Vglobal(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalPrefetchB8Vglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreAddtidB32Vglobal(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreAsyncFromLdsB128Vglobal(const MachineInst *opcode,
+                                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreAsyncFromLdsB32Vglobal(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreAsyncFromLdsB64Vglobal(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreAsyncFromLdsB8Vglobal(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreB128Vglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreB16Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreB32Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreB64Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreB8Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreB96Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreBlockVglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreD16HiB16Vglobal(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreD16HiB8Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalWbVglobal(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalWbinvVglobal(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddCoCiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddCoI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddCoU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddNcU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddPcI64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddkCoI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAllocVgprSop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot0SaveexecB32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot0SaveexecB64Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot0WrexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot0WrexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1SaveexecB32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1SaveexecB64Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1WrexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1WrexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtcProbeBufferSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtcProbeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBarrierInitSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBarrierJoinSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBarrierLeaveSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBarrierSignalIsfirstSop1(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBarrierSignalSop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBarrierWaitSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB128Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB256Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB32Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB512Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB64Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB96Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadI16Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadI8Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadU16Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadU8Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferPrefetchDataSmem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCallI64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCeilF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCeilF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClauseSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClsI32I64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClzI32U32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClzI32U64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNeqF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNeqF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNgeF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNgeF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNgtF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNgtF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNleF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNleF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNlgF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNlgF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNltF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNltF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpOF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpOF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpUF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpUF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCodeEndSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCtzI32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCtzI32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtF16F32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtF32F16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtF32I32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtF32U32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtHiF32F16Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtI32F32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtPkRtzF16F32Sop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtU32F32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDelayAluSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDenormModeSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFloorF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFloorF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFmaakF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFmacF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFmacF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFmamkF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetBarrierStateSop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetPcI64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetShaderCyclesU64Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB128Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB256Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB32Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB512Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB64Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB96Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadI16Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadI8Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadU16Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadU8Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxNumF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxNumF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaximumF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaximumF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinNumF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinNumF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinimumF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinimumF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMonitorSleepSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsd2B32Sop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot0SaveexecB32Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot0SaveexecB64Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot1B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot1B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot1SaveexecB32Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot1SaveexecB64Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrSaveexecB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackHlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPrefetchDataPcRelSmem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPrefetchDataSmem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPrefetchInstPcRelSmem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPrefetchInstSmem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRfeI64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRndneF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRndneF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRoundModeSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsgRtnB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsgRtnB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetPcI64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetVgprMsbSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetprioIncWgSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSleepVarSop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubCoCiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubCoI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubCoU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubNcU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSwapPcI64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTruncF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTruncF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTtracedataImmSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSVersionSopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitAluSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitAsynccntSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitDscntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitIdleSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitKmcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitLoadcntDscntSopp(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitLoadcntSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitStorecntDscntSopp(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitStorecntSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitTensorcntSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitXcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWakeupBarrierSop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadB128Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadB32Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadB64Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadB96Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadBlockVscratch(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadD16B16Vscratch(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadD16HiB16Vscratch(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadD16HiI8Vscratch(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadD16HiU8Vscratch(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadD16I8Vscratch(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadD16U8Vscratch(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadI16Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadI8Vscratch(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadU16Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadU8Vscratch(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchStoreB128Vscratch(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchStoreB16Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchStoreB32Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchStoreB64Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchStoreB8Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchStoreB96Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchStoreBlockVscratch(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchStoreD16HiB16Vscratch(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchStoreD16HiB8Vscratch(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTensorLoadToLdsVimage(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTensorStoreFromLdsVimage(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoCiU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrPkI8I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrPkU8I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBitop3B16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBitop3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClsI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClsI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClzI32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClzI32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosBf16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosBf16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCtzI32B32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCtzI32B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16Bf8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16Bf8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16Fp8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16Fp8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Bf16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Bf16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Bf8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Bf8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Fp8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Fp8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFloorI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFloorI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNearestI32F32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNearestI32F32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkBf16F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkBf8F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkBf8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF16Bf8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF16Bf8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF16Fp8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF16Fp8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF32Bf8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF32Bf8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF32Fp8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF32Fp8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkFp8F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkFp8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkI16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkNormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkNormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkNormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkNormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkRtzF16F32Vop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkRtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalePk16Bf16Bf6Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalePk16Bf16Fp6Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalePk16F16Bf6Vop3(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalePk16F16Fp6Vop3(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalePk16F32Bf6Vop3(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalePk16F32Fp6Vop3(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalePk8Bf16Bf8Vop3(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalePk8Bf16Fp4Vop3(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalePk8Bf16Fp8Vop3(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalePk8F16Bf8Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalePk8F16Fp4Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalePk8F16Fp8Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalePk8F32Bf8Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalePk8F32Fp4Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalePk8F32Fp8Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk16Bf6Bf16Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk16Bf6F16Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk16Bf6F32Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk16Fp6Bf16Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk16Fp6F16Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk16Fp6F32Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk8Bf8Bf16Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk8Bf8F16Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk8Bf8F32Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk8Fp4Bf16Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk8Fp4F16Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk8Fp4F32Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk8Fp8Bf16Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk8Fp8F16Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32Pk8Fp8F32Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk16Bf6Bf16Vop3(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk16Bf6F16Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk16Bf6F32Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk16Fp6Bf16Vop3(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk16Fp6F16Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk16Fp6F32Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk8Bf8Bf16Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk8Bf8F16Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk8Bf8F32Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk8Fp4Bf16Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk8Fp4F16Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk8Fp4F32Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk8Fp8Bf16Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk8Fp8F16Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtScalef32SrPk8Fp8F32Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtSrBf8F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtSrBf8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtSrFp8F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtSrFp8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtSrPkBf16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtSrPkF16F32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4I32Iu8Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8I32Iu4Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpBf16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpBf16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaDx9ZeroF32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixF32Bf16Vop3p(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixhiBf16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixloBf16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaakF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmamkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmamkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmamkF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogBf16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogBf16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlAddU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadCoI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadCoU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadNcI64I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadNcU64U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3NumF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3NumF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxNumF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxNumF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxNumF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxNumF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxNumF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxNumF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaximum3F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaximum3F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaximumF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaximumF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaximumF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaximumminimumF16Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaximumminimumF32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxminI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxminNumF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxminNumF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxminU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3NumF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3NumF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3NumF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3NumF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinNumF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinNumF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinNumF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinNumF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinNumF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinNumF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinimum3F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinimum3F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinimumF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinimumF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinimumF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinimummaximumF16Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinimummaximumF32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinmaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinmaxNumF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinmaxNumF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinmaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovreldB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovreldB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsd2B32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsd2B32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsdB32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsdB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulDx9ZeroF32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulDx9ZeroF32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMullitF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermPk16B4U4Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermPk16B6U4Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermPk16B8U4Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlane16B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlane16SwapB32Vop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlane16SwapB32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlane16VarB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlaneBcastB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlaneDownB32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlaneIdxGenB32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlaneUpB32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlaneXorB32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlanex16B32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlanex16VarB32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPipeflushVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPipeflushVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddBf16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddMaxI16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddMaxU16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddMinI16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddMinU16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmaBf16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmaF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMax3I16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMax3NumF16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMax3U16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxNumBf16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxNumF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaximum3F16Vop3p(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaximumF16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMin3I16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMin3NumF16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMin3U16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinNumBf16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinNumF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinimum3F16Vop3p(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinimumF16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulBf16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPrngB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPrngB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpBf16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpBf16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqBf16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqBf16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPk4I4I8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPk4I4I8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPk4U4U8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPk4U4U8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinBf16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinBf16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtBf16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtBf16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoCiU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoCiU32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevNcU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevNcU32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwapB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwaprelB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacBf1616x16x64Bf16Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacBf16f3216x16x64Bf16Vop3p(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacF1616x16x128Bf8Bf8Vop3p(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacF1616x16x128Bf8Fp8Vop3p(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacF1616x16x128Fp8Bf8Vop3p(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacF1616x16x128Fp8Fp8Vop3p(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacF1616x16x64F16Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacF3216x16x128Bf8Bf8Vop3p(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacF3216x16x128Bf8Fp8Vop3p(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacF3216x16x128Fp8Bf8Vop3p(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacF3216x16x128Fp8Fp8Vop3p(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacF3216x16x64Bf16Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacF3216x16x64F16Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacI3216x16x128Iu8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTanhBf16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTanhBf16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTanhF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTanhF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTanhF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTanhF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaBf1616x16x32Bf16Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaBf16f3216x16x32Bf16Vop3p(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF1616x16x128Bf8Bf8Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF1616x16x128Bf8Fp8Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF1616x16x128Fp8Bf8Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF1616x16x128Fp8Fp8Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF1616x16x32F16Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF1616x16x64Bf8Bf8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF1616x16x64Bf8Fp8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF1616x16x64Fp8Bf8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF1616x16x64Fp8Fp8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x128Bf8Bf8Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x128Bf8Fp8Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x128F8f6f4Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x128Fp8Bf8Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x128Fp8Fp8Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x32Bf16Vop3p(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x32F16Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x4F32Vop3p(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x64Bf8Bf8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x64Bf8Fp8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x64Fp8Bf8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x64Fp8Fp8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3232x16x128F4Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaI3216x16x64Iu8Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXor3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 } // namespace detail
 
 struct DecoderImpl {
 public:
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 
 private:
-  using DecodeFunc = std::unique_ptr<Instruction> (*)(const MachineInst *);
-  static std::unique_ptr<Instruction> decodeInvalid(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> decodeVopd(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopp(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVbuffer(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3p(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> decodeVWmmaScaleF32Vop3px2(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVimage(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVds(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVflat(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVscratch(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVglobal(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSmem(const MachineInst *opcode);
+  using DecodeFunc = DecodeResult (*)(const MachineInst *, const DecodeErrorEmitter &);
+  static DecodeResult decodeInvalid(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult decodeVopd(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVbuffer(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult decodeVWmmaScaleF32Vop3px2(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVimage(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVscratch(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVglobal(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
   static const std::array<DecodeFunc, 512> primary_decode_table;
   static const std::array<DecodeFunc, 256> sub_decode_vopc;
   static const std::array<DecodeFunc, 128> sub_decode_vop1;
@@ -1677,98 +2304,117 @@ bool isVop3pOp(const MachineInst opcode, uint32_t op) {
 
 } // namespace
 
-std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
-  return DecoderImpl::decode(opcode);
+DecodeResult Decoder::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  return DecoderImpl::decode(opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decode(const MachineInst *opcode) {
+DecodeResult DecoderImpl::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
   Sop1MachineInst op = std::bit_cast<decltype(op)>(*opcode);
-  return primary_decode_table[op.encoding](opcode);
+  return primary_decode_table[op.encoding](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decodeInvalid(const MachineInst *opcode) {
-  throw util::InvalidInst(std::format("{:X}", *opcode));
-  return nullptr;
+DecodeResult DecoderImpl::decodeInvalid(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  return emit_error.emit() << "Invalid instruction opcode: " << std::format("{:X}", *opcode);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decodeVopd(const MachineInst *opcode) {
+DecodeResult DecoderImpl::decodeVopd(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vopd::validate_encoding(opcode, emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<Vopd>(opcode);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vopc[op.op](opcode);
+  return sub_decode_vopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop1[op.op](opcode);
+  return sub_decode_vop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sop1[op.op](opcode);
+  return sub_decode_sop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopc[op.op](opcode);
+  return sub_decode_sopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopp(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopp::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopp[op.op](opcode);
+  return sub_decode_sopp[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVbuffer(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVbuffer(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
   Vbuffer::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vbuffer[op.op](opcode);
+  return sub_decode_vbuffer[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3p(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3p(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Vop3p::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3p[op.op](opcode);
+  return sub_decode_vop3p[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decodeVWmmaScaleF32Vop3px2(const MachineInst *opcode) {
+DecodeResult DecoderImpl::decodeVWmmaScaleF32Vop3px2(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
   if (!isVop3pOp(opcode[2], 0x33) && !isVop3pOp(opcode[2], 0x88))
-    return decodeInvalid(opcode);
+    return decodeInvalid(opcode, emit_error);
   return std::make_unique<VWmmaScaleF32Vop3px2>(opcode);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVimage(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVimage(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
   Vimage::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vimage[op.op](opcode);
+  return sub_decode_vimage[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop3::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3[op.op](opcode);
+  return sub_decode_vop3[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVds(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
   Vds::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vds[op.op](opcode);
+  return sub_decode_vds[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVflat(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Vflat::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vflat[op.op](opcode);
+  return sub_decode_vflat[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVscratch(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVscratch(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
   Vscratch::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vscratch[op.op](opcode);
+  return sub_decode_vscratch[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVglobal(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
   Vglobal::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vglobal[op.op](opcode);
+  return sub_decode_vglobal[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSmem(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Smem::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_smem[op.op](opcode);
+  return sub_decode_smem[op.op](opcode, emit_error);
 }
 
 const std::array<DecoderImpl::DecodeFunc, 512> DecoderImpl::primary_decode_table = {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/decoder.h
@@ -8,6 +8,7 @@
 #define ROCJITSU_ISA_ARCH_AMDGPU_CDNA5_DECODER_H_
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/machine_insts.h"
+#include "rocjitsu/isa/decode_result.h"
 #include <array>
 #include <cstddef>
 #include <memory>
@@ -21,7 +22,7 @@ namespace cdna5 {
 class Decoder {
 public:
   static constexpr std::size_t kMaxInstructionWords = 4;
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 };
 
 } // namespace cdna5

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/encodings.cpp
@@ -5,7 +5,6 @@
 // See lib/python/amdisa/README.md for regeneration instructions.
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/encodings.h"
-#include "util/except.h"
 #include <cstring>
 #include <string>
 
@@ -176,19 +175,12 @@ bool Sop1::has_encoded_literal32() const {
   }
 }
 
-Sop1::Sop1(std::string_view mnemonic, const Sop1MachineInst *inst, ExecuteFn exec_fn,
-           LiteralSupport literal_support, int num_encoded_sources)
+Sop1::Sop1(std::string_view mnemonic, const Sop1MachineInst *inst, ExecuteFn exec_fn)
     : IsaInstruction<Isa>(mnemonic, exec_fn), inst_(*inst) {
   size_ = sizeof(OpEncoding);
   raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
-  if (!supports_literal(literal_support, LiteralSupport::Literal32) &&
-      ((num_encoded_sources > 0 && inst_.ssrc0 == 255)))
-    throw util::InvalidInst(std::string(mnemonic) + " does not support 32-bit literals", "");
-  if (!supports_literal(literal_support, LiteralSupport::Literal64) &&
-      ((num_encoded_sources > 0 && inst_.ssrc0 == 254)))
-    throw util::InvalidInst(std::string(mnemonic) + " does not support 64-bit literals", "");
   if (has_encoded_literal64())
     size_ += 2 * sizeof(MachineInst);
   else if (has_encoded_literal32())
@@ -311,21 +303,12 @@ bool Sopc::has_encoded_literal32() const {
   }
 }
 
-Sopc::Sopc(std::string_view mnemonic, const SopcMachineInst *inst, ExecuteFn exec_fn,
-           LiteralSupport literal_support, int num_encoded_sources)
+Sopc::Sopc(std::string_view mnemonic, const SopcMachineInst *inst, ExecuteFn exec_fn)
     : IsaInstruction<Isa>(mnemonic, exec_fn), inst_(*inst) {
   size_ = sizeof(OpEncoding);
   raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
-  if (!supports_literal(literal_support, LiteralSupport::Literal32) &&
-      ((num_encoded_sources > 0 && inst_.ssrc0 == 255) ||
-       (num_encoded_sources > 1 && inst_.ssrc1 == 255)))
-    throw util::InvalidInst(std::string(mnemonic) + " does not support 32-bit literals", "");
-  if (!supports_literal(literal_support, LiteralSupport::Literal64) &&
-      ((num_encoded_sources > 0 && inst_.ssrc0 == 254) ||
-       (num_encoded_sources > 1 && inst_.ssrc1 == 254)))
-    throw util::InvalidInst(std::string(mnemonic) + " does not support 64-bit literals", "");
   if (has_encoded_literal64())
     size_ += 2 * sizeof(MachineInst);
   else if (has_encoded_literal32())
@@ -558,21 +541,12 @@ bool Sop2::has_encoded_literal32() const {
   }
 }
 
-Sop2::Sop2(std::string_view mnemonic, const Sop2MachineInst *inst, ExecuteFn exec_fn,
-           LiteralSupport literal_support, int num_encoded_sources)
+Sop2::Sop2(std::string_view mnemonic, const Sop2MachineInst *inst, ExecuteFn exec_fn)
     : IsaInstruction<Isa>(mnemonic, exec_fn), inst_(*inst) {
   size_ = sizeof(OpEncoding);
   raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
-  if (!supports_literal(literal_support, LiteralSupport::Literal32) &&
-      ((num_encoded_sources > 0 && inst_.ssrc0 == 255) ||
-       (num_encoded_sources > 1 && inst_.ssrc1 == 255)))
-    throw util::InvalidInst(std::string(mnemonic) + " does not support 32-bit literals", "");
-  if (!supports_literal(literal_support, LiteralSupport::Literal64) &&
-      ((num_encoded_sources > 0 && inst_.ssrc0 == 254) ||
-       (num_encoded_sources > 1 && inst_.ssrc1 == 254)))
-    throw util::InvalidInst(std::string(mnemonic) + " does not support 64-bit literals", "");
   if (has_encoded_literal64())
     size_ += 2 * sizeof(MachineInst);
   else if (has_encoded_literal32() || hasImpliedLiteral())
@@ -844,19 +818,12 @@ bool Vop1::has_encoded_literal32() const {
   }
 }
 
-Vop1::Vop1(std::string_view mnemonic, const Vop1MachineInst *inst, ExecuteFn exec_fn,
-           LiteralSupport literal_support, int num_encoded_sources)
+Vop1::Vop1(std::string_view mnemonic, const Vop1MachineInst *inst, ExecuteFn exec_fn)
     : IsaInstruction<Isa>(mnemonic, exec_fn), inst_(*inst) {
   size_ = sizeof(OpEncoding);
   raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
-  if (!supports_literal(literal_support, LiteralSupport::Literal32) &&
-      ((num_encoded_sources > 0 && inst_.src0 == 255)))
-    throw util::InvalidInst(std::string(mnemonic) + " does not support 32-bit literals", "");
-  if (!supports_literal(literal_support, LiteralSupport::Literal64) &&
-      ((num_encoded_sources > 0 && inst_.src0 == 254)))
-    throw util::InvalidInst(std::string(mnemonic) + " does not support 64-bit literals", "");
   if (has_encoded_literal64())
     size_ += 2 * sizeof(MachineInst);
   else if (inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0) ||
@@ -1252,19 +1219,12 @@ bool Vopc::has_encoded_literal32() const {
   }
 }
 
-Vopc::Vopc(std::string_view mnemonic, const VopcMachineInst *inst, ExecuteFn exec_fn,
-           LiteralSupport literal_support, int num_encoded_sources)
+Vopc::Vopc(std::string_view mnemonic, const VopcMachineInst *inst, ExecuteFn exec_fn)
     : IsaInstruction<Isa>(mnemonic, exec_fn), inst_(*inst) {
   size_ = sizeof(OpEncoding);
   raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
-  if (!supports_literal(literal_support, LiteralSupport::Literal32) &&
-      ((num_encoded_sources > 0 && inst_.src0 == 255)))
-    throw util::InvalidInst(std::string(mnemonic) + " does not support 32-bit literals", "");
-  if (!supports_literal(literal_support, LiteralSupport::Literal64) &&
-      ((num_encoded_sources > 0 && inst_.src0 == 254)))
-    throw util::InvalidInst(std::string(mnemonic) + " does not support 64-bit literals", "");
   if (has_encoded_literal64())
     size_ += 2 * sizeof(MachineInst);
   else if (inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0) ||
@@ -1418,19 +1378,12 @@ bool Vop2::has_encoded_literal32() const {
   }
 }
 
-Vop2::Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exec_fn,
-           LiteralSupport literal_support, int num_encoded_sources)
+Vop2::Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exec_fn)
     : IsaInstruction<Isa>(mnemonic, exec_fn), inst_(*inst) {
   size_ = sizeof(OpEncoding);
   raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
-  if (!supports_literal(literal_support, LiteralSupport::Literal32) &&
-      ((num_encoded_sources > 0 && inst_.src0 == 255)))
-    throw util::InvalidInst(std::string(mnemonic) + " does not support 32-bit literals", "");
-  if (!supports_literal(literal_support, LiteralSupport::Literal64) &&
-      ((num_encoded_sources > 0 && inst_.src0 == 254)))
-    throw util::InvalidInst(std::string(mnemonic) + " does not support 64-bit literals", "");
   if (hasImpliedLiteral())
     size_ += impliedLiteralWordCount() * sizeof(MachineInst);
   else if (hasImpliedLiteral64() || has_encoded_literal64())
@@ -2042,26 +1995,12 @@ bool Vop3::has_encoded_literal32() const {
   }
 }
 
-Vop3::Vop3(std::string_view mnemonic, const Vop3MachineInst *inst, ExecuteFn exec_fn,
-           LiteralSupport literal_support, int num_encoded_sources)
+Vop3::Vop3(std::string_view mnemonic, const Vop3MachineInst *inst, ExecuteFn exec_fn)
     : IsaInstruction<Isa>(mnemonic, exec_fn), inst_(*inst) {
   size_ = sizeof(OpEncoding);
   raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
-  if (!supports_literal(literal_support, LiteralSupport::Literal32) &&
-      ((num_encoded_sources > 0 && inst_.src0 == 255) ||
-       (num_encoded_sources > 1 && inst_.src1 == 255) ||
-       (num_encoded_sources > 2 && inst_.src2 == 255)))
-    throw util::InvalidInst(std::string(mnemonic) + " does not support 32-bit literals", "");
-  if (!supports_literal(literal_support, LiteralSupport::Literal64) &&
-      ((num_encoded_sources > 0 && inst_.src0 == 254) ||
-       (num_encoded_sources > 1 && inst_.src1 == 254) ||
-       (num_encoded_sources > 2 && inst_.src2 == 254)))
-    throw util::InvalidInst(std::string(mnemonic) + " does not support 64-bit literals", "");
-  if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
-      (has_encoded_literal32()))
-    throw util::InvalidInst("DPP and literal operands cannot be combined", "");
   if (has_encoded_literal32())
     size_ += sizeof(MachineInst);
   if (inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0))
@@ -2202,7 +2141,6 @@ bool Vop3p::has_encoded_literal32() const {
 }
 
 Vop3p::Vop3p(std::string_view mnemonic, const Vop3pMachineInst *inst, ExecuteFn exec_fn,
-             LiteralSupport literal_support, int num_encoded_sources,
              ExtensionDecodePolicy extension_policy)
     : IsaInstruction<Isa>(mnemonic, exec_fn), inst_(*inst) {
   size_ = sizeof(OpEncoding);
@@ -2210,23 +2148,6 @@ Vop3p::Vop3p(std::string_view mnemonic, const Vop3pMachineInst *inst, ExecuteFn 
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
   if (extension_policy == ExtensionDecodePolicy::Decode) {
-    if ((num_encoded_sources > 0 && inst_.src0 == 254) ||
-        (num_encoded_sources > 1 && inst_.src1 == 254) ||
-        (num_encoded_sources > 2 && inst_.src2 == 254))
-      throw util::InvalidInst("Vop3p does not support Literal64", "");
-    if (!supports_literal(literal_support, LiteralSupport::Literal32) &&
-        ((num_encoded_sources > 0 && inst_.src0 == 255) ||
-         (num_encoded_sources > 1 && inst_.src1 == 255) ||
-         (num_encoded_sources > 2 && inst_.src2 == 255)))
-      throw util::InvalidInst(std::string(mnemonic) + " does not support 32-bit literals", "");
-    if (!supports_literal(literal_support, LiteralSupport::Literal64) &&
-        ((num_encoded_sources > 0 && inst_.src0 == 254) ||
-         (num_encoded_sources > 1 && inst_.src1 == 254) ||
-         (num_encoded_sources > 2 && inst_.src2 == 254)))
-      throw util::InvalidInst(std::string(mnemonic) + " does not support 64-bit literals", "");
-    if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
-        (has_encoded_literal32()))
-      throw util::InvalidInst("DPP and literal operands cannot be combined", "");
     if (has_encoded_literal32())
       size_ += sizeof(MachineInst);
     if (inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0))
@@ -2409,25 +2330,12 @@ bool Vop3SdstEnc::has_encoded_literal32() const {
 }
 
 Vop3SdstEnc::Vop3SdstEnc(std::string_view mnemonic, const Vop3SdstEncMachineInst *inst,
-                         ExecuteFn exec_fn, LiteralSupport literal_support, int num_encoded_sources)
+                         ExecuteFn exec_fn)
     : IsaInstruction<Isa>(mnemonic, exec_fn), inst_(*inst) {
   size_ = sizeof(OpEncoding);
   raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
-  if (!supports_literal(literal_support, LiteralSupport::Literal32) &&
-      ((num_encoded_sources > 0 && inst_.src0 == 255) ||
-       (num_encoded_sources > 1 && inst_.src1 == 255) ||
-       (num_encoded_sources > 2 && inst_.src2 == 255)))
-    throw util::InvalidInst(std::string(mnemonic) + " does not support 32-bit literals", "");
-  if (!supports_literal(literal_support, LiteralSupport::Literal64) &&
-      ((num_encoded_sources > 0 && inst_.src0 == 254) ||
-       (num_encoded_sources > 1 && inst_.src1 == 254) ||
-       (num_encoded_sources > 2 && inst_.src2 == 254)))
-    throw util::InvalidInst(std::string(mnemonic) + " does not support 64-bit literals", "");
-  if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
-      (has_encoded_literal32()))
-    throw util::InvalidInst("DPP and literal operands cannot be combined", "");
   if (has_encoded_literal32())
     size_ += sizeof(MachineInst);
   if (inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/encodings.h
@@ -10,6 +10,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna5/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
+#include "rocjitsu/isa/decode_result.h"
 #include "rocjitsu/isa/instruction.h"
 #include <array>
 #include <cstdint>
@@ -378,10 +379,23 @@ enum class LiteralSupport : uint8_t {
 
 class Sop1 : public IsaInstruction<Isa> {
 public:
-  Sop1(std::string_view mnemonic, const Sop1MachineInst *inst, ExecuteFn exec_fn,
-       LiteralSupport literal_support = LiteralSupport::Both, int num_encoded_sources = 1);
+  Sop1(std::string_view mnemonic, const Sop1MachineInst *inst, ExecuteFn exec_fn);
   bool has_encoded_literal64() const;
   bool has_encoded_literal32() const;
+  static Result validate_encoding([[maybe_unused]] std::string_view mnemonic,
+                                  const Sop1MachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error,
+                                  LiteralSupport literal_support = LiteralSupport::Both,
+                                  int num_encoded_sources = 1) {
+    const auto &inst_ = *inst;
+    if (!supports_literal(literal_support, LiteralSupport::Literal32) &&
+        ((num_encoded_sources > 0 && inst_.ssrc0 == 255))) [[unlikely]]
+      return emit_error.emit() << mnemonic << " does not support 32-bit literals";
+    if (!supports_literal(literal_support, LiteralSupport::Literal64) &&
+        ((num_encoded_sources > 0 && inst_.ssrc0 == 254))) [[unlikely]]
+      return emit_error.emit() << mnemonic << " does not support 64-bit literals";
+    return Result::success();
+  }
   bool default_encoding();
   bool has_lit_0();
   bool has_lit64_0();
@@ -392,10 +406,25 @@ public:
 
 class Sopc : public IsaInstruction<Isa> {
 public:
-  Sopc(std::string_view mnemonic, const SopcMachineInst *inst, ExecuteFn exec_fn,
-       LiteralSupport literal_support = LiteralSupport::Both, int num_encoded_sources = 2);
+  Sopc(std::string_view mnemonic, const SopcMachineInst *inst, ExecuteFn exec_fn);
   bool has_encoded_literal64() const;
   bool has_encoded_literal32() const;
+  static Result validate_encoding([[maybe_unused]] std::string_view mnemonic,
+                                  const SopcMachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error,
+                                  LiteralSupport literal_support = LiteralSupport::Both,
+                                  int num_encoded_sources = 2) {
+    const auto &inst_ = *inst;
+    if (!supports_literal(literal_support, LiteralSupport::Literal32) &&
+        ((num_encoded_sources > 0 && inst_.ssrc0 == 255) ||
+         (num_encoded_sources > 1 && inst_.ssrc1 == 255))) [[unlikely]]
+      return emit_error.emit() << mnemonic << " does not support 32-bit literals";
+    if (!supports_literal(literal_support, LiteralSupport::Literal64) &&
+        ((num_encoded_sources > 0 && inst_.ssrc0 == 254) ||
+         (num_encoded_sources > 1 && inst_.ssrc1 == 254))) [[unlikely]]
+      return emit_error.emit() << mnemonic << " does not support 64-bit literals";
+    return Result::success();
+  }
   bool default_encoding();
   bool has_lit_0();
   bool has_lit_1();
@@ -429,10 +458,25 @@ public:
 
 class Sop2 : public IsaInstruction<Isa> {
 public:
-  Sop2(std::string_view mnemonic, const Sop2MachineInst *inst, ExecuteFn exec_fn,
-       LiteralSupport literal_support = LiteralSupport::Both, int num_encoded_sources = 2);
+  Sop2(std::string_view mnemonic, const Sop2MachineInst *inst, ExecuteFn exec_fn);
   bool has_encoded_literal64() const;
   bool has_encoded_literal32() const;
+  static Result validate_encoding([[maybe_unused]] std::string_view mnemonic,
+                                  const Sop2MachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error,
+                                  LiteralSupport literal_support = LiteralSupport::Both,
+                                  int num_encoded_sources = 2) {
+    const auto &inst_ = *inst;
+    if (!supports_literal(literal_support, LiteralSupport::Literal32) &&
+        ((num_encoded_sources > 0 && inst_.ssrc0 == 255) ||
+         (num_encoded_sources > 1 && inst_.ssrc1 == 255))) [[unlikely]]
+      return emit_error.emit() << mnemonic << " does not support 32-bit literals";
+    if (!supports_literal(literal_support, LiteralSupport::Literal64) &&
+        ((num_encoded_sources > 0 && inst_.ssrc0 == 254) ||
+         (num_encoded_sources > 1 && inst_.ssrc1 == 254))) [[unlikely]]
+      return emit_error.emit() << mnemonic << " does not support 64-bit literals";
+    return Result::success();
+  }
   bool default_encoding();
   bool has_lit_0();
   bool has_lit_1();
@@ -457,10 +501,23 @@ public:
 
 class Vop1 : public IsaInstruction<Isa> {
 public:
-  Vop1(std::string_view mnemonic, const Vop1MachineInst *inst, ExecuteFn exec_fn,
-       LiteralSupport literal_support = LiteralSupport::Both, int num_encoded_sources = 1);
+  Vop1(std::string_view mnemonic, const Vop1MachineInst *inst, ExecuteFn exec_fn);
   bool has_encoded_literal64() const;
   bool has_encoded_literal32() const;
+  static Result validate_encoding([[maybe_unused]] std::string_view mnemonic,
+                                  const Vop1MachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error,
+                                  LiteralSupport literal_support = LiteralSupport::Both,
+                                  int num_encoded_sources = 1) {
+    const auto &inst_ = *inst;
+    if (!supports_literal(literal_support, LiteralSupport::Literal32) &&
+        ((num_encoded_sources > 0 && inst_.src0 == 255))) [[unlikely]]
+      return emit_error.emit() << mnemonic << " does not support 32-bit literals";
+    if (!supports_literal(literal_support, LiteralSupport::Literal64) &&
+        ((num_encoded_sources > 0 && inst_.src0 == 254))) [[unlikely]]
+      return emit_error.emit() << mnemonic << " does not support 64-bit literals";
+    return Result::success();
+  }
   void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
@@ -495,10 +552,23 @@ public:
 
 class Vopc : public IsaInstruction<Isa> {
 public:
-  Vopc(std::string_view mnemonic, const VopcMachineInst *inst, ExecuteFn exec_fn,
-       LiteralSupport literal_support = LiteralSupport::Both, int num_encoded_sources = 1);
+  Vopc(std::string_view mnemonic, const VopcMachineInst *inst, ExecuteFn exec_fn);
   bool has_encoded_literal64() const;
   bool has_encoded_literal32() const;
+  static Result validate_encoding([[maybe_unused]] std::string_view mnemonic,
+                                  const VopcMachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error,
+                                  LiteralSupport literal_support = LiteralSupport::Both,
+                                  int num_encoded_sources = 1) {
+    const auto &inst_ = *inst;
+    if (!supports_literal(literal_support, LiteralSupport::Literal32) &&
+        ((num_encoded_sources > 0 && inst_.src0 == 255))) [[unlikely]]
+      return emit_error.emit() << mnemonic << " does not support 32-bit literals";
+    if (!supports_literal(literal_support, LiteralSupport::Literal64) &&
+        ((num_encoded_sources > 0 && inst_.src0 == 254))) [[unlikely]]
+      return emit_error.emit() << mnemonic << " does not support 64-bit literals";
+    return Result::success();
+  }
   void build_modifiers(std::string &out) const override;
   bool default_encoding();
   bool has_lit();
@@ -530,10 +600,23 @@ public:
 
 class Vop2 : public IsaInstruction<Isa> {
 public:
-  Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exec_fn,
-       LiteralSupport literal_support = LiteralSupport::Both, int num_encoded_sources = 1);
+  Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exec_fn);
   bool has_encoded_literal64() const;
   bool has_encoded_literal32() const;
+  static Result validate_encoding([[maybe_unused]] std::string_view mnemonic,
+                                  const Vop2MachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error,
+                                  LiteralSupport literal_support = LiteralSupport::Both,
+                                  int num_encoded_sources = 1) {
+    const auto &inst_ = *inst;
+    if (!supports_literal(literal_support, LiteralSupport::Literal32) &&
+        ((num_encoded_sources > 0 && inst_.src0 == 255))) [[unlikely]]
+      return emit_error.emit() << mnemonic << " does not support 32-bit literals";
+    if (!supports_literal(literal_support, LiteralSupport::Literal64) &&
+        ((num_encoded_sources > 0 && inst_.src0 == 254))) [[unlikely]]
+      return emit_error.emit() << mnemonic << " does not support 64-bit literals";
+    return Result::success();
+  }
   void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
@@ -572,9 +655,29 @@ public:
 
 class Vop3 : public IsaInstruction<Isa> {
 public:
-  Vop3(std::string_view mnemonic, const Vop3MachineInst *inst, ExecuteFn exec_fn,
-       LiteralSupport literal_support = LiteralSupport::Both, int num_encoded_sources = 3);
+  Vop3(std::string_view mnemonic, const Vop3MachineInst *inst, ExecuteFn exec_fn);
   bool has_encoded_literal32() const;
+  static Result validate_encoding([[maybe_unused]] std::string_view mnemonic,
+                                  const Vop3MachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error,
+                                  LiteralSupport literal_support = LiteralSupport::Both,
+                                  int num_encoded_sources = 3) {
+    const auto &inst_ = *inst;
+    if (!supports_literal(literal_support, LiteralSupport::Literal32) &&
+        ((num_encoded_sources > 0 && inst_.src0 == 255) ||
+         (num_encoded_sources > 1 && inst_.src1 == 255) ||
+         (num_encoded_sources > 2 && inst_.src2 == 255))) [[unlikely]]
+      return emit_error.emit() << mnemonic << " does not support 32-bit literals";
+    if (!supports_literal(literal_support, LiteralSupport::Literal64) &&
+        ((num_encoded_sources > 0 && inst_.src0 == 254) ||
+         (num_encoded_sources > 1 && inst_.src1 == 254) ||
+         (num_encoded_sources > 2 && inst_.src2 == 254))) [[unlikely]]
+      return emit_error.emit() << mnemonic << " does not support 64-bit literals";
+    if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
+        (inst_.src0 == 255 || inst_.src1 == 255 || inst_.src2 == 255)) [[unlikely]]
+      return emit_error.emit() << "DPP and literal operands cannot be combined";
+    return Result::success();
+  }
   void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
@@ -604,9 +707,36 @@ class Vop3p : public IsaInstruction<Isa> {
 public:
   enum class ExtensionDecodePolicy { Decode, Skip };
   Vop3p(std::string_view mnemonic, const Vop3pMachineInst *inst, ExecuteFn exec_fn,
-        LiteralSupport literal_support = LiteralSupport::Both, int num_encoded_sources = 3,
         ExtensionDecodePolicy extension_policy = ExtensionDecodePolicy::Decode);
   bool has_encoded_literal32() const;
+  static Result
+  validate_encoding([[maybe_unused]] std::string_view mnemonic, const Vop3pMachineInst *inst,
+                    const util::DiagnosticEmitter &emit_error,
+                    LiteralSupport literal_support = LiteralSupport::Both,
+                    int num_encoded_sources = 3,
+                    ExtensionDecodePolicy extension_policy = ExtensionDecodePolicy::Decode) {
+    const auto &inst_ = *inst;
+    if (extension_policy == ExtensionDecodePolicy::Decode) {
+      if ((num_encoded_sources > 0 && inst_.src0 == 254) ||
+          (num_encoded_sources > 1 && inst_.src1 == 254) ||
+          (num_encoded_sources > 2 && inst_.src2 == 254)) [[unlikely]]
+        return emit_error.emit() << "Vop3p does not support Literal64";
+      if (!supports_literal(literal_support, LiteralSupport::Literal32) &&
+          ((num_encoded_sources > 0 && inst_.src0 == 255) ||
+           (num_encoded_sources > 1 && inst_.src1 == 255) ||
+           (num_encoded_sources > 2 && inst_.src2 == 255))) [[unlikely]]
+        return emit_error.emit() << mnemonic << " does not support 32-bit literals";
+      if (!supports_literal(literal_support, LiteralSupport::Literal64) &&
+          ((num_encoded_sources > 0 && inst_.src0 == 254) ||
+           (num_encoded_sources > 1 && inst_.src1 == 254) ||
+           (num_encoded_sources > 2 && inst_.src2 == 254))) [[unlikely]]
+        return emit_error.emit() << mnemonic << " does not support 64-bit literals";
+      if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
+          (inst_.src0 == 255 || inst_.src1 == 255 || inst_.src2 == 255)) [[unlikely]]
+        return emit_error.emit() << "DPP and literal operands cannot be combined";
+    }
+    return Result::success();
+  }
   void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
@@ -680,9 +810,29 @@ public:
 
 class Vop3SdstEnc : public IsaInstruction<Isa> {
 public:
-  Vop3SdstEnc(std::string_view mnemonic, const Vop3SdstEncMachineInst *inst, ExecuteFn exec_fn,
-              LiteralSupport literal_support = LiteralSupport::Both, int num_encoded_sources = 3);
+  Vop3SdstEnc(std::string_view mnemonic, const Vop3SdstEncMachineInst *inst, ExecuteFn exec_fn);
   bool has_encoded_literal32() const;
+  static Result validate_encoding([[maybe_unused]] std::string_view mnemonic,
+                                  const Vop3SdstEncMachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error,
+                                  LiteralSupport literal_support = LiteralSupport::Both,
+                                  int num_encoded_sources = 3) {
+    const auto &inst_ = *inst;
+    if (!supports_literal(literal_support, LiteralSupport::Literal32) &&
+        ((num_encoded_sources > 0 && inst_.src0 == 255) ||
+         (num_encoded_sources > 1 && inst_.src1 == 255) ||
+         (num_encoded_sources > 2 && inst_.src2 == 255))) [[unlikely]]
+      return emit_error.emit() << mnemonic << " does not support 32-bit literals";
+    if (!supports_literal(literal_support, LiteralSupport::Literal64) &&
+        ((num_encoded_sources > 0 && inst_.src0 == 254) ||
+         (num_encoded_sources > 1 && inst_.src1 == 254) ||
+         (num_encoded_sources > 2 && inst_.src2 == 254))) [[unlikely]]
+      return emit_error.emit() << mnemonic << " does not support 64-bit literals";
+    if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
+        (inst_.src0 == 255 || inst_.src1 == 255 || inst_.src2 == 255)) [[unlikely]]
+      return emit_error.emit() << "DPP and literal operands cannot be combined";
+    return Result::success();
+  }
   void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/operand.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/operand.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/scalar_static_resolve.h"
-#include "util/except.h"
 #include <format>
 #include <optional>
 #include <stdexcept>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/smem.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/smem.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/smem.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -37,7 +36,11 @@ SLoadB32Smem::SLoadB32Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB32Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB32Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b32", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB32Smem>(opcode);
 }
 } // namespace detail
@@ -60,7 +63,11 @@ SLoadB64Smem::SLoadB64Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB64Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB64Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b64", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB64Smem>(opcode);
 }
 } // namespace detail
@@ -83,7 +90,11 @@ SLoadB128Smem::SLoadB128Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB128Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB128Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b128", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB128Smem>(opcode);
 }
 } // namespace detail
@@ -106,7 +117,11 @@ SLoadB256Smem::SLoadB256Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB256Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB256Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b256", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB256Smem>(opcode);
 }
 } // namespace detail
@@ -129,7 +144,11 @@ SLoadB512Smem::SLoadB512Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB512Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB512Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b512", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB512Smem>(opcode);
 }
 } // namespace detail
@@ -152,7 +171,11 @@ SLoadB96Smem::SLoadB96Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB96Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB96Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b96", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB96Smem>(opcode);
 }
 } // namespace detail
@@ -175,7 +198,11 @@ SLoadI8Smem::SLoadI8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadI8Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadI8Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_i8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadI8Smem>(opcode);
 }
 } // namespace detail
@@ -198,7 +225,11 @@ SLoadU8Smem::SLoadU8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadU8Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadU8Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_u8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadU8Smem>(opcode);
 }
 } // namespace detail
@@ -221,7 +252,11 @@ SLoadI16Smem::SLoadI16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadI16Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadI16Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_i16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadI16Smem>(opcode);
 }
 } // namespace detail
@@ -244,7 +279,11 @@ SLoadU16Smem::SLoadU16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadU16Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadU16Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_u16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadU16Smem>(opcode);
 }
 } // namespace detail
@@ -267,7 +306,12 @@ SBufferLoadB32Smem::SBufferLoadB32Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB32Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB32Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b32", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB32Smem>(opcode);
 }
 } // namespace detail
@@ -290,7 +334,12 @@ SBufferLoadB64Smem::SBufferLoadB64Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB64Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB64Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b64", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB64Smem>(opcode);
 }
 } // namespace detail
@@ -313,7 +362,12 @@ SBufferLoadB128Smem::SBufferLoadB128Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB128Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB128Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b128", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB128Smem>(opcode);
 }
 } // namespace detail
@@ -336,7 +390,12 @@ SBufferLoadB256Smem::SBufferLoadB256Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB256Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB256Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b256", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB256Smem>(opcode);
 }
 } // namespace detail
@@ -359,7 +418,12 @@ SBufferLoadB512Smem::SBufferLoadB512Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB512Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB512Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b512", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB512Smem>(opcode);
 }
 } // namespace detail
@@ -382,7 +446,12 @@ SBufferLoadB96Smem::SBufferLoadB96Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB96Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB96Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b96", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB96Smem>(opcode);
 }
 } // namespace detail
@@ -405,7 +474,12 @@ SBufferLoadI8Smem::SBufferLoadI8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadI8Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadI8Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_i8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadI8Smem>(opcode);
 }
 } // namespace detail
@@ -428,7 +502,12 @@ SBufferLoadU8Smem::SBufferLoadU8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadU8Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadU8Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_u8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadU8Smem>(opcode);
 }
 } // namespace detail
@@ -451,7 +530,12 @@ SBufferLoadI16Smem::SBufferLoadI16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadI16Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadI16Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_i16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadI16Smem>(opcode);
 }
 } // namespace detail
@@ -474,7 +558,12 @@ SBufferLoadU16Smem::SBufferLoadU16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadU16Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadU16Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_u16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadU16Smem>(opcode);
 }
 } // namespace detail
@@ -487,7 +576,11 @@ SDcacheInvSmem::SDcacheInvSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_inv", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheInvSmem>(opcode);
 }
 } // namespace detail
@@ -506,7 +599,11 @@ SAtcProbeSmem::SAtcProbeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtcProbeSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtcProbeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atc_probe", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtcProbeSmem>(opcode);
 }
 } // namespace detail
@@ -525,7 +622,12 @@ SAtcProbeBufferSmem::SAtcProbeBufferSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtcProbeBufferSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtcProbeBufferSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atc_probe_buffer", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtcProbeBufferSmem>(opcode);
 }
 } // namespace detail
@@ -546,7 +648,12 @@ SPrefetchInstSmem::SPrefetchInstSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPrefetchInstSmem(const MachineInst *opcode) {
+DecodeResult decodeSPrefetchInstSmem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_prefetch_inst", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPrefetchInstSmem>(opcode);
 }
 } // namespace detail
@@ -565,7 +672,12 @@ SPrefetchInstPcRelSmem::SPrefetchInstPcRelSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPrefetchInstPcRelSmem(const MachineInst *opcode) {
+DecodeResult decodeSPrefetchInstPcRelSmem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_prefetch_inst_pc_rel", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPrefetchInstPcRelSmem>(opcode);
 }
 } // namespace detail
@@ -586,7 +698,12 @@ SPrefetchDataSmem::SPrefetchDataSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPrefetchDataSmem(const MachineInst *opcode) {
+DecodeResult decodeSPrefetchDataSmem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_prefetch_data", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPrefetchDataSmem>(opcode);
 }
 } // namespace detail
@@ -607,7 +724,12 @@ SBufferPrefetchDataSmem::SBufferPrefetchDataSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferPrefetchDataSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferPrefetchDataSmem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_prefetch_data", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferPrefetchDataSmem>(opcode);
 }
 } // namespace detail
@@ -626,7 +748,12 @@ SPrefetchDataPcRelSmem::SPrefetchDataPcRelSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPrefetchDataPcRelSmem(const MachineInst *opcode) {
+DecodeResult decodeSPrefetchDataPcRelSmem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_prefetch_data_pc_rel", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPrefetchDataPcRelSmem>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sop1.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/sop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -36,7 +35,11 @@ SMovB32Sop1::SMovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -66,7 +69,11 @@ SMovB64Sop1::SMovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -99,7 +106,11 @@ SCmovB32Sop1::SCmovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -133,7 +144,11 @@ SCmovB64Sop1::SCmovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -161,7 +176,11 @@ SBrevB32Sop1::SBrevB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB32Sop1>(opcode);
 }
 } // namespace detail
@@ -190,15 +209,18 @@ SBrevB64Sop1::SBrevB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB64Sop1>(opcode);
 }
 } // namespace detail
 
 SGetShaderCyclesU64Sop1::SGetShaderCyclesU64Sop1(const MachineInst *inst)
     : Sop1("s_get_shader_cycles_u64", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::SGetShaderCyclesU64Sop1), LiteralSupport::None,
-           0),
+           selected_exec_fn(InstructionExecutionId::SGetShaderCyclesU64Sop1)),
       sdst(64, OperandType::OPR_SDST, reinterpret_cast<const OpEncoding *>(inst)->sdst) {
   dst_operands_[0] = &sdst;
   num_src_ = 0;
@@ -206,7 +228,13 @@ SGetShaderCyclesU64Sop1::SGetShaderCyclesU64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetShaderCyclesU64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSGetShaderCyclesU64Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding("s_get_shader_cycles_u64",
+                                              reinterpret_cast<const Sop1::OpEncoding *>(opcode),
+                                              emit_error, LiteralSupport::None, 0);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetShaderCyclesU64Sop1>(opcode);
 }
 } // namespace detail
@@ -234,7 +262,11 @@ SCtzI32B32Sop1::SCtzI32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCtzI32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCtzI32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ctz_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCtzI32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -263,7 +295,11 @@ SCtzI32B64Sop1::SCtzI32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCtzI32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCtzI32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ctz_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCtzI32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -291,7 +327,11 @@ SClzI32U32Sop1::SClzI32U32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClzI32U32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSClzI32U32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_clz_i32_u32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClzI32U32Sop1>(opcode);
 }
 } // namespace detail
@@ -320,7 +360,11 @@ SClzI32U64Sop1::SClzI32U64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClzI32U64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSClzI32U64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_clz_i32_u64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClzI32U64Sop1>(opcode);
 }
 } // namespace detail
@@ -348,7 +392,11 @@ SClsI32Sop1::SClsI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClsI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSClsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cls_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClsI32Sop1>(opcode);
 }
 } // namespace detail
@@ -377,7 +425,11 @@ SClsI32I64Sop1::SClsI32I64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClsI32I64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSClsI32I64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cls_i32_i64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClsI32I64Sop1>(opcode);
 }
 } // namespace detail
@@ -405,7 +457,11 @@ SSextI32I8Sop1::SSextI32I8Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i8", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I8Sop1>(opcode);
 }
 } // namespace detail
@@ -434,7 +490,12 @@ SSextI32I16Sop1::SSextI32I16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I16Sop1>(opcode);
 }
 } // namespace detail
@@ -463,7 +524,12 @@ SBitset0B32Sop1::SBitset0B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B32Sop1>(opcode);
 }
 } // namespace detail
@@ -492,7 +558,12 @@ SBitset0B64Sop1::SBitset0B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B64Sop1>(opcode);
 }
 } // namespace detail
@@ -521,7 +592,12 @@ SBitset1B32Sop1::SBitset1B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B32Sop1>(opcode);
 }
 } // namespace detail
@@ -550,7 +626,12 @@ SBitset1B64Sop1::SBitset1B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B64Sop1>(opcode);
 }
 } // namespace detail
@@ -578,7 +659,12 @@ SBitreplicateB64B32Sop1::SBitreplicateB64B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitreplicate_b64_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitreplicateB64B32Sop1>(opcode);
 }
 } // namespace detail
@@ -609,7 +695,11 @@ SAbsI32Sop1::SAbsI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_abs_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsI32Sop1>(opcode);
 }
 } // namespace detail
@@ -640,7 +730,12 @@ SBcnt0I32B32Sop1::SBcnt0I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -672,7 +767,12 @@ SBcnt0I32B64Sop1::SBcnt0I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -703,7 +803,12 @@ SBcnt1I32B32Sop1::SBcnt1I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -735,7 +840,12 @@ SBcnt1I32B64Sop1::SBcnt1I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -766,7 +876,12 @@ SQuadmaskB32Sop1::SQuadmaskB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB32Sop1>(opcode);
 }
 } // namespace detail
@@ -798,7 +913,12 @@ SQuadmaskB64Sop1::SQuadmaskB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB64Sop1>(opcode);
 }
 } // namespace detail
@@ -829,7 +949,11 @@ SWqmB32Sop1::SWqmB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB32Sop1>(opcode);
 }
 } // namespace detail
@@ -861,7 +985,11 @@ SWqmB64Sop1::SWqmB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB64Sop1>(opcode);
 }
 } // namespace detail
@@ -892,7 +1020,11 @@ SNotB32Sop1::SNotB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB32Sop1>(opcode);
 }
 } // namespace detail
@@ -924,7 +1056,11 @@ SNotB64Sop1::SNotB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB64Sop1>(opcode);
 }
 } // namespace detail
@@ -962,7 +1098,12 @@ SAndSaveexecB32Sop1::SAndSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1001,7 +1142,12 @@ SAndSaveexecB64Sop1::SAndSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1040,7 +1186,12 @@ SOrSaveexecB32Sop1::SOrSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrSaveexecB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1080,7 +1231,12 @@ SOrSaveexecB64Sop1::SOrSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1118,7 +1274,12 @@ SXorSaveexecB32Sop1::SXorSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xor_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1157,7 +1318,12 @@ SXorSaveexecB64Sop1::SXorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1195,7 +1361,12 @@ SNandSaveexecB32Sop1::SNandSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNandSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nand_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1234,7 +1405,12 @@ SNandSaveexecB64Sop1::SNandSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nand_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1272,7 +1448,12 @@ SNorSaveexecB32Sop1::SNorSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nor_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1311,7 +1492,12 @@ SNorSaveexecB64Sop1::SNorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1349,7 +1535,12 @@ SXnorSaveexecB32Sop1::SXnorSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXnorSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xnor_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1388,7 +1579,12 @@ SXnorSaveexecB64Sop1::SXnorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xnor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1426,7 +1622,12 @@ SAndNot0SaveexecB32Sop1::SAndNot0SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot0SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot0SaveexecB32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not0_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot0SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1465,7 +1666,12 @@ SAndNot0SaveexecB64Sop1::SAndNot0SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot0SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot0SaveexecB64Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not0_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot0SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1503,7 +1709,12 @@ SOrNot0SaveexecB32Sop1::SOrNot0SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot0SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrNot0SaveexecB32Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_not0_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot0SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1542,7 +1753,12 @@ SOrNot0SaveexecB64Sop1::SOrNot0SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot0SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrNot0SaveexecB64Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_not0_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot0SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1580,7 +1796,12 @@ SAndNot1SaveexecB32Sop1::SAndNot1SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1SaveexecB32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not1_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1619,7 +1840,12 @@ SAndNot1SaveexecB64Sop1::SAndNot1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1SaveexecB64Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1657,7 +1883,12 @@ SOrNot1SaveexecB32Sop1::SOrNot1SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot1SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrNot1SaveexecB32Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_not1_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot1SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1696,7 +1927,12 @@ SOrNot1SaveexecB64Sop1::SOrNot1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrNot1SaveexecB64Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_not1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1734,7 +1970,12 @@ SAndNot0WrexecB32Sop1::SAndNot0WrexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot0WrexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot0WrexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not0_wrexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot0WrexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1773,7 +2014,12 @@ SAndNot0WrexecB64Sop1::SAndNot0WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot0WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot0WrexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not0_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot0WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1811,7 +2057,12 @@ SAndNot1WrexecB32Sop1::SAndNot1WrexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1WrexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1WrexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not1_wrexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1WrexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1850,14 +2101,19 @@ SAndNot1WrexecB64Sop1::SAndNot1WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1WrexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not1_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1WrexecB64Sop1>(opcode);
 }
 } // namespace detail
 
 SMovrelsB32Sop1::SMovrelsB32Sop1(const MachineInst *inst)
     : Sop1("s_movrels_b32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::SMovrelsB32Sop1), LiteralSupport::None),
+           selected_exec_fn(InstructionExecutionId::SMovrelsB32Sop1)),
       sdst(32, OperandType::OPR_SDST, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       ssrc0(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssrc0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -1870,14 +2126,20 @@ SMovrelsB32Sop1::SMovrelsB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Sop1::validate_encoding("s_movrels_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode),
+                              emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB32Sop1>(opcode);
 }
 } // namespace detail
 
 SMovrelsB64Sop1::SMovrelsB64Sop1(const MachineInst *inst)
     : Sop1("s_movrels_b64", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::SMovrelsB64Sop1), LiteralSupport::None),
+           selected_exec_fn(InstructionExecutionId::SMovrelsB64Sop1)),
       sdst(64, OperandType::OPR_SDST, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       ssrc0(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssrc0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -1890,7 +2152,13 @@ SMovrelsB64Sop1::SMovrelsB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Sop1::validate_encoding("s_movrels_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode),
+                              emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1921,7 +2189,12 @@ SMovreldB32Sop1::SMovreldB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1953,14 +2226,19 @@ SMovreldB64Sop1::SMovreldB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB64Sop1>(opcode);
 }
 } // namespace detail
 
 SMovrelsd2B32Sop1::SMovrelsd2B32Sop1(const MachineInst *inst)
     : Sop1("s_movrelsd_2_b32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::SMovrelsd2B32Sop1), LiteralSupport::None),
+           selected_exec_fn(InstructionExecutionId::SMovrelsd2B32Sop1)),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       ssrc0(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssrc0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -1973,14 +2251,20 @@ SMovrelsd2B32Sop1::SMovrelsd2B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsd2B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsd2B32Sop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding("s_movrelsd_2_b32",
+                                              reinterpret_cast<const Sop1::OpEncoding *>(opcode),
+                                              emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsd2B32Sop1>(opcode);
 }
 } // namespace detail
 
 SGetPcI64Sop1::SGetPcI64Sop1(const MachineInst *inst)
     : Sop1("s_get_pc_i64", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::SGetPcI64Sop1), LiteralSupport::None, 0),
+           selected_exec_fn(InstructionExecutionId::SGetPcI64Sop1)),
       sdst(64, OperandType::OPR_SDST, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       pc(64, OperandType::OPR_PC, 0) {
   dst_operands_[0] = &sdst;
@@ -1991,14 +2275,19 @@ SGetPcI64Sop1::SGetPcI64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetPcI64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSGetPcI64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Sop1::validate_encoding("s_get_pc_i64", reinterpret_cast<const Sop1::OpEncoding *>(opcode),
+                              emit_error, LiteralSupport::None, 0);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetPcI64Sop1>(opcode);
 }
 } // namespace detail
 
 SSetPcI64Sop1::SSetPcI64Sop1(const MachineInst *inst)
     : Sop1("s_set_pc_i64", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::SSetPcI64Sop1), LiteralSupport::None),
+           selected_exec_fn(InstructionExecutionId::SSetPcI64Sop1)),
       ssrc0(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssrc0),
       pc(64, OperandType::OPR_PC, 0) {
   src_operands_[0] = &ssrc0;
@@ -2010,14 +2299,19 @@ SSetPcI64Sop1::SSetPcI64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetPcI64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSetPcI64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Sop1::validate_encoding("s_set_pc_i64", reinterpret_cast<const Sop1::OpEncoding *>(opcode),
+                              emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetPcI64Sop1>(opcode);
 }
 } // namespace detail
 
 SSwapPcI64Sop1::SSwapPcI64Sop1(const MachineInst *inst)
     : Sop1("s_swap_pc_i64", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::SSwapPcI64Sop1), LiteralSupport::None),
+           selected_exec_fn(InstructionExecutionId::SSwapPcI64Sop1)),
       sdst(64, OperandType::OPR_SDST, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       ssrc0(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssrc0),
       pc(64, OperandType::OPR_PC, 0), pc_in(64, OperandType::OPR_PC, 0) {
@@ -2033,14 +2327,19 @@ SSwapPcI64Sop1::SSwapPcI64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSwapPcI64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSwapPcI64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Sop1::validate_encoding("s_swap_pc_i64", reinterpret_cast<const Sop1::OpEncoding *>(opcode),
+                              emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSwapPcI64Sop1>(opcode);
 }
 } // namespace detail
 
 SRfeI64Sop1::SRfeI64Sop1(const MachineInst *inst)
     : Sop1("s_rfe_i64", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::SRfeI64Sop1), LiteralSupport::None),
+           selected_exec_fn(InstructionExecutionId::SRfeI64Sop1)),
       ssrc0(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssrc0),
       pc(64, OperandType::OPR_PC, 0) {
   src_operands_[0] = &ssrc0;
@@ -2051,7 +2350,12 @@ SRfeI64Sop1::SRfeI64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRfeI64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSRfeI64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Sop1::validate_encoding("s_rfe_i64", reinterpret_cast<const Sop1::OpEncoding *>(opcode),
+                              emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRfeI64Sop1>(opcode);
 }
 } // namespace detail
@@ -2082,14 +2386,18 @@ SAddPcI64Sop1::SAddPcI64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddPcI64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAddPcI64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_add_pc_i64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddPcI64Sop1>(opcode);
 }
 } // namespace detail
 
 SSendmsgRtnB32Sop1::SSendmsgRtnB32Sop1(const MachineInst *inst)
     : Sop1("s_sendmsg_rtn_b32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::SSendmsgRtnB32Sop1), LiteralSupport::None, 0),
+           selected_exec_fn(InstructionExecutionId::SSendmsgRtnB32Sop1)),
       sdst(32, OperandType::OPR_SDST, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       ssrc0(32, OperandType::OPR_SENDMSG_RTN, reinterpret_cast<const OpEncoding *>(inst)->ssrc0) {
   dst_operands_[0] = &sdst;
@@ -2099,14 +2407,20 @@ SSendmsgRtnB32Sop1::SSendmsgRtnB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsgRtnB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSendmsgRtnB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding("s_sendmsg_rtn_b32",
+                                              reinterpret_cast<const Sop1::OpEncoding *>(opcode),
+                                              emit_error, LiteralSupport::None, 0);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsgRtnB32Sop1>(opcode);
 }
 } // namespace detail
 
 SSendmsgRtnB64Sop1::SSendmsgRtnB64Sop1(const MachineInst *inst)
     : Sop1("s_sendmsg_rtn_b64", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::SSendmsgRtnB64Sop1), LiteralSupport::None, 0),
+           selected_exec_fn(InstructionExecutionId::SSendmsgRtnB64Sop1)),
       sdst(64, OperandType::OPR_SDST, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       ssrc0(32, OperandType::OPR_SENDMSG_RTN, reinterpret_cast<const OpEncoding *>(inst)->ssrc0) {
   dst_operands_[0] = &sdst;
@@ -2116,14 +2430,20 @@ SSendmsgRtnB64Sop1::SSendmsgRtnB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsgRtnB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSendmsgRtnB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding("s_sendmsg_rtn_b64",
+                                              reinterpret_cast<const Sop1::OpEncoding *>(opcode),
+                                              emit_error, LiteralSupport::None, 0);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsgRtnB64Sop1>(opcode);
 }
 } // namespace detail
 
 SBarrierSignalSop1::SBarrierSignalSop1(const MachineInst *inst)
     : Sop1("s_barrier_signal", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::SBarrierSignalSop1), LiteralSupport::None),
+           selected_exec_fn(InstructionExecutionId::SBarrierSignalSop1)),
       ssrc0(32, OperandType::OPR_SSRC_BARRIER_ID,
             reinterpret_cast<const OpEncoding *>(inst)->ssrc0) {
   src_operands_[0] = &ssrc0;
@@ -2133,15 +2453,20 @@ SBarrierSignalSop1::SBarrierSignalSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBarrierSignalSop1(const MachineInst *opcode) {
+DecodeResult decodeSBarrierSignalSop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding("s_barrier_signal",
+                                              reinterpret_cast<const Sop1::OpEncoding *>(opcode),
+                                              emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBarrierSignalSop1>(opcode);
 }
 } // namespace detail
 
 SBarrierSignalIsfirstSop1::SBarrierSignalIsfirstSop1(const MachineInst *inst)
     : Sop1("s_barrier_signal_isfirst", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::SBarrierSignalIsfirstSop1),
-           LiteralSupport::None),
+           selected_exec_fn(InstructionExecutionId::SBarrierSignalIsfirstSop1)),
       ssrc0(32, OperandType::OPR_SSRC_BARRIER_ID,
             reinterpret_cast<const OpEncoding *>(inst)->ssrc0),
       scc(1, OperandType::OPR_SSRC_SPECIAL_SCC, 253) {
@@ -2153,14 +2478,20 @@ SBarrierSignalIsfirstSop1::SBarrierSignalIsfirstSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBarrierSignalIsfirstSop1(const MachineInst *opcode) {
+DecodeResult decodeSBarrierSignalIsfirstSop1(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding("s_barrier_signal_isfirst",
+                                              reinterpret_cast<const Sop1::OpEncoding *>(opcode),
+                                              emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBarrierSignalIsfirstSop1>(opcode);
 }
 } // namespace detail
 
 SGetBarrierStateSop1::SGetBarrierStateSop1(const MachineInst *inst)
     : Sop1("s_get_barrier_state", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::SGetBarrierStateSop1), LiteralSupport::None),
+           selected_exec_fn(InstructionExecutionId::SGetBarrierStateSop1)),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       ssrc0(32, OperandType::OPR_SSRC_BARRIER_ID,
             reinterpret_cast<const OpEncoding *>(inst)->ssrc0) {
@@ -2171,14 +2502,20 @@ SGetBarrierStateSop1::SGetBarrierStateSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetBarrierStateSop1(const MachineInst *opcode) {
+DecodeResult decodeSGetBarrierStateSop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding("s_get_barrier_state",
+                                              reinterpret_cast<const Sop1::OpEncoding *>(opcode),
+                                              emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetBarrierStateSop1>(opcode);
 }
 } // namespace detail
 
 SBarrierInitSop1::SBarrierInitSop1(const MachineInst *inst)
     : Sop1("s_barrier_init", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::SBarrierInitSop1), LiteralSupport::None),
+           selected_exec_fn(InstructionExecutionId::SBarrierInitSop1)),
       ssrc0(32, OperandType::OPR_SSRC_BARRIER_ID,
             reinterpret_cast<const OpEncoding *>(inst)->ssrc0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2190,14 +2527,20 @@ SBarrierInitSop1::SBarrierInitSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBarrierInitSop1(const MachineInst *opcode) {
+DecodeResult decodeSBarrierInitSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Sop1::validate_encoding("s_barrier_init", reinterpret_cast<const Sop1::OpEncoding *>(opcode),
+                              emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBarrierInitSop1>(opcode);
 }
 } // namespace detail
 
 SBarrierJoinSop1::SBarrierJoinSop1(const MachineInst *inst)
     : Sop1("s_barrier_join", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::SBarrierJoinSop1), LiteralSupport::None),
+           selected_exec_fn(InstructionExecutionId::SBarrierJoinSop1)),
       ssrc0(32, OperandType::OPR_SSRC_BARRIER_ID,
             reinterpret_cast<const OpEncoding *>(inst)->ssrc0) {
   src_operands_[0] = &ssrc0;
@@ -2206,7 +2549,13 @@ SBarrierJoinSop1::SBarrierJoinSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBarrierJoinSop1(const MachineInst *opcode) {
+DecodeResult decodeSBarrierJoinSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Sop1::validate_encoding("s_barrier_join", reinterpret_cast<const Sop1::OpEncoding *>(opcode),
+                              emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBarrierJoinSop1>(opcode);
 }
 } // namespace detail
@@ -2235,14 +2584,18 @@ SAllocVgprSop1::SAllocVgprSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAllocVgprSop1(const MachineInst *opcode) {
+DecodeResult decodeSAllocVgprSop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_alloc_vgpr", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAllocVgprSop1>(opcode);
 }
 } // namespace detail
 
 SWakeupBarrierSop1::SWakeupBarrierSop1(const MachineInst *inst)
     : Sop1("s_wakeup_barrier", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::SWakeupBarrierSop1), LiteralSupport::None),
+           selected_exec_fn(InstructionExecutionId::SWakeupBarrierSop1)),
       ssrc0(32, OperandType::OPR_SSRC_BARRIER_ID,
             reinterpret_cast<const OpEncoding *>(inst)->ssrc0) {
   src_operands_[0] = &ssrc0;
@@ -2251,7 +2604,13 @@ SWakeupBarrierSop1::SWakeupBarrierSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWakeupBarrierSop1(const MachineInst *opcode) {
+DecodeResult decodeSWakeupBarrierSop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding("s_wakeup_barrier",
+                                              reinterpret_cast<const Sop1::OpEncoding *>(opcode),
+                                              emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWakeupBarrierSop1>(opcode);
 }
 } // namespace detail
@@ -2277,7 +2636,11 @@ SSleepVarSop1::SSleepVarSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSleepVarSop1(const MachineInst *opcode) {
+DecodeResult decodeSSleepVarSop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sleep_var", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSleepVarSop1>(opcode);
 }
 } // namespace detail
@@ -2305,7 +2668,11 @@ SCeilF32Sop1::SCeilF32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCeilF32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCeilF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ceil_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCeilF32Sop1>(opcode);
 }
 } // namespace detail
@@ -2333,7 +2700,11 @@ SFloorF32Sop1::SFloorF32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFloorF32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFloorF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_floor_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFloorF32Sop1>(opcode);
 }
 } // namespace detail
@@ -2361,7 +2732,11 @@ STruncF32Sop1::STruncF32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTruncF32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSTruncF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_trunc_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STruncF32Sop1>(opcode);
 }
 } // namespace detail
@@ -2389,7 +2764,11 @@ SRndneF32Sop1::SRndneF32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRndneF32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSRndneF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_rndne_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRndneF32Sop1>(opcode);
 }
 } // namespace detail
@@ -2417,7 +2796,11 @@ SCvtF32I32Sop1::SCvtF32I32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtF32I32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtF32I32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_f32_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtF32I32Sop1>(opcode);
 }
 } // namespace detail
@@ -2445,7 +2828,11 @@ SCvtF32U32Sop1::SCvtF32U32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtF32U32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtF32U32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_f32_u32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtF32U32Sop1>(opcode);
 }
 } // namespace detail
@@ -2473,7 +2860,11 @@ SCvtI32F32Sop1::SCvtI32F32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtI32F32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtI32F32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_i32_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtI32F32Sop1>(opcode);
 }
 } // namespace detail
@@ -2501,7 +2892,11 @@ SCvtU32F32Sop1::SCvtU32F32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtU32F32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtU32F32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_u32_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtU32F32Sop1>(opcode);
 }
 } // namespace detail
@@ -2529,7 +2924,11 @@ SCvtF16F32Sop1::SCvtF16F32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtF16F32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtF16F32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_f16_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtF16F32Sop1>(opcode);
 }
 } // namespace detail
@@ -2571,7 +2970,11 @@ SCvtF32F16Sop1::SCvtF32F16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtF32F16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtF32F16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_f32_f16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtF32F16Sop1>(opcode);
 }
 } // namespace detail
@@ -2600,7 +3003,12 @@ SCvtHiF32F16Sop1::SCvtHiF32F16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtHiF32F16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtHiF32F16Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_hi_f32_f16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtHiF32F16Sop1>(opcode);
 }
 } // namespace detail
@@ -2629,7 +3037,11 @@ SCeilF16Sop1::SCeilF16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCeilF16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCeilF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ceil_f16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCeilF16Sop1>(opcode);
 }
 } // namespace detail
@@ -2670,7 +3082,11 @@ SFloorF16Sop1::SFloorF16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFloorF16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFloorF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_floor_f16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFloorF16Sop1>(opcode);
 }
 } // namespace detail
@@ -2712,7 +3128,11 @@ STruncF16Sop1::STruncF16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTruncF16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSTruncF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_trunc_f16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STruncF16Sop1>(opcode);
 }
 } // namespace detail
@@ -2754,7 +3174,11 @@ SRndneF16Sop1::SRndneF16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRndneF16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSRndneF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_rndne_f16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRndneF16Sop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sop2.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/sop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -25,11 +24,6 @@ SAddCoU32Sop2::SAddCoU32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_ADD_CO_U32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -56,7 +50,17 @@ SAddCoU32Sop2::SAddCoU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddCoU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddCoU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_add_co_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_ADD_CO_U32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SAddCoU32Sop2>(opcode);
 }
 } // namespace detail
@@ -74,11 +78,6 @@ SSubCoU32Sop2::SSubCoU32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_SUB_CO_U32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -105,7 +104,17 @@ SSubCoU32Sop2::SSubCoU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubCoU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubCoU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_sub_co_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_SUB_CO_U32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SSubCoU32Sop2>(opcode);
 }
 } // namespace detail
@@ -123,11 +132,6 @@ SAddCoI32Sop2::SAddCoI32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_ADD_CO_I32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -154,7 +158,17 @@ SAddCoI32Sop2::SAddCoI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddCoI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddCoI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_add_co_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_ADD_CO_I32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SAddCoI32Sop2>(opcode);
 }
 } // namespace detail
@@ -172,11 +186,6 @@ SSubCoI32Sop2::SSubCoI32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_SUB_CO_I32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -203,7 +212,17 @@ SSubCoI32Sop2::SSubCoI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubCoI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubCoI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_sub_co_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_SUB_CO_I32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SSubCoI32Sop2>(opcode);
 }
 } // namespace detail
@@ -223,11 +242,6 @@ SAddCoCiU32Sop2::SAddCoCiU32Sop2(const MachineInst *inst)
   src_operands_[2] = &scc_in;
   num_src_ = 3;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_ADD_CO_CI_U32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -255,7 +269,18 @@ SAddCoCiU32Sop2::SAddCoCiU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddCoCiU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddCoCiU32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_add_co_ci_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_ADD_CO_CI_U32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SAddCoCiU32Sop2>(opcode);
 }
 } // namespace detail
@@ -275,11 +300,6 @@ SSubCoCiU32Sop2::SSubCoCiU32Sop2(const MachineInst *inst)
   src_operands_[2] = &scc_in;
   num_src_ = 3;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_SUB_CO_CI_U32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -307,7 +327,18 @@ SSubCoCiU32Sop2::SSubCoCiU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubCoCiU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubCoCiU32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_sub_co_ci_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_SUB_CO_CI_U32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SSubCoCiU32Sop2>(opcode);
 }
 } // namespace detail
@@ -325,11 +356,6 @@ SAbsdiffI32Sop2::SAbsdiffI32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_ABSDIFF_I32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -356,7 +382,18 @@ SAbsdiffI32Sop2::SAbsdiffI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_absdiff_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_ABSDIFF_I32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SAbsdiffI32Sop2>(opcode);
 }
 } // namespace detail
@@ -374,11 +411,6 @@ SLshlB32Sop2::SLshlB32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_LSHL_B32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -405,7 +437,17 @@ SLshlB32Sop2::SLshlB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_LSHL_B32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SLshlB32Sop2>(opcode);
 }
 } // namespace detail
@@ -423,11 +465,6 @@ SLshlB64Sop2::SLshlB64Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_LSHL_B64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -455,7 +492,17 @@ SLshlB64Sop2::SLshlB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_LSHL_B64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SLshlB64Sop2>(opcode);
 }
 } // namespace detail
@@ -473,11 +520,6 @@ SLshrB32Sop2::SLshrB32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_LSHR_B32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -504,7 +546,17 @@ SLshrB32Sop2::SLshrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_LSHR_B32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SLshrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -522,11 +574,6 @@ SLshrB64Sop2::SLshrB64Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_LSHR_B64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -554,7 +601,17 @@ SLshrB64Sop2::SLshrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_LSHR_B64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SLshrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -572,11 +629,6 @@ SAshrI32Sop2::SAshrI32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_ASHR_I32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -603,7 +655,17 @@ SAshrI32Sop2::SAshrI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_ASHR_I32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SAshrI32Sop2>(opcode);
 }
 } // namespace detail
@@ -621,11 +683,6 @@ SAshrI64Sop2::SAshrI64Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_ASHR_I64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -653,7 +710,17 @@ SAshrI64Sop2::SAshrI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_ASHR_I64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SAshrI64Sop2>(opcode);
 }
 } // namespace detail
@@ -671,11 +738,6 @@ SLshl1AddU32Sop2::SLshl1AddU32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_LSHL1_ADD_U32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -702,7 +764,18 @@ SLshl1AddU32Sop2::SLshl1AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_lshl1_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_LSHL1_ADD_U32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SLshl1AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -720,11 +793,6 @@ SLshl2AddU32Sop2::SLshl2AddU32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_LSHL2_ADD_U32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -751,7 +819,18 @@ SLshl2AddU32Sop2::SLshl2AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_lshl2_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_LSHL2_ADD_U32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SLshl2AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -769,11 +848,6 @@ SLshl3AddU32Sop2::SLshl3AddU32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_LSHL3_ADD_U32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -800,7 +874,18 @@ SLshl3AddU32Sop2::SLshl3AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_lshl3_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_LSHL3_ADD_U32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SLshl3AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -818,11 +903,6 @@ SLshl4AddU32Sop2::SLshl4AddU32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_LSHL4_ADD_U32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -849,7 +929,18 @@ SLshl4AddU32Sop2::SLshl4AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_lshl4_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_LSHL4_ADD_U32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SLshl4AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -867,11 +958,6 @@ SMinI32Sop2::SMinI32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_MIN_I32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -898,7 +984,17 @@ SMinI32Sop2::SMinI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_min_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_MIN_I32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SMinI32Sop2>(opcode);
 }
 } // namespace detail
@@ -916,11 +1012,6 @@ SMinU32Sop2::SMinU32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_MIN_U32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -947,7 +1038,17 @@ SMinU32Sop2::SMinU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_min_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_MIN_U32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SMinU32Sop2>(opcode);
 }
 } // namespace detail
@@ -965,11 +1066,6 @@ SMaxI32Sop2::SMaxI32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_MAX_I32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -996,7 +1092,17 @@ SMaxI32Sop2::SMaxI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_max_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_MAX_I32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SMaxI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1014,11 +1120,6 @@ SMaxU32Sop2::SMaxU32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_MAX_U32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1045,7 +1146,17 @@ SMaxU32Sop2::SMaxU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_max_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_MAX_U32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SMaxU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1063,11 +1174,6 @@ SAndB32Sop2::SAndB32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_AND_B32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1094,7 +1200,17 @@ SAndB32Sop2::SAndB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_and_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_AND_B32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SAndB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1112,11 +1228,6 @@ SAndB64Sop2::SAndB64Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_AND_B64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -1145,7 +1256,17 @@ SAndB64Sop2::SAndB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_and_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_AND_B64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SAndB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1163,11 +1284,6 @@ SOrB32Sop2::SOrB32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_OR_B32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1195,7 +1311,17 @@ SOrB32Sop2::SOrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_or_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_OR_B32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SOrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1213,11 +1339,6 @@ SOrB64Sop2::SOrB64Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_OR_B64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -1247,7 +1368,17 @@ SOrB64Sop2::SOrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_or_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_OR_B64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SOrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1265,11 +1396,6 @@ SXorB32Sop2::SXorB32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_XOR_B32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1296,7 +1422,17 @@ SXorB32Sop2::SXorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_XOR_B32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SXorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1314,11 +1450,6 @@ SXorB64Sop2::SXorB64Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_XOR_B64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -1347,7 +1478,17 @@ SXorB64Sop2::SXorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_XOR_B64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SXorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1365,11 +1506,6 @@ SNandB32Sop2::SNandB32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_NAND_B32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1396,7 +1532,17 @@ SNandB32Sop2::SNandB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_NAND_B32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SNandB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1414,11 +1560,6 @@ SNandB64Sop2::SNandB64Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_NAND_B64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -1447,7 +1588,17 @@ SNandB64Sop2::SNandB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_NAND_B64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SNandB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1465,11 +1616,6 @@ SNorB32Sop2::SNorB32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_NOR_B32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1496,7 +1642,17 @@ SNorB32Sop2::SNorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_NOR_B32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SNorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1514,11 +1670,6 @@ SNorB64Sop2::SNorB64Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_NOR_B64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -1547,7 +1698,17 @@ SNorB64Sop2::SNorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_NOR_B64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SNorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1565,11 +1726,6 @@ SXnorB32Sop2::SXnorB32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_XNOR_B32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1596,7 +1752,17 @@ SXnorB32Sop2::SXnorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_XNOR_B32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SXnorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1614,11 +1780,6 @@ SXnorB64Sop2::SXnorB64Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_XNOR_B64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -1647,7 +1808,17 @@ SXnorB64Sop2::SXnorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_XNOR_B64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SXnorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1665,11 +1836,6 @@ SAndNot1B32Sop2::SAndNot1B32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_AND_NOT1_B32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1696,7 +1862,18 @@ SAndNot1B32Sop2::SAndNot1B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1B32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_and_not1_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_AND_NOT1_B32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SAndNot1B32Sop2>(opcode);
 }
 } // namespace detail
@@ -1714,11 +1891,6 @@ SAndNot1B64Sop2::SAndNot1B64Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_AND_NOT1_B64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -1747,7 +1919,18 @@ SAndNot1B64Sop2::SAndNot1B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1B64Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_and_not1_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_AND_NOT1_B64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SAndNot1B64Sop2>(opcode);
 }
 } // namespace detail
@@ -1765,11 +1948,6 @@ SOrNot1B32Sop2::SOrNot1B32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_OR_NOT1_B32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1796,7 +1974,17 @@ SOrNot1B32Sop2::SOrNot1B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot1B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrNot1B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_or_not1_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_OR_NOT1_B32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SOrNot1B32Sop2>(opcode);
 }
 } // namespace detail
@@ -1814,11 +2002,6 @@ SOrNot1B64Sop2::SOrNot1B64Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_OR_NOT1_B64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -1847,7 +2030,17 @@ SOrNot1B64Sop2::SOrNot1B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot1B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrNot1B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_or_not1_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_OR_NOT1_B64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SOrNot1B64Sop2>(opcode);
 }
 } // namespace detail
@@ -1865,11 +2058,6 @@ SBfeU32Sop2::SBfeU32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_BFE_U32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1896,7 +2084,17 @@ SBfeU32Sop2::SBfeU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_BFE_U32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SBfeU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1914,11 +2112,6 @@ SBfeI32Sop2::SBfeI32Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_BFE_I32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1945,7 +2138,17 @@ SBfeI32Sop2::SBfeI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_BFE_I32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SBfeI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1963,11 +2166,6 @@ SBfeU64Sop2::SBfeU64Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_BFE_U64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -1995,7 +2193,17 @@ SBfeU64Sop2::SBfeU64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_BFE_U64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SBfeU64Sop2>(opcode);
 }
 } // namespace detail
@@ -2013,11 +2221,6 @@ SBfeI64Sop2::SBfeI64Sop2(const MachineInst *inst)
   dst_operands_[1] = &scc;
   num_src_ = 2;
   num_dst_ = 2;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_BFE_I64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -2045,7 +2248,17 @@ SBfeI64Sop2::SBfeI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_BFE_I64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SBfeI64Sop2>(opcode);
 }
 } // namespace detail
@@ -2061,11 +2274,6 @@ SBfmB32Sop2::SBfmB32Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_BFM_B32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -2091,7 +2299,17 @@ SBfmB32Sop2::SBfmB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_BFM_B32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SBfmB32Sop2>(opcode);
 }
 } // namespace detail
@@ -2107,11 +2325,6 @@ SBfmB64Sop2::SBfmB64Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_BFM_B64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -2137,7 +2350,17 @@ SBfmB64Sop2::SBfmB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_BFM_B64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SBfmB64Sop2>(opcode);
 }
 } // namespace detail
@@ -2153,11 +2376,6 @@ SMulI32Sop2::SMulI32Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_MUL_I32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -2183,7 +2401,17 @@ SMulI32Sop2::SMulI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_mul_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_MUL_I32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SMulI32Sop2>(opcode);
 }
 } // namespace detail
@@ -2199,11 +2427,6 @@ SMulHiU32Sop2::SMulHiU32Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_MUL_HI_U32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -2229,7 +2452,17 @@ SMulHiU32Sop2::SMulHiU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_MUL_HI_U32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SMulHiU32Sop2>(opcode);
 }
 } // namespace detail
@@ -2245,11 +2478,6 @@ SMulHiI32Sop2::SMulHiI32Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_MUL_HI_I32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -2275,7 +2503,17 @@ SMulHiI32Sop2::SMulHiI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_MUL_HI_I32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SMulHiI32Sop2>(opcode);
 }
 } // namespace detail
@@ -2293,11 +2531,6 @@ SCselectB32Sop2::SCselectB32Sop2(const MachineInst *inst)
   src_operands_[2] = &scc;
   num_src_ = 3;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CSELECT_B32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -2324,7 +2557,18 @@ SCselectB32Sop2::SCselectB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CSELECT_B32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCselectB32Sop2>(opcode);
 }
 } // namespace detail
@@ -2342,11 +2586,6 @@ SCselectB64Sop2::SCselectB64Sop2(const MachineInst *inst)
   src_operands_[2] = &scc;
   num_src_ = 3;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CSELECT_B64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -2375,7 +2614,18 @@ SCselectB64Sop2::SCselectB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CSELECT_B64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCselectB64Sop2>(opcode);
 }
 } // namespace detail
@@ -2391,11 +2641,6 @@ SPackLlB32B16Sop2::SPackLlB32B16Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_PACK_LL_B32_B16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -2423,7 +2668,18 @@ SPackLlB32B16Sop2::SPackLlB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_pack_ll_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_PACK_LL_B32_B16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SPackLlB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -2439,11 +2695,6 @@ SPackLhB32B16Sop2::SPackLhB32B16Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_PACK_LH_B32_B16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -2470,7 +2721,18 @@ SPackLhB32B16Sop2::SPackLhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_pack_lh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_PACK_LH_B32_B16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SPackLhB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -2486,11 +2748,6 @@ SPackHhB32B16Sop2::SPackHhB32B16Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_PACK_HH_B32_B16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -2516,7 +2773,18 @@ SPackHhB32B16Sop2::SPackHhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_pack_hh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_PACK_HH_B32_B16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SPackHhB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -2532,11 +2800,6 @@ SPackHlB32B16Sop2::SPackHlB32B16Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_PACK_HL_B32_B16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -2563,7 +2826,18 @@ SPackHlB32B16Sop2::SPackHlB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackHlB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackHlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_pack_hl_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_PACK_HL_B32_B16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SPackHlB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -2579,11 +2853,6 @@ SAddF32Sop2::SAddF32Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_ADD_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -2609,7 +2878,17 @@ SAddF32Sop2::SAddF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_add_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_ADD_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SAddF32Sop2>(opcode);
 }
 } // namespace detail
@@ -2625,11 +2904,6 @@ SSubF32Sop2::SSubF32Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_SUB_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -2655,7 +2929,17 @@ SSubF32Sop2::SSubF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_sub_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_SUB_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SSubF32Sop2>(opcode);
 }
 } // namespace detail
@@ -2671,11 +2955,6 @@ SMinNumF32Sop2::SMinNumF32Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_MIN_NUM_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -2701,7 +2980,17 @@ SMinNumF32Sop2::SMinNumF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinNumF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinNumF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_min_num_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_MIN_NUM_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SMinNumF32Sop2>(opcode);
 }
 } // namespace detail
@@ -2717,11 +3006,6 @@ SMaxNumF32Sop2::SMaxNumF32Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_MAX_NUM_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -2747,7 +3031,17 @@ SMaxNumF32Sop2::SMaxNumF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxNumF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxNumF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_max_num_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_MAX_NUM_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SMaxNumF32Sop2>(opcode);
 }
 } // namespace detail
@@ -2763,11 +3057,6 @@ SMulF32Sop2::SMulF32Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_MUL_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -2793,14 +3082,24 @@ SMulF32Sop2::SMulF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_mul_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_MUL_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SMulF32Sop2>(opcode);
 }
 } // namespace detail
 
 SFmaakF32Sop2::SFmaakF32Sop2(const MachineInst *inst)
     : Sop2("s_fmaak_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::SFmaakF32Sop2), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::SFmaakF32Sop2)),
       sdst(32, OperandType::OPR_SDST, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       ssrc0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->ssrc0),
       ssrc1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->ssrc1),
@@ -2825,14 +3124,19 @@ SFmaakF32Sop2::SFmaakF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFmaakF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSFmaakF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Sop2::validate_encoding("s_fmaak_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode),
+                              emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFmaakF32Sop2>(opcode);
 }
 } // namespace detail
 
 SFmamkF32Sop2::SFmamkF32Sop2(const MachineInst *inst)
     : Sop2("s_fmamk_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::SFmamkF32Sop2), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::SFmamkF32Sop2)),
       sdst(32, OperandType::OPR_SDST, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       ssrc0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->ssrc0),
       literal(32, OperandType::OPR_SIMM32, 0),
@@ -2857,7 +3161,12 @@ SFmamkF32Sop2::SFmamkF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFmamkF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSFmamkF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Sop2::validate_encoding("s_fmamk_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode),
+                              emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFmamkF32Sop2>(opcode);
 }
 } // namespace detail
@@ -2874,11 +3183,6 @@ SFmacF32Sop2::SFmacF32Sop2(const MachineInst *inst)
   src_operands_[2] = &ssrc1;
   num_src_ = 3;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_FMAC_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -2904,7 +3208,17 @@ SFmacF32Sop2::SFmacF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFmacF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSFmacF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_fmac_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_FMAC_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SFmacF32Sop2>(opcode);
 }
 } // namespace detail
@@ -2920,11 +3234,6 @@ SCvtPkRtzF16F32Sop2::SCvtPkRtzF16F32Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CVT_PK_RTZ_F16_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -2950,7 +3259,18 @@ SCvtPkRtzF16F32Sop2::SCvtPkRtzF16F32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtPkRtzF16F32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCvtPkRtzF16F32Sop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_cvt_pk_rtz_f16_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CVT_PK_RTZ_F16_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCvtPkRtzF16F32Sop2>(opcode);
 }
 } // namespace detail
@@ -2966,11 +3286,6 @@ SAddF16Sop2::SAddF16Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_ADD_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -2998,7 +3313,17 @@ SAddF16Sop2::SAddF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_add_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_ADD_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SAddF16Sop2>(opcode);
 }
 } // namespace detail
@@ -3026,11 +3351,6 @@ SSubF16Sop2::SSubF16Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_SUB_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -3058,7 +3378,17 @@ SSubF16Sop2::SSubF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_sub_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_SUB_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SSubF16Sop2>(opcode);
 }
 } // namespace detail
@@ -3086,11 +3416,6 @@ SMinNumF16Sop2::SMinNumF16Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_MIN_NUM_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -3118,7 +3443,17 @@ SMinNumF16Sop2::SMinNumF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinNumF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinNumF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_min_num_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_MIN_NUM_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SMinNumF16Sop2>(opcode);
 }
 } // namespace detail
@@ -3147,11 +3482,6 @@ SMaxNumF16Sop2::SMaxNumF16Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_MAX_NUM_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -3179,7 +3509,17 @@ SMaxNumF16Sop2::SMaxNumF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxNumF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxNumF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_max_num_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_MAX_NUM_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SMaxNumF16Sop2>(opcode);
 }
 } // namespace detail
@@ -3208,11 +3548,6 @@ SMulF16Sop2::SMulF16Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_MUL_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -3240,7 +3575,17 @@ SMulF16Sop2::SMulF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_mul_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_MUL_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SMulF16Sop2>(opcode);
 }
 } // namespace detail
@@ -3269,11 +3614,6 @@ SFmacF16Sop2::SFmacF16Sop2(const MachineInst *inst)
   src_operands_[2] = &ssrc1;
   num_src_ = 3;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_FMAC_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -3301,7 +3641,17 @@ SFmacF16Sop2::SFmacF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFmacF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSFmacF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_fmac_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_FMAC_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SFmacF16Sop2>(opcode);
 }
 } // namespace detail
@@ -3329,11 +3679,6 @@ SMinimumF32Sop2::SMinimumF32Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_MINIMUM_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -3359,7 +3704,18 @@ SMinimumF32Sop2::SMinimumF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinimumF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinimumF32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_minimum_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_MINIMUM_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SMinimumF32Sop2>(opcode);
 }
 } // namespace detail
@@ -3375,11 +3731,6 @@ SMaximumF32Sop2::SMaximumF32Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_MAXIMUM_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -3405,7 +3756,18 @@ SMaximumF32Sop2::SMaximumF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaximumF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaximumF32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_maximum_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_MAXIMUM_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SMaximumF32Sop2>(opcode);
 }
 } // namespace detail
@@ -3421,11 +3783,6 @@ SMinimumF16Sop2::SMinimumF16Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_MINIMUM_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -3453,7 +3810,18 @@ SMinimumF16Sop2::SMinimumF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinimumF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinimumF16Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_minimum_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_MINIMUM_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SMinimumF16Sop2>(opcode);
 }
 } // namespace detail
@@ -3482,11 +3850,6 @@ SMaximumF16Sop2::SMaximumF16Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_MAXIMUM_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -3514,7 +3877,18 @@ SMaximumF16Sop2::SMaximumF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaximumF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaximumF16Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_maximum_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_MAXIMUM_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SMaximumF16Sop2>(opcode);
 }
 } // namespace detail
@@ -3543,11 +3917,6 @@ SAddNcU64Sop2::SAddNcU64Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_ADD_NC_U64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -3575,7 +3944,17 @@ SAddNcU64Sop2::SAddNcU64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddNcU64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddNcU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_add_nc_u64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_ADD_NC_U64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SAddNcU64Sop2>(opcode);
 }
 } // namespace detail
@@ -3591,11 +3970,6 @@ SSubNcU64Sop2::SSubNcU64Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_SUB_NC_U64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -3623,7 +3997,17 @@ SSubNcU64Sop2::SSubNcU64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubNcU64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubNcU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_sub_nc_u64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_SUB_NC_U64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SSubNcU64Sop2>(opcode);
 }
 } // namespace detail
@@ -3639,11 +4023,6 @@ SMulU64Sop2::SMulU64Sop2(const MachineInst *inst)
   src_operands_[1] = &ssrc1;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_MUL_U64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -3671,7 +4050,17 @@ SMulU64Sop2::SMulU64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulU64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sop2::validate_encoding(
+      "s_mul_u64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sop2::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_MUL_U64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SMulU64Sop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sopc.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/sopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -23,11 +22,6 @@ SCmpEqI32Sopc::SCmpEqI32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_EQ_I32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -54,7 +48,17 @@ SCmpEqI32Sopc::SCmpEqI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_EQ_I32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpEqI32Sopc>(opcode);
 }
 } // namespace detail
@@ -70,11 +74,6 @@ SCmpLgI32Sopc::SCmpLgI32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_LG_I32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -101,7 +100,17 @@ SCmpLgI32Sopc::SCmpLgI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_LG_I32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpLgI32Sopc>(opcode);
 }
 } // namespace detail
@@ -117,11 +126,6 @@ SCmpGtI32Sopc::SCmpGtI32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_GT_I32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -148,7 +152,17 @@ SCmpGtI32Sopc::SCmpGtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_GT_I32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpGtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -164,11 +178,6 @@ SCmpGeI32Sopc::SCmpGeI32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_GE_I32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -195,7 +204,17 @@ SCmpGeI32Sopc::SCmpGeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_GE_I32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpGeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -211,11 +230,6 @@ SCmpLtI32Sopc::SCmpLtI32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_LT_I32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -242,7 +256,17 @@ SCmpLtI32Sopc::SCmpLtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_LT_I32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpLtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -258,11 +282,6 @@ SCmpLeI32Sopc::SCmpLeI32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_LE_I32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -289,7 +308,17 @@ SCmpLeI32Sopc::SCmpLeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_LE_I32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpLeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -305,11 +334,6 @@ SCmpEqU32Sopc::SCmpEqU32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_EQ_U32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -336,7 +360,17 @@ SCmpEqU32Sopc::SCmpEqU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_EQ_U32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpEqU32Sopc>(opcode);
 }
 } // namespace detail
@@ -352,11 +386,6 @@ SCmpLgU32Sopc::SCmpLgU32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_LG_U32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -383,7 +412,17 @@ SCmpLgU32Sopc::SCmpLgU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_LG_U32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpLgU32Sopc>(opcode);
 }
 } // namespace detail
@@ -399,11 +438,6 @@ SCmpGtU32Sopc::SCmpGtU32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_GT_U32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -430,7 +464,17 @@ SCmpGtU32Sopc::SCmpGtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_GT_U32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpGtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -446,11 +490,6 @@ SCmpGeU32Sopc::SCmpGeU32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_GE_U32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -477,7 +516,17 @@ SCmpGeU32Sopc::SCmpGeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_GE_U32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpGeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -493,11 +542,6 @@ SCmpLtU32Sopc::SCmpLtU32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_LT_U32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -524,7 +568,17 @@ SCmpLtU32Sopc::SCmpLtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_LT_U32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpLtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -540,11 +594,6 @@ SCmpLeU32Sopc::SCmpLeU32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_LE_U32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -571,7 +620,17 @@ SCmpLeU32Sopc::SCmpLeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_LE_U32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpLeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -587,11 +646,6 @@ SBitcmp0B32Sopc::SBitcmp0B32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_BITCMP0_B32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -618,7 +672,18 @@ SBitcmp0B32Sopc::SBitcmp0B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_BITCMP0_B32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SBitcmp0B32Sopc>(opcode);
 }
 } // namespace detail
@@ -634,11 +699,6 @@ SBitcmp1B32Sopc::SBitcmp1B32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_BITCMP1_B32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -665,7 +725,18 @@ SBitcmp1B32Sopc::SBitcmp1B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_BITCMP1_B32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SBitcmp1B32Sopc>(opcode);
 }
 } // namespace detail
@@ -681,11 +752,6 @@ SBitcmp0B64Sopc::SBitcmp0B64Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_BITCMP0_B64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -713,7 +779,18 @@ SBitcmp0B64Sopc::SBitcmp0B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_BITCMP0_B64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SBitcmp0B64Sopc>(opcode);
 }
 } // namespace detail
@@ -729,11 +806,6 @@ SBitcmp1B64Sopc::SBitcmp1B64Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_BITCMP1_B64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -761,7 +833,18 @@ SBitcmp1B64Sopc::SBitcmp1B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_BITCMP1_B64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SBitcmp1B64Sopc>(opcode);
 }
 } // namespace detail
@@ -777,11 +860,6 @@ SCmpEqU64Sopc::SCmpEqU64Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_EQ_U64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -810,7 +888,17 @@ SCmpEqU64Sopc::SCmpEqU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_EQ_U64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpEqU64Sopc>(opcode);
 }
 } // namespace detail
@@ -826,11 +914,6 @@ SCmpLgU64Sopc::SCmpLgU64Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_LG_U64 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand::make_literal32(
         64,
@@ -859,7 +942,17 @@ SCmpLgU64Sopc::SCmpLgU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_LG_U64 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpLgU64Sopc>(opcode);
 }
 } // namespace detail
@@ -875,11 +968,6 @@ SCmpLtF32Sopc::SCmpLtF32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_LT_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -906,7 +994,17 @@ SCmpLtF32Sopc::SCmpLtF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_LT_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpLtF32Sopc>(opcode);
 }
 } // namespace detail
@@ -922,11 +1020,6 @@ SCmpLtF16Sopc::SCmpLtF16Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_LT_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -955,7 +1048,17 @@ SCmpLtF16Sopc::SCmpLtF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_LT_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpLtF16Sopc>(opcode);
 }
 } // namespace detail
@@ -971,11 +1074,6 @@ SCmpEqF32Sopc::SCmpEqF32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_EQ_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1002,7 +1100,17 @@ SCmpEqF32Sopc::SCmpEqF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_EQ_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpEqF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1018,11 +1126,6 @@ SCmpEqF16Sopc::SCmpEqF16Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_EQ_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -1051,7 +1154,17 @@ SCmpEqF16Sopc::SCmpEqF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_EQ_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpEqF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1067,11 +1180,6 @@ SCmpLeF32Sopc::SCmpLeF32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_LE_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1098,7 +1206,17 @@ SCmpLeF32Sopc::SCmpLeF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_LE_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpLeF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1114,11 +1232,6 @@ SCmpLeF16Sopc::SCmpLeF16Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_LE_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -1147,7 +1260,17 @@ SCmpLeF16Sopc::SCmpLeF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_LE_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpLeF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1163,11 +1286,6 @@ SCmpGtF32Sopc::SCmpGtF32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_GT_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1194,7 +1312,17 @@ SCmpGtF32Sopc::SCmpGtF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_GT_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpGtF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1210,11 +1338,6 @@ SCmpGtF16Sopc::SCmpGtF16Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_GT_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -1243,7 +1366,17 @@ SCmpGtF16Sopc::SCmpGtF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_GT_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpGtF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1259,11 +1392,6 @@ SCmpLgF32Sopc::SCmpLgF32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_LG_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1290,7 +1418,17 @@ SCmpLgF32Sopc::SCmpLgF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_LG_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpLgF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1306,11 +1444,6 @@ SCmpLgF16Sopc::SCmpLgF16Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_LG_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -1339,7 +1472,17 @@ SCmpLgF16Sopc::SCmpLgF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_LG_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpLgF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1355,11 +1498,6 @@ SCmpGeF32Sopc::SCmpGeF32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_GE_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1386,7 +1524,17 @@ SCmpGeF32Sopc::SCmpGeF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_GE_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpGeF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1402,11 +1550,6 @@ SCmpGeF16Sopc::SCmpGeF16Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_GE_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -1435,7 +1578,17 @@ SCmpGeF16Sopc::SCmpGeF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_GE_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpGeF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1451,11 +1604,6 @@ SCmpOF32Sopc::SCmpOF32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_O_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1482,7 +1630,17 @@ SCmpOF32Sopc::SCmpOF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpOF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpOF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_o_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_O_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpOF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1498,11 +1656,6 @@ SCmpOF16Sopc::SCmpOF16Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_O_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -1531,7 +1684,17 @@ SCmpOF16Sopc::SCmpOF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpOF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpOF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_o_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_O_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpOF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1547,11 +1710,6 @@ SCmpUF32Sopc::SCmpUF32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_U_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1578,7 +1736,17 @@ SCmpUF32Sopc::SCmpUF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpUF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpUF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_u_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_U_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpUF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1594,11 +1762,6 @@ SCmpUF16Sopc::SCmpUF16Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_U_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -1627,7 +1790,17 @@ SCmpUF16Sopc::SCmpUF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpUF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpUF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_u_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_U_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpUF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1643,11 +1816,6 @@ SCmpNgeF32Sopc::SCmpNgeF32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_NGE_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1674,7 +1842,17 @@ SCmpNgeF32Sopc::SCmpNgeF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNgeF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNgeF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nge_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_NGE_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpNgeF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1690,11 +1868,6 @@ SCmpNgeF16Sopc::SCmpNgeF16Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_NGE_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -1723,7 +1896,17 @@ SCmpNgeF16Sopc::SCmpNgeF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNgeF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNgeF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nge_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_NGE_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpNgeF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1739,11 +1922,6 @@ SCmpNlgF32Sopc::SCmpNlgF32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_NLG_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1770,7 +1948,17 @@ SCmpNlgF32Sopc::SCmpNlgF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNlgF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNlgF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nlg_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_NLG_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpNlgF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1786,11 +1974,6 @@ SCmpNlgF16Sopc::SCmpNlgF16Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_NLG_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -1819,7 +2002,17 @@ SCmpNlgF16Sopc::SCmpNlgF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNlgF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNlgF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nlg_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_NLG_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpNlgF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1835,11 +2028,6 @@ SCmpNgtF32Sopc::SCmpNgtF32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_NGT_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1866,7 +2054,17 @@ SCmpNgtF32Sopc::SCmpNgtF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNgtF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNgtF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ngt_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_NGT_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpNgtF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1882,11 +2080,6 @@ SCmpNgtF16Sopc::SCmpNgtF16Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_NGT_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -1915,7 +2108,17 @@ SCmpNgtF16Sopc::SCmpNgtF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNgtF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNgtF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ngt_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_NGT_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpNgtF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1931,11 +2134,6 @@ SCmpNleF32Sopc::SCmpNleF32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_NLE_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -1962,7 +2160,17 @@ SCmpNleF32Sopc::SCmpNleF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNleF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNleF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nle_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_NLE_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpNleF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1978,11 +2186,6 @@ SCmpNleF16Sopc::SCmpNleF16Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_NLE_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -2011,7 +2214,17 @@ SCmpNleF16Sopc::SCmpNleF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNleF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNleF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nle_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_NLE_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpNleF16Sopc>(opcode);
 }
 } // namespace detail
@@ -2027,11 +2240,6 @@ SCmpNeqF32Sopc::SCmpNeqF32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_NEQ_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -2058,7 +2266,17 @@ SCmpNeqF32Sopc::SCmpNeqF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNeqF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNeqF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_neq_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_NEQ_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpNeqF32Sopc>(opcode);
 }
 } // namespace detail
@@ -2074,11 +2292,6 @@ SCmpNeqF16Sopc::SCmpNeqF16Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_NEQ_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -2107,7 +2320,17 @@ SCmpNeqF16Sopc::SCmpNeqF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNeqF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNeqF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_neq_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_NEQ_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpNeqF16Sopc>(opcode);
 }
 } // namespace detail
@@ -2123,11 +2346,6 @@ SCmpNltF32Sopc::SCmpNltF32Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_NLT_F32 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -2154,7 +2372,17 @@ SCmpNltF32Sopc::SCmpNltF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNltF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNltF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nlt_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_NLT_F32 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpNltF32Sopc>(opcode);
 }
 } // namespace detail
@@ -2170,11 +2398,6 @@ SCmpNltF16Sopc::SCmpNltF16Sopc(const MachineInst *inst)
   dst_operands_[0] = &scc;
   num_src_ = 2;
   num_dst_ = 1;
-  if ((reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 255) &&
-      (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 254 ||
-       reinterpret_cast<const OpEncoding *>(inst)->ssrc1 == 254))
-    throw util::InvalidInst("S_CMP_NLT_F16 may not mix 32-bit and 64-bit literals", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->ssrc0 == 255)
     ssrc0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -2203,7 +2426,17 @@ SCmpNltF16Sopc::SCmpNltF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNltF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNltF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nlt_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if ((reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 255 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 255) &&
+      (reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc0 == 254 ||
+       reinterpret_cast<const Sopc::OpEncoding *>(inst)->ssrc1 == 254)) [[unlikely]]
+    return emit_error.emit() << "S_CMP_NLT_F16 may not mix 32-bit and 64-bit literals";
   return std::make_unique<SCmpNltF16Sopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sopk.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -24,7 +23,11 @@ SMovkI32Sopk::SMovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_movk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -39,7 +42,11 @@ SVersionSopk::SVersionSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSVersionSopk(const MachineInst *opcode) {
+DecodeResult decodeSVersionSopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_version", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SVersionSopk>(opcode);
 }
 } // namespace detail
@@ -61,7 +68,11 @@ SCmovkI32Sopk::SCmovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmovk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -82,7 +93,11 @@ SAddkCoI32Sopk::SAddkCoI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddkCoI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSAddkCoI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_addk_co_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddkCoI32Sopk>(opcode);
 }
 } // namespace detail
@@ -100,7 +115,11 @@ SMulkI32Sopk::SMulkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_mulk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -117,7 +136,11 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_getreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -134,7 +157,11 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -165,7 +192,12 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_imm32_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregImm32B32Sopk>(opcode);
 }
 } // namespace detail
@@ -201,7 +233,11 @@ SCallI64Sopk::SCallI64Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCallI64Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCallI64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_call_i64", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCallI64Sopk>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sopp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sopp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/sopp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -22,7 +21,11 @@ SNopSopp::SNopSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode) {
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_nop", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNopSopp>(opcode);
 }
 } // namespace detail
@@ -37,7 +40,11 @@ SSethaltSopp::SSethaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sethalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSethaltSopp>(opcode);
 }
 } // namespace detail
@@ -52,7 +59,11 @@ SSleepSopp::SSleepSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode) {
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sleep", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSleepSopp>(opcode);
 }
 } // namespace detail
@@ -67,7 +78,12 @@ SMonitorSleepSopp::SMonitorSleepSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMonitorSleepSopp(const MachineInst *opcode) {
+DecodeResult decodeSMonitorSleepSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_monitor_sleep", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMonitorSleepSopp>(opcode);
 }
 } // namespace detail
@@ -82,7 +98,11 @@ SClauseSopp::SClauseSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClauseSopp(const MachineInst *opcode) {
+DecodeResult decodeSClauseSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_clause", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClauseSopp>(opcode);
 }
 } // namespace detail
@@ -98,7 +118,12 @@ SSetVgprMsbSopp::SSetVgprMsbSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetVgprMsbSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetVgprMsbSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_set_vgpr_msb", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetVgprMsbSopp>(opcode);
 }
 } // namespace detail
@@ -113,7 +138,11 @@ SDelayAluSopp::SDelayAluSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDelayAluSopp(const MachineInst *opcode) {
+DecodeResult decodeSDelayAluSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_delay_alu", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDelayAluSopp>(opcode);
 }
 } // namespace detail
@@ -129,7 +158,11 @@ SWaitAluSopp::SWaitAluSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitAluSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitAluSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_alu", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitAluSopp>(opcode);
 }
 } // namespace detail
@@ -143,7 +176,11 @@ SWaitIdleSopp::SWaitIdleSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitIdleSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitIdleSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_idle", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitIdleSopp>(opcode);
 }
 } // namespace detail
@@ -158,7 +195,11 @@ STrapSopp::STrapSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode) {
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_trap", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STrapSopp>(opcode);
 }
 } // namespace detail
@@ -173,7 +214,11 @@ SRoundModeSopp::SRoundModeSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRoundModeSopp(const MachineInst *opcode) {
+DecodeResult decodeSRoundModeSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_round_mode", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRoundModeSopp>(opcode);
 }
 } // namespace detail
@@ -188,7 +233,12 @@ SDenormModeSopp::SDenormModeSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDenormModeSopp(const MachineInst *opcode) {
+DecodeResult decodeSDenormModeSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_denorm_mode", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDenormModeSopp>(opcode);
 }
 } // namespace detail
@@ -204,7 +254,12 @@ SBarrierWaitSopp::SBarrierWaitSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBarrierWaitSopp(const MachineInst *opcode) {
+DecodeResult decodeSBarrierWaitSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_barrier_wait", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBarrierWaitSopp>(opcode);
 }
 } // namespace detail
@@ -220,7 +275,12 @@ SBarrierLeaveSopp::SBarrierLeaveSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBarrierLeaveSopp(const MachineInst *opcode) {
+DecodeResult decodeSBarrierLeaveSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_barrier_leave", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBarrierLeaveSopp>(opcode);
 }
 } // namespace detail
@@ -233,7 +293,11 @@ SCodeEndSopp::SCodeEndSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCodeEndSopp(const MachineInst *opcode) {
+DecodeResult decodeSCodeEndSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_code_end", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCodeEndSopp>(opcode);
 }
 } // namespace detail
@@ -250,7 +314,11 @@ SBranchSopp::SBranchSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode) {
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_branch", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBranchSopp>(opcode);
 }
 } // namespace detail
@@ -275,7 +343,12 @@ SCbranchScc0Sopp::SCbranchScc0Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc0", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc0Sopp>(opcode);
 }
 } // namespace detail
@@ -300,7 +373,12 @@ SCbranchScc1Sopp::SCbranchScc1Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc1", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc1Sopp>(opcode);
 }
 } // namespace detail
@@ -325,7 +403,12 @@ SCbranchVcczSopp::SCbranchVcczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVcczSopp>(opcode);
 }
 } // namespace detail
@@ -350,7 +433,12 @@ SCbranchVccnzSopp::SCbranchVccnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVccnzSopp>(opcode);
 }
 } // namespace detail
@@ -375,7 +463,12 @@ SCbranchExeczSopp::SCbranchExeczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExeczSopp>(opcode);
 }
 } // namespace detail
@@ -400,7 +493,12 @@ SCbranchExecnzSopp::SCbranchExecnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExecnzSopp>(opcode);
 }
 } // namespace detail
@@ -419,7 +517,11 @@ SEndpgmSopp::SEndpgmSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSopp>(opcode);
 }
 } // namespace detail
@@ -433,7 +535,12 @@ SEndpgmSavedSopp::SEndpgmSavedSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm_saved", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSavedSopp>(opcode);
 }
 } // namespace detail
@@ -446,7 +553,11 @@ SWakeupSopp::SWakeupSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode) {
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wakeup", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWakeupSopp>(opcode);
 }
 } // namespace detail
@@ -461,7 +572,11 @@ SSetprioSopp::SSetprioSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setprio", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetprioSopp>(opcode);
 }
 } // namespace detail
@@ -479,7 +594,11 @@ SSendmsgSopp::SSendmsgSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsg", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsgSopp>(opcode);
 }
 } // namespace detail
@@ -497,7 +616,12 @@ SSendmsghaltSopp::SSendmsghaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsghalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsghaltSopp>(opcode);
 }
 } // namespace detail
@@ -512,7 +636,12 @@ SIncperflevelSopp::SIncperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_incperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIncperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -527,7 +656,12 @@ SDecperflevelSopp::SDecperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_decperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDecperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -543,7 +677,12 @@ STtracedataSopp::STtracedataSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode) {
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_ttracedata", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STtracedataSopp>(opcode);
 }
 } // namespace detail
@@ -558,7 +697,12 @@ STtracedataImmSopp::STtracedataImmSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTtracedataImmSopp(const MachineInst *opcode) {
+DecodeResult decodeSTtracedataImmSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_ttracedata_imm", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STtracedataImmSopp>(opcode);
 }
 } // namespace detail
@@ -571,7 +715,11 @@ SIcacheInvSopp::SIcacheInvSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode) {
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_icache_inv", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIcacheInvSopp>(opcode);
 }
 } // namespace detail
@@ -586,7 +734,12 @@ SSetprioIncWgSopp::SSetprioIncWgSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetprioIncWgSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetprioIncWgSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setprio_inc_wg", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetprioIncWgSopp>(opcode);
 }
 } // namespace detail
@@ -602,7 +755,12 @@ SWaitLoadcntSopp::SWaitLoadcntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitLoadcntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitLoadcntSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_loadcnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitLoadcntSopp>(opcode);
 }
 } // namespace detail
@@ -618,7 +776,12 @@ SWaitStorecntSopp::SWaitStorecntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitStorecntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitStorecntSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_storecnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitStorecntSopp>(opcode);
 }
 } // namespace detail
@@ -634,7 +797,11 @@ SWaitXcntSopp::SWaitXcntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitXcntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitXcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_xcnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitXcntSopp>(opcode);
 }
 } // namespace detail
@@ -650,7 +817,11 @@ SWaitDscntSopp::SWaitDscntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitDscntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitDscntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_dscnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitDscntSopp>(opcode);
 }
 } // namespace detail
@@ -666,7 +837,11 @@ SWaitKmcntSopp::SWaitKmcntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitKmcntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitKmcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_kmcnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitKmcntSopp>(opcode);
 }
 } // namespace detail
@@ -682,7 +857,12 @@ SWaitLoadcntDscntSopp::SWaitLoadcntDscntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitLoadcntDscntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitLoadcntDscntSopp(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_loadcnt_dscnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitLoadcntDscntSopp>(opcode);
 }
 } // namespace detail
@@ -698,7 +878,12 @@ SWaitStorecntDscntSopp::SWaitStorecntDscntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitStorecntDscntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitStorecntDscntSopp(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_storecnt_dscnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitStorecntDscntSopp>(opcode);
 }
 } // namespace detail
@@ -714,7 +899,12 @@ SWaitAsynccntSopp::SWaitAsynccntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitAsynccntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitAsynccntSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_asynccnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitAsynccntSopp>(opcode);
 }
 } // namespace detail
@@ -730,7 +920,12 @@ SWaitTensorcntSopp::SWaitTensorcntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitTensorcntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitTensorcntSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_tensorcnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitTensorcntSopp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vbuffer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vbuffer.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vbuffer.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -46,7 +45,12 @@ BufferLoadU8Vbuffer::BufferLoadU8Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadU8Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadU8Vbuffer(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_u8", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadU8Vbuffer>(opcode);
 }
 } // namespace detail
@@ -74,7 +78,12 @@ BufferLoadI8Vbuffer::BufferLoadI8Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadI8Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadI8Vbuffer(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_i8", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadI8Vbuffer>(opcode);
 }
 } // namespace detail
@@ -102,7 +111,12 @@ BufferLoadU16Vbuffer::BufferLoadU16Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadU16Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadU16Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_u16", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadU16Vbuffer>(opcode);
 }
 } // namespace detail
@@ -130,7 +144,12 @@ BufferLoadI16Vbuffer::BufferLoadI16Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadI16Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadI16Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_i16", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadI16Vbuffer>(opcode);
 }
 } // namespace detail
@@ -158,7 +177,12 @@ BufferLoadB32Vbuffer::BufferLoadB32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadB32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadB32Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_b32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadB32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -186,7 +210,12 @@ BufferLoadB64Vbuffer::BufferLoadB64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadB64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadB64Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_b64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadB64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -214,7 +243,12 @@ BufferLoadB96Vbuffer::BufferLoadB96Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadB96Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadB96Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_b96", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadB96Vbuffer>(opcode);
 }
 } // namespace detail
@@ -242,7 +276,12 @@ BufferLoadB128Vbuffer::BufferLoadB128Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadB128Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadB128Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_b128", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadB128Vbuffer>(opcode);
 }
 } // namespace detail
@@ -270,7 +309,12 @@ BufferStoreB8Vbuffer::BufferStoreB8Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB8Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB8Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_b8", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB8Vbuffer>(opcode);
 }
 } // namespace detail
@@ -298,7 +342,12 @@ BufferStoreB16Vbuffer::BufferStoreB16Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB16Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB16Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_b16", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB16Vbuffer>(opcode);
 }
 } // namespace detail
@@ -326,7 +375,12 @@ BufferStoreB32Vbuffer::BufferStoreB32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB32Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_b32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -354,7 +408,12 @@ BufferStoreB64Vbuffer::BufferStoreB64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB64Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_b64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -382,7 +441,12 @@ BufferStoreB96Vbuffer::BufferStoreB96Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB96Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB96Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_b96", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB96Vbuffer>(opcode);
 }
 } // namespace detail
@@ -410,7 +474,12 @@ BufferStoreB128Vbuffer::BufferStoreB128Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB128Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB128Vbuffer(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_b128", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB128Vbuffer>(opcode);
 }
 } // namespace detail
@@ -438,7 +507,12 @@ BufferLoadD16U8Vbuffer::BufferLoadD16U8Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16U8Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16U8Vbuffer(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_d16_u8", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16U8Vbuffer>(opcode);
 }
 } // namespace detail
@@ -479,7 +553,12 @@ BufferLoadD16I8Vbuffer::BufferLoadD16I8Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16I8Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16I8Vbuffer(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_d16_i8", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16I8Vbuffer>(opcode);
 }
 } // namespace detail
@@ -520,7 +599,12 @@ BufferLoadD16B16Vbuffer::BufferLoadD16B16Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16B16Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16B16Vbuffer(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_d16_b16", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16B16Vbuffer>(opcode);
 }
 } // namespace detail
@@ -561,7 +645,12 @@ BufferLoadD16HiU8Vbuffer::BufferLoadD16HiU8Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16HiU8Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16HiU8Vbuffer(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_d16_hi_u8", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16HiU8Vbuffer>(opcode);
 }
 } // namespace detail
@@ -602,7 +691,12 @@ BufferLoadD16HiI8Vbuffer::BufferLoadD16HiI8Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16HiI8Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16HiI8Vbuffer(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_d16_hi_i8", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16HiI8Vbuffer>(opcode);
 }
 } // namespace detail
@@ -643,7 +737,12 @@ BufferLoadD16HiB16Vbuffer::BufferLoadD16HiB16Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16HiB16Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16HiB16Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_d16_hi_b16", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16HiB16Vbuffer>(opcode);
 }
 } // namespace detail
@@ -684,7 +783,12 @@ BufferStoreD16HiB8Vbuffer::BufferStoreD16HiB8Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16HiB8Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16HiB8Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_d16_hi_b8", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16HiB8Vbuffer>(opcode);
 }
 } // namespace detail
@@ -712,7 +816,12 @@ BufferStoreD16HiB16Vbuffer::BufferStoreD16HiB16Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16HiB16Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16HiB16Vbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_d16_hi_b16", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16HiB16Vbuffer>(opcode);
 }
 } // namespace detail
@@ -744,7 +853,12 @@ BufferAtomicSwapB32Vbuffer::BufferAtomicSwapB32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapB32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapB32Vbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_swap_b32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapB32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -778,7 +892,13 @@ BufferAtomicCmpswapB32Vbuffer::BufferAtomicCmpswapB32Vbuffer(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapB32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapB32Vbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_atomic_cmpswap_b32",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapB32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -810,7 +930,12 @@ BufferAtomicAddU32Vbuffer::BufferAtomicAddU32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddU32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_add_u32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddU32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -842,7 +967,12 @@ BufferAtomicSubU32Vbuffer::BufferAtomicSubU32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubU32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_sub_u32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubU32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -874,7 +1004,13 @@ BufferAtomicSubClampU32Vbuffer::BufferAtomicSubClampU32Vbuffer(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubClampU32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubClampU32Vbuffer(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_atomic_sub_clamp_u32",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubClampU32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -906,7 +1042,12 @@ BufferAtomicMinI32Vbuffer::BufferAtomicMinI32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinI32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinI32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_min_i32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinI32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -938,7 +1079,12 @@ BufferAtomicMinU32Vbuffer::BufferAtomicMinU32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinU32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_min_u32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinU32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -970,7 +1116,12 @@ BufferAtomicMaxI32Vbuffer::BufferAtomicMaxI32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxI32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxI32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_max_i32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxI32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1002,7 +1153,12 @@ BufferAtomicMaxU32Vbuffer::BufferAtomicMaxU32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxU32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_max_u32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxU32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1034,7 +1190,12 @@ BufferAtomicAndB32Vbuffer::BufferAtomicAndB32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndB32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndB32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_and_b32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndB32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1066,7 +1227,12 @@ BufferAtomicOrB32Vbuffer::BufferAtomicOrB32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrB32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrB32Vbuffer(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_or_b32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrB32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1098,7 +1264,12 @@ BufferAtomicXorB32Vbuffer::BufferAtomicXorB32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorB32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorB32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_xor_b32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorB32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1130,7 +1301,12 @@ BufferAtomicIncU32Vbuffer::BufferAtomicIncU32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncU32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_inc_u32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncU32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1162,7 +1338,12 @@ BufferAtomicDecU32Vbuffer::BufferAtomicDecU32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecU32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_dec_u32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecU32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1194,7 +1375,12 @@ BufferAtomicSwapB64Vbuffer::BufferAtomicSwapB64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapB64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapB64Vbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_swap_b64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapB64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1228,7 +1414,13 @@ BufferAtomicCmpswapB64Vbuffer::BufferAtomicCmpswapB64Vbuffer(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapB64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapB64Vbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_atomic_cmpswap_b64",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapB64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1260,7 +1452,12 @@ BufferAtomicAddU64Vbuffer::BufferAtomicAddU64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddU64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_add_u64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddU64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1292,7 +1489,12 @@ BufferAtomicSubU64Vbuffer::BufferAtomicSubU64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubU64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_sub_u64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubU64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1324,7 +1526,12 @@ BufferAtomicMinI64Vbuffer::BufferAtomicMinI64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinI64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinI64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_min_i64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinI64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1356,7 +1563,12 @@ BufferAtomicMinU64Vbuffer::BufferAtomicMinU64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinU64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_min_u64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinU64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1388,7 +1600,12 @@ BufferAtomicMaxI64Vbuffer::BufferAtomicMaxI64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxI64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxI64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_max_i64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxI64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1420,7 +1637,12 @@ BufferAtomicMaxU64Vbuffer::BufferAtomicMaxU64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxU64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_max_u64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxU64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1452,7 +1674,12 @@ BufferAtomicAndB64Vbuffer::BufferAtomicAndB64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndB64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndB64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_and_b64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndB64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1484,7 +1711,12 @@ BufferAtomicOrB64Vbuffer::BufferAtomicOrB64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrB64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrB64Vbuffer(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_or_b64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrB64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1516,7 +1748,12 @@ BufferAtomicXorB64Vbuffer::BufferAtomicXorB64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorB64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorB64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_xor_b64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorB64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1548,7 +1785,12 @@ BufferAtomicIncU64Vbuffer::BufferAtomicIncU64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncU64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_inc_u64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncU64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1580,7 +1822,12 @@ BufferAtomicDecU64Vbuffer::BufferAtomicDecU64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecU64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_dec_u64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecU64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1612,7 +1859,13 @@ BufferAtomicCondSubU32Vbuffer::BufferAtomicCondSubU32Vbuffer(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCondSubU32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCondSubU32Vbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_atomic_cond_sub_u32",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCondSubU32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1644,7 +1897,13 @@ BufferAtomicMinNumF32Vbuffer::BufferAtomicMinNumF32Vbuffer(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinNumF32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinNumF32Vbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_atomic_min_num_f32",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinNumF32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1676,7 +1935,13 @@ BufferAtomicMaxNumF32Vbuffer::BufferAtomicMaxNumF32Vbuffer(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxNumF32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxNumF32Vbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_atomic_max_num_f32",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxNumF32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1708,7 +1973,12 @@ BufferAtomicAddF64Vbuffer::BufferAtomicAddF64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddF64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_add_f64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddF64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1740,7 +2010,12 @@ BufferAtomicAddF32Vbuffer::BufferAtomicAddF32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddF32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_add_f32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddF32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1772,7 +2047,13 @@ BufferAtomicPkAddF16Vbuffer::BufferAtomicPkAddF16Vbuffer(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicPkAddF16Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicPkAddF16Vbuffer(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_atomic_pk_add_f16",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicPkAddF16Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1804,7 +2085,13 @@ BufferAtomicPkAddBf16Vbuffer::BufferAtomicPkAddBf16Vbuffer(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicPkAddBf16Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicPkAddBf16Vbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_atomic_pk_add_bf16",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicPkAddBf16Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1836,7 +2123,13 @@ BufferAtomicMinNumF64Vbuffer::BufferAtomicMinNumF64Vbuffer(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinNumF64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinNumF64Vbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_atomic_min_num_f64",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinNumF64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1868,7 +2161,13 @@ BufferAtomicMaxNumF64Vbuffer::BufferAtomicMaxNumF64Vbuffer(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxNumF64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxNumF64Vbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_atomic_max_num_f64",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxNumF64Vbuffer>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vds.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vds.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vds.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -33,7 +32,11 @@ DsAddU32Vds::DsAddU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_add_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU32Vds>(opcode);
 }
 } // namespace detail
@@ -58,7 +61,11 @@ DsSubU32Vds::DsSubU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_sub_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU32Vds>(opcode);
 }
 } // namespace detail
@@ -83,7 +90,11 @@ DsRsubU32Vds::DsRsubU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_rsub_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU32Vds>(opcode);
 }
 } // namespace detail
@@ -108,7 +119,11 @@ DsIncU32Vds::DsIncU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_inc_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU32Vds>(opcode);
 }
 } // namespace detail
@@ -133,7 +148,11 @@ DsDecU32Vds::DsDecU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_dec_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU32Vds>(opcode);
 }
 } // namespace detail
@@ -158,7 +177,11 @@ DsMinI32Vds::DsMinI32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_i32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI32Vds>(opcode);
 }
 } // namespace detail
@@ -183,7 +206,11 @@ DsMaxI32Vds::DsMaxI32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_i32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI32Vds>(opcode);
 }
 } // namespace detail
@@ -208,7 +235,11 @@ DsMinU32Vds::DsMinU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU32Vds>(opcode);
 }
 } // namespace detail
@@ -233,7 +264,11 @@ DsMaxU32Vds::DsMaxU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU32Vds>(opcode);
 }
 } // namespace detail
@@ -258,7 +293,11 @@ DsAndB32Vds::DsAndB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_and_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB32Vds>(opcode);
 }
 } // namespace detail
@@ -283,7 +322,11 @@ DsOrB32Vds::DsOrB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_or_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB32Vds>(opcode);
 }
 } // namespace detail
@@ -308,7 +351,11 @@ DsXorB32Vds::DsXorB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_xor_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB32Vds>(opcode);
 }
 } // namespace detail
@@ -336,7 +383,11 @@ DsMskorB32Vds::DsMskorB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_mskor_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB32Vds>(opcode);
 }
 } // namespace detail
@@ -359,7 +410,11 @@ DsStoreB32Vds::DsStoreB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB32Vds>(opcode);
 }
 } // namespace detail
@@ -385,7 +440,12 @@ DsStore2addrB32Vds::DsStore2addrB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStore2addrB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStore2addrB32Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_2addr_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStore2addrB32Vds>(opcode);
 }
 } // namespace detail
@@ -411,7 +471,12 @@ DsStore2addrStride64B32Vds::DsStore2addrStride64B32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStore2addrStride64B32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStore2addrStride64B32Vds(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_2addr_stride64_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStore2addrStride64B32Vds>(opcode);
 }
 } // namespace detail
@@ -439,7 +504,12 @@ DsCmpstoreB32Vds::DsCmpstoreB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreB32Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_cmpstore_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreB32Vds>(opcode);
 }
 } // namespace detail
@@ -464,7 +534,11 @@ DsMinNumF32Vds::DsMinNumF32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinNumF32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinNumF32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_num_f32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinNumF32Vds>(opcode);
 }
 } // namespace detail
@@ -489,7 +563,11 @@ DsMaxNumF32Vds::DsMaxNumF32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxNumF32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxNumF32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_num_f32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxNumF32Vds>(opcode);
 }
 } // namespace detail
@@ -502,7 +580,11 @@ DsNopVds::DsNopVds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsNopVds(const MachineInst *opcode) {
+DecodeResult decodeDsNopVds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_nop", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsNopVds>(opcode);
 }
 } // namespace detail
@@ -527,7 +609,11 @@ DsAddF32Vds::DsAddF32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddF32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAddF32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_add_f32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddF32Vds>(opcode);
 }
 } // namespace detail
@@ -550,7 +636,11 @@ DsStoreB8Vds::DsStoreB8Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB8Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB8Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_b8", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB8Vds>(opcode);
 }
 } // namespace detail
@@ -573,7 +663,11 @@ DsStoreB16Vds::DsStoreB16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_b16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB16Vds>(opcode);
 }
 } // namespace detail
@@ -601,7 +695,11 @@ DsAddRtnU32Vds::DsAddRtnU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_add_rtn_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU32Vds>(opcode);
 }
 } // namespace detail
@@ -629,7 +727,11 @@ DsSubRtnU32Vds::DsSubRtnU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_sub_rtn_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU32Vds>(opcode);
 }
 } // namespace detail
@@ -657,7 +759,12 @@ DsRsubRtnU32Vds::DsRsubRtnU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU32Vds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_rsub_rtn_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU32Vds>(opcode);
 }
 } // namespace detail
@@ -685,7 +792,11 @@ DsIncRtnU32Vds::DsIncRtnU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_inc_rtn_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU32Vds>(opcode);
 }
 } // namespace detail
@@ -713,7 +824,11 @@ DsDecRtnU32Vds::DsDecRtnU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_dec_rtn_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU32Vds>(opcode);
 }
 } // namespace detail
@@ -741,7 +856,11 @@ DsMinRtnI32Vds::DsMinRtnI32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_rtn_i32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI32Vds>(opcode);
 }
 } // namespace detail
@@ -769,7 +888,11 @@ DsMaxRtnI32Vds::DsMaxRtnI32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_rtn_i32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI32Vds>(opcode);
 }
 } // namespace detail
@@ -797,7 +920,11 @@ DsMinRtnU32Vds::DsMinRtnU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_rtn_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU32Vds>(opcode);
 }
 } // namespace detail
@@ -825,7 +952,11 @@ DsMaxRtnU32Vds::DsMaxRtnU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_rtn_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU32Vds>(opcode);
 }
 } // namespace detail
@@ -853,7 +984,11 @@ DsAndRtnB32Vds::DsAndRtnB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_and_rtn_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB32Vds>(opcode);
 }
 } // namespace detail
@@ -881,7 +1016,11 @@ DsOrRtnB32Vds::DsOrRtnB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_or_rtn_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB32Vds>(opcode);
 }
 } // namespace detail
@@ -909,7 +1048,11 @@ DsXorRtnB32Vds::DsXorRtnB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_xor_rtn_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB32Vds>(opcode);
 }
 } // namespace detail
@@ -940,7 +1083,12 @@ DsMskorRtnB32Vds::DsMskorRtnB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB32Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_mskor_rtn_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB32Vds>(opcode);
 }
 } // namespace detail
@@ -968,7 +1116,12 @@ DsStorexchgRtnB32Vds::DsStorexchgRtnB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchgRtnB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchgRtnB32Vds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_storexchg_rtn_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchgRtnB32Vds>(opcode);
 }
 } // namespace detail
@@ -999,7 +1152,12 @@ DsStorexchg2addrRtnB32Vds::DsStorexchg2addrRtnB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchg2addrRtnB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchg2addrRtnB32Vds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_storexchg_2addr_rtn_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchg2addrRtnB32Vds>(opcode);
 }
 } // namespace detail
@@ -1030,7 +1188,13 @@ DsStorexchg2addrStride64RtnB32Vds::DsStorexchg2addrStride64RtnB32Vds(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchg2addrStride64RtnB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchg2addrStride64RtnB32Vds(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vds::validate_encoding("ds_storexchg_2addr_stride64_rtn_b32",
+                             reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchg2addrStride64RtnB32Vds>(opcode);
 }
 } // namespace detail
@@ -1061,7 +1225,12 @@ DsCmpstoreRtnB32Vds::DsCmpstoreRtnB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreRtnB32Vds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_cmpstore_rtn_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreRtnB32Vds>(opcode);
 }
 } // namespace detail
@@ -1089,7 +1258,12 @@ DsMinNumRtnF32Vds::DsMinNumRtnF32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinNumRtnF32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinNumRtnF32Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_num_rtn_f32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinNumRtnF32Vds>(opcode);
 }
 } // namespace detail
@@ -1117,7 +1291,12 @@ DsMaxNumRtnF32Vds::DsMaxNumRtnF32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxNumRtnF32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxNumRtnF32Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_num_rtn_f32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxNumRtnF32Vds>(opcode);
 }
 } // namespace detail
@@ -1136,7 +1315,12 @@ DsSwizzleB32Vds::DsSwizzleB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSwizzleB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsSwizzleB32Vds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_swizzle_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSwizzleB32Vds>(opcode);
 }
 } // namespace detail
@@ -1159,7 +1343,11 @@ DsLoadB32Vds::DsLoadB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadB32Vds>(opcode);
 }
 } // namespace detail
@@ -1182,7 +1370,12 @@ DsLoad2addrB32Vds::DsLoad2addrB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoad2addrB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoad2addrB32Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_2addr_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoad2addrB32Vds>(opcode);
 }
 } // namespace detail
@@ -1205,7 +1398,12 @@ DsLoad2addrStride64B32Vds::DsLoad2addrStride64B32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoad2addrStride64B32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoad2addrStride64B32Vds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_2addr_stride64_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoad2addrStride64B32Vds>(opcode);
 }
 } // namespace detail
@@ -1228,7 +1426,11 @@ DsLoadI8Vds::DsLoadI8Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadI8Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadI8Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_i8", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadI8Vds>(opcode);
 }
 } // namespace detail
@@ -1251,7 +1453,11 @@ DsLoadU8Vds::DsLoadU8Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU8Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU8Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_u8", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU8Vds>(opcode);
 }
 } // namespace detail
@@ -1274,7 +1480,11 @@ DsLoadI16Vds::DsLoadI16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadI16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadI16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_i16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadI16Vds>(opcode);
 }
 } // namespace detail
@@ -1297,7 +1507,11 @@ DsLoadU16Vds::DsLoadU16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_u16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU16Vds>(opcode);
 }
 } // namespace detail
@@ -1319,7 +1533,11 @@ DsConsumeVds::DsConsumeVds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsConsumeVds(const MachineInst *opcode) {
+DecodeResult decodeDsConsumeVds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_consume", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsConsumeVds>(opcode);
 }
 } // namespace detail
@@ -1341,7 +1559,11 @@ DsAppendVds::DsAppendVds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAppendVds(const MachineInst *opcode) {
+DecodeResult decodeDsAppendVds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_append", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAppendVds>(opcode);
 }
 } // namespace detail
@@ -1366,7 +1588,11 @@ DsAddU64Vds::DsAddU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_add_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU64Vds>(opcode);
 }
 } // namespace detail
@@ -1391,7 +1617,11 @@ DsSubU64Vds::DsSubU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_sub_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU64Vds>(opcode);
 }
 } // namespace detail
@@ -1416,7 +1646,11 @@ DsRsubU64Vds::DsRsubU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_rsub_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU64Vds>(opcode);
 }
 } // namespace detail
@@ -1441,7 +1675,11 @@ DsIncU64Vds::DsIncU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_inc_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU64Vds>(opcode);
 }
 } // namespace detail
@@ -1466,7 +1704,11 @@ DsDecU64Vds::DsDecU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_dec_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU64Vds>(opcode);
 }
 } // namespace detail
@@ -1491,7 +1733,11 @@ DsMinI64Vds::DsMinI64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_i64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI64Vds>(opcode);
 }
 } // namespace detail
@@ -1516,7 +1762,11 @@ DsMaxI64Vds::DsMaxI64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_i64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI64Vds>(opcode);
 }
 } // namespace detail
@@ -1541,7 +1791,11 @@ DsMinU64Vds::DsMinU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU64Vds>(opcode);
 }
 } // namespace detail
@@ -1566,7 +1820,11 @@ DsMaxU64Vds::DsMaxU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU64Vds>(opcode);
 }
 } // namespace detail
@@ -1591,7 +1849,11 @@ DsAndB64Vds::DsAndB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_and_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB64Vds>(opcode);
 }
 } // namespace detail
@@ -1616,7 +1878,11 @@ DsOrB64Vds::DsOrB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_or_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB64Vds>(opcode);
 }
 } // namespace detail
@@ -1641,7 +1907,11 @@ DsXorB64Vds::DsXorB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_xor_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB64Vds>(opcode);
 }
 } // namespace detail
@@ -1669,7 +1939,11 @@ DsMskorB64Vds::DsMskorB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_mskor_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB64Vds>(opcode);
 }
 } // namespace detail
@@ -1692,7 +1966,11 @@ DsStoreB64Vds::DsStoreB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB64Vds>(opcode);
 }
 } // namespace detail
@@ -1718,7 +1996,12 @@ DsStore2addrB64Vds::DsStore2addrB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStore2addrB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStore2addrB64Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_2addr_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStore2addrB64Vds>(opcode);
 }
 } // namespace detail
@@ -1744,7 +2027,12 @@ DsStore2addrStride64B64Vds::DsStore2addrStride64B64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStore2addrStride64B64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStore2addrStride64B64Vds(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_2addr_stride64_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStore2addrStride64B64Vds>(opcode);
 }
 } // namespace detail
@@ -1772,7 +2060,12 @@ DsCmpstoreB64Vds::DsCmpstoreB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreB64Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_cmpstore_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreB64Vds>(opcode);
 }
 } // namespace detail
@@ -1797,7 +2090,11 @@ DsMinNumF64Vds::DsMinNumF64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinNumF64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinNumF64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_num_f64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinNumF64Vds>(opcode);
 }
 } // namespace detail
@@ -1822,7 +2119,11 @@ DsMaxNumF64Vds::DsMaxNumF64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxNumF64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxNumF64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_num_f64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxNumF64Vds>(opcode);
 }
 } // namespace detail
@@ -1847,7 +2148,11 @@ DsAddF64Vds::DsAddF64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddF64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAddF64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_add_f64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddF64Vds>(opcode);
 }
 } // namespace detail
@@ -1869,7 +2174,13 @@ DsAtomicAsyncBarrierArriveB64Vds::DsAtomicAsyncBarrierArriveB64Vds(const Machine
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAtomicAsyncBarrierArriveB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAtomicAsyncBarrierArriveB64Vds(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vds::validate_encoding("ds_atomic_async_barrier_arrive_b64",
+                             reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAtomicAsyncBarrierArriveB64Vds>(opcode);
 }
 } // namespace detail
@@ -1897,7 +2208,11 @@ DsAddRtnU64Vds::DsAddRtnU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_add_rtn_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU64Vds>(opcode);
 }
 } // namespace detail
@@ -1925,7 +2240,11 @@ DsSubRtnU64Vds::DsSubRtnU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_sub_rtn_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU64Vds>(opcode);
 }
 } // namespace detail
@@ -1953,7 +2272,12 @@ DsRsubRtnU64Vds::DsRsubRtnU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU64Vds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_rsub_rtn_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU64Vds>(opcode);
 }
 } // namespace detail
@@ -1981,7 +2305,11 @@ DsIncRtnU64Vds::DsIncRtnU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_inc_rtn_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU64Vds>(opcode);
 }
 } // namespace detail
@@ -2009,7 +2337,11 @@ DsDecRtnU64Vds::DsDecRtnU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_dec_rtn_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU64Vds>(opcode);
 }
 } // namespace detail
@@ -2037,7 +2369,11 @@ DsMinRtnI64Vds::DsMinRtnI64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_rtn_i64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI64Vds>(opcode);
 }
 } // namespace detail
@@ -2065,7 +2401,11 @@ DsMaxRtnI64Vds::DsMaxRtnI64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_rtn_i64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI64Vds>(opcode);
 }
 } // namespace detail
@@ -2093,7 +2433,11 @@ DsMinRtnU64Vds::DsMinRtnU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_rtn_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU64Vds>(opcode);
 }
 } // namespace detail
@@ -2121,7 +2465,11 @@ DsMaxRtnU64Vds::DsMaxRtnU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_rtn_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU64Vds>(opcode);
 }
 } // namespace detail
@@ -2149,7 +2497,11 @@ DsAndRtnB64Vds::DsAndRtnB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_and_rtn_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -2177,7 +2529,11 @@ DsOrRtnB64Vds::DsOrRtnB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_or_rtn_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -2205,7 +2561,11 @@ DsXorRtnB64Vds::DsXorRtnB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_xor_rtn_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -2236,7 +2596,12 @@ DsMskorRtnB64Vds::DsMskorRtnB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB64Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_mskor_rtn_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -2264,7 +2629,12 @@ DsStorexchgRtnB64Vds::DsStorexchgRtnB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchgRtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchgRtnB64Vds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_storexchg_rtn_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchgRtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -2295,7 +2665,12 @@ DsStorexchg2addrRtnB64Vds::DsStorexchg2addrRtnB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchg2addrRtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchg2addrRtnB64Vds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_storexchg_2addr_rtn_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchg2addrRtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -2326,7 +2701,13 @@ DsStorexchg2addrStride64RtnB64Vds::DsStorexchg2addrStride64RtnB64Vds(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchg2addrStride64RtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchg2addrStride64RtnB64Vds(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vds::validate_encoding("ds_storexchg_2addr_stride64_rtn_b64",
+                             reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchg2addrStride64RtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -2357,7 +2738,12 @@ DsCmpstoreRtnB64Vds::DsCmpstoreRtnB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreRtnB64Vds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_cmpstore_rtn_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreRtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -2385,7 +2771,12 @@ DsMinNumRtnF64Vds::DsMinNumRtnF64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinNumRtnF64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinNumRtnF64Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_num_rtn_f64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinNumRtnF64Vds>(opcode);
 }
 } // namespace detail
@@ -2413,7 +2804,12 @@ DsMaxNumRtnF64Vds::DsMaxNumRtnF64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxNumRtnF64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxNumRtnF64Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_num_rtn_f64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxNumRtnF64Vds>(opcode);
 }
 } // namespace detail
@@ -2441,7 +2837,11 @@ DsAddRtnF64Vds::DsAddRtnF64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnF64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnF64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_add_rtn_f64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnF64Vds>(opcode);
 }
 } // namespace detail
@@ -2469,7 +2869,13 @@ DsAtomicBarrierArriveRtnB64Vds::DsAtomicBarrierArriveRtnB64Vds(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAtomicBarrierArriveRtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAtomicBarrierArriveRtnB64Vds(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vds::validate_encoding("ds_atomic_barrier_arrive_rtn_b64",
+                             reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAtomicBarrierArriveRtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -2492,7 +2898,11 @@ DsLoadB64Vds::DsLoadB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadB64Vds>(opcode);
 }
 } // namespace detail
@@ -2515,7 +2925,12 @@ DsLoad2addrB64Vds::DsLoad2addrB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoad2addrB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoad2addrB64Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_2addr_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoad2addrB64Vds>(opcode);
 }
 } // namespace detail
@@ -2538,7 +2953,12 @@ DsLoad2addrStride64B64Vds::DsLoad2addrStride64B64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoad2addrStride64B64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoad2addrStride64B64Vds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_2addr_stride64_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoad2addrStride64B64Vds>(opcode);
 }
 } // namespace detail
@@ -2566,7 +2986,11 @@ DsAddRtnF32Vds::DsAddRtnF32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnF32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnF32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_add_rtn_f32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnF32Vds>(opcode);
 }
 } // namespace detail
@@ -2594,7 +3018,12 @@ DsCondxchg32RtnB64Vds::DsCondxchg32RtnB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsCondxchg32RtnB64Vds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_condxchg32_rtn_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCondxchg32RtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -2619,7 +3048,12 @@ DsCondSubU32Vds::DsCondSubU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCondSubU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsCondSubU32Vds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_cond_sub_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCondSubU32Vds>(opcode);
 }
 } // namespace detail
@@ -2644,7 +3078,12 @@ DsSubClampU32Vds::DsSubClampU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubClampU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsSubClampU32Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_sub_clamp_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubClampU32Vds>(opcode);
 }
 } // namespace detail
@@ -2669,7 +3108,11 @@ DsPkAddF16Vds::DsPkAddF16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPkAddF16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsPkAddF16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_pk_add_f16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPkAddF16Vds>(opcode);
 }
 } // namespace detail
@@ -2694,7 +3137,11 @@ DsPkAddBf16Vds::DsPkAddBf16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPkAddBf16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsPkAddBf16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_pk_add_bf16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPkAddBf16Vds>(opcode);
 }
 } // namespace detail
@@ -2717,7 +3164,12 @@ DsStoreB8D16HiVds::DsStoreB8D16HiVds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB8D16HiVds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB8D16HiVds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_b8_d16_hi", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB8D16HiVds>(opcode);
 }
 } // namespace detail
@@ -2740,7 +3192,12 @@ DsStoreB16D16HiVds::DsStoreB16D16HiVds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB16D16HiVds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB16D16HiVds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_b16_d16_hi", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB16D16HiVds>(opcode);
 }
 } // namespace detail
@@ -2763,7 +3220,11 @@ DsLoadU8D16Vds::DsLoadU8D16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU8D16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU8D16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_u8_d16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU8D16Vds>(opcode);
 }
 } // namespace detail
@@ -2799,7 +3260,12 @@ DsLoadU8D16HiVds::DsLoadU8D16HiVds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU8D16HiVds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU8D16HiVds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_u8_d16_hi", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU8D16HiVds>(opcode);
 }
 } // namespace detail
@@ -2835,7 +3301,11 @@ DsLoadI8D16Vds::DsLoadI8D16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadI8D16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadI8D16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_i8_d16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadI8D16Vds>(opcode);
 }
 } // namespace detail
@@ -2871,7 +3341,12 @@ DsLoadI8D16HiVds::DsLoadI8D16HiVds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadI8D16HiVds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadI8D16HiVds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_i8_d16_hi", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadI8D16HiVds>(opcode);
 }
 } // namespace detail
@@ -2907,7 +3382,12 @@ DsLoadU16D16Vds::DsLoadU16D16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU16D16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU16D16Vds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_u16_d16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU16D16Vds>(opcode);
 }
 } // namespace detail
@@ -2943,7 +3423,12 @@ DsLoadU16D16HiVds::DsLoadU16D16HiVds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU16D16HiVds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU16D16HiVds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_u16_d16_hi", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU16D16HiVds>(opcode);
 }
 } // namespace detail
@@ -2984,7 +3469,12 @@ DsCondSubRtnU32Vds::DsCondSubRtnU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCondSubRtnU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsCondSubRtnU32Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_cond_sub_rtn_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCondSubRtnU32Vds>(opcode);
 }
 } // namespace detail
@@ -3012,7 +3502,12 @@ DsSubClampRtnU32Vds::DsSubClampRtnU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubClampRtnU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsSubClampRtnU32Vds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_sub_clamp_rtn_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubClampRtnU32Vds>(opcode);
 }
 } // namespace detail
@@ -3040,7 +3535,12 @@ DsPkAddRtnF16Vds::DsPkAddRtnF16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPkAddRtnF16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsPkAddRtnF16Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_pk_add_rtn_f16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPkAddRtnF16Vds>(opcode);
 }
 } // namespace detail
@@ -3068,7 +3568,12 @@ DsPkAddRtnBf16Vds::DsPkAddRtnBf16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPkAddRtnBf16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsPkAddRtnBf16Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_pk_add_rtn_bf16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPkAddRtnBf16Vds>(opcode);
 }
 } // namespace detail
@@ -3090,7 +3595,12 @@ DsStoreAddtidB32Vds::DsStoreAddtidB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreAddtidB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreAddtidB32Vds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_addtid_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreAddtidB32Vds>(opcode);
 }
 } // namespace detail
@@ -3112,7 +3622,12 @@ DsLoadAddtidB32Vds::DsLoadAddtidB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadAddtidB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadAddtidB32Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_addtid_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadAddtidB32Vds>(opcode);
 }
 } // namespace detail
@@ -3134,7 +3649,12 @@ DsPermuteB32Vds::DsPermuteB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPermuteB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsPermuteB32Vds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_permute_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPermuteB32Vds>(opcode);
 }
 } // namespace detail
@@ -3156,7 +3676,12 @@ DsBpermuteB32Vds::DsBpermuteB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsBpermuteB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsBpermuteB32Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_bpermute_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsBpermuteB32Vds>(opcode);
 }
 } // namespace detail
@@ -3178,7 +3703,12 @@ DsBpermuteFiB32Vds::DsBpermuteFiB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsBpermuteFiB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsBpermuteFiB32Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_bpermute_fi_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsBpermuteFiB32Vds>(opcode);
 }
 } // namespace detail
@@ -3201,7 +3731,11 @@ DsStoreB96Vds::DsStoreB96Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB96Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB96Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_b96", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB96Vds>(opcode);
 }
 } // namespace detail
@@ -3224,7 +3758,11 @@ DsStoreB128Vds::DsStoreB128Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB128Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB128Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_b128", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB128Vds>(opcode);
 }
 } // namespace detail
@@ -3247,7 +3785,12 @@ DsLoadTr4B64Vds::DsLoadTr4B64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadTr4B64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadTr4B64Vds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_tr4_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadTr4B64Vds>(opcode);
 }
 } // namespace detail
@@ -3270,7 +3813,12 @@ DsLoadTr6B96Vds::DsLoadTr6B96Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadTr6B96Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadTr6B96Vds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_tr6_b96", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadTr6B96Vds>(opcode);
 }
 } // namespace detail
@@ -3293,7 +3841,12 @@ DsLoadTr16B128Vds::DsLoadTr16B128Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadTr16B128Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadTr16B128Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_tr16_b128", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadTr16B128Vds>(opcode);
 }
 } // namespace detail
@@ -3316,7 +3869,12 @@ DsLoadTr8B64Vds::DsLoadTr8B64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadTr8B64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadTr8B64Vds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_tr8_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadTr8B64Vds>(opcode);
 }
 } // namespace detail
@@ -3339,7 +3897,11 @@ DsLoadB96Vds::DsLoadB96Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadB96Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadB96Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_b96", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadB96Vds>(opcode);
 }
 } // namespace detail
@@ -3362,7 +3924,11 @@ DsLoadB128Vds::DsLoadB128Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadB128Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadB128Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_b128", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadB128Vds>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vflat.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vflat.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vflat.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -42,7 +41,12 @@ FlatLoadU8Vflat::FlatLoadU8Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadU8Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadU8Vflat(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_u8", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadU8Vflat>(opcode);
 }
 } // namespace detail
@@ -69,7 +73,12 @@ FlatLoadI8Vflat::FlatLoadI8Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadI8Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadI8Vflat(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_i8", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadI8Vflat>(opcode);
 }
 } // namespace detail
@@ -96,7 +105,12 @@ FlatLoadU16Vflat::FlatLoadU16Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadU16Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadU16Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_u16", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadU16Vflat>(opcode);
 }
 } // namespace detail
@@ -123,7 +137,12 @@ FlatLoadI16Vflat::FlatLoadI16Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadI16Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadI16Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_i16", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadI16Vflat>(opcode);
 }
 } // namespace detail
@@ -150,7 +169,12 @@ FlatLoadB32Vflat::FlatLoadB32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadB32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadB32Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_b32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadB32Vflat>(opcode);
 }
 } // namespace detail
@@ -177,7 +201,12 @@ FlatLoadB64Vflat::FlatLoadB64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadB64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadB64Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_b64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadB64Vflat>(opcode);
 }
 } // namespace detail
@@ -204,7 +233,12 @@ FlatLoadB96Vflat::FlatLoadB96Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadB96Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadB96Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_b96", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadB96Vflat>(opcode);
 }
 } // namespace detail
@@ -231,7 +265,12 @@ FlatLoadB128Vflat::FlatLoadB128Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadB128Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadB128Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_b128", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadB128Vflat>(opcode);
 }
 } // namespace detail
@@ -258,7 +297,12 @@ FlatStoreB8Vflat::FlatStoreB8Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB8Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB8Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_store_b8", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB8Vflat>(opcode);
 }
 } // namespace detail
@@ -285,7 +329,12 @@ FlatStoreB16Vflat::FlatStoreB16Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB16Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB16Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_store_b16", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB16Vflat>(opcode);
 }
 } // namespace detail
@@ -312,7 +361,12 @@ FlatStoreB32Vflat::FlatStoreB32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB32Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_store_b32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB32Vflat>(opcode);
 }
 } // namespace detail
@@ -339,7 +393,12 @@ FlatStoreB64Vflat::FlatStoreB64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB64Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_store_b64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB64Vflat>(opcode);
 }
 } // namespace detail
@@ -366,7 +425,12 @@ FlatStoreB96Vflat::FlatStoreB96Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB96Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB96Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_store_b96", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB96Vflat>(opcode);
 }
 } // namespace detail
@@ -393,7 +457,12 @@ FlatStoreB128Vflat::FlatStoreB128Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB128Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB128Vflat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_store_b128", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB128Vflat>(opcode);
 }
 } // namespace detail
@@ -420,7 +489,12 @@ FlatLoadD16U8Vflat::FlatLoadD16U8Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16U8Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16U8Vflat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_d16_u8", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16U8Vflat>(opcode);
 }
 } // namespace detail
@@ -460,7 +534,12 @@ FlatLoadD16I8Vflat::FlatLoadD16I8Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16I8Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16I8Vflat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_d16_i8", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16I8Vflat>(opcode);
 }
 } // namespace detail
@@ -500,7 +579,12 @@ FlatLoadD16B16Vflat::FlatLoadD16B16Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16B16Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16B16Vflat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_d16_b16", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16B16Vflat>(opcode);
 }
 } // namespace detail
@@ -540,7 +624,12 @@ FlatLoadD16HiU8Vflat::FlatLoadD16HiU8Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16HiU8Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16HiU8Vflat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_d16_hi_u8", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16HiU8Vflat>(opcode);
 }
 } // namespace detail
@@ -580,7 +669,12 @@ FlatLoadD16HiI8Vflat::FlatLoadD16HiI8Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16HiI8Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16HiI8Vflat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_d16_hi_i8", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16HiI8Vflat>(opcode);
 }
 } // namespace detail
@@ -620,7 +714,12 @@ FlatLoadD16HiB16Vflat::FlatLoadD16HiB16Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16HiB16Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16HiB16Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_d16_hi_b16", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16HiB16Vflat>(opcode);
 }
 } // namespace detail
@@ -660,7 +759,12 @@ FlatStoreD16HiB8Vflat::FlatStoreD16HiB8Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreD16HiB8Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreD16HiB8Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_store_d16_hi_b8", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreD16HiB8Vflat>(opcode);
 }
 } // namespace detail
@@ -687,7 +791,12 @@ FlatStoreD16HiB16Vflat::FlatStoreD16HiB16Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreD16HiB16Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreD16HiB16Vflat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_store_d16_hi_b16", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreD16HiB16Vflat>(opcode);
 }
 } // namespace detail
@@ -720,7 +829,12 @@ FlatAtomicSwapB32Vflat::FlatAtomicSwapB32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapB32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapB32Vflat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_swap_b32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapB32Vflat>(opcode);
 }
 } // namespace detail
@@ -753,7 +867,12 @@ FlatAtomicCmpswapB32Vflat::FlatAtomicCmpswapB32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapB32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapB32Vflat(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_cmpswap_b32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapB32Vflat>(opcode);
 }
 } // namespace detail
@@ -786,7 +905,12 @@ FlatAtomicAddU32Vflat::FlatAtomicAddU32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddU32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_add_u32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddU32Vflat>(opcode);
 }
 } // namespace detail
@@ -819,7 +943,12 @@ FlatAtomicSubU32Vflat::FlatAtomicSubU32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubU32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_sub_u32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubU32Vflat>(opcode);
 }
 } // namespace detail
@@ -852,7 +981,12 @@ FlatAtomicSubClampU32Vflat::FlatAtomicSubClampU32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubClampU32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubClampU32Vflat(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_sub_clamp_u32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubClampU32Vflat>(opcode);
 }
 } // namespace detail
@@ -885,7 +1019,12 @@ FlatAtomicMinI32Vflat::FlatAtomicMinI32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinI32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinI32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_min_i32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinI32Vflat>(opcode);
 }
 } // namespace detail
@@ -918,7 +1057,12 @@ FlatAtomicMinU32Vflat::FlatAtomicMinU32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinU32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_min_u32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinU32Vflat>(opcode);
 }
 } // namespace detail
@@ -951,7 +1095,12 @@ FlatAtomicMaxI32Vflat::FlatAtomicMaxI32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxI32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxI32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_max_i32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxI32Vflat>(opcode);
 }
 } // namespace detail
@@ -984,7 +1133,12 @@ FlatAtomicMaxU32Vflat::FlatAtomicMaxU32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxU32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_max_u32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxU32Vflat>(opcode);
 }
 } // namespace detail
@@ -1017,7 +1171,12 @@ FlatAtomicAndB32Vflat::FlatAtomicAndB32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndB32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndB32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_and_b32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndB32Vflat>(opcode);
 }
 } // namespace detail
@@ -1050,7 +1209,12 @@ FlatAtomicOrB32Vflat::FlatAtomicOrB32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrB32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrB32Vflat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_or_b32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrB32Vflat>(opcode);
 }
 } // namespace detail
@@ -1083,7 +1247,12 @@ FlatAtomicXorB32Vflat::FlatAtomicXorB32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorB32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorB32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_xor_b32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorB32Vflat>(opcode);
 }
 } // namespace detail
@@ -1116,7 +1285,12 @@ FlatAtomicIncU32Vflat::FlatAtomicIncU32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncU32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_inc_u32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncU32Vflat>(opcode);
 }
 } // namespace detail
@@ -1149,7 +1323,12 @@ FlatAtomicDecU32Vflat::FlatAtomicDecU32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecU32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_dec_u32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecU32Vflat>(opcode);
 }
 } // namespace detail
@@ -1182,7 +1361,12 @@ FlatAtomicSwapB64Vflat::FlatAtomicSwapB64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapB64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapB64Vflat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_swap_b64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapB64Vflat>(opcode);
 }
 } // namespace detail
@@ -1215,7 +1399,12 @@ FlatAtomicCmpswapB64Vflat::FlatAtomicCmpswapB64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapB64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapB64Vflat(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_cmpswap_b64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapB64Vflat>(opcode);
 }
 } // namespace detail
@@ -1248,7 +1437,12 @@ FlatAtomicAddU64Vflat::FlatAtomicAddU64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddU64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_add_u64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddU64Vflat>(opcode);
 }
 } // namespace detail
@@ -1281,7 +1475,12 @@ FlatAtomicSubU64Vflat::FlatAtomicSubU64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubU64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_sub_u64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubU64Vflat>(opcode);
 }
 } // namespace detail
@@ -1314,7 +1513,12 @@ FlatAtomicMinI64Vflat::FlatAtomicMinI64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinI64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinI64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_min_i64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinI64Vflat>(opcode);
 }
 } // namespace detail
@@ -1347,7 +1551,12 @@ FlatAtomicMinU64Vflat::FlatAtomicMinU64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinU64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_min_u64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinU64Vflat>(opcode);
 }
 } // namespace detail
@@ -1380,7 +1589,12 @@ FlatAtomicMaxI64Vflat::FlatAtomicMaxI64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxI64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxI64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_max_i64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxI64Vflat>(opcode);
 }
 } // namespace detail
@@ -1413,7 +1627,12 @@ FlatAtomicMaxU64Vflat::FlatAtomicMaxU64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxU64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_max_u64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxU64Vflat>(opcode);
 }
 } // namespace detail
@@ -1446,7 +1665,12 @@ FlatAtomicAndB64Vflat::FlatAtomicAndB64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndB64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndB64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_and_b64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndB64Vflat>(opcode);
 }
 } // namespace detail
@@ -1479,7 +1703,12 @@ FlatAtomicOrB64Vflat::FlatAtomicOrB64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrB64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrB64Vflat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_or_b64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrB64Vflat>(opcode);
 }
 } // namespace detail
@@ -1512,7 +1741,12 @@ FlatAtomicXorB64Vflat::FlatAtomicXorB64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorB64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorB64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_xor_b64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorB64Vflat>(opcode);
 }
 } // namespace detail
@@ -1545,7 +1779,12 @@ FlatAtomicIncU64Vflat::FlatAtomicIncU64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncU64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_inc_u64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncU64Vflat>(opcode);
 }
 } // namespace detail
@@ -1578,7 +1817,12 @@ FlatAtomicDecU64Vflat::FlatAtomicDecU64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecU64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_dec_u64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecU64Vflat>(opcode);
 }
 } // namespace detail
@@ -1611,7 +1855,12 @@ FlatAtomicCondSubU32Vflat::FlatAtomicCondSubU32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCondSubU32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCondSubU32Vflat(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_cond_sub_u32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCondSubU32Vflat>(opcode);
 }
 } // namespace detail
@@ -1644,7 +1893,12 @@ FlatAtomicMinNumF32Vflat::FlatAtomicMinNumF32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinNumF32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinNumF32Vflat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_min_num_f32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinNumF32Vflat>(opcode);
 }
 } // namespace detail
@@ -1677,7 +1931,12 @@ FlatAtomicMaxNumF32Vflat::FlatAtomicMaxNumF32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxNumF32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxNumF32Vflat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_max_num_f32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxNumF32Vflat>(opcode);
 }
 } // namespace detail
@@ -1710,7 +1969,12 @@ FlatAtomicAddF64Vflat::FlatAtomicAddF64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddF64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddF64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_add_f64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddF64Vflat>(opcode);
 }
 } // namespace detail
@@ -1743,7 +2007,12 @@ FlatAtomicAddF32Vflat::FlatAtomicAddF32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddF32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddF32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_add_f32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddF32Vflat>(opcode);
 }
 } // namespace detail
@@ -1776,7 +2045,12 @@ FlatAtomicPkAddF16Vflat::FlatAtomicPkAddF16Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicPkAddF16Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicPkAddF16Vflat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_pk_add_f16", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicPkAddF16Vflat>(opcode);
 }
 } // namespace detail
@@ -1809,7 +2083,12 @@ FlatAtomicPkAddBf16Vflat::FlatAtomicPkAddBf16Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicPkAddBf16Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicPkAddBf16Vflat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_pk_add_bf16", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicPkAddBf16Vflat>(opcode);
 }
 } // namespace detail
@@ -1842,7 +2121,12 @@ FlatAtomicMinNumF64Vflat::FlatAtomicMinNumF64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinNumF64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinNumF64Vflat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_min_num_f64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinNumF64Vflat>(opcode);
 }
 } // namespace detail
@@ -1875,7 +2159,12 @@ FlatAtomicMaxNumF64Vflat::FlatAtomicMaxNumF64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxNumF64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxNumF64Vflat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_max_num_f64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxNumF64Vflat>(opcode);
 }
 } // namespace detail
@@ -1898,7 +2187,12 @@ FlatPrefetchB8Vflat::FlatPrefetchB8Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatPrefetchB8Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatPrefetchB8Vflat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_prefetch_b8", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatPrefetchB8Vflat>(opcode);
 }
 } // namespace detail
@@ -1925,7 +2219,12 @@ FlatLoadMonitorB32Vflat::FlatLoadMonitorB32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadMonitorB32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadMonitorB32Vflat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_monitor_b32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadMonitorB32Vflat>(opcode);
 }
 } // namespace detail
@@ -1952,7 +2251,12 @@ FlatLoadMonitorB64Vflat::FlatLoadMonitorB64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadMonitorB64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadMonitorB64Vflat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_monitor_b64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadMonitorB64Vflat>(opcode);
 }
 } // namespace detail
@@ -1979,7 +2283,12 @@ FlatLoadMonitorB128Vflat::FlatLoadMonitorB128Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadMonitorB128Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadMonitorB128Vflat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_monitor_b128", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadMonitorB128Vflat>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vglobal.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vglobal.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vglobal.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -42,7 +41,12 @@ GlobalLoadU8Vglobal::GlobalLoadU8Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadU8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadU8Vglobal(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_u8", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadU8Vglobal>(opcode);
 }
 } // namespace detail
@@ -69,7 +73,12 @@ GlobalLoadI8Vglobal::GlobalLoadI8Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadI8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadI8Vglobal(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_i8", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadI8Vglobal>(opcode);
 }
 } // namespace detail
@@ -96,7 +105,12 @@ GlobalLoadU16Vglobal::GlobalLoadU16Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadU16Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadU16Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_u16", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadU16Vglobal>(opcode);
 }
 } // namespace detail
@@ -123,7 +137,12 @@ GlobalLoadI16Vglobal::GlobalLoadI16Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadI16Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadI16Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_i16", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadI16Vglobal>(opcode);
 }
 } // namespace detail
@@ -150,7 +169,12 @@ GlobalLoadB32Vglobal::GlobalLoadB32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadB32Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_b32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -177,7 +201,12 @@ GlobalLoadB64Vglobal::GlobalLoadB64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadB64Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_b64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -204,7 +233,12 @@ GlobalLoadB96Vglobal::GlobalLoadB96Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadB96Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadB96Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_b96", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadB96Vglobal>(opcode);
 }
 } // namespace detail
@@ -231,7 +265,12 @@ GlobalLoadB128Vglobal::GlobalLoadB128Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadB128Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadB128Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_b128", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadB128Vglobal>(opcode);
 }
 } // namespace detail
@@ -258,7 +297,12 @@ GlobalStoreB8Vglobal::GlobalStoreB8Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreB8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreB8Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_b8", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreB8Vglobal>(opcode);
 }
 } // namespace detail
@@ -285,7 +329,12 @@ GlobalStoreB16Vglobal::GlobalStoreB16Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreB16Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreB16Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_b16", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreB16Vglobal>(opcode);
 }
 } // namespace detail
@@ -312,7 +361,12 @@ GlobalStoreB32Vglobal::GlobalStoreB32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreB32Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_b32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -339,7 +393,12 @@ GlobalStoreB64Vglobal::GlobalStoreB64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreB64Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_b64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -366,7 +425,12 @@ GlobalStoreB96Vglobal::GlobalStoreB96Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreB96Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreB96Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_b96", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreB96Vglobal>(opcode);
 }
 } // namespace detail
@@ -393,7 +457,12 @@ GlobalStoreB128Vglobal::GlobalStoreB128Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreB128Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreB128Vglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_b128", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreB128Vglobal>(opcode);
 }
 } // namespace detail
@@ -420,7 +489,12 @@ GlobalLoadD16U8Vglobal::GlobalLoadD16U8Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadD16U8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadD16U8Vglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_d16_u8", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadD16U8Vglobal>(opcode);
 }
 } // namespace detail
@@ -460,7 +534,12 @@ GlobalLoadD16I8Vglobal::GlobalLoadD16I8Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadD16I8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadD16I8Vglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_d16_i8", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadD16I8Vglobal>(opcode);
 }
 } // namespace detail
@@ -500,7 +579,12 @@ GlobalLoadD16B16Vglobal::GlobalLoadD16B16Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadD16B16Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadD16B16Vglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_d16_b16", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadD16B16Vglobal>(opcode);
 }
 } // namespace detail
@@ -540,7 +624,12 @@ GlobalLoadD16HiU8Vglobal::GlobalLoadD16HiU8Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadD16HiU8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadD16HiU8Vglobal(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_d16_hi_u8", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadD16HiU8Vglobal>(opcode);
 }
 } // namespace detail
@@ -580,7 +669,12 @@ GlobalLoadD16HiI8Vglobal::GlobalLoadD16HiI8Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadD16HiI8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadD16HiI8Vglobal(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_d16_hi_i8", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadD16HiI8Vglobal>(opcode);
 }
 } // namespace detail
@@ -620,7 +714,12 @@ GlobalLoadD16HiB16Vglobal::GlobalLoadD16HiB16Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadD16HiB16Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadD16HiB16Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_d16_hi_b16", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadD16HiB16Vglobal>(opcode);
 }
 } // namespace detail
@@ -660,7 +759,12 @@ GlobalStoreD16HiB8Vglobal::GlobalStoreD16HiB8Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreD16HiB8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreD16HiB8Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_d16_hi_b8", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreD16HiB8Vglobal>(opcode);
 }
 } // namespace detail
@@ -687,7 +791,12 @@ GlobalStoreD16HiB16Vglobal::GlobalStoreD16HiB16Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreD16HiB16Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreD16HiB16Vglobal(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_d16_hi_b16", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreD16HiB16Vglobal>(opcode);
 }
 } // namespace detail
@@ -710,7 +819,12 @@ GlobalLoadAddtidB32Vglobal::GlobalLoadAddtidB32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadAddtidB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadAddtidB32Vglobal(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_addtid_b32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadAddtidB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -733,7 +847,12 @@ GlobalStoreAddtidB32Vglobal::GlobalStoreAddtidB32Vglobal(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreAddtidB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreAddtidB32Vglobal(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_addtid_b32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreAddtidB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -746,7 +865,12 @@ GlobalInvVglobal::GlobalInvVglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalInvVglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalInvVglobal(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_inv", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalInvVglobal>(opcode);
 }
 } // namespace detail
@@ -759,7 +883,12 @@ GlobalWbVglobal::GlobalWbVglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalWbVglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalWbVglobal(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_wb", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalWbVglobal>(opcode);
 }
 } // namespace detail
@@ -792,7 +921,12 @@ GlobalAtomicSwapB32Vglobal::GlobalAtomicSwapB32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicSwapB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicSwapB32Vglobal(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_swap_b32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicSwapB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -825,7 +959,13 @@ GlobalAtomicCmpswapB32Vglobal::GlobalAtomicCmpswapB32Vglobal(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicCmpswapB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicCmpswapB32Vglobal(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_cmpswap_b32",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicCmpswapB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -858,7 +998,12 @@ GlobalAtomicAddU32Vglobal::GlobalAtomicAddU32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicAddU32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicAddU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_add_u32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicAddU32Vglobal>(opcode);
 }
 } // namespace detail
@@ -891,7 +1036,12 @@ GlobalAtomicSubU32Vglobal::GlobalAtomicSubU32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicSubU32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicSubU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_sub_u32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicSubU32Vglobal>(opcode);
 }
 } // namespace detail
@@ -924,7 +1074,13 @@ GlobalAtomicSubClampU32Vglobal::GlobalAtomicSubClampU32Vglobal(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicSubClampU32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicSubClampU32Vglobal(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_sub_clamp_u32",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicSubClampU32Vglobal>(opcode);
 }
 } // namespace detail
@@ -957,7 +1113,12 @@ GlobalAtomicMinI32Vglobal::GlobalAtomicMinI32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMinI32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMinI32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_min_i32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMinI32Vglobal>(opcode);
 }
 } // namespace detail
@@ -990,7 +1151,12 @@ GlobalAtomicMinU32Vglobal::GlobalAtomicMinU32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMinU32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMinU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_min_u32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMinU32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1023,7 +1189,12 @@ GlobalAtomicMaxI32Vglobal::GlobalAtomicMaxI32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxI32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMaxI32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_max_i32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMaxI32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1056,7 +1227,12 @@ GlobalAtomicMaxU32Vglobal::GlobalAtomicMaxU32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxU32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMaxU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_max_u32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMaxU32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1089,7 +1265,12 @@ GlobalAtomicAndB32Vglobal::GlobalAtomicAndB32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicAndB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicAndB32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_and_b32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicAndB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1122,7 +1303,12 @@ GlobalAtomicOrB32Vglobal::GlobalAtomicOrB32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicOrB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicOrB32Vglobal(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_or_b32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicOrB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1155,7 +1341,12 @@ GlobalAtomicXorB32Vglobal::GlobalAtomicXorB32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicXorB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicXorB32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_xor_b32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicXorB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1188,7 +1379,12 @@ GlobalAtomicIncU32Vglobal::GlobalAtomicIncU32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicIncU32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicIncU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_inc_u32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicIncU32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1221,7 +1417,12 @@ GlobalAtomicDecU32Vglobal::GlobalAtomicDecU32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicDecU32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicDecU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_dec_u32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicDecU32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1254,7 +1455,12 @@ GlobalAtomicSwapB64Vglobal::GlobalAtomicSwapB64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicSwapB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicSwapB64Vglobal(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_swap_b64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicSwapB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1287,7 +1493,13 @@ GlobalAtomicCmpswapB64Vglobal::GlobalAtomicCmpswapB64Vglobal(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicCmpswapB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicCmpswapB64Vglobal(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_cmpswap_b64",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicCmpswapB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1320,7 +1532,12 @@ GlobalAtomicAddU64Vglobal::GlobalAtomicAddU64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicAddU64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicAddU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_add_u64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicAddU64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1353,7 +1570,12 @@ GlobalAtomicSubU64Vglobal::GlobalAtomicSubU64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicSubU64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicSubU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_sub_u64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicSubU64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1386,7 +1608,12 @@ GlobalAtomicMinI64Vglobal::GlobalAtomicMinI64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMinI64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMinI64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_min_i64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMinI64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1419,7 +1646,12 @@ GlobalAtomicMinU64Vglobal::GlobalAtomicMinU64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMinU64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMinU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_min_u64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMinU64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1452,7 +1684,12 @@ GlobalAtomicMaxI64Vglobal::GlobalAtomicMaxI64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxI64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMaxI64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_max_i64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMaxI64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1485,7 +1722,12 @@ GlobalAtomicMaxU64Vglobal::GlobalAtomicMaxU64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxU64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMaxU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_max_u64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMaxU64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1518,7 +1760,12 @@ GlobalAtomicAndB64Vglobal::GlobalAtomicAndB64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicAndB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicAndB64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_and_b64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicAndB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1551,7 +1798,12 @@ GlobalAtomicOrB64Vglobal::GlobalAtomicOrB64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicOrB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicOrB64Vglobal(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_or_b64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicOrB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1584,7 +1836,12 @@ GlobalAtomicXorB64Vglobal::GlobalAtomicXorB64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicXorB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicXorB64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_xor_b64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicXorB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1617,7 +1874,12 @@ GlobalAtomicIncU64Vglobal::GlobalAtomicIncU64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicIncU64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicIncU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_inc_u64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicIncU64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1650,7 +1912,12 @@ GlobalAtomicDecU64Vglobal::GlobalAtomicDecU64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicDecU64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicDecU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_dec_u64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicDecU64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1663,7 +1930,12 @@ GlobalWbinvVglobal::GlobalWbinvVglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalWbinvVglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalWbinvVglobal(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_wbinv", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalWbinvVglobal>(opcode);
 }
 } // namespace detail
@@ -1696,7 +1968,13 @@ GlobalAtomicCondSubU32Vglobal::GlobalAtomicCondSubU32Vglobal(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicCondSubU32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicCondSubU32Vglobal(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_cond_sub_u32",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicCondSubU32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1729,7 +2007,13 @@ GlobalAtomicMinNumF32Vglobal::GlobalAtomicMinNumF32Vglobal(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMinNumF32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMinNumF32Vglobal(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_min_num_f32",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMinNumF32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1762,7 +2046,13 @@ GlobalAtomicMaxNumF32Vglobal::GlobalAtomicMaxNumF32Vglobal(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxNumF32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMaxNumF32Vglobal(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_max_num_f32",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMaxNumF32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1791,7 +2081,12 @@ GlobalLoadBlockVglobal::GlobalLoadBlockVglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadBlockVglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadBlockVglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_block", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadBlockVglobal>(opcode);
 }
 } // namespace detail
@@ -1820,7 +2115,12 @@ GlobalStoreBlockVglobal::GlobalStoreBlockVglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreBlockVglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreBlockVglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_block", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreBlockVglobal>(opcode);
 }
 } // namespace detail
@@ -1853,7 +2153,12 @@ GlobalAtomicAddF64Vglobal::GlobalAtomicAddF64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicAddF64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicAddF64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_add_f64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicAddF64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1886,7 +2191,12 @@ GlobalAtomicAddF32Vglobal::GlobalAtomicAddF32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicAddF32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicAddF32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_add_f32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicAddF32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1913,7 +2223,12 @@ GlobalLoadTr16B128Vglobal::GlobalLoadTr16B128Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadTr16B128Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadTr16B128Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_tr16_b128", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadTr16B128Vglobal>(opcode);
 }
 } // namespace detail
@@ -1940,7 +2255,12 @@ GlobalLoadTr8B64Vglobal::GlobalLoadTr8B64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadTr8B64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadTr8B64Vglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_tr8_b64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadTr8B64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1973,7 +2293,13 @@ GlobalAtomicPkAddF16Vglobal::GlobalAtomicPkAddF16Vglobal(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicPkAddF16Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicPkAddF16Vglobal(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_pk_add_f16",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicPkAddF16Vglobal>(opcode);
 }
 } // namespace detail
@@ -2006,7 +2332,13 @@ GlobalAtomicPkAddBf16Vglobal::GlobalAtomicPkAddBf16Vglobal(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicPkAddBf16Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicPkAddBf16Vglobal(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_pk_add_bf16",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicPkAddBf16Vglobal>(opcode);
 }
 } // namespace detail
@@ -2039,7 +2371,13 @@ GlobalAtomicMinNumF64Vglobal::GlobalAtomicMinNumF64Vglobal(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMinNumF64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMinNumF64Vglobal(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_min_num_f64",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMinNumF64Vglobal>(opcode);
 }
 } // namespace detail
@@ -2072,7 +2410,13 @@ GlobalAtomicMaxNumF64Vglobal::GlobalAtomicMaxNumF64Vglobal(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxNumF64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMaxNumF64Vglobal(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_max_num_f64",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMaxNumF64Vglobal>(opcode);
 }
 } // namespace detail
@@ -2095,7 +2439,12 @@ GlobalPrefetchB8Vglobal::GlobalPrefetchB8Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalPrefetchB8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalPrefetchB8Vglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_prefetch_b8", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalPrefetchB8Vglobal>(opcode);
 }
 } // namespace detail
@@ -2124,7 +2473,13 @@ GlobalLoadAsyncToLdsB8Vglobal::GlobalLoadAsyncToLdsB8Vglobal(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadAsyncToLdsB8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadAsyncToLdsB8Vglobal(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_load_async_to_lds_b8",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadAsyncToLdsB8Vglobal>(opcode);
 }
 } // namespace detail
@@ -2153,7 +2508,13 @@ GlobalLoadAsyncToLdsB32Vglobal::GlobalLoadAsyncToLdsB32Vglobal(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadAsyncToLdsB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadAsyncToLdsB32Vglobal(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_load_async_to_lds_b32",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadAsyncToLdsB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -2182,7 +2543,13 @@ GlobalLoadAsyncToLdsB64Vglobal::GlobalLoadAsyncToLdsB64Vglobal(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadAsyncToLdsB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadAsyncToLdsB64Vglobal(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_load_async_to_lds_b64",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadAsyncToLdsB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -2211,7 +2578,13 @@ GlobalLoadAsyncToLdsB128Vglobal::GlobalLoadAsyncToLdsB128Vglobal(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadAsyncToLdsB128Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadAsyncToLdsB128Vglobal(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_load_async_to_lds_b128",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadAsyncToLdsB128Vglobal>(opcode);
 }
 } // namespace detail
@@ -2240,7 +2613,13 @@ GlobalStoreAsyncFromLdsB8Vglobal::GlobalStoreAsyncFromLdsB8Vglobal(const Machine
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreAsyncFromLdsB8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreAsyncFromLdsB8Vglobal(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_store_async_from_lds_b8",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreAsyncFromLdsB8Vglobal>(opcode);
 }
 } // namespace detail
@@ -2269,7 +2648,13 @@ GlobalStoreAsyncFromLdsB32Vglobal::GlobalStoreAsyncFromLdsB32Vglobal(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreAsyncFromLdsB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreAsyncFromLdsB32Vglobal(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_store_async_from_lds_b32",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreAsyncFromLdsB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -2298,7 +2683,13 @@ GlobalStoreAsyncFromLdsB64Vglobal::GlobalStoreAsyncFromLdsB64Vglobal(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreAsyncFromLdsB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreAsyncFromLdsB64Vglobal(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_store_async_from_lds_b64",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreAsyncFromLdsB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -2327,7 +2718,13 @@ GlobalStoreAsyncFromLdsB128Vglobal::GlobalStoreAsyncFromLdsB128Vglobal(const Mac
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreAsyncFromLdsB128Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreAsyncFromLdsB128Vglobal(const MachineInst *opcode,
+                                                      const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_store_async_from_lds_b128",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreAsyncFromLdsB128Vglobal>(opcode);
 }
 } // namespace detail
@@ -2356,7 +2753,12 @@ ClusterLoadB32Vglobal::ClusterLoadB32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeClusterLoadB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeClusterLoadB32Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "cluster_load_b32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ClusterLoadB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -2385,7 +2787,12 @@ ClusterLoadB64Vglobal::ClusterLoadB64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeClusterLoadB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeClusterLoadB64Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "cluster_load_b64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ClusterLoadB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -2414,7 +2821,12 @@ ClusterLoadB128Vglobal::ClusterLoadB128Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeClusterLoadB128Vglobal(const MachineInst *opcode) {
+DecodeResult decodeClusterLoadB128Vglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "cluster_load_b128", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ClusterLoadB128Vglobal>(opcode);
 }
 } // namespace detail
@@ -2446,7 +2858,13 @@ ClusterLoadAsyncToLdsB8Vglobal::ClusterLoadAsyncToLdsB8Vglobal(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeClusterLoadAsyncToLdsB8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeClusterLoadAsyncToLdsB8Vglobal(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("cluster_load_async_to_lds_b8",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ClusterLoadAsyncToLdsB8Vglobal>(opcode);
 }
 } // namespace detail
@@ -2478,7 +2896,13 @@ ClusterLoadAsyncToLdsB32Vglobal::ClusterLoadAsyncToLdsB32Vglobal(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeClusterLoadAsyncToLdsB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeClusterLoadAsyncToLdsB32Vglobal(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("cluster_load_async_to_lds_b32",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ClusterLoadAsyncToLdsB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -2510,7 +2934,13 @@ ClusterLoadAsyncToLdsB64Vglobal::ClusterLoadAsyncToLdsB64Vglobal(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeClusterLoadAsyncToLdsB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeClusterLoadAsyncToLdsB64Vglobal(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("cluster_load_async_to_lds_b64",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ClusterLoadAsyncToLdsB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -2542,7 +2972,13 @@ ClusterLoadAsyncToLdsB128Vglobal::ClusterLoadAsyncToLdsB128Vglobal(const Machine
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeClusterLoadAsyncToLdsB128Vglobal(const MachineInst *opcode) {
+DecodeResult decodeClusterLoadAsyncToLdsB128Vglobal(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("cluster_load_async_to_lds_b128",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ClusterLoadAsyncToLdsB128Vglobal>(opcode);
 }
 } // namespace detail
@@ -2569,7 +3005,12 @@ GlobalLoadMonitorB32Vglobal::GlobalLoadMonitorB32Vglobal(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadMonitorB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadMonitorB32Vglobal(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_monitor_b32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadMonitorB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -2596,7 +3037,12 @@ GlobalLoadMonitorB64Vglobal::GlobalLoadMonitorB64Vglobal(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadMonitorB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadMonitorB64Vglobal(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_monitor_b64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadMonitorB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -2623,7 +3069,13 @@ GlobalLoadMonitorB128Vglobal::GlobalLoadMonitorB128Vglobal(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadMonitorB128Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadMonitorB128Vglobal(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_load_monitor_b128",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadMonitorB128Vglobal>(opcode);
 }
 } // namespace detail
@@ -2650,7 +3102,12 @@ GlobalLoadTr4B64Vglobal::GlobalLoadTr4B64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadTr4B64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadTr4B64Vglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_tr4_b64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadTr4B64Vglobal>(opcode);
 }
 } // namespace detail
@@ -2677,7 +3134,12 @@ GlobalLoadTr6B96Vglobal::GlobalLoadTr6B96Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadTr6B96Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadTr6B96Vglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_tr6_b96", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadTr6B96Vglobal>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vimage.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vimage.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vimage.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -28,7 +27,12 @@ TensorLoadToLdsVimage::TensorLoadToLdsVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTensorLoadToLdsVimage(const MachineInst *opcode) {
+DecodeResult decodeTensorLoadToLdsVimage(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "tensor_load_to_lds", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TensorLoadToLdsVimage>(opcode);
 }
 } // namespace detail
@@ -49,7 +53,12 @@ TensorStoreFromLdsVimage::TensorStoreFromLdsVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTensorStoreFromLdsVimage(const MachineInst *opcode) {
+DecodeResult decodeTensorStoreFromLdsVimage(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "tensor_store_from_lds", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TensorStoreFromLdsVimage>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop1.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -17,13 +16,21 @@ VNopVop1::VNopVop1(const MachineInst *inst)
     : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0) ? "v_nop_dpp"
                                                                                       : "v_nop_e32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VNopVop1), LiteralSupport::None, 0) {
+           selected_exec_fn(InstructionExecutionId::VNopVop1)) {
   num_src_ = 0;
   num_dst_ = 0;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode) {
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_nop_dpp"
+          : "v_nop_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error, LiteralSupport::None, 0);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop1>(opcode);
 }
 } // namespace detail
@@ -73,7 +80,15 @@ VMovB32Vop1::VMovB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_mov_b32_dpp"
+          : "v_mov_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop1>(opcode);
 }
 } // namespace detail
@@ -83,21 +98,30 @@ VReadfirstlaneB32Vop1::VReadfirstlaneB32Vop1(const MachineInst *inst)
                ? "v_readfirstlane_b32_dpp"
                : "v_readfirstlane_b32_e32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VReadfirstlaneB32Vop1), LiteralSupport::None),
+           selected_exec_fn(InstructionExecutionId::VReadfirstlaneB32Vop1)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_readfirstlane_b32_dpp"
+          : "v_readfirstlane_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support DPP";
   return std::make_unique<VReadfirstlaneB32Vop1>(opcode);
 }
 } // namespace detail
@@ -135,14 +159,22 @@ VCvtI32F64Vop1::VCvtI32F64Vop1(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_I32_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f64_dpp"
+          : "v_cvt_i32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_I32_F64 does not support DPP8";
   return std::make_unique<VCvtI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -179,14 +211,22 @@ VCvtF64I32Vop1::VCvtF64I32Vop1(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_I32 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_i32_dpp"
+          : "v_cvt_f64_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_I32 does not support DPP8";
   return std::make_unique<VCvtF64I32Vop1>(opcode);
 }
 } // namespace detail
@@ -236,7 +276,15 @@ VCvtF32I32Vop1::VCvtF32I32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_i32_dpp"
+          : "v_cvt_f32_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop1>(opcode);
 }
 } // namespace detail
@@ -286,7 +334,15 @@ VCvtF32U32Vop1::VCvtF32U32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_u32_dpp"
+          : "v_cvt_f32_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop1>(opcode);
 }
 } // namespace detail
@@ -336,7 +392,15 @@ VCvtU32F32Vop1::VCvtU32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f32_dpp"
+          : "v_cvt_u32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -386,7 +450,15 @@ VCvtI32F32Vop1::VCvtI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f32_dpp"
+          : "v_cvt_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -438,7 +510,15 @@ VCvtF16F32Vop1::VCvtF16F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_f32_dpp"
+          : "v_cvt_f16_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop1>(opcode);
 }
 } // namespace detail
@@ -503,7 +583,15 @@ VCvtF32F16Vop1::VCvtF32F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f16_dpp"
+          : "v_cvt_f32_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop1>(opcode);
 }
 } // namespace detail
@@ -553,7 +641,16 @@ VCvtNearestI32F32Vop1::VCvtNearestI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNearestI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNearestI32F32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_nearest_i32_f32_dpp"
+          : "v_cvt_nearest_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNearestI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -603,7 +700,16 @@ VCvtFloorI32F32Vop1::VCvtFloorI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFloorI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtFloorI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_floor_i32_f32_dpp"
+          : "v_cvt_floor_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFloorI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -653,7 +759,16 @@ VCvtOffF32I4Vop1::VCvtOffF32I4Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_off_f32_i4_dpp"
+          : "v_cvt_off_f32_i4_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop1>(opcode);
 }
 } // namespace detail
@@ -691,14 +806,22 @@ VCvtF32F64Vop1::VCvtF32F64Vop1(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F32_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f64_dpp"
+          : "v_cvt_f32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F32_F64 does not support DPP8";
   return std::make_unique<VCvtF32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -735,14 +858,22 @@ VCvtF64F32Vop1::VCvtF64F32Vop1(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_F32 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_f32_dpp"
+          : "v_cvt_f64_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support DPP8";
   return std::make_unique<VCvtF64F32Vop1>(opcode);
 }
 } // namespace detail
@@ -792,7 +923,16 @@ VCvtF32Ubyte0Vop1::VCvtF32Ubyte0Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte0_dpp"
+          : "v_cvt_f32_ubyte0_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop1>(opcode);
 }
 } // namespace detail
@@ -842,7 +982,16 @@ VCvtF32Ubyte1Vop1::VCvtF32Ubyte1Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte1_dpp"
+          : "v_cvt_f32_ubyte1_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop1>(opcode);
 }
 } // namespace detail
@@ -892,7 +1041,16 @@ VCvtF32Ubyte2Vop1::VCvtF32Ubyte2Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte2_dpp"
+          : "v_cvt_f32_ubyte2_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop1>(opcode);
 }
 } // namespace detail
@@ -942,7 +1100,16 @@ VCvtF32Ubyte3Vop1::VCvtF32Ubyte3Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte3_dpp"
+          : "v_cvt_f32_ubyte3_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop1>(opcode);
 }
 } // namespace detail
@@ -980,14 +1147,22 @@ VCvtU32F64Vop1::VCvtU32F64Vop1(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_U32_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f64_dpp"
+          : "v_cvt_u32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_U32_F64 does not support DPP8";
   return std::make_unique<VCvtU32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -1024,14 +1199,22 @@ VCvtF64U32Vop1::VCvtF64U32Vop1(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_U32 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_u32_dpp"
+          : "v_cvt_f64_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_U32 does not support DPP8";
   return std::make_unique<VCvtF64U32Vop1>(opcode);
 }
 } // namespace detail
@@ -1069,14 +1252,22 @@ VTruncF64Vop1::VTruncF64Vop1(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_TRUNC_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f64_dpp"
+          : "v_trunc_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_TRUNC_F64 does not support DPP8";
   return std::make_unique<VTruncF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1114,14 +1305,22 @@ VCeilF64Vop1::VCeilF64Vop1(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CEIL_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f64_dpp"
+          : "v_ceil_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CEIL_F64 does not support DPP8";
   return std::make_unique<VCeilF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1159,14 +1358,22 @@ VRndneF64Vop1::VRndneF64Vop1(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RNDNE_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f64_dpp"
+          : "v_rndne_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support DPP8";
   return std::make_unique<VRndneF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1204,14 +1411,22 @@ VFloorF64Vop1::VFloorF64Vop1(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FLOOR_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_floor_f64_dpp"
+          : "v_floor_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FLOOR_F64 does not support DPP8";
   return std::make_unique<VFloorF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1221,13 +1436,21 @@ VPipeflushVop1::VPipeflushVop1(const MachineInst *inst)
                ? "v_pipeflush_dpp"
                : "v_pipeflush_e32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPipeflushVop1), LiteralSupport::None, 0) {
+           selected_exec_fn(InstructionExecutionId::VPipeflushVop1)) {
   num_src_ = 0;
   num_dst_ = 0;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPipeflushVop1(const MachineInst *opcode) {
+DecodeResult decodeVPipeflushVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_pipeflush_dpp"
+          : "v_pipeflush_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error, LiteralSupport::None, 0);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPipeflushVop1>(opcode);
 }
 } // namespace detail
@@ -1281,7 +1504,15 @@ VMovB16Vop1::VMovB16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_mov_b16_dpp"
+          : "v_mov_b16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB16Vop1>(opcode);
 }
 } // namespace detail
@@ -1331,14 +1562,22 @@ VMovB64Vop1::VMovB64Vop1(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MOV_B64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovB64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_mov_b64_dpp"
+          : "v_mov_b64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MOV_B64 does not support DPP8";
   return std::make_unique<VMovB64Vop1>(opcode);
 }
 } // namespace detail
@@ -1388,7 +1627,15 @@ VTanhF32Vop1::VTanhF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTanhF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTanhF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_tanh_f32_dpp"
+          : "v_tanh_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTanhF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1442,7 +1689,15 @@ VTanhF16Vop1::VTanhF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTanhF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTanhF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_tanh_f16_dpp"
+          : "v_tanh_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTanhF16Vop1>(opcode);
 }
 } // namespace detail
@@ -1504,7 +1759,15 @@ VFractF32Vop1::VFractF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_fract_f32_dpp"
+          : "v_fract_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1554,7 +1817,15 @@ VTruncF32Vop1::VTruncF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f32_dpp"
+          : "v_trunc_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1604,7 +1875,15 @@ VCeilF32Vop1::VCeilF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f32_dpp"
+          : "v_ceil_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1654,7 +1933,15 @@ VRndneF32Vop1::VRndneF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f32_dpp"
+          : "v_rndne_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1704,7 +1991,15 @@ VFloorF32Vop1::VFloorF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_floor_f32_dpp"
+          : "v_floor_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1754,7 +2049,15 @@ VExpF32Vop1::VExpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_exp_f32_dpp"
+          : "v_exp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1804,7 +2107,15 @@ VLogF32Vop1::VLogF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_log_f32_dpp"
+          : "v_log_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1854,7 +2165,15 @@ VRcpF32Vop1::VRcpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f32_dpp"
+          : "v_rcp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1904,7 +2223,16 @@ VRcpIflagF32Vop1::VRcpIflagF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_iflag_f32_dpp"
+          : "v_rcp_iflag_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1954,7 +2282,15 @@ VRsqF32Vop1::VRsqF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f32_dpp"
+          : "v_rsq_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1983,15 +2319,23 @@ VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RCP_F64 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f64_dpp"
+          : "v_rcp_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support DPP";
   return std::make_unique<VRcpF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2020,15 +2364,23 @@ VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RSQ_F64 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f64_dpp"
+          : "v_rsq_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support DPP";
   return std::make_unique<VRsqF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2078,7 +2430,15 @@ VSqrtF32Vop1::VSqrtF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f32_dpp"
+          : "v_sqrt_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop1>(opcode);
 }
 } // namespace detail
@@ -2107,15 +2467,23 @@ VSqrtF64Vop1::VSqrtF64Vop1(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SQRT_F64 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f64_dpp"
+          : "v_sqrt_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support DPP";
   return std::make_unique<VSqrtF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2165,7 +2533,15 @@ VSinF32Vop1::VSinF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sin_f32_dpp"
+          : "v_sin_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop1>(opcode);
 }
 } // namespace detail
@@ -2215,7 +2591,15 @@ VCosF32Vop1::VCosF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cos_f32_dpp"
+          : "v_cos_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop1>(opcode);
 }
 } // namespace detail
@@ -2265,7 +2649,15 @@ VNotB32Vop1::VNotB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_not_b32_dpp"
+          : "v_not_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2315,7 +2707,15 @@ VBfrevB32Vop1::VBfrevB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_bfrev_b32_dpp"
+          : "v_bfrev_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2365,7 +2765,15 @@ VClzI32U32Vop1::VClzI32U32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClzI32U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVClzI32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_clz_i32_u32_dpp"
+          : "v_clz_i32_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClzI32U32Vop1>(opcode);
 }
 } // namespace detail
@@ -2415,7 +2823,15 @@ VCtzI32B32Vop1::VCtzI32B32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCtzI32B32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCtzI32B32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ctz_i32_b32_dpp"
+          : "v_ctz_i32_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCtzI32B32Vop1>(opcode);
 }
 } // namespace detail
@@ -2465,7 +2881,15 @@ VClsI32Vop1::VClsI32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClsI32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVClsI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cls_i32_dpp"
+          : "v_cls_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClsI32Vop1>(opcode);
 }
 } // namespace detail
@@ -2503,14 +2927,23 @@ VFrexpExpI32F64Vop1::VFrexpExpI32F64Vop1(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_EXP_I32_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f64_dpp"
+          : "v_frexp_exp_i32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_EXP_I32_F64 does not support DPP8";
   return std::make_unique<VFrexpExpI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -2548,14 +2981,23 @@ VFrexpMantF64Vop1::VFrexpMantF64Vop1(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_MANT_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f64_dpp"
+          : "v_frexp_mant_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_MANT_F64 does not support DPP8";
   return std::make_unique<VFrexpMantF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2593,14 +3035,22 @@ VFractF64Vop1::VFractF64Vop1(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FRACT_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_fract_f64_dpp"
+          : "v_fract_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FRACT_F64 does not support DPP8";
   return std::make_unique<VFractF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2650,7 +3100,16 @@ VFrexpExpI32F32Vop1::VFrexpExpI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f32_dpp"
+          : "v_frexp_exp_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -2700,7 +3159,16 @@ VFrexpMantF32Vop1::VFrexpMantF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f32_dpp"
+          : "v_frexp_mant_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop1>(opcode);
 }
 } // namespace detail
@@ -2753,7 +3221,16 @@ VMovreldB32Vop1::VMovreldB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovreldB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovreldB32Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movreld_b32_dpp"
+          : "v_movreld_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovreldB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2763,7 +3240,7 @@ VMovrelsB32Vop1::VMovrelsB32Vop1(const MachineInst *inst)
                ? "v_movrels_b32_dpp"
                : "v_movrels_b32_e32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMovrelsB32Vop1), LiteralSupport::None),
+           selected_exec_fn(InstructionExecutionId::VMovrelsB32Vop1)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2795,7 +3272,16 @@ VMovrelsB32Vop1::VMovrelsB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsB32Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movrels_b32_dpp"
+          : "v_movrels_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2805,7 +3291,7 @@ VMovrelsdB32Vop1::VMovrelsdB32Vop1(const MachineInst *inst)
                ? "v_movrelsd_b32_dpp"
                : "v_movrelsd_b32_e32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMovrelsdB32Vop1), LiteralSupport::None),
+           selected_exec_fn(InstructionExecutionId::VMovrelsdB32Vop1)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2837,7 +3323,16 @@ VMovrelsdB32Vop1::VMovrelsdB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsdB32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_b32_dpp"
+          : "v_movrelsd_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsdB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2847,7 +3342,7 @@ VMovrelsd2B32Vop1::VMovrelsd2B32Vop1(const MachineInst *inst)
                ? "v_movrelsd_2_b32_dpp"
                : "v_movrelsd_2_b32_e32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMovrelsd2B32Vop1), LiteralSupport::None),
+           selected_exec_fn(InstructionExecutionId::VMovrelsd2B32Vop1)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2879,7 +3374,16 @@ VMovrelsd2B32Vop1::VMovrelsd2B32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsd2B32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_2_b32_dpp"
+          : "v_movrelsd_2_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsd2B32Vop1>(opcode);
 }
 } // namespace detail
@@ -2889,8 +3393,7 @@ VPermlane16SwapB32Vop1::VPermlane16SwapB32Vop1(const MachineInst *inst)
                ? "v_permlane16_swap_b32_dpp"
                : "v_permlane16_swap_b32_e32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPermlane16SwapB32Vop1), LiteralSupport::None,
-           0),
+           selected_exec_fn(InstructionExecutionId::VPermlane16SwapB32Vop1)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2899,15 +3402,24 @@ VPermlane16SwapB32Vop1::VPermlane16SwapB32Vop1(const MachineInst *inst)
   src_operands_[1] = &src0;
   num_src_ = 2;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANE16_SWAP_B32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlane16SwapB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVPermlane16SwapB32Vop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_permlane16_swap_b32_dpp"
+          : "v_permlane16_swap_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error, LiteralSupport::None, 0);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE16_SWAP_B32 does not support DPP";
   return std::make_unique<VPermlane16SwapB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2961,7 +3473,15 @@ VTanhBf16Vop1::VTanhBf16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTanhBf16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTanhBf16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_tanh_bf16_dpp"
+          : "v_tanh_bf16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTanhBf16Vop1>(opcode);
 }
 } // namespace detail
@@ -3024,7 +3544,15 @@ VPrngB32Vop1::VPrngB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPrngB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVPrngB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_prng_b32_dpp"
+          : "v_prng_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPrngB32Vop1>(opcode);
 }
 } // namespace detail
@@ -3078,7 +3606,15 @@ VCvtF16U16Vop1::VCvtF16U16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_u16_dpp"
+          : "v_cvt_f16_u16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop1>(opcode);
 }
 } // namespace detail
@@ -3145,7 +3681,15 @@ VCvtF16I16Vop1::VCvtF16I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_i16_dpp"
+          : "v_cvt_f16_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop1>(opcode);
 }
 } // namespace detail
@@ -3212,7 +3756,15 @@ VCvtU16F16Vop1::VCvtU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u16_f16_dpp"
+          : "v_cvt_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3279,7 +3831,15 @@ VCvtI16F16Vop1::VCvtI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i16_f16_dpp"
+          : "v_cvt_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3346,7 +3906,15 @@ VRcpF16Vop1::VRcpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f16_dpp"
+          : "v_rcp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3412,7 +3980,15 @@ VSqrtF16Vop1::VSqrtF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f16_dpp"
+          : "v_sqrt_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3478,7 +4054,15 @@ VRsqF16Vop1::VRsqF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f16_dpp"
+          : "v_rsq_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3544,7 +4128,15 @@ VLogF16Vop1::VLogF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_log_f16_dpp"
+          : "v_log_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3610,7 +4202,15 @@ VExpF16Vop1::VExpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_exp_f16_dpp"
+          : "v_exp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3676,7 +4276,16 @@ VFrexpMantF16Vop1::VFrexpMantF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f16_dpp"
+          : "v_frexp_mant_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3743,7 +4352,16 @@ VFrexpExpI16F16Vop1::VFrexpExpI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i16_f16_dpp"
+          : "v_frexp_exp_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3810,7 +4428,15 @@ VFloorF16Vop1::VFloorF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_floor_f16_dpp"
+          : "v_floor_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3877,7 +4503,15 @@ VCeilF16Vop1::VCeilF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f16_dpp"
+          : "v_ceil_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3943,7 +4577,15 @@ VTruncF16Vop1::VTruncF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f16_dpp"
+          : "v_trunc_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop1>(opcode);
 }
 } // namespace detail
@@ -4010,7 +4652,15 @@ VRndneF16Vop1::VRndneF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f16_dpp"
+          : "v_rndne_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop1>(opcode);
 }
 } // namespace detail
@@ -4077,7 +4727,15 @@ VFractF16Vop1::VFractF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_fract_f16_dpp"
+          : "v_fract_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop1>(opcode);
 }
 } // namespace detail
@@ -4144,7 +4802,15 @@ VSinF16Vop1::VSinF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sin_f16_dpp"
+          : "v_sin_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop1>(opcode);
 }
 } // namespace detail
@@ -4210,7 +4876,15 @@ VCosF16Vop1::VCosF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cos_f16_dpp"
+          : "v_cos_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop1>(opcode);
 }
 } // namespace detail
@@ -4274,7 +4948,16 @@ VSatPkU8I16Vop1::VSatPkU8I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sat_pk_u8_i16_dpp"
+          : "v_sat_pk_u8_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop1>(opcode);
 }
 } // namespace detail
@@ -4341,7 +5024,16 @@ VCvtNormI16F16Vop1::VCvtNormI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_i16_f16_dpp"
+          : "v_cvt_norm_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -4408,7 +5100,16 @@ VCvtNormU16F16Vop1::VCvtNormU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_u16_f16_dpp"
+          : "v_cvt_norm_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -4431,7 +5132,7 @@ VSwapB32Vop1::VSwapB32Vop1(const MachineInst *inst)
                ? "v_swap_b32_dpp"
                : "v_swap_b32_e32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSwapB32Vop1), LiteralSupport::None, 0),
+           selected_exec_fn(InstructionExecutionId::VSwapB32Vop1)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4440,15 +5141,23 @@ VSwapB32Vop1::VSwapB32Vop1(const MachineInst *inst)
   src_operands_[1] = &src0;
   num_src_ = 2;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWAP_B32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swap_b32_dpp"
+          : "v_swap_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error, LiteralSupport::None, 0);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B32 does not support DPP";
   return std::make_unique<VSwapB32Vop1>(opcode);
 }
 } // namespace detail
@@ -4458,7 +5167,7 @@ VSwapB16Vop1::VSwapB16Vop1(const MachineInst *inst)
                ? "v_swap_b16_dpp"
                : "v_swap_b16_e32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSwapB16Vop1), LiteralSupport::None, 0),
+           selected_exec_fn(InstructionExecutionId::VSwapB16Vop1)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), true,
            true),
@@ -4469,15 +5178,23 @@ VSwapB16Vop1::VSwapB16Vop1(const MachineInst *inst)
   src_operands_[1] = &src0;
   num_src_ = 2;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWAP_B16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwapB16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwapB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swap_b16_dpp"
+          : "v_swap_b16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error, LiteralSupport::None, 0);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B16 does not support DPP";
   return std::make_unique<VSwapB16Vop1>(opcode);
 }
 } // namespace detail
@@ -4503,7 +5220,7 @@ VSwaprelB32Vop1::VSwaprelB32Vop1(const MachineInst *inst)
                ? "v_swaprel_b32_dpp"
                : "v_swaprel_b32_e32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSwaprelB32Vop1), LiteralSupport::None, 0),
+           selected_exec_fn(InstructionExecutionId::VSwaprelB32Vop1)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -4512,16 +5229,25 @@ VSwaprelB32Vop1::VSwaprelB32Vop1(const MachineInst *inst)
   src_operands_[0] = &m0;
   num_src_ = 1;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWAPREL_B32 does not support DPP", "");
   m0.apply_fieldless_caps(false, false, false);
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwaprelB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwaprelB32Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swaprel_b32_dpp"
+          : "v_swaprel_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error, LiteralSupport::None, 0);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SWAPREL_B32 does not support DPP";
   return std::make_unique<VSwaprelB32Vop1>(opcode);
 }
 } // namespace detail
@@ -4575,7 +5301,15 @@ VNotB16Vop1::VNotB16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVNotB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_not_b16_dpp"
+          : "v_not_b16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB16Vop1>(opcode);
 }
 } // namespace detail
@@ -4639,7 +5373,15 @@ VCvtI32I16Vop1::VCvtI32I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_i16_dpp"
+          : "v_cvt_i32_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32I16Vop1>(opcode);
 }
 } // namespace detail
@@ -4691,7 +5433,15 @@ VCvtU32U16Vop1::VCvtU32U16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32U16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_u16_dpp"
+          : "v_cvt_u32_u16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32U16Vop1>(opcode);
 }
 } // namespace detail
@@ -4741,7 +5491,15 @@ VCvtF32Fp8Vop1::VCvtF32Fp8Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Fp8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Fp8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_fp8_dpp"
+          : "v_cvt_f32_fp8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Fp8Vop1>(opcode);
 }
 } // namespace detail
@@ -4791,7 +5549,15 @@ VCvtF32Bf8Vop1::VCvtF32Bf8Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Bf8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Bf8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_bf8_dpp"
+          : "v_cvt_f32_bf8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Bf8Vop1>(opcode);
 }
 } // namespace detail
@@ -4821,15 +5587,24 @@ VCvtPkF32Fp8Vop1::VCvtPkF32Fp8Vop1(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_PK_F32_FP8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF32Fp8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF32Fp8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_f32_fp8_dpp"
+          : "v_cvt_pk_f32_fp8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_PK_F32_FP8 does not support DPP";
   return std::make_unique<VCvtPkF32Fp8Vop1>(opcode);
 }
 } // namespace detail
@@ -4859,15 +5634,24 @@ VCvtPkF32Bf8Vop1::VCvtPkF32Bf8Vop1(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_PK_F32_BF8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF32Bf8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF32Bf8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_f32_bf8_dpp"
+          : "v_cvt_pk_f32_bf8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_PK_F32_BF8 does not support DPP";
   return std::make_unique<VCvtPkF32Bf8Vop1>(opcode);
 }
 } // namespace detail
@@ -4919,7 +5703,16 @@ VCvtF32Bf16Vop1::VCvtF32Bf16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Bf16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Bf16Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_bf16_dpp"
+          : "v_cvt_f32_bf16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Bf16Vop1>(opcode);
 }
 } // namespace detail
@@ -4971,7 +5764,16 @@ VSatPk4I4I8Vop1::VSatPk4I4I8Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPk4I4I8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSatPk4I4I8Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sat_pk4_i4_i8_dpp"
+          : "v_sat_pk4_i4_i8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPk4I4I8Vop1>(opcode);
 }
 } // namespace detail
@@ -5036,7 +5838,16 @@ VSatPk4U4U8Vop1::VSatPk4U4U8Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPk4U4U8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSatPk4U4U8Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sat_pk4_u4_u8_dpp"
+          : "v_sat_pk4_u4_u8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPk4U4U8Vop1>(opcode);
 }
 } // namespace detail
@@ -5101,7 +5912,16 @@ VCvtPkF16Fp8Vop1::VCvtPkF16Fp8Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF16Fp8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF16Fp8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_f16_fp8_dpp"
+          : "v_cvt_pk_f16_fp8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkF16Fp8Vop1>(opcode);
 }
 } // namespace detail
@@ -5153,7 +5973,16 @@ VCvtPkF16Bf8Vop1::VCvtPkF16Bf8Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF16Bf8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF16Bf8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_f16_bf8_dpp"
+          : "v_cvt_pk_f16_bf8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkF16Bf8Vop1>(opcode);
 }
 } // namespace detail
@@ -5205,7 +6034,15 @@ VCvtF16Fp8Vop1::VCvtF16Fp8Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16Fp8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16Fp8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_fp8_dpp"
+          : "v_cvt_f16_fp8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16Fp8Vop1>(opcode);
 }
 } // namespace detail
@@ -5270,7 +6107,15 @@ VCvtF16Bf8Vop1::VCvtF16Bf8Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16Bf8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16Bf8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_bf8_dpp"
+          : "v_cvt_f16_bf8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16Bf8Vop1>(opcode);
 }
 } // namespace detail
@@ -5337,7 +6182,15 @@ VRcpBf16Vop1::VRcpBf16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpBf16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpBf16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_bf16_dpp"
+          : "v_rcp_bf16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpBf16Vop1>(opcode);
 }
 } // namespace detail
@@ -5403,7 +6256,15 @@ VSqrtBf16Vop1::VSqrtBf16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtBf16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtBf16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_bf16_dpp"
+          : "v_sqrt_bf16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtBf16Vop1>(opcode);
 }
 } // namespace detail
@@ -5470,7 +6331,15 @@ VRsqBf16Vop1::VRsqBf16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqBf16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqBf16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_bf16_dpp"
+          : "v_rsq_bf16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqBf16Vop1>(opcode);
 }
 } // namespace detail
@@ -5536,7 +6405,15 @@ VLogBf16Vop1::VLogBf16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogBf16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogBf16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_log_bf16_dpp"
+          : "v_log_bf16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogBf16Vop1>(opcode);
 }
 } // namespace detail
@@ -5602,7 +6479,15 @@ VExpBf16Vop1::VExpBf16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpBf16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpBf16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_exp_bf16_dpp"
+          : "v_exp_bf16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpBf16Vop1>(opcode);
 }
 } // namespace detail
@@ -5668,7 +6553,15 @@ VSinBf16Vop1::VSinBf16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinBf16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinBf16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sin_bf16_dpp"
+          : "v_sin_bf16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinBf16Vop1>(opcode);
 }
 } // namespace detail
@@ -5734,7 +6627,15 @@ VCosBf16Vop1::VCosBf16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosBf16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosBf16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cos_bf16_dpp"
+          : "v_cos_bf16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosBf16Vop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop2.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -64,7 +63,16 @@ VCndmaskB32Vop2::VCndmaskB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_cndmask_b32_dpp"
+          : "v_cndmask_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop2>(opcode);
 }
 } // namespace detail
@@ -104,15 +112,23 @@ VAddF64Vop2::VAddF64Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_ADD_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_f64_dpp"
+          : "v_add_f64_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_ADD_F64 does not support DPP8";
   return std::make_unique<VAddF64Vop2>(opcode);
 }
 } // namespace detail
@@ -165,7 +181,15 @@ VAddF32Vop2::VAddF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_f32_dpp"
+          : "v_add_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop2>(opcode);
 }
 } // namespace detail
@@ -218,7 +242,15 @@ VSubF32Vop2::VSubF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_f32_dpp"
+          : "v_sub_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop2>(opcode);
 }
 } // namespace detail
@@ -271,7 +303,15 @@ VSubrevF32Vop2::VSubrevF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f32_dpp"
+          : "v_subrev_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop2>(opcode);
 }
 } // namespace detail
@@ -311,15 +351,23 @@ VMulF64Vop2::VMulF64Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_f64_dpp"
+          : "v_mul_f64_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_F64 does not support DPP8";
   return std::make_unique<VMulF64Vop2>(opcode);
 }
 } // namespace detail
@@ -372,7 +420,16 @@ VMulDx9ZeroF32Vop2::VMulDx9ZeroF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulDx9ZeroF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulDx9ZeroF32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_dx9_zero_f32_dpp"
+          : "v_mul_dx9_zero_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulDx9ZeroF32Vop2>(opcode);
 }
 } // namespace detail
@@ -425,7 +482,15 @@ VMulF32Vop2::VMulF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_f32_dpp"
+          : "v_mul_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop2>(opcode);
 }
 } // namespace detail
@@ -478,7 +543,15 @@ VMulI32I24Vop2::VMulI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_i32_i24_dpp"
+          : "v_mul_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -531,7 +604,16 @@ VMulHiI32I24Vop2::VMulHiI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_i32_i24_dpp"
+          : "v_mul_hi_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -584,7 +666,15 @@ VMulU32U24Vop2::VMulU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_u32_u24_dpp"
+          : "v_mul_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -637,7 +727,16 @@ VMulHiU32U24Vop2::VMulHiU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_u32_u24_dpp"
+          : "v_mul_hi_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -677,15 +776,23 @@ VMinNumF64Vop2::VMinNumF64Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MIN_NUM_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinNumF64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinNumF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_num_f64_dpp"
+          : "v_min_num_f64_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MIN_NUM_F64 does not support DPP8";
   return std::make_unique<VMinNumF64Vop2>(opcode);
 }
 } // namespace detail
@@ -725,15 +832,23 @@ VMaxNumF64Vop2::VMaxNumF64Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAX_NUM_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxNumF64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxNumF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_num_f64_dpp"
+          : "v_max_num_f64_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MAX_NUM_F64 does not support DPP8";
   return std::make_unique<VMaxNumF64Vop2>(opcode);
 }
 } // namespace detail
@@ -786,7 +901,15 @@ VMinI32Vop2::VMinI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_i32_dpp"
+          : "v_min_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop2>(opcode);
 }
 } // namespace detail
@@ -839,7 +962,15 @@ VMaxI32Vop2::VMaxI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_i32_dpp"
+          : "v_max_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop2>(opcode);
 }
 } // namespace detail
@@ -892,7 +1023,15 @@ VMinU32Vop2::VMinU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_u32_dpp"
+          : "v_min_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop2>(opcode);
 }
 } // namespace detail
@@ -945,7 +1084,15 @@ VMaxU32Vop2::VMaxU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_u32_dpp"
+          : "v_max_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop2>(opcode);
 }
 } // namespace detail
@@ -998,7 +1145,15 @@ VMinNumF32Vop2::VMinNumF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinNumF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinNumF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_num_f32_dpp"
+          : "v_min_num_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinNumF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1051,7 +1206,15 @@ VMaxNumF32Vop2::VMaxNumF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxNumF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxNumF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_num_f32_dpp"
+          : "v_max_num_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxNumF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1092,15 +1255,23 @@ VFmacF64Vop2::VFmacF64Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAC_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f64_dpp"
+          : "v_fmac_f64_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_F64 does not support DPP8";
   return std::make_unique<VFmacF64Vop2>(opcode);
 }
 } // namespace detail
@@ -1153,7 +1324,16 @@ VLshlrevB32Vop2::VLshlrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b32_dpp"
+          : "v_lshlrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1206,7 +1386,16 @@ VLshrrevB32Vop2::VLshrrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_lshrrev_b32_dpp"
+          : "v_lshrrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1259,7 +1448,16 @@ VAshrrevI32Vop2::VAshrrevI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_ashrrev_i32_dpp"
+          : "v_ashrrev_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop2>(opcode);
 }
 } // namespace detail
@@ -1312,7 +1510,15 @@ VAndB32Vop2::VAndB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_and_b32_dpp"
+          : "v_and_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1365,7 +1571,15 @@ VOrB32Vop2::VOrB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_or_b32_dpp"
+          : "v_or_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1418,7 +1632,15 @@ VXorB32Vop2::VXorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_xor_b32_dpp"
+          : "v_xor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1471,7 +1693,15 @@ VXnorB32Vop2::VXnorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_xnor_b32_dpp"
+          : "v_xnor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1510,15 +1740,24 @@ VLshlrevB64Vop2::VLshlrevB64Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_LSHLREV_B64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB64Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b64_dpp"
+          : "v_lshlrev_b64_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_LSHLREV_B64 does not support DPP8";
   return std::make_unique<VLshlrevB64Vop2>(opcode);
 }
 } // namespace detail
@@ -1577,7 +1816,16 @@ VAddCoCiU32Vop2::VAddCoCiU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddCoCiU32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_co_ci_u32_dpp"
+          : "v_add_co_ci_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoCiU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1636,7 +1884,16 @@ VSubCoCiU32Vop2::VSubCoCiU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubCoCiU32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_co_ci_u32_dpp"
+          : "v_sub_co_ci_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoCiU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1695,7 +1952,16 @@ VSubrevCoCiU32Vop2::VSubrevCoCiU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoCiU32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_co_ci_u32_dpp"
+          : "v_subrev_co_ci_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoCiU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1705,7 +1971,7 @@ VFmamkF64Vop2::VFmamkF64Vop2(const MachineInst *inst)
                ? "v_fmamk_f64_dpp"
                : "v_fmamk_f64_e32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFmamkF64Vop2), LiteralSupport::Literal64),
+           selected_exec_fn(InstructionExecutionId::VFmamkF64Vop2)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       literal64(64, OperandType::OPR_SIMM64, 0),
@@ -1727,16 +1993,24 @@ VFmamkF64Vop2::VFmamkF64Vop2(const MachineInst *inst)
                       (static_cast<uint64_t>(reinterpret_cast<const uint32_t *>(inst)[2]) << 32) |
                           reinterpret_cast<const uint32_t *>(inst)[1],
                       true);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAMK_F64 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src2);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmamkF64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmamkF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmamk_f64_dpp"
+          : "v_fmamk_f64_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal64);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F64 does not support DPP";
   return std::make_unique<VFmamkF64Vop2>(opcode);
 }
 } // namespace detail
@@ -1746,7 +2020,7 @@ VFmaakF64Vop2::VFmaakF64Vop2(const MachineInst *inst)
                ? "v_fmaak_f64_dpp"
                : "v_fmaak_f64_e32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFmaakF64Vop2), LiteralSupport::Literal64),
+           selected_exec_fn(InstructionExecutionId::VFmaakF64Vop2)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1768,16 +2042,24 @@ VFmaakF64Vop2::VFmaakF64Vop2(const MachineInst *inst)
                       (static_cast<uint64_t>(reinterpret_cast<const uint32_t *>(inst)[2]) << 32) |
                           reinterpret_cast<const uint32_t *>(inst)[1],
                       true);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAAK_F64 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaakF64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmaakF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmaak_f64_dpp"
+          : "v_fmaak_f64_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal64);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F64 does not support DPP";
   return std::make_unique<VFmaakF64Vop2>(opcode);
 }
 } // namespace detail
@@ -1830,7 +2112,15 @@ VAddNcU32Vop2::VAddNcU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_u32_dpp"
+          : "v_add_nc_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1883,7 +2173,15 @@ VSubNcU32Vop2::VSubNcU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_u32_dpp"
+          : "v_sub_nc_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1936,7 +2234,16 @@ VSubrevNcU32Vop2::VSubrevNcU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevNcU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_nc_u32_dpp"
+          : "v_subrev_nc_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevNcU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1976,15 +2283,23 @@ VAddNcU64Vop2::VAddNcU64Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_ADD_NC_U64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_u64_dpp"
+          : "v_add_nc_u64_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_ADD_NC_U64 does not support DPP8";
   return std::make_unique<VAddNcU64Vop2>(opcode);
 }
 } // namespace detail
@@ -2024,15 +2339,23 @@ VSubNcU64Vop2::VSubNcU64Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SUB_NC_U64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_u64_dpp"
+          : "v_sub_nc_u64_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SUB_NC_U64 does not support DPP8";
   return std::make_unique<VSubNcU64Vop2>(opcode);
 }
 } // namespace detail
@@ -2063,16 +2386,24 @@ VMulU64Vop2::VMulU64Vop2(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_U64 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulU64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_u64_dpp"
+          : "v_mul_u64_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_U64 does not support DPP";
   return std::make_unique<VMulU64Vop2>(opcode);
 }
 } // namespace detail
@@ -2126,7 +2457,15 @@ VFmacF32Vop2::VFmacF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f32_dpp"
+          : "v_fmac_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF32Vop2>(opcode);
 }
 } // namespace detail
@@ -2136,7 +2475,7 @@ VFmamkF32Vop2::VFmamkF32Vop2(const MachineInst *inst)
                ? "v_fmamk_f32_dpp"
                : "v_fmamk_f32_e32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFmamkF32Vop2), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VFmamkF32Vop2)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       literal(32, OperandType::OPR_SIMM32, 0),
@@ -2154,16 +2493,24 @@ VFmamkF32Vop2::VFmamkF32Vop2(const MachineInst *inst)
   literal =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAMK_F32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src2);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmamkF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmamkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmamk_f32_dpp"
+          : "v_fmamk_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F32 does not support DPP";
   return std::make_unique<VFmamkF32Vop2>(opcode);
 }
 } // namespace detail
@@ -2173,7 +2520,7 @@ VFmaakF32Vop2::VFmaakF32Vop2(const MachineInst *inst)
                ? "v_fmaak_f32_dpp"
                : "v_fmaak_f32_e32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFmaakF32Vop2), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VFmaakF32Vop2)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -2191,16 +2538,24 @@ VFmaakF32Vop2::VFmaakF32Vop2(const MachineInst *inst)
   literal =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAAK_F32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaakF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmaakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmaak_f32_dpp"
+          : "v_fmaak_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F32 does not support DPP";
   return std::make_unique<VFmaakF32Vop2>(opcode);
 }
 } // namespace detail
@@ -2253,7 +2608,16 @@ VCvtPkRtzF16F32Vop2::VCvtPkRtzF16F32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkRtzF16F32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkRtzF16F32Vop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_rtz_f16_f32_dpp"
+          : "v_cvt_pk_rtz_f16_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkRtzF16F32Vop2>(opcode);
 }
 } // namespace detail
@@ -2311,7 +2675,15 @@ VMinNumF16Vop2::VMinNumF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinNumF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinNumF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_num_f16_dpp"
+          : "v_min_num_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinNumF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2382,7 +2754,15 @@ VMaxNumF16Vop2::VMaxNumF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxNumF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxNumF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_num_f16_dpp"
+          : "v_max_num_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxNumF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2453,7 +2833,15 @@ VAddF16Vop2::VAddF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_f16_dpp"
+          : "v_add_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2523,7 +2911,15 @@ VSubF16Vop2::VSubF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_f16_dpp"
+          : "v_sub_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2593,7 +2989,15 @@ VSubrevF16Vop2::VSubrevF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f16_dpp"
+          : "v_subrev_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2664,7 +3068,15 @@ VMulF16Vop2::VMulF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_f16_dpp"
+          : "v_mul_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2735,7 +3147,15 @@ VFmacF16Vop2::VFmacF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f16_dpp"
+          : "v_fmac_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2757,7 +3177,7 @@ VFmamkF16Vop2::VFmamkF16Vop2(const MachineInst *inst)
                ? "v_fmamk_f16_dpp"
                : "v_fmamk_f16_e32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFmamkF16Vop2), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VFmamkF16Vop2)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2781,16 +3201,24 @@ VFmamkF16Vop2::VFmamkF16Vop2(const MachineInst *inst)
       Operand(16, OperandType::OPR_SIMM16,
               static_cast<int>(
                   (reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAMK_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src2);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmamkF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmamkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmamk_f16_dpp"
+          : "v_fmamk_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F16 does not support DPP";
   return std::make_unique<VFmamkF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2813,7 +3241,7 @@ VFmaakF16Vop2::VFmaakF16Vop2(const MachineInst *inst)
                ? "v_fmaak_f16_dpp"
                : "v_fmaak_f16_e32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFmaakF16Vop2), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VFmaakF16Vop2)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2837,16 +3265,24 @@ VFmaakF16Vop2::VFmaakF16Vop2(const MachineInst *inst)
       Operand(16, OperandType::OPR_SIMM16,
               static_cast<int>(
                   (reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAAK_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaakF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmaakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmaak_f16_dpp"
+          : "v_fmaak_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F16 does not support DPP";
   return std::make_unique<VFmaakF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2917,7 +3353,15 @@ VLdexpF16Vop2::VLdexpF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_ldexp_f16_dpp"
+          : "v_ldexp_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2961,16 +3405,24 @@ VPkFmacF16Vop2::VPkFmacF16Vop2(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_FMAC_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_pk_fmac_f16_dpp"
+          : "v_pk_fmac_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PK_FMAC_F16 does not support DPP";
   return std::make_unique<VPkFmacF16Vop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_alu.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_alu.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -18,7 +17,7 @@ VTruncF64Vop3::VTruncF64Vop3(const MachineInst *inst)
                ? "v_trunc_f64_e64_dpp"
                : "v_trunc_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VTruncF64Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VTruncF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -39,14 +38,22 @@ VTruncF64Vop3::VTruncF64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_TRUNC_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f64_e64_dpp"
+          : "v_trunc_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_TRUNC_F64 does not support DPP8";
   return std::make_unique<VTruncF64Vop3>(opcode);
 }
 } // namespace detail
@@ -56,7 +63,7 @@ VCeilF64Vop3::VCeilF64Vop3(const MachineInst *inst)
                ? "v_ceil_f64_e64_dpp"
                : "v_ceil_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCeilF64Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCeilF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -77,14 +84,22 @@ VCeilF64Vop3::VCeilF64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CEIL_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f64_e64_dpp"
+          : "v_ceil_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CEIL_F64 does not support DPP8";
   return std::make_unique<VCeilF64Vop3>(opcode);
 }
 } // namespace detail
@@ -94,7 +109,7 @@ VRndneF64Vop3::VRndneF64Vop3(const MachineInst *inst)
                ? "v_rndne_f64_e64_dpp"
                : "v_rndne_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VRndneF64Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VRndneF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -115,14 +130,22 @@ VRndneF64Vop3::VRndneF64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RNDNE_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f64_e64_dpp"
+          : "v_rndne_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support DPP8";
   return std::make_unique<VRndneF64Vop3>(opcode);
 }
 } // namespace detail
@@ -132,7 +155,7 @@ VFloorF64Vop3::VFloorF64Vop3(const MachineInst *inst)
                ? "v_floor_f64_e64_dpp"
                : "v_floor_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFloorF64Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VFloorF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -153,14 +176,22 @@ VFloorF64Vop3::VFloorF64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FLOOR_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_floor_f64_e64_dpp"
+          : "v_floor_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FLOOR_F64 does not support DPP8";
   return std::make_unique<VFloorF64Vop3>(opcode);
 }
 } // namespace detail
@@ -170,7 +201,7 @@ VTanhF32Vop3::VTanhF32Vop3(const MachineInst *inst)
                ? "v_tanh_f32_e64_dpp"
                : "v_tanh_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VTanhF32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VTanhF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -203,7 +234,15 @@ VTanhF32Vop3::VTanhF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTanhF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTanhF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_tanh_f32_e64_dpp"
+          : "v_tanh_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTanhF32Vop3>(opcode);
 }
 } // namespace detail
@@ -213,7 +252,7 @@ VTanhF16Vop3::VTanhF16Vop3(const MachineInst *inst)
                ? "v_tanh_f16_e64_dpp"
                : "v_tanh_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VTanhF16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VTanhF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -250,7 +289,15 @@ VTanhF16Vop3::VTanhF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTanhF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTanhF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_tanh_f16_e64_dpp"
+          : "v_tanh_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTanhF16Vop3>(opcode);
 }
 } // namespace detail
@@ -272,7 +319,7 @@ VFractF32Vop3::VFractF32Vop3(const MachineInst *inst)
                ? "v_fract_f32_e64_dpp"
                : "v_fract_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFractF32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VFractF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -305,7 +352,15 @@ VFractF32Vop3::VFractF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fract_f32_e64_dpp"
+          : "v_fract_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop3>(opcode);
 }
 } // namespace detail
@@ -315,7 +370,7 @@ VTruncF32Vop3::VTruncF32Vop3(const MachineInst *inst)
                ? "v_trunc_f32_e64_dpp"
                : "v_trunc_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VTruncF32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VTruncF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -348,7 +403,15 @@ VTruncF32Vop3::VTruncF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f32_e64_dpp"
+          : "v_trunc_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop3>(opcode);
 }
 } // namespace detail
@@ -358,7 +421,7 @@ VCeilF32Vop3::VCeilF32Vop3(const MachineInst *inst)
                ? "v_ceil_f32_e64_dpp"
                : "v_ceil_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCeilF32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCeilF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -391,7 +454,15 @@ VCeilF32Vop3::VCeilF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f32_e64_dpp"
+          : "v_ceil_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop3>(opcode);
 }
 } // namespace detail
@@ -401,7 +472,7 @@ VRndneF32Vop3::VRndneF32Vop3(const MachineInst *inst)
                ? "v_rndne_f32_e64_dpp"
                : "v_rndne_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VRndneF32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VRndneF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -434,7 +505,15 @@ VRndneF32Vop3::VRndneF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f32_e64_dpp"
+          : "v_rndne_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop3>(opcode);
 }
 } // namespace detail
@@ -444,7 +523,7 @@ VFloorF32Vop3::VFloorF32Vop3(const MachineInst *inst)
                ? "v_floor_f32_e64_dpp"
                : "v_floor_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFloorF32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VFloorF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -477,7 +556,15 @@ VFloorF32Vop3::VFloorF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_floor_f32_e64_dpp"
+          : "v_floor_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop3>(opcode);
 }
 } // namespace detail
@@ -487,7 +574,7 @@ VExpF32Vop3::VExpF32Vop3(const MachineInst *inst)
                ? "v_exp_f32_e64_dpp"
                : "v_exp_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VExpF32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VExpF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -520,7 +607,15 @@ VExpF32Vop3::VExpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_exp_f32_e64_dpp"
+          : "v_exp_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -530,7 +625,7 @@ VLogF32Vop3::VLogF32Vop3(const MachineInst *inst)
                ? "v_log_f32_e64_dpp"
                : "v_log_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VLogF32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VLogF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -563,7 +658,15 @@ VLogF32Vop3::VLogF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_log_f32_e64_dpp"
+          : "v_log_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop3>(opcode);
 }
 } // namespace detail
@@ -573,7 +676,7 @@ VRcpF32Vop3::VRcpF32Vop3(const MachineInst *inst)
                ? "v_rcp_f32_e64_dpp"
                : "v_rcp_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VRcpF32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VRcpF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -606,7 +709,15 @@ VRcpF32Vop3::VRcpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f32_e64_dpp"
+          : "v_rcp_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -616,8 +727,7 @@ VRcpIflagF32Vop3::VRcpIflagF32Vop3(const MachineInst *inst)
                ? "v_rcp_iflag_f32_e64_dpp"
                : "v_rcp_iflag_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VRcpIflagF32Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VRcpIflagF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -650,7 +760,16 @@ VRcpIflagF32Vop3::VRcpIflagF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rcp_iflag_f32_e64_dpp"
+          : "v_rcp_iflag_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop3>(opcode);
 }
 } // namespace detail
@@ -660,7 +779,7 @@ VRsqF32Vop3::VRsqF32Vop3(const MachineInst *inst)
                ? "v_rsq_f32_e64_dpp"
                : "v_rsq_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VRsqF32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VRsqF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -693,7 +812,15 @@ VRsqF32Vop3::VRsqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f32_e64_dpp"
+          : "v_rsq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -703,7 +830,7 @@ VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
                ? "v_rcp_f64_e64_dpp"
                : "v_rcp_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VRcpF64Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VRcpF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -715,15 +842,23 @@ VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RCP_F64 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f64_e64_dpp"
+          : "v_rcp_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support DPP";
   return std::make_unique<VRcpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -733,7 +868,7 @@ VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
                ? "v_rsq_f64_e64_dpp"
                : "v_rsq_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VRsqF64Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VRsqF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -745,15 +880,23 @@ VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RSQ_F64 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f64_e64_dpp"
+          : "v_rsq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support DPP";
   return std::make_unique<VRsqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -763,7 +906,7 @@ VSqrtF32Vop3::VSqrtF32Vop3(const MachineInst *inst)
                ? "v_sqrt_f32_e64_dpp"
                : "v_sqrt_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSqrtF32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSqrtF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -796,7 +939,15 @@ VSqrtF32Vop3::VSqrtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f32_e64_dpp"
+          : "v_sqrt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -806,7 +957,7 @@ VSqrtF64Vop3::VSqrtF64Vop3(const MachineInst *inst)
                ? "v_sqrt_f64_e64_dpp"
                : "v_sqrt_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSqrtF64Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSqrtF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -818,15 +969,23 @@ VSqrtF64Vop3::VSqrtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SQRT_F64 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f64_e64_dpp"
+          : "v_sqrt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support DPP";
   return std::make_unique<VSqrtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -836,7 +995,7 @@ VSinF32Vop3::VSinF32Vop3(const MachineInst *inst)
                ? "v_sin_f32_e64_dpp"
                : "v_sin_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSinF32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSinF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -869,7 +1028,15 @@ VSinF32Vop3::VSinF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sin_f32_e64_dpp"
+          : "v_sin_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop3>(opcode);
 }
 } // namespace detail
@@ -879,7 +1046,7 @@ VCosF32Vop3::VCosF32Vop3(const MachineInst *inst)
                ? "v_cos_f32_e64_dpp"
                : "v_cos_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCosF32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCosF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -912,7 +1079,15 @@ VCosF32Vop3::VCosF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cos_f32_e64_dpp"
+          : "v_cos_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop3>(opcode);
 }
 } // namespace detail
@@ -922,7 +1097,7 @@ VNotB32Vop3::VNotB32Vop3(const MachineInst *inst)
                ? "v_not_b32_e64_dpp"
                : "v_not_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VNotB32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VNotB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -955,7 +1130,15 @@ VNotB32Vop3::VNotB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_not_b32_e64_dpp"
+          : "v_not_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop3>(opcode);
 }
 } // namespace detail
@@ -965,7 +1148,7 @@ VBfrevB32Vop3::VBfrevB32Vop3(const MachineInst *inst)
                ? "v_bfrev_b32_e64_dpp"
                : "v_bfrev_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VBfrevB32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VBfrevB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -998,7 +1181,15 @@ VBfrevB32Vop3::VBfrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfrev_b32_e64_dpp"
+          : "v_bfrev_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1008,7 +1199,7 @@ VClzI32U32Vop3::VClzI32U32Vop3(const MachineInst *inst)
                ? "v_clz_i32_u32_e64_dpp"
                : "v_clz_i32_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VClzI32U32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VClzI32U32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1041,7 +1232,15 @@ VClzI32U32Vop3::VClzI32U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClzI32U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVClzI32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_clz_i32_u32_e64_dpp"
+          : "v_clz_i32_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClzI32U32Vop3>(opcode);
 }
 } // namespace detail
@@ -1051,7 +1250,7 @@ VCtzI32B32Vop3::VCtzI32B32Vop3(const MachineInst *inst)
                ? "v_ctz_i32_b32_e64_dpp"
                : "v_ctz_i32_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCtzI32B32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCtzI32B32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1084,7 +1283,15 @@ VCtzI32B32Vop3::VCtzI32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCtzI32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCtzI32B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ctz_i32_b32_e64_dpp"
+          : "v_ctz_i32_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCtzI32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -1094,7 +1301,7 @@ VClsI32Vop3::VClsI32Vop3(const MachineInst *inst)
                ? "v_cls_i32_e64_dpp"
                : "v_cls_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VClsI32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VClsI32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1127,7 +1334,15 @@ VClsI32Vop3::VClsI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClsI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVClsI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cls_i32_e64_dpp"
+          : "v_cls_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClsI32Vop3>(opcode);
 }
 } // namespace detail
@@ -1137,7 +1352,7 @@ VFractF64Vop3::VFractF64Vop3(const MachineInst *inst)
                ? "v_fract_f64_e64_dpp"
                : "v_fract_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFractF64Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VFractF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1158,14 +1373,22 @@ VFractF64Vop3::VFractF64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FRACT_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fract_f64_e64_dpp"
+          : "v_fract_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FRACT_F64 does not support DPP8";
   return std::make_unique<VFractF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1175,7 +1398,7 @@ VTanhBf16Vop3::VTanhBf16Vop3(const MachineInst *inst)
                ? "v_tanh_bf16_e64_dpp"
                : "v_tanh_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VTanhBf16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VTanhBf16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1212,7 +1435,15 @@ VTanhBf16Vop3::VTanhBf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTanhBf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTanhBf16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_tanh_bf16_e64_dpp"
+          : "v_tanh_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTanhBf16Vop3>(opcode);
 }
 } // namespace detail
@@ -1235,7 +1466,7 @@ VRcpF16Vop3::VRcpF16Vop3(const MachineInst *inst)
                ? "v_rcp_f16_e64_dpp"
                : "v_rcp_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VRcpF16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VRcpF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1272,7 +1503,15 @@ VRcpF16Vop3::VRcpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f16_e64_dpp"
+          : "v_rcp_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1294,7 +1533,7 @@ VSqrtF16Vop3::VSqrtF16Vop3(const MachineInst *inst)
                ? "v_sqrt_f16_e64_dpp"
                : "v_sqrt_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSqrtF16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSqrtF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1331,7 +1570,15 @@ VSqrtF16Vop3::VSqrtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f16_e64_dpp"
+          : "v_sqrt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1353,7 +1600,7 @@ VRsqF16Vop3::VRsqF16Vop3(const MachineInst *inst)
                ? "v_rsq_f16_e64_dpp"
                : "v_rsq_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VRsqF16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VRsqF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1390,7 +1637,15 @@ VRsqF16Vop3::VRsqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f16_e64_dpp"
+          : "v_rsq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1412,7 +1667,7 @@ VLogF16Vop3::VLogF16Vop3(const MachineInst *inst)
                ? "v_log_f16_e64_dpp"
                : "v_log_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VLogF16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VLogF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1449,7 +1704,15 @@ VLogF16Vop3::VLogF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_log_f16_e64_dpp"
+          : "v_log_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1471,7 +1734,7 @@ VExpF16Vop3::VExpF16Vop3(const MachineInst *inst)
                ? "v_exp_f16_e64_dpp"
                : "v_exp_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VExpF16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VExpF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1508,7 +1771,15 @@ VExpF16Vop3::VExpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_exp_f16_e64_dpp"
+          : "v_exp_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1530,7 +1801,7 @@ VFloorF16Vop3::VFloorF16Vop3(const MachineInst *inst)
                ? "v_floor_f16_e64_dpp"
                : "v_floor_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFloorF16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VFloorF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1567,7 +1838,15 @@ VFloorF16Vop3::VFloorF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_floor_f16_e64_dpp"
+          : "v_floor_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1590,7 +1869,7 @@ VCeilF16Vop3::VCeilF16Vop3(const MachineInst *inst)
                ? "v_ceil_f16_e64_dpp"
                : "v_ceil_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCeilF16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCeilF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1627,7 +1906,15 @@ VCeilF16Vop3::VCeilF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f16_e64_dpp"
+          : "v_ceil_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1649,7 +1936,7 @@ VTruncF16Vop3::VTruncF16Vop3(const MachineInst *inst)
                ? "v_trunc_f16_e64_dpp"
                : "v_trunc_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VTruncF16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VTruncF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1686,7 +1973,15 @@ VTruncF16Vop3::VTruncF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f16_e64_dpp"
+          : "v_trunc_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1709,7 +2004,7 @@ VRndneF16Vop3::VRndneF16Vop3(const MachineInst *inst)
                ? "v_rndne_f16_e64_dpp"
                : "v_rndne_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VRndneF16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VRndneF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1746,7 +2041,15 @@ VRndneF16Vop3::VRndneF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f16_e64_dpp"
+          : "v_rndne_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1769,7 +2072,7 @@ VFractF16Vop3::VFractF16Vop3(const MachineInst *inst)
                ? "v_fract_f16_e64_dpp"
                : "v_fract_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFractF16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VFractF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1806,7 +2109,15 @@ VFractF16Vop3::VFractF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fract_f16_e64_dpp"
+          : "v_fract_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1829,7 +2140,7 @@ VSinF16Vop3::VSinF16Vop3(const MachineInst *inst)
                ? "v_sin_f16_e64_dpp"
                : "v_sin_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSinF16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSinF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1866,7 +2177,15 @@ VSinF16Vop3::VSinF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sin_f16_e64_dpp"
+          : "v_sin_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1888,7 +2207,7 @@ VCosF16Vop3::VCosF16Vop3(const MachineInst *inst)
                ? "v_cos_f16_e64_dpp"
                : "v_cos_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCosF16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCosF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1925,7 +2244,15 @@ VCosF16Vop3::VCosF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cos_f16_e64_dpp"
+          : "v_cos_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1947,7 +2274,7 @@ VNotB16Vop3::VNotB16Vop3(const MachineInst *inst)
                ? "v_not_b16_e64_dpp"
                : "v_not_b16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VNotB16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VNotB16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1984,7 +2311,15 @@ VNotB16Vop3::VNotB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVNotB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_not_b16_e64_dpp"
+          : "v_not_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB16Vop3>(opcode);
 }
 } // namespace detail
@@ -2006,7 +2341,7 @@ VRcpBf16Vop3::VRcpBf16Vop3(const MachineInst *inst)
                ? "v_rcp_bf16_e64_dpp"
                : "v_rcp_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VRcpBf16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VRcpBf16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2043,7 +2378,15 @@ VRcpBf16Vop3::VRcpBf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpBf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpBf16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rcp_bf16_e64_dpp"
+          : "v_rcp_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpBf16Vop3>(opcode);
 }
 } // namespace detail
@@ -2065,7 +2408,7 @@ VSqrtBf16Vop3::VSqrtBf16Vop3(const MachineInst *inst)
                ? "v_sqrt_bf16_e64_dpp"
                : "v_sqrt_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSqrtBf16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSqrtBf16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2102,7 +2445,15 @@ VSqrtBf16Vop3::VSqrtBf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtBf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtBf16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_bf16_e64_dpp"
+          : "v_sqrt_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtBf16Vop3>(opcode);
 }
 } // namespace detail
@@ -2125,7 +2476,7 @@ VRsqBf16Vop3::VRsqBf16Vop3(const MachineInst *inst)
                ? "v_rsq_bf16_e64_dpp"
                : "v_rsq_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VRsqBf16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VRsqBf16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2162,7 +2513,15 @@ VRsqBf16Vop3::VRsqBf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqBf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqBf16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rsq_bf16_e64_dpp"
+          : "v_rsq_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqBf16Vop3>(opcode);
 }
 } // namespace detail
@@ -2184,7 +2543,7 @@ VLogBf16Vop3::VLogBf16Vop3(const MachineInst *inst)
                ? "v_log_bf16_e64_dpp"
                : "v_log_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VLogBf16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VLogBf16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2221,7 +2580,15 @@ VLogBf16Vop3::VLogBf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogBf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogBf16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_log_bf16_e64_dpp"
+          : "v_log_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogBf16Vop3>(opcode);
 }
 } // namespace detail
@@ -2243,7 +2610,7 @@ VExpBf16Vop3::VExpBf16Vop3(const MachineInst *inst)
                ? "v_exp_bf16_e64_dpp"
                : "v_exp_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VExpBf16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VExpBf16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2280,7 +2647,15 @@ VExpBf16Vop3::VExpBf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpBf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpBf16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_exp_bf16_e64_dpp"
+          : "v_exp_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpBf16Vop3>(opcode);
 }
 } // namespace detail
@@ -2302,7 +2677,7 @@ VSinBf16Vop3::VSinBf16Vop3(const MachineInst *inst)
                ? "v_sin_bf16_e64_dpp"
                : "v_sin_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSinBf16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSinBf16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2339,7 +2714,15 @@ VSinBf16Vop3::VSinBf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinBf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinBf16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sin_bf16_e64_dpp"
+          : "v_sin_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinBf16Vop3>(opcode);
 }
 } // namespace detail
@@ -2361,7 +2744,7 @@ VCosBf16Vop3::VCosBf16Vop3(const MachineInst *inst)
                ? "v_cos_bf16_e64_dpp"
                : "v_cos_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCosBf16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCosBf16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2398,7 +2781,15 @@ VCosBf16Vop3::VCosBf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosBf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosBf16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cos_bf16_e64_dpp"
+          : "v_cos_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosBf16Vop3>(opcode);
 }
 } // namespace detail
@@ -2420,7 +2811,7 @@ VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
                ? "v_add_f64_e64_dpp"
                : "v_add_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAddF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VAddF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2448,15 +2839,23 @@ VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_ADD_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_f64_e64_dpp"
+          : "v_add_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_ADD_F64 does not support DPP8";
   return std::make_unique<VAddF64Vop3>(opcode);
 }
 } // namespace detail
@@ -2466,7 +2865,7 @@ VAddF32Vop3::VAddF32Vop3(const MachineInst *inst)
                ? "v_add_f32_e64_dpp"
                : "v_add_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAddF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VAddF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2506,7 +2905,15 @@ VAddF32Vop3::VAddF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_f32_e64_dpp"
+          : "v_add_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2516,7 +2923,7 @@ VSubF32Vop3::VSubF32Vop3(const MachineInst *inst)
                ? "v_sub_f32_e64_dpp"
                : "v_sub_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSubF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VSubF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2556,7 +2963,15 @@ VSubF32Vop3::VSubF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_f32_e64_dpp"
+          : "v_sub_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2566,7 +2981,7 @@ VSubrevF32Vop3::VSubrevF32Vop3(const MachineInst *inst)
                ? "v_subrev_f32_e64_dpp"
                : "v_subrev_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSubrevF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VSubrevF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2606,7 +3021,15 @@ VSubrevF32Vop3::VSubrevF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f32_e64_dpp"
+          : "v_subrev_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2616,7 +3039,7 @@ VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
                ? "v_mul_f64_e64_dpp"
                : "v_mul_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMulF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMulF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2644,15 +3067,23 @@ VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_f64_e64_dpp"
+          : "v_mul_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_F64 does not support DPP8";
   return std::make_unique<VMulF64Vop3>(opcode);
 }
 } // namespace detail
@@ -2662,8 +3093,7 @@ VMulDx9ZeroF32Vop3::VMulDx9ZeroF32Vop3(const MachineInst *inst)
                ? "v_mul_dx9_zero_f32_e64_dpp"
                : "v_mul_dx9_zero_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMulDx9ZeroF32Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VMulDx9ZeroF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2703,7 +3133,16 @@ VMulDx9ZeroF32Vop3::VMulDx9ZeroF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulDx9ZeroF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulDx9ZeroF32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_dx9_zero_f32_e64_dpp"
+          : "v_mul_dx9_zero_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulDx9ZeroF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2713,7 +3152,7 @@ VMulF32Vop3::VMulF32Vop3(const MachineInst *inst)
                ? "v_mul_f32_e64_dpp"
                : "v_mul_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMulF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMulF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2753,7 +3192,15 @@ VMulF32Vop3::VMulF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_f32_e64_dpp"
+          : "v_mul_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2763,7 +3210,7 @@ VMulI32I24Vop3::VMulI32I24Vop3(const MachineInst *inst)
                ? "v_mul_i32_i24_e64_dpp"
                : "v_mul_i32_i24",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMulI32I24Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMulI32I24Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2803,7 +3250,15 @@ VMulI32I24Vop3::VMulI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_i32_i24_e64_dpp"
+          : "v_mul_i32_i24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -2813,8 +3268,7 @@ VMulHiI32I24Vop3::VMulHiI32I24Vop3(const MachineInst *inst)
                ? "v_mul_hi_i32_i24_e64_dpp"
                : "v_mul_hi_i32_i24",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMulHiI32I24Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VMulHiI32I24Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2854,7 +3308,16 @@ VMulHiI32I24Vop3::VMulHiI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_i32_i24_e64_dpp"
+          : "v_mul_hi_i32_i24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -2864,7 +3327,7 @@ VMulU32U24Vop3::VMulU32U24Vop3(const MachineInst *inst)
                ? "v_mul_u32_u24_e64_dpp"
                : "v_mul_u32_u24",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMulU32U24Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMulU32U24Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2904,7 +3367,15 @@ VMulU32U24Vop3::VMulU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_u32_u24_e64_dpp"
+          : "v_mul_u32_u24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -2914,8 +3385,7 @@ VMulHiU32U24Vop3::VMulHiU32U24Vop3(const MachineInst *inst)
                ? "v_mul_hi_u32_u24_e64_dpp"
                : "v_mul_hi_u32_u24",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMulHiU32U24Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VMulHiU32U24Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2955,7 +3425,16 @@ VMulHiU32U24Vop3::VMulHiU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_u32_u24_e64_dpp"
+          : "v_mul_hi_u32_u24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -2965,7 +3444,7 @@ VMinNumF64Vop3::VMinNumF64Vop3(const MachineInst *inst)
                ? "v_min_num_f64_e64_dpp"
                : "v_min_num_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinNumF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMinNumF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2993,15 +3472,23 @@ VMinNumF64Vop3::VMinNumF64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MIN_NUM_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinNumF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinNumF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_num_f64_e64_dpp"
+          : "v_min_num_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MIN_NUM_F64 does not support DPP8";
   return std::make_unique<VMinNumF64Vop3>(opcode);
 }
 } // namespace detail
@@ -3011,7 +3498,7 @@ VMaxNumF64Vop3::VMaxNumF64Vop3(const MachineInst *inst)
                ? "v_max_num_f64_e64_dpp"
                : "v_max_num_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaxNumF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMaxNumF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3039,15 +3526,23 @@ VMaxNumF64Vop3::VMaxNumF64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAX_NUM_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxNumF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxNumF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_num_f64_e64_dpp"
+          : "v_max_num_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MAX_NUM_F64 does not support DPP8";
   return std::make_unique<VMaxNumF64Vop3>(opcode);
 }
 } // namespace detail
@@ -3057,7 +3552,7 @@ VMinI32Vop3::VMinI32Vop3(const MachineInst *inst)
                ? "v_min_i32_e64_dpp"
                : "v_min_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinI32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMinI32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3097,7 +3592,15 @@ VMinI32Vop3::VMinI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_i32_e64_dpp"
+          : "v_min_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop3>(opcode);
 }
 } // namespace detail
@@ -3107,7 +3610,7 @@ VMaxI32Vop3::VMaxI32Vop3(const MachineInst *inst)
                ? "v_max_i32_e64_dpp"
                : "v_max_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaxI32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMaxI32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3147,7 +3650,15 @@ VMaxI32Vop3::VMaxI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_i32_e64_dpp"
+          : "v_max_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop3>(opcode);
 }
 } // namespace detail
@@ -3157,7 +3668,7 @@ VMinU32Vop3::VMinU32Vop3(const MachineInst *inst)
                ? "v_min_u32_e64_dpp"
                : "v_min_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinU32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMinU32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3197,7 +3708,15 @@ VMinU32Vop3::VMinU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_u32_e64_dpp"
+          : "v_min_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3207,7 +3726,7 @@ VMaxU32Vop3::VMaxU32Vop3(const MachineInst *inst)
                ? "v_max_u32_e64_dpp"
                : "v_max_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaxU32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMaxU32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3247,7 +3766,15 @@ VMaxU32Vop3::VMaxU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_u32_e64_dpp"
+          : "v_max_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3257,7 +3784,7 @@ VMinNumF32Vop3::VMinNumF32Vop3(const MachineInst *inst)
                ? "v_min_num_f32_e64_dpp"
                : "v_min_num_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinNumF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMinNumF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3297,7 +3824,15 @@ VMinNumF32Vop3::VMinNumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinNumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinNumF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_num_f32_e64_dpp"
+          : "v_min_num_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinNumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3307,7 +3842,7 @@ VMaxNumF32Vop3::VMaxNumF32Vop3(const MachineInst *inst)
                ? "v_max_num_f32_e64_dpp"
                : "v_max_num_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaxNumF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMaxNumF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3347,7 +3882,15 @@ VMaxNumF32Vop3::VMaxNumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxNumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxNumF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_num_f32_e64_dpp"
+          : "v_max_num_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxNumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3357,7 +3900,7 @@ VFmacF64Vop3::VFmacF64Vop3(const MachineInst *inst)
                ? "v_fmac_f64_e64_dpp"
                : "v_fmac_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFmacF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VFmacF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3386,15 +3929,23 @@ VFmacF64Vop3::VFmacF64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAC_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f64_e64_dpp"
+          : "v_fmac_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_F64 does not support DPP8";
   return std::make_unique<VFmacF64Vop3>(opcode);
 }
 } // namespace detail
@@ -3404,7 +3955,7 @@ VLshlrevB32Vop3::VLshlrevB32Vop3(const MachineInst *inst)
                ? "v_lshlrev_b32_e64_dpp"
                : "v_lshlrev_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VLshlrevB32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VLshlrevB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3444,7 +3995,16 @@ VLshlrevB32Vop3::VLshlrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b32_e64_dpp"
+          : "v_lshlrev_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3454,7 +4014,7 @@ VLshrrevB32Vop3::VLshrrevB32Vop3(const MachineInst *inst)
                ? "v_lshrrev_b32_e64_dpp"
                : "v_lshrrev_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VLshrrevB32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VLshrrevB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3494,7 +4054,16 @@ VLshrrevB32Vop3::VLshrrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshrrev_b32_e64_dpp"
+          : "v_lshrrev_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3504,7 +4073,7 @@ VAshrrevI32Vop3::VAshrrevI32Vop3(const MachineInst *inst)
                ? "v_ashrrev_i32_e64_dpp"
                : "v_ashrrev_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAshrrevI32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VAshrrevI32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3544,7 +4113,16 @@ VAshrrevI32Vop3::VAshrrevI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ashrrev_i32_e64_dpp"
+          : "v_ashrrev_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop3>(opcode);
 }
 } // namespace detail
@@ -3554,7 +4132,7 @@ VAndB32Vop3::VAndB32Vop3(const MachineInst *inst)
                ? "v_and_b32_e64_dpp"
                : "v_and_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAndB32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VAndB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3594,7 +4172,15 @@ VAndB32Vop3::VAndB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_and_b32_e64_dpp"
+          : "v_and_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3604,7 +4190,7 @@ VOrB32Vop3::VOrB32Vop3(const MachineInst *inst)
                ? "v_or_b32_e64_dpp"
                : "v_or_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VOrB32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VOrB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3644,7 +4230,15 @@ VOrB32Vop3::VOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_or_b32_e64_dpp"
+          : "v_or_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3654,7 +4248,7 @@ VXorB32Vop3::VXorB32Vop3(const MachineInst *inst)
                ? "v_xor_b32_e64_dpp"
                : "v_xor_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VXorB32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VXorB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3694,7 +4288,15 @@ VXorB32Vop3::VXorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xor_b32_e64_dpp"
+          : "v_xor_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3704,7 +4306,7 @@ VXnorB32Vop3::VXnorB32Vop3(const MachineInst *inst)
                ? "v_xnor_b32_e64_dpp"
                : "v_xnor_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VXnorB32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VXnorB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3744,7 +4346,15 @@ VXnorB32Vop3::VXnorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xnor_b32_e64_dpp"
+          : "v_xnor_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3754,7 +4364,7 @@ VLshlrevB64Vop3::VLshlrevB64Vop3(const MachineInst *inst)
                ? "v_lshlrev_b64_e64_dpp"
                : "v_lshlrev_b64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VLshlrevB64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VLshlrevB64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3781,15 +4391,24 @@ VLshlrevB64Vop3::VLshlrevB64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_LSHLREV_B64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b64_e64_dpp"
+          : "v_lshlrev_b64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_LSHLREV_B64 does not support DPP8";
   return std::make_unique<VLshlrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -3799,7 +4418,7 @@ VAddNcU32Vop3::VAddNcU32Vop3(const MachineInst *inst)
                ? "v_add_nc_u32_e64_dpp"
                : "v_add_nc_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAddNcU32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VAddNcU32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3839,7 +4458,15 @@ VAddNcU32Vop3::VAddNcU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_u32_e64_dpp"
+          : "v_add_nc_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3849,7 +4476,7 @@ VSubNcU32Vop3::VSubNcU32Vop3(const MachineInst *inst)
                ? "v_sub_nc_u32_e64_dpp"
                : "v_sub_nc_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSubNcU32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VSubNcU32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3889,7 +4516,15 @@ VSubNcU32Vop3::VSubNcU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_u32_e64_dpp"
+          : "v_sub_nc_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3899,8 +4534,7 @@ VSubrevNcU32Vop3::VSubrevNcU32Vop3(const MachineInst *inst)
                ? "v_subrev_nc_u32_e64_dpp"
                : "v_subrev_nc_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSubrevNcU32Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VSubrevNcU32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3940,7 +4574,16 @@ VSubrevNcU32Vop3::VSubrevNcU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevNcU32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_subrev_nc_u32_e64_dpp"
+          : "v_subrev_nc_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevNcU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3950,7 +4593,7 @@ VAddNcU64Vop3::VAddNcU64Vop3(const MachineInst *inst)
                ? "v_add_nc_u64_e64_dpp"
                : "v_add_nc_u64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAddNcU64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VAddNcU64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3978,15 +4621,23 @@ VAddNcU64Vop3::VAddNcU64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_ADD_NC_U64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_u64_e64_dpp"
+          : "v_add_nc_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_ADD_NC_U64 does not support DPP8";
   return std::make_unique<VAddNcU64Vop3>(opcode);
 }
 } // namespace detail
@@ -3996,7 +4647,7 @@ VSubNcU64Vop3::VSubNcU64Vop3(const MachineInst *inst)
                ? "v_sub_nc_u64_e64_dpp"
                : "v_sub_nc_u64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSubNcU64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VSubNcU64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4024,15 +4675,23 @@ VSubNcU64Vop3::VSubNcU64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SUB_NC_U64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_u64_e64_dpp"
+          : "v_sub_nc_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SUB_NC_U64 does not support DPP8";
   return std::make_unique<VSubNcU64Vop3>(opcode);
 }
 } // namespace detail
@@ -4042,7 +4701,7 @@ VMulU64Vop3::VMulU64Vop3(const MachineInst *inst)
                ? "v_mul_u64_e64_dpp"
                : "v_mul_u64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMulU64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMulU64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4061,16 +4720,24 @@ VMulU64Vop3::VMulU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_U64 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_u64_e64_dpp"
+          : "v_mul_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_U64 does not support DPP";
   return std::make_unique<VMulU64Vop3>(opcode);
 }
 } // namespace detail
@@ -4080,7 +4747,7 @@ VFmacF32Vop3::VFmacF32Vop3(const MachineInst *inst)
                ? "v_fmac_f32_e64_dpp"
                : "v_fmac_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFmacF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VFmacF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4121,7 +4788,15 @@ VFmacF32Vop3::VFmacF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f32_e64_dpp"
+          : "v_fmac_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4131,7 +4806,7 @@ VMinNumF16Vop3::VMinNumF16Vop3(const MachineInst *inst)
                ? "v_min_num_f16_e64_dpp"
                : "v_min_num_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinNumF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMinNumF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4179,7 +4854,15 @@ VMinNumF16Vop3::VMinNumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinNumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinNumF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_num_f16_e64_dpp"
+          : "v_min_num_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinNumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4202,7 +4885,7 @@ VMaxNumF16Vop3::VMaxNumF16Vop3(const MachineInst *inst)
                ? "v_max_num_f16_e64_dpp"
                : "v_max_num_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaxNumF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMaxNumF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4250,7 +4933,15 @@ VMaxNumF16Vop3::VMaxNumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxNumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxNumF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_num_f16_e64_dpp"
+          : "v_max_num_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxNumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4273,7 +4964,7 @@ VAddF16Vop3::VAddF16Vop3(const MachineInst *inst)
                ? "v_add_f16_e64_dpp"
                : "v_add_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAddF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VAddF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4321,7 +5012,15 @@ VAddF16Vop3::VAddF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_f16_e64_dpp"
+          : "v_add_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4343,7 +5042,7 @@ VSubF16Vop3::VSubF16Vop3(const MachineInst *inst)
                ? "v_sub_f16_e64_dpp"
                : "v_sub_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSubF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VSubF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4391,7 +5090,15 @@ VSubF16Vop3::VSubF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_f16_e64_dpp"
+          : "v_sub_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4413,7 +5120,7 @@ VSubrevF16Vop3::VSubrevF16Vop3(const MachineInst *inst)
                ? "v_subrev_f16_e64_dpp"
                : "v_subrev_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSubrevF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VSubrevF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4461,7 +5168,15 @@ VSubrevF16Vop3::VSubrevF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f16_e64_dpp"
+          : "v_subrev_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4484,7 +5199,7 @@ VMulF16Vop3::VMulF16Vop3(const MachineInst *inst)
                ? "v_mul_f16_e64_dpp"
                : "v_mul_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMulF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMulF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4532,7 +5247,15 @@ VMulF16Vop3::VMulF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_f16_e64_dpp"
+          : "v_mul_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4554,7 +5277,7 @@ VFmacF16Vop3::VFmacF16Vop3(const MachineInst *inst)
                ? "v_fmac_f16_e64_dpp"
                : "v_fmac_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFmacF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VFmacF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4603,7 +5326,15 @@ VFmacF16Vop3::VFmacF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f16_e64_dpp"
+          : "v_fmac_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4625,7 +5356,7 @@ VLdexpF16Vop3::VLdexpF16Vop3(const MachineInst *inst)
                ? "v_ldexp_f16_e64_dpp"
                : "v_ldexp_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VLdexpF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VLdexpF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4673,7 +5404,15 @@ VLdexpF16Vop3::VLdexpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ldexp_f16_e64_dpp"
+          : "v_ldexp_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4696,7 +5435,7 @@ VDivFixupF32Vop3::VDivFixupF32Vop3(const MachineInst *inst)
                ? "v_div_fixup_f32_e64_dpp"
                : "v_div_fixup_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VDivFixupF32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VDivFixupF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4719,9 +5458,6 @@ VDivFixupF32Vop3::VDivFixupF32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_FIXUP_F32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -4729,7 +5465,19 @@ VDivFixupF32Vop3::VDivFixupF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fixup_f32_e64_dpp"
+          : "v_div_fixup_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_DIV_FIXUP_F32 does not support DPP";
   return std::make_unique<VDivFixupF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4739,7 +5487,7 @@ VDivFixupF64Vop3::VDivFixupF64Vop3(const MachineInst *inst)
                ? "v_div_fixup_f64_e64_dpp"
                : "v_div_fixup_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VDivFixupF64Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VDivFixupF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4774,8 +5522,6 @@ VDivFixupF64Vop3::VDivFixupF64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_FIXUP_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -4783,7 +5529,18 @@ VDivFixupF64Vop3::VDivFixupF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fixup_f64_e64_dpp"
+          : "v_div_fixup_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_DIV_FIXUP_F64 does not support DPP8";
   return std::make_unique<VDivFixupF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4793,7 +5550,7 @@ VBitop3B16Vop3::VBitop3B16Vop3(const MachineInst *inst)
                ? "v_bitop3_b16_e64_dpp"
                : "v_bitop3_b16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VBitop3B16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VBitop3B16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4852,7 +5609,15 @@ VBitop3B16Vop3::VBitop3B16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBitop3B16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBitop3B16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bitop3_b16_e64_dpp"
+          : "v_bitop3_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBitop3B16Vop3>(opcode);
 }
 } // namespace detail
@@ -4875,7 +5640,7 @@ VBitop3B32Vop3::VBitop3B32Vop3(const MachineInst *inst)
                ? "v_bitop3_b32_e64_dpp"
                : "v_bitop3_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VBitop3B32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VBitop3B32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4922,7 +5687,15 @@ VBitop3B32Vop3::VBitop3B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBitop3B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBitop3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bitop3_b32_e64_dpp"
+          : "v_bitop3_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBitop3B32Vop3>(opcode);
 }
 } // namespace detail
@@ -4932,7 +5705,7 @@ VDivFmasF32Vop3::VDivFmasF32Vop3(const MachineInst *inst)
                ? "v_div_fmas_f32_e64_dpp"
                : "v_div_fmas_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VDivFmasF32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VDivFmasF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4957,9 +5730,6 @@ VDivFmasF32Vop3::VDivFmasF32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_FMAS_F32 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -4968,7 +5738,19 @@ VDivFmasF32Vop3::VDivFmasF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fmas_f32_e64_dpp"
+          : "v_div_fmas_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_DIV_FMAS_F32 does not support DPP";
   return std::make_unique<VDivFmasF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4978,7 +5760,7 @@ VDivFmasF64Vop3::VDivFmasF64Vop3(const MachineInst *inst)
                ? "v_div_fmas_f64_e64_dpp"
                : "v_div_fmas_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VDivFmasF64Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VDivFmasF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5015,8 +5797,6 @@ VDivFmasF64Vop3::VDivFmasF64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_FMAS_F64 does not support DPP8", "");
   vcc.apply_fieldless_caps(false, false, false);
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -5025,7 +5805,18 @@ VDivFmasF64Vop3::VDivFmasF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fmas_f64_e64_dpp"
+          : "v_div_fmas_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_DIV_FMAS_F64 does not support DPP8";
   return std::make_unique<VDivFmasF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5035,7 +5826,7 @@ VDivFixupF16Vop3::VDivFixupF16Vop3(const MachineInst *inst)
                ? "v_div_fixup_f16_e64_dpp"
                : "v_div_fixup_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VDivFixupF16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VDivFixupF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5094,7 +5885,16 @@ VDivFixupF16Vop3::VDivFixupF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fixup_f16_e64_dpp"
+          : "v_div_fixup_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5117,26 +5917,35 @@ VSExpF32Vop3::VSExpF32Vop3(const MachineInst *inst)
                ? "v_s_exp_f32_e64_dpp"
                : "v_s_exp_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSExpF32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSExpF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_EXP_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_EXP_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSExpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_exp_f32_e64_dpp"
+          : "v_s_exp_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_EXP_F32 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_EXP_F32 does not support DPP";
   return std::make_unique<VSExpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5146,27 +5955,36 @@ VSExpF16Vop3::VSExpF16Vop3(const MachineInst *inst)
                ? "v_s_exp_f16_e64_dpp"
                : "v_s_exp_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSExpF16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSExpF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_EXP_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_EXP_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSExpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_exp_f16_e64_dpp"
+          : "v_s_exp_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_EXP_F16 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_EXP_F16 does not support DPP";
   return std::make_unique<VSExpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5176,26 +5994,35 @@ VSLogF32Vop3::VSLogF32Vop3(const MachineInst *inst)
                ? "v_s_log_f32_e64_dpp"
                : "v_s_log_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSLogF32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSLogF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_LOG_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_LOG_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSLogF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_log_f32_e64_dpp"
+          : "v_s_log_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_LOG_F32 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_LOG_F32 does not support DPP";
   return std::make_unique<VSLogF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5205,27 +6032,36 @@ VSLogF16Vop3::VSLogF16Vop3(const MachineInst *inst)
                ? "v_s_log_f16_e64_dpp"
                : "v_s_log_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSLogF16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSLogF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_LOG_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_LOG_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSLogF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_log_f16_e64_dpp"
+          : "v_s_log_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_LOG_F16 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_LOG_F16 does not support DPP";
   return std::make_unique<VSLogF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5235,26 +6071,35 @@ VSRcpF32Vop3::VSRcpF32Vop3(const MachineInst *inst)
                ? "v_s_rcp_f32_e64_dpp"
                : "v_s_rcp_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSRcpF32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSRcpF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_RCP_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_RCP_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSRcpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_rcp_f32_e64_dpp"
+          : "v_s_rcp_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_RCP_F32 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_RCP_F32 does not support DPP";
   return std::make_unique<VSRcpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5264,27 +6109,36 @@ VSRcpF16Vop3::VSRcpF16Vop3(const MachineInst *inst)
                ? "v_s_rcp_f16_e64_dpp"
                : "v_s_rcp_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSRcpF16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSRcpF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_RCP_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_RCP_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSRcpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_rcp_f16_e64_dpp"
+          : "v_s_rcp_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_RCP_F16 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_RCP_F16 does not support DPP";
   return std::make_unique<VSRcpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5294,26 +6148,35 @@ VSRsqF32Vop3::VSRsqF32Vop3(const MachineInst *inst)
                ? "v_s_rsq_f32_e64_dpp"
                : "v_s_rsq_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSRsqF32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSRsqF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_RSQ_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_RSQ_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSRsqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_rsq_f32_e64_dpp"
+          : "v_s_rsq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_RSQ_F32 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_RSQ_F32 does not support DPP";
   return std::make_unique<VSRsqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5323,27 +6186,36 @@ VSRsqF16Vop3::VSRsqF16Vop3(const MachineInst *inst)
                ? "v_s_rsq_f16_e64_dpp"
                : "v_s_rsq_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSRsqF16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSRsqF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_RSQ_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_RSQ_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSRsqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_rsq_f16_e64_dpp"
+          : "v_s_rsq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_RSQ_F16 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_RSQ_F16 does not support DPP";
   return std::make_unique<VSRsqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5353,26 +6225,35 @@ VSSqrtF32Vop3::VSSqrtF32Vop3(const MachineInst *inst)
                ? "v_s_sqrt_f32_e64_dpp"
                : "v_s_sqrt_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSSqrtF32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSSqrtF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_SQRT_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_SQRT_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSSqrtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_sqrt_f32_e64_dpp"
+          : "v_s_sqrt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_SQRT_F32 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_SQRT_F32 does not support DPP";
   return std::make_unique<VSSqrtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5382,27 +6263,36 @@ VSSqrtF16Vop3::VSSqrtF16Vop3(const MachineInst *inst)
                ? "v_s_sqrt_f16_e64_dpp"
                : "v_s_sqrt_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSSqrtF16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSSqrtF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_SQRT_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_SQRT_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSSqrtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_sqrt_f16_e64_dpp"
+          : "v_s_sqrt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_SQRT_F16 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_SQRT_F16 does not support DPP";
   return std::make_unique<VSSqrtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5412,7 +6302,7 @@ VAddNcU16Vop3::VAddNcU16Vop3(const MachineInst *inst)
                ? "v_add_nc_u16_e64_dpp"
                : "v_add_nc_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAddNcU16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VAddNcU16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5460,7 +6350,15 @@ VAddNcU16Vop3::VAddNcU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_u16_e64_dpp"
+          : "v_add_nc_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcU16Vop3>(opcode);
 }
 } // namespace detail
@@ -5483,7 +6381,7 @@ VSubNcU16Vop3::VSubNcU16Vop3(const MachineInst *inst)
                ? "v_sub_nc_u16_e64_dpp"
                : "v_sub_nc_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSubNcU16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VSubNcU16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5531,7 +6429,15 @@ VSubNcU16Vop3::VSubNcU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_u16_e64_dpp"
+          : "v_sub_nc_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcU16Vop3>(opcode);
 }
 } // namespace detail
@@ -5554,7 +6460,7 @@ VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
                ? "v_mul_lo_u16_e64_dpp"
                : "v_mul_lo_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMulLoU16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMulLoU16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5602,7 +6508,15 @@ VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_lo_u16_e64_dpp"
+          : "v_mul_lo_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU16Vop3>(opcode);
 }
 } // namespace detail
@@ -5625,7 +6539,7 @@ VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
                ? "v_max_u16_e64_dpp"
                : "v_max_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaxU16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMaxU16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5673,7 +6587,15 @@ VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_u16_e64_dpp"
+          : "v_max_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU16Vop3>(opcode);
 }
 } // namespace detail
@@ -5695,7 +6617,7 @@ VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
                ? "v_max_i16_e64_dpp"
                : "v_max_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaxI16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMaxI16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5743,7 +6665,15 @@ VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_i16_e64_dpp"
+          : "v_max_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI16Vop3>(opcode);
 }
 } // namespace detail
@@ -5765,7 +6695,7 @@ VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
                ? "v_min_u16_e64_dpp"
                : "v_min_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinU16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMinU16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5813,7 +6743,15 @@ VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_u16_e64_dpp"
+          : "v_min_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU16Vop3>(opcode);
 }
 } // namespace detail
@@ -5835,7 +6773,7 @@ VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
                ? "v_min_i16_e64_dpp"
                : "v_min_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinI16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMinI16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5883,7 +6821,15 @@ VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_i16_e64_dpp"
+          : "v_min_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI16Vop3>(opcode);
 }
 } // namespace detail
@@ -5905,7 +6851,7 @@ VAddNcI16Vop3::VAddNcI16Vop3(const MachineInst *inst)
                ? "v_add_nc_i16_e64_dpp"
                : "v_add_nc_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAddNcI16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VAddNcI16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5953,7 +6899,15 @@ VAddNcI16Vop3::VAddNcI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_i16_e64_dpp"
+          : "v_add_nc_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcI16Vop3>(opcode);
 }
 } // namespace detail
@@ -5976,7 +6930,7 @@ VSubNcI16Vop3::VSubNcI16Vop3(const MachineInst *inst)
                ? "v_sub_nc_i16_e64_dpp"
                : "v_sub_nc_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSubNcI16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VSubNcI16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6024,7 +6978,15 @@ VSubNcI16Vop3::VSubNcI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_i16_e64_dpp"
+          : "v_sub_nc_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcI16Vop3>(opcode);
 }
 } // namespace detail
@@ -6047,7 +7009,7 @@ VMinU64Vop3::VMinU64Vop3(const MachineInst *inst)
                ? "v_min_u64_e64_dpp"
                : "v_min_u64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinU64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMinU64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6075,15 +7037,23 @@ VMinU64Vop3::VMinU64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MIN_U64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_u64_e64_dpp"
+          : "v_min_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MIN_U64 does not support DPP8";
   return std::make_unique<VMinU64Vop3>(opcode);
 }
 } // namespace detail
@@ -6093,7 +7063,7 @@ VMaxU64Vop3::VMaxU64Vop3(const MachineInst *inst)
                ? "v_max_u64_e64_dpp"
                : "v_max_u64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaxU64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMaxU64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6121,15 +7091,23 @@ VMaxU64Vop3::VMaxU64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAX_U64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_u64_e64_dpp"
+          : "v_max_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MAX_U64 does not support DPP8";
   return std::make_unique<VMaxU64Vop3>(opcode);
 }
 } // namespace detail
@@ -6139,7 +7117,7 @@ VMinI64Vop3::VMinI64Vop3(const MachineInst *inst)
                ? "v_min_i64_e64_dpp"
                : "v_min_i64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinI64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMinI64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6167,15 +7145,23 @@ VMinI64Vop3::VMinI64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MIN_I64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_i64_e64_dpp"
+          : "v_min_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MIN_I64 does not support DPP8";
   return std::make_unique<VMinI64Vop3>(opcode);
 }
 } // namespace detail
@@ -6185,7 +7171,7 @@ VMaxI64Vop3::VMaxI64Vop3(const MachineInst *inst)
                ? "v_max_i64_e64_dpp"
                : "v_max_i64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaxI64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMaxI64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6213,15 +7199,23 @@ VMaxI64Vop3::VMaxI64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAX_I64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_i64_e64_dpp"
+          : "v_max_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MAX_I64 does not support DPP8";
   return std::make_unique<VMaxI64Vop3>(opcode);
 }
 } // namespace detail
@@ -6231,7 +7225,7 @@ VLdexpF32Vop3::VLdexpF32Vop3(const MachineInst *inst)
                ? "v_ldexp_f32_e64_dpp"
                : "v_ldexp_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VLdexpF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VLdexpF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6271,7 +7265,15 @@ VLdexpF32Vop3::VLdexpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ldexp_f32_e64_dpp"
+          : "v_ldexp_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6281,7 +7283,7 @@ VBfmB32Vop3::VBfmB32Vop3(const MachineInst *inst)
                ? "v_bfm_b32_e64_dpp"
                : "v_bfm_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VBfmB32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VBfmB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6321,7 +7323,15 @@ VBfmB32Vop3::VBfmB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfm_b32_e64_dpp"
+          : "v_bfm_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfmB32Vop3>(opcode);
 }
 } // namespace detail
@@ -6331,7 +7341,7 @@ VBcntU32B32Vop3::VBcntU32B32Vop3(const MachineInst *inst)
                ? "v_bcnt_u32_b32_e64_dpp"
                : "v_bcnt_u32_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VBcntU32B32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VBcntU32B32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6371,7 +7381,16 @@ VBcntU32B32Vop3::VBcntU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bcnt_u32_b32_e64_dpp"
+          : "v_bcnt_u32_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBcntU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -6381,8 +7400,7 @@ VMbcntLoU32B32Vop3::VMbcntLoU32B32Vop3(const MachineInst *inst)
                ? "v_mbcnt_lo_u32_b32_e64_dpp"
                : "v_mbcnt_lo_u32_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMbcntLoU32B32Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VMbcntLoU32B32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6422,7 +7440,16 @@ VMbcntLoU32B32Vop3::VMbcntLoU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mbcnt_lo_u32_b32_e64_dpp"
+          : "v_mbcnt_lo_u32_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntLoU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -6432,8 +7459,7 @@ VMbcntHiU32B32Vop3::VMbcntHiU32B32Vop3(const MachineInst *inst)
                ? "v_mbcnt_hi_u32_b32_e64_dpp"
                : "v_mbcnt_hi_u32_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMbcntHiU32B32Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VMbcntHiU32B32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6473,7 +7499,16 @@ VMbcntHiU32B32Vop3::VMbcntHiU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mbcnt_hi_u32_b32_e64_dpp"
+          : "v_mbcnt_hi_u32_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntHiU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -6483,7 +7518,7 @@ VSubNcI32Vop3::VSubNcI32Vop3(const MachineInst *inst)
                ? "v_sub_nc_i32_e64_dpp"
                : "v_sub_nc_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSubNcI32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VSubNcI32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6523,7 +7558,15 @@ VSubNcI32Vop3::VSubNcI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_i32_e64_dpp"
+          : "v_sub_nc_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcI32Vop3>(opcode);
 }
 } // namespace detail
@@ -6533,7 +7576,7 @@ VAddNcI32Vop3::VAddNcI32Vop3(const MachineInst *inst)
                ? "v_add_nc_i32_e64_dpp"
                : "v_add_nc_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAddNcI32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VAddNcI32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6573,7 +7616,15 @@ VAddNcI32Vop3::VAddNcI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_i32_e64_dpp"
+          : "v_add_nc_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcI32Vop3>(opcode);
 }
 } // namespace detail
@@ -6583,7 +7634,7 @@ VLdexpF64Vop3::VLdexpF64Vop3(const MachineInst *inst)
                ? "v_ldexp_f64_e64_dpp"
                : "v_ldexp_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VLdexpF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VLdexpF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6610,15 +7661,23 @@ VLdexpF64Vop3::VLdexpF64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_LDEXP_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ldexp_f64_e64_dpp"
+          : "v_ldexp_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_LDEXP_F64 does not support DPP8";
   return std::make_unique<VLdexpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6628,7 +7687,7 @@ VMulLoU32Vop3::VMulLoU32Vop3(const MachineInst *inst)
                ? "v_mul_lo_u32_e64_dpp"
                : "v_mul_lo_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMulLoU32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMulLoU32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6654,15 +7713,23 @@ VMulLoU32Vop3::VMulLoU32Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_LO_U32 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_lo_u32_e64_dpp"
+          : "v_mul_lo_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_LO_U32 does not support DPP8";
   return std::make_unique<VMulLoU32Vop3>(opcode);
 }
 } // namespace detail
@@ -6672,7 +7739,7 @@ VMulHiU32Vop3::VMulHiU32Vop3(const MachineInst *inst)
                ? "v_mul_hi_u32_e64_dpp"
                : "v_mul_hi_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMulHiU32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMulHiU32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6698,15 +7765,23 @@ VMulHiU32Vop3::VMulHiU32Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_HI_U32 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_u32_e64_dpp"
+          : "v_mul_hi_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_HI_U32 does not support DPP8";
   return std::make_unique<VMulHiU32Vop3>(opcode);
 }
 } // namespace detail
@@ -6716,7 +7791,7 @@ VMulHiI32Vop3::VMulHiI32Vop3(const MachineInst *inst)
                ? "v_mul_hi_i32_e64_dpp"
                : "v_mul_hi_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMulHiI32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMulHiI32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6742,15 +7817,23 @@ VMulHiI32Vop3::VMulHiI32Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_HI_I32 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_i32_e64_dpp"
+          : "v_mul_hi_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_HI_I32 does not support DPP8";
   return std::make_unique<VMulHiI32Vop3>(opcode);
 }
 } // namespace detail
@@ -6760,7 +7843,7 @@ VLshlrevB16Vop3::VLshlrevB16Vop3(const MachineInst *inst)
                ? "v_lshlrev_b16_e64_dpp"
                : "v_lshlrev_b16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VLshlrevB16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VLshlrevB16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6808,7 +7891,16 @@ VLshlrevB16Vop3::VLshlrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b16_e64_dpp"
+          : "v_lshlrev_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -6831,7 +7923,7 @@ VLshrrevB16Vop3::VLshrrevB16Vop3(const MachineInst *inst)
                ? "v_lshrrev_b16_e64_dpp"
                : "v_lshrrev_b16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VLshrrevB16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VLshrrevB16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6879,7 +7971,16 @@ VLshrrevB16Vop3::VLshrrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshrrev_b16_e64_dpp"
+          : "v_lshrrev_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -6902,7 +8003,7 @@ VAshrrevI16Vop3::VAshrrevI16Vop3(const MachineInst *inst)
                ? "v_ashrrev_i16_e64_dpp"
                : "v_ashrrev_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAshrrevI16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VAshrrevI16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6950,7 +8051,16 @@ VAshrrevI16Vop3::VAshrrevI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ashrrev_i16_e64_dpp"
+          : "v_ashrrev_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI16Vop3>(opcode);
 }
 } // namespace detail
@@ -6973,7 +8083,7 @@ VLshrrevB64Vop3::VLshrrevB64Vop3(const MachineInst *inst)
                ? "v_lshrrev_b64_e64_dpp"
                : "v_lshrrev_b64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VLshrrevB64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VLshrrevB64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7000,15 +8110,24 @@ VLshrrevB64Vop3::VLshrrevB64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_LSHRREV_B64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshrrev_b64_e64_dpp"
+          : "v_lshrrev_b64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_LSHRREV_B64 does not support DPP8";
   return std::make_unique<VLshrrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -7018,7 +8137,7 @@ VAshrrevI64Vop3::VAshrrevI64Vop3(const MachineInst *inst)
                ? "v_ashrrev_i64_e64_dpp"
                : "v_ashrrev_i64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAshrrevI64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VAshrrevI64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7045,15 +8164,24 @@ VAshrrevI64Vop3::VAshrrevI64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_ASHRREV_I64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ashrrev_i64_e64_dpp"
+          : "v_ashrrev_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_ASHRREV_I64 does not support DPP8";
   return std::make_unique<VAshrrevI64Vop3>(opcode);
 }
 } // namespace detail
@@ -7063,7 +8191,7 @@ VMinimumF64Vop3::VMinimumF64Vop3(const MachineInst *inst)
                ? "v_minimum_f64_e64_dpp"
                : "v_minimum_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinimumF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMinimumF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7091,15 +8219,24 @@ VMinimumF64Vop3::VMinimumF64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MINIMUM_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinimumF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinimumF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minimum_f64_e64_dpp"
+          : "v_minimum_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MINIMUM_F64 does not support DPP8";
   return std::make_unique<VMinimumF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7109,7 +8246,7 @@ VMaximumF64Vop3::VMaximumF64Vop3(const MachineInst *inst)
                ? "v_maximum_f64_e64_dpp"
                : "v_maximum_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaximumF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMaximumF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7137,15 +8274,24 @@ VMaximumF64Vop3::VMaximumF64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAXIMUM_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaximumF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaximumF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maximum_f64_e64_dpp"
+          : "v_maximum_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MAXIMUM_F64 does not support DPP8";
   return std::make_unique<VMaximumF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7155,7 +8301,7 @@ VAndB16Vop3::VAndB16Vop3(const MachineInst *inst)
                ? "v_and_b16_e64_dpp"
                : "v_and_b16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAndB16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VAndB16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7203,7 +8349,15 @@ VAndB16Vop3::VAndB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_and_b16_e64_dpp"
+          : "v_and_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB16Vop3>(opcode);
 }
 } // namespace detail
@@ -7225,7 +8379,7 @@ VOrB16Vop3::VOrB16Vop3(const MachineInst *inst)
                ? "v_or_b16_e64_dpp"
                : "v_or_b16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VOrB16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VOrB16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7273,7 +8427,15 @@ VOrB16Vop3::VOrB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOrB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_or_b16_e64_dpp"
+          : "v_or_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB16Vop3>(opcode);
 }
 } // namespace detail
@@ -7295,7 +8457,7 @@ VXorB16Vop3::VXorB16Vop3(const MachineInst *inst)
                ? "v_xor_b16_e64_dpp"
                : "v_xor_b16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VXorB16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VXorB16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7343,7 +8505,15 @@ VXorB16Vop3::VXorB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXorB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xor_b16_e64_dpp"
+          : "v_xor_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB16Vop3>(opcode);
 }
 } // namespace detail
@@ -7365,7 +8535,7 @@ VMinimumF32Vop3::VMinimumF32Vop3(const MachineInst *inst)
                ? "v_minimum_f32_e64_dpp"
                : "v_minimum_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinimumF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMinimumF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7405,7 +8575,16 @@ VMinimumF32Vop3::VMinimumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinimumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinimumF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minimum_f32_e64_dpp"
+          : "v_minimum_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinimumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7415,7 +8594,7 @@ VMaximumF32Vop3::VMaximumF32Vop3(const MachineInst *inst)
                ? "v_maximum_f32_e64_dpp"
                : "v_maximum_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaximumF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMaximumF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7455,7 +8634,16 @@ VMaximumF32Vop3::VMaximumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaximumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaximumF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maximum_f32_e64_dpp"
+          : "v_maximum_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaximumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7465,7 +8653,7 @@ VMinimumF16Vop3::VMinimumF16Vop3(const MachineInst *inst)
                ? "v_minimum_f16_e64_dpp"
                : "v_minimum_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinimumF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMinimumF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7513,7 +8701,16 @@ VMinimumF16Vop3::VMinimumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinimumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinimumF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minimum_f16_e64_dpp"
+          : "v_minimum_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinimumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -7536,7 +8733,7 @@ VMaximumF16Vop3::VMaximumF16Vop3(const MachineInst *inst)
                ? "v_maximum_f16_e64_dpp"
                : "v_maximum_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaximumF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VMaximumF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7584,7 +8781,16 @@ VMaximumF16Vop3::VMaximumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaximumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaximumF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maximum_f16_e64_dpp"
+          : "v_maximum_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaximumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -7607,8 +8813,7 @@ VAddCoCiU32Vop3SdstEnc::VAddCoCiU32Vop3SdstEnc(const MachineInst *inst)
                       ? "v_add_co_ci_u32_e64_dpp"
                       : "v_add_co_ci_u32",
                   reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(InstructionExecutionId::VAddCoCiU32Vop3SdstEnc),
-                  LiteralSupport::Literal32),
+                  selected_exec_fn(InstructionExecutionId::VAddCoCiU32Vop3SdstEnc)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -7652,7 +8857,17 @@ VAddCoCiU32Vop3SdstEnc::VAddCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_add_co_ci_u32_e64_dpp"
+          : "v_add_co_ci_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error,
+      LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoCiU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -7662,8 +8877,7 @@ VSubCoCiU32Vop3SdstEnc::VSubCoCiU32Vop3SdstEnc(const MachineInst *inst)
                       ? "v_sub_co_ci_u32_e64_dpp"
                       : "v_sub_co_ci_u32",
                   reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(InstructionExecutionId::VSubCoCiU32Vop3SdstEnc),
-                  LiteralSupport::Literal32),
+                  selected_exec_fn(InstructionExecutionId::VSubCoCiU32Vop3SdstEnc)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -7707,7 +8921,17 @@ VSubCoCiU32Vop3SdstEnc::VSubCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_sub_co_ci_u32_e64_dpp"
+          : "v_sub_co_ci_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error,
+      LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoCiU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -7717,8 +8941,7 @@ VSubrevCoCiU32Vop3SdstEnc::VSubrevCoCiU32Vop3SdstEnc(const MachineInst *inst)
                       ? "v_subrev_co_ci_u32_e64_dpp"
                       : "v_subrev_co_ci_u32",
                   reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(InstructionExecutionId::VSubrevCoCiU32Vop3SdstEnc),
-                  LiteralSupport::Literal32),
+                  selected_exec_fn(InstructionExecutionId::VSubrevCoCiU32Vop3SdstEnc)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -7762,7 +8985,17 @@ VSubrevCoCiU32Vop3SdstEnc::VSubrevCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_subrev_co_ci_u32_e64_dpp"
+          : "v_subrev_co_ci_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error,
+      LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoCiU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -7772,8 +9005,7 @@ VDivScaleF32Vop3SdstEnc::VDivScaleF32Vop3SdstEnc(const MachineInst *inst)
                       ? "v_div_scale_f32_e64_dpp"
                       : "v_div_scale_f32",
                   reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(InstructionExecutionId::VDivScaleF32Vop3SdstEnc),
-                  LiteralSupport::Literal32),
+                  selected_exec_fn(InstructionExecutionId::VDivScaleF32Vop3SdstEnc)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -7798,9 +9030,6 @@ VDivScaleF32Vop3SdstEnc::VDivScaleF32Vop3SdstEnc(const MachineInst *inst)
     src2 = Operand(32, OperandType::OPR_SIMM32,
                    static_cast<int>(
                        reinterpret_cast<const Vop3SdstEncInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_SCALE_F32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -7808,7 +9037,21 @@ VDivScaleF32Vop3SdstEnc::VDivScaleF32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_div_scale_f32_e64_dpp"
+          : "v_div_scale_f32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error,
+      LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DIV_SCALE_F32 does not support DPP";
   return std::make_unique<VDivScaleF32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -7818,8 +9061,7 @@ VDivScaleF64Vop3SdstEnc::VDivScaleF64Vop3SdstEnc(const MachineInst *inst)
                       ? "v_div_scale_f64_e64_dpp"
                       : "v_div_scale_f64",
                   reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(InstructionExecutionId::VDivScaleF64Vop3SdstEnc),
-                  LiteralSupport::Literal32),
+                  selected_exec_fn(InstructionExecutionId::VDivScaleF64Vop3SdstEnc)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -7859,8 +9101,6 @@ VDivScaleF64Vop3SdstEnc::VDivScaleF64Vop3SdstEnc(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_SCALE_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -7868,7 +9108,20 @@ VDivScaleF64Vop3SdstEnc::VDivScaleF64Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_div_scale_f64_e64_dpp"
+          : "v_div_scale_f64",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error,
+      LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DIV_SCALE_F64 does not support DPP8";
   return std::make_unique<VDivScaleF64Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -7878,8 +9131,7 @@ VMadCoU64U32Vop3SdstEnc::VMadCoU64U32Vop3SdstEnc(const MachineInst *inst)
                       ? "v_mad_co_u64_u32_e64_dpp"
                       : "v_mad_co_u64_u32",
                   reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(InstructionExecutionId::VMadCoU64U32Vop3SdstEnc),
-                  LiteralSupport::Literal32),
+                  selected_exec_fn(InstructionExecutionId::VMadCoU64U32Vop3SdstEnc)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -7915,8 +9167,6 @@ VMadCoU64U32Vop3SdstEnc::VMadCoU64U32Vop3SdstEnc(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAD_CO_U64_U32 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -7924,7 +9174,20 @@ VMadCoU64U32Vop3SdstEnc::VMadCoU64U32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadCoU64U32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadCoU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_mad_co_u64_u32_e64_dpp"
+          : "v_mad_co_u64_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error,
+      LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_MAD_CO_U64_U32 does not support DPP8";
   return std::make_unique<VMadCoU64U32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -7934,8 +9197,7 @@ VMadCoI64I32Vop3SdstEnc::VMadCoI64I32Vop3SdstEnc(const MachineInst *inst)
                       ? "v_mad_co_i64_i32_e64_dpp"
                       : "v_mad_co_i64_i32",
                   reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(InstructionExecutionId::VMadCoI64I32Vop3SdstEnc),
-                  LiteralSupport::Literal32),
+                  selected_exec_fn(InstructionExecutionId::VMadCoI64I32Vop3SdstEnc)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -7971,8 +9233,6 @@ VMadCoI64I32Vop3SdstEnc::VMadCoI64I32Vop3SdstEnc(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAD_CO_I64_I32 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -7980,7 +9240,20 @@ VMadCoI64I32Vop3SdstEnc::VMadCoI64I32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadCoI64I32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadCoI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_mad_co_i64_i32_e64_dpp"
+          : "v_mad_co_i64_i32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error,
+      LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_MAD_CO_I64_I32 does not support DPP8";
   return std::make_unique<VMadCoI64I32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -7990,8 +9263,7 @@ VAddCoU32Vop3SdstEnc::VAddCoU32Vop3SdstEnc(const MachineInst *inst)
                       ? "v_add_co_u32_e64_dpp"
                       : "v_add_co_u32",
                   reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(InstructionExecutionId::VAddCoU32Vop3SdstEnc),
-                  LiteralSupport::Literal32, 2),
+                  selected_exec_fn(InstructionExecutionId::VAddCoU32Vop3SdstEnc)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -8033,7 +9305,17 @@ VAddCoU32Vop3SdstEnc::VAddCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_add_co_u32_e64_dpp"
+          : "v_add_co_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error,
+      LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -8043,8 +9325,7 @@ VSubCoU32Vop3SdstEnc::VSubCoU32Vop3SdstEnc(const MachineInst *inst)
                       ? "v_sub_co_u32_e64_dpp"
                       : "v_sub_co_u32",
                   reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(InstructionExecutionId::VSubCoU32Vop3SdstEnc),
-                  LiteralSupport::Literal32, 2),
+                  selected_exec_fn(InstructionExecutionId::VSubCoU32Vop3SdstEnc)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -8086,7 +9367,17 @@ VSubCoU32Vop3SdstEnc::VSubCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_sub_co_u32_e64_dpp"
+          : "v_sub_co_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error,
+      LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -8096,8 +9387,7 @@ VSubrevCoU32Vop3SdstEnc::VSubrevCoU32Vop3SdstEnc(const MachineInst *inst)
                       ? "v_subrev_co_u32_e64_dpp"
                       : "v_subrev_co_u32",
                   reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(InstructionExecutionId::VSubrevCoU32Vop3SdstEnc),
-                  LiteralSupport::Literal32, 2),
+                  selected_exec_fn(InstructionExecutionId::VSubrevCoU32Vop3SdstEnc)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -8139,7 +9429,17 @@ VSubrevCoU32Vop3SdstEnc::VSubrevCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_subrev_co_u32_e64_dpp"
+          : "v_subrev_co_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error,
+      LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_cmp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_cmp.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -18,7 +17,7 @@ VCmpLtF16Vop3::VCmpLtF16Vop3(const MachineInst *inst)
                ? "v_cmp_lt_f16_e64_dpp"
                : "v_cmp_lt_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLtF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLtF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -65,7 +64,15 @@ VCmpLtF16Vop3::VCmpLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f16_e64_dpp"
+          : "v_cmp_lt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -75,7 +82,7 @@ VCmpEqF16Vop3::VCmpEqF16Vop3(const MachineInst *inst)
                ? "v_cmp_eq_f16_e64_dpp"
                : "v_cmp_eq_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpEqF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpEqF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -122,7 +129,15 @@ VCmpEqF16Vop3::VCmpEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f16_e64_dpp"
+          : "v_cmp_eq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -132,7 +147,7 @@ VCmpLeF16Vop3::VCmpLeF16Vop3(const MachineInst *inst)
                ? "v_cmp_le_f16_e64_dpp"
                : "v_cmp_le_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLeF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLeF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -179,7 +194,15 @@ VCmpLeF16Vop3::VCmpLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f16_e64_dpp"
+          : "v_cmp_le_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -189,7 +212,7 @@ VCmpGtF16Vop3::VCmpGtF16Vop3(const MachineInst *inst)
                ? "v_cmp_gt_f16_e64_dpp"
                : "v_cmp_gt_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpGtF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpGtF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -236,7 +259,15 @@ VCmpGtF16Vop3::VCmpGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f16_e64_dpp"
+          : "v_cmp_gt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -246,7 +277,7 @@ VCmpLgF16Vop3::VCmpLgF16Vop3(const MachineInst *inst)
                ? "v_cmp_lg_f16_e64_dpp"
                : "v_cmp_lg_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLgF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLgF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -293,7 +324,15 @@ VCmpLgF16Vop3::VCmpLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f16_e64_dpp"
+          : "v_cmp_lg_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -303,7 +342,7 @@ VCmpGeF16Vop3::VCmpGeF16Vop3(const MachineInst *inst)
                ? "v_cmp_ge_f16_e64_dpp"
                : "v_cmp_ge_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpGeF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpGeF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -350,7 +389,15 @@ VCmpGeF16Vop3::VCmpGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f16_e64_dpp"
+          : "v_cmp_ge_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -360,7 +407,7 @@ VCmpOF16Vop3::VCmpOF16Vop3(const MachineInst *inst)
                ? "v_cmp_o_f16_e64_dpp"
                : "v_cmp_o_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpOF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpOF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -407,7 +454,15 @@ VCmpOF16Vop3::VCmpOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f16_e64_dpp"
+          : "v_cmp_o_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -417,7 +472,7 @@ VCmpUF16Vop3::VCmpUF16Vop3(const MachineInst *inst)
                ? "v_cmp_u_f16_e64_dpp"
                : "v_cmp_u_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpUF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpUF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -464,7 +519,15 @@ VCmpUF16Vop3::VCmpUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f16_e64_dpp"
+          : "v_cmp_u_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -474,7 +537,7 @@ VCmpNgeF16Vop3::VCmpNgeF16Vop3(const MachineInst *inst)
                ? "v_cmp_nge_f16_e64_dpp"
                : "v_cmp_nge_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNgeF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNgeF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -521,7 +584,15 @@ VCmpNgeF16Vop3::VCmpNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f16_e64_dpp"
+          : "v_cmp_nge_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -531,7 +602,7 @@ VCmpNlgF16Vop3::VCmpNlgF16Vop3(const MachineInst *inst)
                ? "v_cmp_nlg_f16_e64_dpp"
                : "v_cmp_nlg_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNlgF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNlgF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -578,7 +649,15 @@ VCmpNlgF16Vop3::VCmpNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f16_e64_dpp"
+          : "v_cmp_nlg_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -588,7 +667,7 @@ VCmpNgtF16Vop3::VCmpNgtF16Vop3(const MachineInst *inst)
                ? "v_cmp_ngt_f16_e64_dpp"
                : "v_cmp_ngt_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNgtF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNgtF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -635,7 +714,15 @@ VCmpNgtF16Vop3::VCmpNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f16_e64_dpp"
+          : "v_cmp_ngt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -645,7 +732,7 @@ VCmpNleF16Vop3::VCmpNleF16Vop3(const MachineInst *inst)
                ? "v_cmp_nle_f16_e64_dpp"
                : "v_cmp_nle_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNleF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNleF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -692,7 +779,15 @@ VCmpNleF16Vop3::VCmpNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f16_e64_dpp"
+          : "v_cmp_nle_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -702,7 +797,7 @@ VCmpNeqF16Vop3::VCmpNeqF16Vop3(const MachineInst *inst)
                ? "v_cmp_neq_f16_e64_dpp"
                : "v_cmp_neq_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNeqF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNeqF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -749,7 +844,15 @@ VCmpNeqF16Vop3::VCmpNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f16_e64_dpp"
+          : "v_cmp_neq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -759,7 +862,7 @@ VCmpNltF16Vop3::VCmpNltF16Vop3(const MachineInst *inst)
                ? "v_cmp_nlt_f16_e64_dpp"
                : "v_cmp_nlt_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNltF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNltF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -806,7 +909,15 @@ VCmpNltF16Vop3::VCmpNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f16_e64_dpp"
+          : "v_cmp_nlt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -816,7 +927,7 @@ VCmpLtF32Vop3::VCmpLtF32Vop3(const MachineInst *inst)
                ? "v_cmp_lt_f32_e64_dpp"
                : "v_cmp_lt_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLtF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLtF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -855,7 +966,15 @@ VCmpLtF32Vop3::VCmpLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f32_e64_dpp"
+          : "v_cmp_lt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -865,7 +984,7 @@ VCmpEqF32Vop3::VCmpEqF32Vop3(const MachineInst *inst)
                ? "v_cmp_eq_f32_e64_dpp"
                : "v_cmp_eq_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpEqF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpEqF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -904,7 +1023,15 @@ VCmpEqF32Vop3::VCmpEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f32_e64_dpp"
+          : "v_cmp_eq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -914,7 +1041,7 @@ VCmpLeF32Vop3::VCmpLeF32Vop3(const MachineInst *inst)
                ? "v_cmp_le_f32_e64_dpp"
                : "v_cmp_le_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLeF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLeF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -953,7 +1080,15 @@ VCmpLeF32Vop3::VCmpLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f32_e64_dpp"
+          : "v_cmp_le_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -963,7 +1098,7 @@ VCmpGtF32Vop3::VCmpGtF32Vop3(const MachineInst *inst)
                ? "v_cmp_gt_f32_e64_dpp"
                : "v_cmp_gt_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpGtF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpGtF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1002,7 +1137,15 @@ VCmpGtF32Vop3::VCmpGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f32_e64_dpp"
+          : "v_cmp_gt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1012,7 +1155,7 @@ VCmpLgF32Vop3::VCmpLgF32Vop3(const MachineInst *inst)
                ? "v_cmp_lg_f32_e64_dpp"
                : "v_cmp_lg_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLgF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLgF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1051,7 +1194,15 @@ VCmpLgF32Vop3::VCmpLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f32_e64_dpp"
+          : "v_cmp_lg_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1061,7 +1212,7 @@ VCmpGeF32Vop3::VCmpGeF32Vop3(const MachineInst *inst)
                ? "v_cmp_ge_f32_e64_dpp"
                : "v_cmp_ge_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpGeF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpGeF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1100,7 +1251,15 @@ VCmpGeF32Vop3::VCmpGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f32_e64_dpp"
+          : "v_cmp_ge_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1110,7 +1269,7 @@ VCmpOF32Vop3::VCmpOF32Vop3(const MachineInst *inst)
                ? "v_cmp_o_f32_e64_dpp"
                : "v_cmp_o_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpOF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpOF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1149,7 +1308,15 @@ VCmpOF32Vop3::VCmpOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f32_e64_dpp"
+          : "v_cmp_o_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1159,7 +1326,7 @@ VCmpUF32Vop3::VCmpUF32Vop3(const MachineInst *inst)
                ? "v_cmp_u_f32_e64_dpp"
                : "v_cmp_u_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpUF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpUF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1198,7 +1365,15 @@ VCmpUF32Vop3::VCmpUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f32_e64_dpp"
+          : "v_cmp_u_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1208,7 +1383,7 @@ VCmpNgeF32Vop3::VCmpNgeF32Vop3(const MachineInst *inst)
                ? "v_cmp_nge_f32_e64_dpp"
                : "v_cmp_nge_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNgeF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNgeF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1247,7 +1422,15 @@ VCmpNgeF32Vop3::VCmpNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f32_e64_dpp"
+          : "v_cmp_nge_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1257,7 +1440,7 @@ VCmpNlgF32Vop3::VCmpNlgF32Vop3(const MachineInst *inst)
                ? "v_cmp_nlg_f32_e64_dpp"
                : "v_cmp_nlg_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNlgF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNlgF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1296,7 +1479,15 @@ VCmpNlgF32Vop3::VCmpNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f32_e64_dpp"
+          : "v_cmp_nlg_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1306,7 +1497,7 @@ VCmpNgtF32Vop3::VCmpNgtF32Vop3(const MachineInst *inst)
                ? "v_cmp_ngt_f32_e64_dpp"
                : "v_cmp_ngt_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNgtF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNgtF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1345,7 +1536,15 @@ VCmpNgtF32Vop3::VCmpNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f32_e64_dpp"
+          : "v_cmp_ngt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1355,7 +1554,7 @@ VCmpNleF32Vop3::VCmpNleF32Vop3(const MachineInst *inst)
                ? "v_cmp_nle_f32_e64_dpp"
                : "v_cmp_nle_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNleF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNleF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1394,7 +1593,15 @@ VCmpNleF32Vop3::VCmpNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f32_e64_dpp"
+          : "v_cmp_nle_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1404,7 +1611,7 @@ VCmpNeqF32Vop3::VCmpNeqF32Vop3(const MachineInst *inst)
                ? "v_cmp_neq_f32_e64_dpp"
                : "v_cmp_neq_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNeqF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNeqF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1443,7 +1650,15 @@ VCmpNeqF32Vop3::VCmpNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f32_e64_dpp"
+          : "v_cmp_neq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1453,7 +1668,7 @@ VCmpNltF32Vop3::VCmpNltF32Vop3(const MachineInst *inst)
                ? "v_cmp_nlt_f32_e64_dpp"
                : "v_cmp_nlt_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNltF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNltF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1492,7 +1707,15 @@ VCmpNltF32Vop3::VCmpNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f32_e64_dpp"
+          : "v_cmp_nlt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1502,7 +1725,7 @@ VCmpLtF64Vop3::VCmpLtF64Vop3(const MachineInst *inst)
                ? "v_cmp_lt_f64_e64_dpp"
                : "v_cmp_lt_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLtF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLtF64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1521,15 +1744,23 @@ VCmpLtF64Vop3::VCmpLtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_F64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f64_e64_dpp"
+          : "v_cmp_lt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support DPP";
   return std::make_unique<VCmpLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1539,7 +1770,7 @@ VCmpEqF64Vop3::VCmpEqF64Vop3(const MachineInst *inst)
                ? "v_cmp_eq_f64_e64_dpp"
                : "v_cmp_eq_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpEqF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpEqF64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1558,15 +1789,23 @@ VCmpEqF64Vop3::VCmpEqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f64_e64_dpp"
+          : "v_cmp_eq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support DPP";
   return std::make_unique<VCmpEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1576,7 +1815,7 @@ VCmpLeF64Vop3::VCmpLeF64Vop3(const MachineInst *inst)
                ? "v_cmp_le_f64_e64_dpp"
                : "v_cmp_le_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLeF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLeF64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1595,15 +1834,23 @@ VCmpLeF64Vop3::VCmpLeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_F64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f64_e64_dpp"
+          : "v_cmp_le_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support DPP";
   return std::make_unique<VCmpLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1613,7 +1860,7 @@ VCmpGtF64Vop3::VCmpGtF64Vop3(const MachineInst *inst)
                ? "v_cmp_gt_f64_e64_dpp"
                : "v_cmp_gt_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpGtF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpGtF64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1632,15 +1879,23 @@ VCmpGtF64Vop3::VCmpGtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_F64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f64_e64_dpp"
+          : "v_cmp_gt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support DPP";
   return std::make_unique<VCmpGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1650,7 +1905,7 @@ VCmpLgF64Vop3::VCmpLgF64Vop3(const MachineInst *inst)
                ? "v_cmp_lg_f64_e64_dpp"
                : "v_cmp_lg_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLgF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLgF64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1669,15 +1924,23 @@ VCmpLgF64Vop3::VCmpLgF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LG_F64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f64_e64_dpp"
+          : "v_cmp_lg_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support DPP";
   return std::make_unique<VCmpLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1687,7 +1950,7 @@ VCmpGeF64Vop3::VCmpGeF64Vop3(const MachineInst *inst)
                ? "v_cmp_ge_f64_e64_dpp"
                : "v_cmp_ge_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpGeF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpGeF64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1706,15 +1969,23 @@ VCmpGeF64Vop3::VCmpGeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_F64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f64_e64_dpp"
+          : "v_cmp_ge_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support DPP";
   return std::make_unique<VCmpGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1724,7 +1995,7 @@ VCmpOF64Vop3::VCmpOF64Vop3(const MachineInst *inst)
                ? "v_cmp_o_f64_e64_dpp"
                : "v_cmp_o_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpOF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpOF64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1743,15 +2014,23 @@ VCmpOF64Vop3::VCmpOF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_O_F64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f64_e64_dpp"
+          : "v_cmp_o_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support DPP";
   return std::make_unique<VCmpOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1761,7 +2040,7 @@ VCmpUF64Vop3::VCmpUF64Vop3(const MachineInst *inst)
                ? "v_cmp_u_f64_e64_dpp"
                : "v_cmp_u_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpUF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpUF64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1780,15 +2059,23 @@ VCmpUF64Vop3::VCmpUF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_U_F64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f64_e64_dpp"
+          : "v_cmp_u_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support DPP";
   return std::make_unique<VCmpUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1798,7 +2085,7 @@ VCmpNgeF64Vop3::VCmpNgeF64Vop3(const MachineInst *inst)
                ? "v_cmp_nge_f64_e64_dpp"
                : "v_cmp_nge_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNgeF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNgeF64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1817,15 +2104,23 @@ VCmpNgeF64Vop3::VCmpNgeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f64_e64_dpp"
+          : "v_cmp_nge_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support DPP";
   return std::make_unique<VCmpNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1835,7 +2130,7 @@ VCmpNlgF64Vop3::VCmpNlgF64Vop3(const MachineInst *inst)
                ? "v_cmp_nlg_f64_e64_dpp"
                : "v_cmp_nlg_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNlgF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNlgF64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1854,15 +2149,23 @@ VCmpNlgF64Vop3::VCmpNlgF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f64_e64_dpp"
+          : "v_cmp_nlg_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support DPP";
   return std::make_unique<VCmpNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1872,7 +2175,7 @@ VCmpNgtF64Vop3::VCmpNgtF64Vop3(const MachineInst *inst)
                ? "v_cmp_ngt_f64_e64_dpp"
                : "v_cmp_ngt_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNgtF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNgtF64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1891,15 +2194,23 @@ VCmpNgtF64Vop3::VCmpNgtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f64_e64_dpp"
+          : "v_cmp_ngt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support DPP";
   return std::make_unique<VCmpNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1909,7 +2220,7 @@ VCmpNleF64Vop3::VCmpNleF64Vop3(const MachineInst *inst)
                ? "v_cmp_nle_f64_e64_dpp"
                : "v_cmp_nle_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNleF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNleF64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1928,15 +2239,23 @@ VCmpNleF64Vop3::VCmpNleF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f64_e64_dpp"
+          : "v_cmp_nle_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support DPP";
   return std::make_unique<VCmpNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1946,7 +2265,7 @@ VCmpNeqF64Vop3::VCmpNeqF64Vop3(const MachineInst *inst)
                ? "v_cmp_neq_f64_e64_dpp"
                : "v_cmp_neq_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNeqF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNeqF64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1965,15 +2284,23 @@ VCmpNeqF64Vop3::VCmpNeqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f64_e64_dpp"
+          : "v_cmp_neq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support DPP";
   return std::make_unique<VCmpNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1983,7 +2310,7 @@ VCmpNltF64Vop3::VCmpNltF64Vop3(const MachineInst *inst)
                ? "v_cmp_nlt_f64_e64_dpp"
                : "v_cmp_nlt_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNltF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNltF64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2002,15 +2329,23 @@ VCmpNltF64Vop3::VCmpNltF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f64_e64_dpp"
+          : "v_cmp_nlt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support DPP";
   return std::make_unique<VCmpNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -2020,7 +2355,7 @@ VCmpLtI16Vop3::VCmpLtI16Vop3(const MachineInst *inst)
                ? "v_cmp_lt_i16_e64_dpp"
                : "v_cmp_lt_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLtI16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLtI16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2067,7 +2402,15 @@ VCmpLtI16Vop3::VCmpLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i16_e64_dpp"
+          : "v_cmp_lt_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -2077,7 +2420,7 @@ VCmpEqI16Vop3::VCmpEqI16Vop3(const MachineInst *inst)
                ? "v_cmp_eq_i16_e64_dpp"
                : "v_cmp_eq_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpEqI16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpEqI16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2124,7 +2467,15 @@ VCmpEqI16Vop3::VCmpEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i16_e64_dpp"
+          : "v_cmp_eq_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -2134,7 +2485,7 @@ VCmpLeI16Vop3::VCmpLeI16Vop3(const MachineInst *inst)
                ? "v_cmp_le_i16_e64_dpp"
                : "v_cmp_le_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLeI16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLeI16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2181,7 +2532,15 @@ VCmpLeI16Vop3::VCmpLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i16_e64_dpp"
+          : "v_cmp_le_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -2191,7 +2550,7 @@ VCmpGtI16Vop3::VCmpGtI16Vop3(const MachineInst *inst)
                ? "v_cmp_gt_i16_e64_dpp"
                : "v_cmp_gt_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpGtI16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpGtI16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2238,7 +2597,15 @@ VCmpGtI16Vop3::VCmpGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i16_e64_dpp"
+          : "v_cmp_gt_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -2248,7 +2615,7 @@ VCmpNeI16Vop3::VCmpNeI16Vop3(const MachineInst *inst)
                ? "v_cmp_ne_i16_e64_dpp"
                : "v_cmp_ne_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNeI16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNeI16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2295,7 +2662,15 @@ VCmpNeI16Vop3::VCmpNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i16_e64_dpp"
+          : "v_cmp_ne_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -2305,7 +2680,7 @@ VCmpGeI16Vop3::VCmpGeI16Vop3(const MachineInst *inst)
                ? "v_cmp_ge_i16_e64_dpp"
                : "v_cmp_ge_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpGeI16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpGeI16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2352,7 +2727,15 @@ VCmpGeI16Vop3::VCmpGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i16_e64_dpp"
+          : "v_cmp_ge_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -2362,7 +2745,7 @@ VCmpLtU16Vop3::VCmpLtU16Vop3(const MachineInst *inst)
                ? "v_cmp_lt_u16_e64_dpp"
                : "v_cmp_lt_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLtU16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLtU16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2409,7 +2792,15 @@ VCmpLtU16Vop3::VCmpLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u16_e64_dpp"
+          : "v_cmp_lt_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2419,7 +2810,7 @@ VCmpEqU16Vop3::VCmpEqU16Vop3(const MachineInst *inst)
                ? "v_cmp_eq_u16_e64_dpp"
                : "v_cmp_eq_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpEqU16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpEqU16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2466,7 +2857,15 @@ VCmpEqU16Vop3::VCmpEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u16_e64_dpp"
+          : "v_cmp_eq_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2476,7 +2875,7 @@ VCmpLeU16Vop3::VCmpLeU16Vop3(const MachineInst *inst)
                ? "v_cmp_le_u16_e64_dpp"
                : "v_cmp_le_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLeU16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLeU16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2523,7 +2922,15 @@ VCmpLeU16Vop3::VCmpLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u16_e64_dpp"
+          : "v_cmp_le_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2533,7 +2940,7 @@ VCmpGtU16Vop3::VCmpGtU16Vop3(const MachineInst *inst)
                ? "v_cmp_gt_u16_e64_dpp"
                : "v_cmp_gt_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpGtU16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpGtU16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2580,7 +2987,15 @@ VCmpGtU16Vop3::VCmpGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u16_e64_dpp"
+          : "v_cmp_gt_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2590,7 +3005,7 @@ VCmpNeU16Vop3::VCmpNeU16Vop3(const MachineInst *inst)
                ? "v_cmp_ne_u16_e64_dpp"
                : "v_cmp_ne_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNeU16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNeU16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2637,7 +3052,15 @@ VCmpNeU16Vop3::VCmpNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u16_e64_dpp"
+          : "v_cmp_ne_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2647,7 +3070,7 @@ VCmpGeU16Vop3::VCmpGeU16Vop3(const MachineInst *inst)
                ? "v_cmp_ge_u16_e64_dpp"
                : "v_cmp_ge_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpGeU16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpGeU16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2694,7 +3117,15 @@ VCmpGeU16Vop3::VCmpGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u16_e64_dpp"
+          : "v_cmp_ge_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2704,7 +3135,7 @@ VCmpLtI32Vop3::VCmpLtI32Vop3(const MachineInst *inst)
                ? "v_cmp_lt_i32_e64_dpp"
                : "v_cmp_lt_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLtI32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLtI32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2743,7 +3174,15 @@ VCmpLtI32Vop3::VCmpLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i32_e64_dpp"
+          : "v_cmp_lt_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -2753,7 +3192,7 @@ VCmpEqI32Vop3::VCmpEqI32Vop3(const MachineInst *inst)
                ? "v_cmp_eq_i32_e64_dpp"
                : "v_cmp_eq_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpEqI32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpEqI32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2792,7 +3231,15 @@ VCmpEqI32Vop3::VCmpEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i32_e64_dpp"
+          : "v_cmp_eq_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -2802,7 +3249,7 @@ VCmpLeI32Vop3::VCmpLeI32Vop3(const MachineInst *inst)
                ? "v_cmp_le_i32_e64_dpp"
                : "v_cmp_le_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLeI32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLeI32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2841,7 +3288,15 @@ VCmpLeI32Vop3::VCmpLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i32_e64_dpp"
+          : "v_cmp_le_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -2851,7 +3306,7 @@ VCmpGtI32Vop3::VCmpGtI32Vop3(const MachineInst *inst)
                ? "v_cmp_gt_i32_e64_dpp"
                : "v_cmp_gt_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpGtI32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpGtI32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2890,7 +3345,15 @@ VCmpGtI32Vop3::VCmpGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i32_e64_dpp"
+          : "v_cmp_gt_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -2900,7 +3363,7 @@ VCmpNeI32Vop3::VCmpNeI32Vop3(const MachineInst *inst)
                ? "v_cmp_ne_i32_e64_dpp"
                : "v_cmp_ne_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNeI32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNeI32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2939,7 +3402,15 @@ VCmpNeI32Vop3::VCmpNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i32_e64_dpp"
+          : "v_cmp_ne_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -2949,7 +3420,7 @@ VCmpGeI32Vop3::VCmpGeI32Vop3(const MachineInst *inst)
                ? "v_cmp_ge_i32_e64_dpp"
                : "v_cmp_ge_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpGeI32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpGeI32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2988,7 +3459,15 @@ VCmpGeI32Vop3::VCmpGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i32_e64_dpp"
+          : "v_cmp_ge_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -2998,7 +3477,7 @@ VCmpLtU32Vop3::VCmpLtU32Vop3(const MachineInst *inst)
                ? "v_cmp_lt_u32_e64_dpp"
                : "v_cmp_lt_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLtU32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLtU32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3037,7 +3516,15 @@ VCmpLtU32Vop3::VCmpLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u32_e64_dpp"
+          : "v_cmp_lt_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3047,7 +3534,7 @@ VCmpEqU32Vop3::VCmpEqU32Vop3(const MachineInst *inst)
                ? "v_cmp_eq_u32_e64_dpp"
                : "v_cmp_eq_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpEqU32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpEqU32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3086,7 +3573,15 @@ VCmpEqU32Vop3::VCmpEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u32_e64_dpp"
+          : "v_cmp_eq_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3096,7 +3591,7 @@ VCmpLeU32Vop3::VCmpLeU32Vop3(const MachineInst *inst)
                ? "v_cmp_le_u32_e64_dpp"
                : "v_cmp_le_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLeU32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLeU32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3135,7 +3630,15 @@ VCmpLeU32Vop3::VCmpLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u32_e64_dpp"
+          : "v_cmp_le_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3145,7 +3648,7 @@ VCmpGtU32Vop3::VCmpGtU32Vop3(const MachineInst *inst)
                ? "v_cmp_gt_u32_e64_dpp"
                : "v_cmp_gt_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpGtU32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpGtU32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3184,7 +3687,15 @@ VCmpGtU32Vop3::VCmpGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u32_e64_dpp"
+          : "v_cmp_gt_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3194,7 +3705,7 @@ VCmpNeU32Vop3::VCmpNeU32Vop3(const MachineInst *inst)
                ? "v_cmp_ne_u32_e64_dpp"
                : "v_cmp_ne_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNeU32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNeU32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3233,7 +3744,15 @@ VCmpNeU32Vop3::VCmpNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u32_e64_dpp"
+          : "v_cmp_ne_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3243,7 +3762,7 @@ VCmpGeU32Vop3::VCmpGeU32Vop3(const MachineInst *inst)
                ? "v_cmp_ge_u32_e64_dpp"
                : "v_cmp_ge_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpGeU32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpGeU32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3282,7 +3801,15 @@ VCmpGeU32Vop3::VCmpGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u32_e64_dpp"
+          : "v_cmp_ge_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3292,7 +3819,7 @@ VCmpLtI64Vop3::VCmpLtI64Vop3(const MachineInst *inst)
                ? "v_cmp_lt_i64_e64_dpp"
                : "v_cmp_lt_i64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLtI64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLtI64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3311,15 +3838,23 @@ VCmpLtI64Vop3::VCmpLtI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_I64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i64_e64_dpp"
+          : "v_cmp_lt_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support DPP";
   return std::make_unique<VCmpLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -3329,7 +3864,7 @@ VCmpEqI64Vop3::VCmpEqI64Vop3(const MachineInst *inst)
                ? "v_cmp_eq_i64_e64_dpp"
                : "v_cmp_eq_i64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpEqI64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpEqI64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3348,15 +3883,23 @@ VCmpEqI64Vop3::VCmpEqI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i64_e64_dpp"
+          : "v_cmp_eq_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support DPP";
   return std::make_unique<VCmpEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -3366,7 +3909,7 @@ VCmpLeI64Vop3::VCmpLeI64Vop3(const MachineInst *inst)
                ? "v_cmp_le_i64_e64_dpp"
                : "v_cmp_le_i64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLeI64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLeI64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3385,15 +3928,23 @@ VCmpLeI64Vop3::VCmpLeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_I64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i64_e64_dpp"
+          : "v_cmp_le_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support DPP";
   return std::make_unique<VCmpLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -3403,7 +3954,7 @@ VCmpGtI64Vop3::VCmpGtI64Vop3(const MachineInst *inst)
                ? "v_cmp_gt_i64_e64_dpp"
                : "v_cmp_gt_i64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpGtI64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpGtI64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3422,15 +3973,23 @@ VCmpGtI64Vop3::VCmpGtI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_I64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i64_e64_dpp"
+          : "v_cmp_gt_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support DPP";
   return std::make_unique<VCmpGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -3440,7 +3999,7 @@ VCmpNeI64Vop3::VCmpNeI64Vop3(const MachineInst *inst)
                ? "v_cmp_ne_i64_e64_dpp"
                : "v_cmp_ne_i64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNeI64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNeI64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3459,15 +4018,23 @@ VCmpNeI64Vop3::VCmpNeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_I64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i64_e64_dpp"
+          : "v_cmp_ne_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support DPP";
   return std::make_unique<VCmpNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -3477,7 +4044,7 @@ VCmpGeI64Vop3::VCmpGeI64Vop3(const MachineInst *inst)
                ? "v_cmp_ge_i64_e64_dpp"
                : "v_cmp_ge_i64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpGeI64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpGeI64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3496,15 +4063,23 @@ VCmpGeI64Vop3::VCmpGeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_I64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i64_e64_dpp"
+          : "v_cmp_ge_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support DPP";
   return std::make_unique<VCmpGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -3514,7 +4089,7 @@ VCmpLtU64Vop3::VCmpLtU64Vop3(const MachineInst *inst)
                ? "v_cmp_lt_u64_e64_dpp"
                : "v_cmp_lt_u64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLtU64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLtU64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3533,15 +4108,23 @@ VCmpLtU64Vop3::VCmpLtU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_U64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u64_e64_dpp"
+          : "v_cmp_lt_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support DPP";
   return std::make_unique<VCmpLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -3551,7 +4134,7 @@ VCmpEqU64Vop3::VCmpEqU64Vop3(const MachineInst *inst)
                ? "v_cmp_eq_u64_e64_dpp"
                : "v_cmp_eq_u64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpEqU64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpEqU64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3570,15 +4153,23 @@ VCmpEqU64Vop3::VCmpEqU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u64_e64_dpp"
+          : "v_cmp_eq_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support DPP";
   return std::make_unique<VCmpEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -3588,7 +4179,7 @@ VCmpLeU64Vop3::VCmpLeU64Vop3(const MachineInst *inst)
                ? "v_cmp_le_u64_e64_dpp"
                : "v_cmp_le_u64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpLeU64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpLeU64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3607,15 +4198,23 @@ VCmpLeU64Vop3::VCmpLeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_U64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u64_e64_dpp"
+          : "v_cmp_le_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support DPP";
   return std::make_unique<VCmpLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -3625,7 +4224,7 @@ VCmpGtU64Vop3::VCmpGtU64Vop3(const MachineInst *inst)
                ? "v_cmp_gt_u64_e64_dpp"
                : "v_cmp_gt_u64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpGtU64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpGtU64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3644,15 +4243,23 @@ VCmpGtU64Vop3::VCmpGtU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_U64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u64_e64_dpp"
+          : "v_cmp_gt_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support DPP";
   return std::make_unique<VCmpGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -3662,7 +4269,7 @@ VCmpNeU64Vop3::VCmpNeU64Vop3(const MachineInst *inst)
                ? "v_cmp_ne_u64_e64_dpp"
                : "v_cmp_ne_u64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpNeU64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpNeU64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3681,15 +4288,23 @@ VCmpNeU64Vop3::VCmpNeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_U64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u64_e64_dpp"
+          : "v_cmp_ne_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support DPP";
   return std::make_unique<VCmpNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -3699,7 +4314,7 @@ VCmpGeU64Vop3::VCmpGeU64Vop3(const MachineInst *inst)
                ? "v_cmp_ge_u64_e64_dpp"
                : "v_cmp_ge_u64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpGeU64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpGeU64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3718,15 +4333,23 @@ VCmpGeU64Vop3::VCmpGeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_U64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u64_e64_dpp"
+          : "v_cmp_ge_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support DPP";
   return std::make_unique<VCmpGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -3736,8 +4359,7 @@ VCmpClassF16Vop3::VCmpClassF16Vop3(const MachineInst *inst)
                ? "v_cmp_class_f16_e64_dpp"
                : "v_cmp_class_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpClassF16Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCmpClassF16Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3784,7 +4406,16 @@ VCmpClassF16Vop3::VCmpClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f16_e64_dpp"
+          : "v_cmp_class_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3794,8 +4425,7 @@ VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)
                ? "v_cmp_class_f32_e64_dpp"
                : "v_cmp_class_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpClassF32Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCmpClassF32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3834,7 +4464,16 @@ VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f32_e64_dpp"
+          : "v_cmp_class_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3844,8 +4483,7 @@ VCmpClassF64Vop3::VCmpClassF64Vop3(const MachineInst *inst)
                ? "v_cmp_class_f64_e64_dpp"
                : "v_cmp_class_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpClassF64Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCmpClassF64Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3863,15 +4501,24 @@ VCmpClassF64Vop3::VCmpClassF64Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f64_e64_dpp"
+          : "v_cmp_class_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support DPP";
   return std::make_unique<VCmpClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -3881,7 +4528,7 @@ VCmpxLtF16Vop3::VCmpxLtF16Vop3(const MachineInst *inst)
                ? "v_cmpx_lt_f16_e64_dpp"
                : "v_cmpx_lt_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLtF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLtF16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3932,7 +4579,15 @@ VCmpxLtF16Vop3::VCmpxLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f16_e64_dpp"
+          : "v_cmpx_lt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3942,7 +4597,7 @@ VCmpxEqF16Vop3::VCmpxEqF16Vop3(const MachineInst *inst)
                ? "v_cmpx_eq_f16_e64_dpp"
                : "v_cmpx_eq_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxEqF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxEqF16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3993,7 +4648,15 @@ VCmpxEqF16Vop3::VCmpxEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f16_e64_dpp"
+          : "v_cmpx_eq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4003,7 +4666,7 @@ VCmpxLeF16Vop3::VCmpxLeF16Vop3(const MachineInst *inst)
                ? "v_cmpx_le_f16_e64_dpp"
                : "v_cmpx_le_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLeF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLeF16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4054,7 +4717,15 @@ VCmpxLeF16Vop3::VCmpxLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f16_e64_dpp"
+          : "v_cmpx_le_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4064,7 +4735,7 @@ VCmpxGtF16Vop3::VCmpxGtF16Vop3(const MachineInst *inst)
                ? "v_cmpx_gt_f16_e64_dpp"
                : "v_cmpx_gt_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxGtF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxGtF16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4115,7 +4786,15 @@ VCmpxGtF16Vop3::VCmpxGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f16_e64_dpp"
+          : "v_cmpx_gt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4125,7 +4804,7 @@ VCmpxLgF16Vop3::VCmpxLgF16Vop3(const MachineInst *inst)
                ? "v_cmpx_lg_f16_e64_dpp"
                : "v_cmpx_lg_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLgF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLgF16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4176,7 +4855,15 @@ VCmpxLgF16Vop3::VCmpxLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f16_e64_dpp"
+          : "v_cmpx_lg_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4186,7 +4873,7 @@ VCmpxGeF16Vop3::VCmpxGeF16Vop3(const MachineInst *inst)
                ? "v_cmpx_ge_f16_e64_dpp"
                : "v_cmpx_ge_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxGeF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxGeF16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4237,7 +4924,15 @@ VCmpxGeF16Vop3::VCmpxGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f16_e64_dpp"
+          : "v_cmpx_ge_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4247,7 +4942,7 @@ VCmpxOF16Vop3::VCmpxOF16Vop3(const MachineInst *inst)
                ? "v_cmpx_o_f16_e64_dpp"
                : "v_cmpx_o_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxOF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxOF16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4298,7 +4993,15 @@ VCmpxOF16Vop3::VCmpxOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f16_e64_dpp"
+          : "v_cmpx_o_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4308,7 +5011,7 @@ VCmpxUF16Vop3::VCmpxUF16Vop3(const MachineInst *inst)
                ? "v_cmpx_u_f16_e64_dpp"
                : "v_cmpx_u_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxUF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxUF16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4359,7 +5062,15 @@ VCmpxUF16Vop3::VCmpxUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f16_e64_dpp"
+          : "v_cmpx_u_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4369,7 +5080,7 @@ VCmpxNgeF16Vop3::VCmpxNgeF16Vop3(const MachineInst *inst)
                ? "v_cmpx_nge_f16_e64_dpp"
                : "v_cmpx_nge_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNgeF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNgeF16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4420,7 +5131,16 @@ VCmpxNgeF16Vop3::VCmpxNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f16_e64_dpp"
+          : "v_cmpx_nge_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4430,7 +5150,7 @@ VCmpxNlgF16Vop3::VCmpxNlgF16Vop3(const MachineInst *inst)
                ? "v_cmpx_nlg_f16_e64_dpp"
                : "v_cmpx_nlg_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNlgF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNlgF16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4481,7 +5201,16 @@ VCmpxNlgF16Vop3::VCmpxNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f16_e64_dpp"
+          : "v_cmpx_nlg_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4491,7 +5220,7 @@ VCmpxNgtF16Vop3::VCmpxNgtF16Vop3(const MachineInst *inst)
                ? "v_cmpx_ngt_f16_e64_dpp"
                : "v_cmpx_ngt_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNgtF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNgtF16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4542,7 +5271,16 @@ VCmpxNgtF16Vop3::VCmpxNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f16_e64_dpp"
+          : "v_cmpx_ngt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4552,7 +5290,7 @@ VCmpxNleF16Vop3::VCmpxNleF16Vop3(const MachineInst *inst)
                ? "v_cmpx_nle_f16_e64_dpp"
                : "v_cmpx_nle_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNleF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNleF16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4603,7 +5341,16 @@ VCmpxNleF16Vop3::VCmpxNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f16_e64_dpp"
+          : "v_cmpx_nle_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4613,7 +5360,7 @@ VCmpxNeqF16Vop3::VCmpxNeqF16Vop3(const MachineInst *inst)
                ? "v_cmpx_neq_f16_e64_dpp"
                : "v_cmpx_neq_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNeqF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNeqF16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4664,7 +5411,16 @@ VCmpxNeqF16Vop3::VCmpxNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f16_e64_dpp"
+          : "v_cmpx_neq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4674,7 +5430,7 @@ VCmpxNltF16Vop3::VCmpxNltF16Vop3(const MachineInst *inst)
                ? "v_cmpx_nlt_f16_e64_dpp"
                : "v_cmpx_nlt_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNltF16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNltF16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4725,7 +5481,16 @@ VCmpxNltF16Vop3::VCmpxNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f16_e64_dpp"
+          : "v_cmpx_nlt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4735,7 +5500,7 @@ VCmpxLtF32Vop3::VCmpxLtF32Vop3(const MachineInst *inst)
                ? "v_cmpx_lt_f32_e64_dpp"
                : "v_cmpx_lt_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLtF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLtF32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4778,7 +5543,15 @@ VCmpxLtF32Vop3::VCmpxLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f32_e64_dpp"
+          : "v_cmpx_lt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4788,7 +5561,7 @@ VCmpxEqF32Vop3::VCmpxEqF32Vop3(const MachineInst *inst)
                ? "v_cmpx_eq_f32_e64_dpp"
                : "v_cmpx_eq_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxEqF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxEqF32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4831,7 +5604,15 @@ VCmpxEqF32Vop3::VCmpxEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f32_e64_dpp"
+          : "v_cmpx_eq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4841,7 +5622,7 @@ VCmpxLeF32Vop3::VCmpxLeF32Vop3(const MachineInst *inst)
                ? "v_cmpx_le_f32_e64_dpp"
                : "v_cmpx_le_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLeF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLeF32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4884,7 +5665,15 @@ VCmpxLeF32Vop3::VCmpxLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f32_e64_dpp"
+          : "v_cmpx_le_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4894,7 +5683,7 @@ VCmpxGtF32Vop3::VCmpxGtF32Vop3(const MachineInst *inst)
                ? "v_cmpx_gt_f32_e64_dpp"
                : "v_cmpx_gt_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxGtF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxGtF32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4937,7 +5726,15 @@ VCmpxGtF32Vop3::VCmpxGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f32_e64_dpp"
+          : "v_cmpx_gt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4947,7 +5744,7 @@ VCmpxLgF32Vop3::VCmpxLgF32Vop3(const MachineInst *inst)
                ? "v_cmpx_lg_f32_e64_dpp"
                : "v_cmpx_lg_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLgF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLgF32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4990,7 +5787,15 @@ VCmpxLgF32Vop3::VCmpxLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f32_e64_dpp"
+          : "v_cmpx_lg_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5000,7 +5805,7 @@ VCmpxGeF32Vop3::VCmpxGeF32Vop3(const MachineInst *inst)
                ? "v_cmpx_ge_f32_e64_dpp"
                : "v_cmpx_ge_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxGeF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxGeF32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5043,7 +5848,15 @@ VCmpxGeF32Vop3::VCmpxGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f32_e64_dpp"
+          : "v_cmpx_ge_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5053,7 +5866,7 @@ VCmpxOF32Vop3::VCmpxOF32Vop3(const MachineInst *inst)
                ? "v_cmpx_o_f32_e64_dpp"
                : "v_cmpx_o_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxOF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxOF32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5096,7 +5909,15 @@ VCmpxOF32Vop3::VCmpxOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f32_e64_dpp"
+          : "v_cmpx_o_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5106,7 +5927,7 @@ VCmpxUF32Vop3::VCmpxUF32Vop3(const MachineInst *inst)
                ? "v_cmpx_u_f32_e64_dpp"
                : "v_cmpx_u_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxUF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxUF32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5149,7 +5970,15 @@ VCmpxUF32Vop3::VCmpxUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f32_e64_dpp"
+          : "v_cmpx_u_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5159,7 +5988,7 @@ VCmpxNgeF32Vop3::VCmpxNgeF32Vop3(const MachineInst *inst)
                ? "v_cmpx_nge_f32_e64_dpp"
                : "v_cmpx_nge_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNgeF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNgeF32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5202,7 +6031,16 @@ VCmpxNgeF32Vop3::VCmpxNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f32_e64_dpp"
+          : "v_cmpx_nge_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5212,7 +6050,7 @@ VCmpxNlgF32Vop3::VCmpxNlgF32Vop3(const MachineInst *inst)
                ? "v_cmpx_nlg_f32_e64_dpp"
                : "v_cmpx_nlg_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNlgF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNlgF32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5255,7 +6093,16 @@ VCmpxNlgF32Vop3::VCmpxNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f32_e64_dpp"
+          : "v_cmpx_nlg_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5265,7 +6112,7 @@ VCmpxNgtF32Vop3::VCmpxNgtF32Vop3(const MachineInst *inst)
                ? "v_cmpx_ngt_f32_e64_dpp"
                : "v_cmpx_ngt_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNgtF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNgtF32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5308,7 +6155,16 @@ VCmpxNgtF32Vop3::VCmpxNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f32_e64_dpp"
+          : "v_cmpx_ngt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5318,7 +6174,7 @@ VCmpxNleF32Vop3::VCmpxNleF32Vop3(const MachineInst *inst)
                ? "v_cmpx_nle_f32_e64_dpp"
                : "v_cmpx_nle_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNleF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNleF32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5361,7 +6217,16 @@ VCmpxNleF32Vop3::VCmpxNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f32_e64_dpp"
+          : "v_cmpx_nle_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5371,7 +6236,7 @@ VCmpxNeqF32Vop3::VCmpxNeqF32Vop3(const MachineInst *inst)
                ? "v_cmpx_neq_f32_e64_dpp"
                : "v_cmpx_neq_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNeqF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNeqF32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5414,7 +6279,16 @@ VCmpxNeqF32Vop3::VCmpxNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f32_e64_dpp"
+          : "v_cmpx_neq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5424,7 +6298,7 @@ VCmpxNltF32Vop3::VCmpxNltF32Vop3(const MachineInst *inst)
                ? "v_cmpx_nlt_f32_e64_dpp"
                : "v_cmpx_nlt_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNltF32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNltF32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5467,7 +6341,16 @@ VCmpxNltF32Vop3::VCmpxNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f32_e64_dpp"
+          : "v_cmpx_nlt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5477,7 +6360,7 @@ VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
                ? "v_cmpx_lt_f64_e64_dpp"
                : "v_cmpx_lt_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLtF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLtF64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5498,9 +6381,6 @@ VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -5508,7 +6388,18 @@ VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f64_e64_dpp"
+          : "v_cmpx_lt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support DPP";
   return std::make_unique<VCmpxLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5518,7 +6409,7 @@ VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
                ? "v_cmpx_eq_f64_e64_dpp"
                : "v_cmpx_eq_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxEqF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxEqF64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5539,9 +6430,6 @@ VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -5549,7 +6437,18 @@ VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f64_e64_dpp"
+          : "v_cmpx_eq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support DPP";
   return std::make_unique<VCmpxEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5559,7 +6458,7 @@ VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
                ? "v_cmpx_le_f64_e64_dpp"
                : "v_cmpx_le_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLeF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLeF64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5580,9 +6479,6 @@ VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -5590,7 +6486,18 @@ VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f64_e64_dpp"
+          : "v_cmpx_le_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support DPP";
   return std::make_unique<VCmpxLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5600,7 +6507,7 @@ VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
                ? "v_cmpx_gt_f64_e64_dpp"
                : "v_cmpx_gt_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxGtF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxGtF64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5621,9 +6528,6 @@ VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -5631,7 +6535,18 @@ VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f64_e64_dpp"
+          : "v_cmpx_gt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support DPP";
   return std::make_unique<VCmpxGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5641,7 +6556,7 @@ VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
                ? "v_cmpx_lg_f64_e64_dpp"
                : "v_cmpx_lg_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLgF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLgF64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5662,9 +6577,6 @@ VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -5672,7 +6584,18 @@ VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f64_e64_dpp"
+          : "v_cmpx_lg_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support DPP";
   return std::make_unique<VCmpxLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5682,7 +6605,7 @@ VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
                ? "v_cmpx_ge_f64_e64_dpp"
                : "v_cmpx_ge_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxGeF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxGeF64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5703,9 +6626,6 @@ VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -5713,7 +6633,18 @@ VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f64_e64_dpp"
+          : "v_cmpx_ge_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support DPP";
   return std::make_unique<VCmpxGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5723,7 +6654,7 @@ VCmpxOF64Vop3::VCmpxOF64Vop3(const MachineInst *inst)
                ? "v_cmpx_o_f64_e64_dpp"
                : "v_cmpx_o_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxOF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxOF64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5744,9 +6675,6 @@ VCmpxOF64Vop3::VCmpxOF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_O_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -5754,7 +6682,18 @@ VCmpxOF64Vop3::VCmpxOF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f64_e64_dpp"
+          : "v_cmpx_o_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support DPP";
   return std::make_unique<VCmpxOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5764,7 +6703,7 @@ VCmpxUF64Vop3::VCmpxUF64Vop3(const MachineInst *inst)
                ? "v_cmpx_u_f64_e64_dpp"
                : "v_cmpx_u_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxUF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxUF64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5785,9 +6724,6 @@ VCmpxUF64Vop3::VCmpxUF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_U_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -5795,7 +6731,18 @@ VCmpxUF64Vop3::VCmpxUF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f64_e64_dpp"
+          : "v_cmpx_u_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support DPP";
   return std::make_unique<VCmpxUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5805,7 +6752,7 @@ VCmpxNgeF64Vop3::VCmpxNgeF64Vop3(const MachineInst *inst)
                ? "v_cmpx_nge_f64_e64_dpp"
                : "v_cmpx_nge_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNgeF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNgeF64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5826,9 +6773,6 @@ VCmpxNgeF64Vop3::VCmpxNgeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -5836,7 +6780,19 @@ VCmpxNgeF64Vop3::VCmpxNgeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f64_e64_dpp"
+          : "v_cmpx_nge_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support DPP";
   return std::make_unique<VCmpxNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5846,7 +6802,7 @@ VCmpxNlgF64Vop3::VCmpxNlgF64Vop3(const MachineInst *inst)
                ? "v_cmpx_nlg_f64_e64_dpp"
                : "v_cmpx_nlg_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNlgF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNlgF64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5867,9 +6823,6 @@ VCmpxNlgF64Vop3::VCmpxNlgF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -5877,7 +6830,19 @@ VCmpxNlgF64Vop3::VCmpxNlgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f64_e64_dpp"
+          : "v_cmpx_nlg_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support DPP";
   return std::make_unique<VCmpxNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5887,7 +6852,7 @@ VCmpxNgtF64Vop3::VCmpxNgtF64Vop3(const MachineInst *inst)
                ? "v_cmpx_ngt_f64_e64_dpp"
                : "v_cmpx_ngt_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNgtF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNgtF64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5908,9 +6873,6 @@ VCmpxNgtF64Vop3::VCmpxNgtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -5918,7 +6880,19 @@ VCmpxNgtF64Vop3::VCmpxNgtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f64_e64_dpp"
+          : "v_cmpx_ngt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support DPP";
   return std::make_unique<VCmpxNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5928,7 +6902,7 @@ VCmpxNleF64Vop3::VCmpxNleF64Vop3(const MachineInst *inst)
                ? "v_cmpx_nle_f64_e64_dpp"
                : "v_cmpx_nle_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNleF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNleF64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5949,9 +6923,6 @@ VCmpxNleF64Vop3::VCmpxNleF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -5959,7 +6930,19 @@ VCmpxNleF64Vop3::VCmpxNleF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f64_e64_dpp"
+          : "v_cmpx_nle_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support DPP";
   return std::make_unique<VCmpxNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5969,7 +6952,7 @@ VCmpxNeqF64Vop3::VCmpxNeqF64Vop3(const MachineInst *inst)
                ? "v_cmpx_neq_f64_e64_dpp"
                : "v_cmpx_neq_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNeqF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNeqF64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5990,9 +6973,6 @@ VCmpxNeqF64Vop3::VCmpxNeqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -6000,7 +6980,19 @@ VCmpxNeqF64Vop3::VCmpxNeqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f64_e64_dpp"
+          : "v_cmpx_neq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support DPP";
   return std::make_unique<VCmpxNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6010,7 +7002,7 @@ VCmpxNltF64Vop3::VCmpxNltF64Vop3(const MachineInst *inst)
                ? "v_cmpx_nlt_f64_e64_dpp"
                : "v_cmpx_nlt_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNltF64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNltF64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6031,9 +7023,6 @@ VCmpxNltF64Vop3::VCmpxNltF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -6041,7 +7030,19 @@ VCmpxNltF64Vop3::VCmpxNltF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f64_e64_dpp"
+          : "v_cmpx_nlt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support DPP";
   return std::make_unique<VCmpxNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6051,7 +7052,7 @@ VCmpxLtI16Vop3::VCmpxLtI16Vop3(const MachineInst *inst)
                ? "v_cmpx_lt_i16_e64_dpp"
                : "v_cmpx_lt_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLtI16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLtI16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6102,7 +7103,15 @@ VCmpxLtI16Vop3::VCmpxLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i16_e64_dpp"
+          : "v_cmpx_lt_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -6112,7 +7121,7 @@ VCmpxEqI16Vop3::VCmpxEqI16Vop3(const MachineInst *inst)
                ? "v_cmpx_eq_i16_e64_dpp"
                : "v_cmpx_eq_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxEqI16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxEqI16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6163,7 +7172,15 @@ VCmpxEqI16Vop3::VCmpxEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i16_e64_dpp"
+          : "v_cmpx_eq_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -6173,7 +7190,7 @@ VCmpxLeI16Vop3::VCmpxLeI16Vop3(const MachineInst *inst)
                ? "v_cmpx_le_i16_e64_dpp"
                : "v_cmpx_le_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLeI16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLeI16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6224,7 +7241,15 @@ VCmpxLeI16Vop3::VCmpxLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i16_e64_dpp"
+          : "v_cmpx_le_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -6234,7 +7259,7 @@ VCmpxGtI16Vop3::VCmpxGtI16Vop3(const MachineInst *inst)
                ? "v_cmpx_gt_i16_e64_dpp"
                : "v_cmpx_gt_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxGtI16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxGtI16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6285,7 +7310,15 @@ VCmpxGtI16Vop3::VCmpxGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i16_e64_dpp"
+          : "v_cmpx_gt_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -6295,7 +7328,7 @@ VCmpxNeI16Vop3::VCmpxNeI16Vop3(const MachineInst *inst)
                ? "v_cmpx_ne_i16_e64_dpp"
                : "v_cmpx_ne_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNeI16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNeI16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6346,7 +7379,15 @@ VCmpxNeI16Vop3::VCmpxNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i16_e64_dpp"
+          : "v_cmpx_ne_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -6356,7 +7397,7 @@ VCmpxGeI16Vop3::VCmpxGeI16Vop3(const MachineInst *inst)
                ? "v_cmpx_ge_i16_e64_dpp"
                : "v_cmpx_ge_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxGeI16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxGeI16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6407,7 +7448,15 @@ VCmpxGeI16Vop3::VCmpxGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i16_e64_dpp"
+          : "v_cmpx_ge_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -6417,7 +7466,7 @@ VCmpxLtU16Vop3::VCmpxLtU16Vop3(const MachineInst *inst)
                ? "v_cmpx_lt_u16_e64_dpp"
                : "v_cmpx_lt_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLtU16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLtU16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6468,7 +7517,15 @@ VCmpxLtU16Vop3::VCmpxLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u16_e64_dpp"
+          : "v_cmpx_lt_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -6478,7 +7535,7 @@ VCmpxEqU16Vop3::VCmpxEqU16Vop3(const MachineInst *inst)
                ? "v_cmpx_eq_u16_e64_dpp"
                : "v_cmpx_eq_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxEqU16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxEqU16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6529,7 +7586,15 @@ VCmpxEqU16Vop3::VCmpxEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u16_e64_dpp"
+          : "v_cmpx_eq_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -6539,7 +7604,7 @@ VCmpxLeU16Vop3::VCmpxLeU16Vop3(const MachineInst *inst)
                ? "v_cmpx_le_u16_e64_dpp"
                : "v_cmpx_le_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLeU16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLeU16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6590,7 +7655,15 @@ VCmpxLeU16Vop3::VCmpxLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u16_e64_dpp"
+          : "v_cmpx_le_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -6600,7 +7673,7 @@ VCmpxGtU16Vop3::VCmpxGtU16Vop3(const MachineInst *inst)
                ? "v_cmpx_gt_u16_e64_dpp"
                : "v_cmpx_gt_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxGtU16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxGtU16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6651,7 +7724,15 @@ VCmpxGtU16Vop3::VCmpxGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u16_e64_dpp"
+          : "v_cmpx_gt_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -6661,7 +7742,7 @@ VCmpxNeU16Vop3::VCmpxNeU16Vop3(const MachineInst *inst)
                ? "v_cmpx_ne_u16_e64_dpp"
                : "v_cmpx_ne_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNeU16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNeU16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6712,7 +7793,15 @@ VCmpxNeU16Vop3::VCmpxNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u16_e64_dpp"
+          : "v_cmpx_ne_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -6722,7 +7811,7 @@ VCmpxGeU16Vop3::VCmpxGeU16Vop3(const MachineInst *inst)
                ? "v_cmpx_ge_u16_e64_dpp"
                : "v_cmpx_ge_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxGeU16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxGeU16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6773,7 +7862,15 @@ VCmpxGeU16Vop3::VCmpxGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u16_e64_dpp"
+          : "v_cmpx_ge_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -6783,7 +7880,7 @@ VCmpxLtI32Vop3::VCmpxLtI32Vop3(const MachineInst *inst)
                ? "v_cmpx_lt_i32_e64_dpp"
                : "v_cmpx_lt_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLtI32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLtI32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6826,7 +7923,15 @@ VCmpxLtI32Vop3::VCmpxLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i32_e64_dpp"
+          : "v_cmpx_lt_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -6836,7 +7941,7 @@ VCmpxEqI32Vop3::VCmpxEqI32Vop3(const MachineInst *inst)
                ? "v_cmpx_eq_i32_e64_dpp"
                : "v_cmpx_eq_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxEqI32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxEqI32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6879,7 +7984,15 @@ VCmpxEqI32Vop3::VCmpxEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i32_e64_dpp"
+          : "v_cmpx_eq_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -6889,7 +8002,7 @@ VCmpxLeI32Vop3::VCmpxLeI32Vop3(const MachineInst *inst)
                ? "v_cmpx_le_i32_e64_dpp"
                : "v_cmpx_le_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLeI32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLeI32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6932,7 +8045,15 @@ VCmpxLeI32Vop3::VCmpxLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i32_e64_dpp"
+          : "v_cmpx_le_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -6942,7 +8063,7 @@ VCmpxGtI32Vop3::VCmpxGtI32Vop3(const MachineInst *inst)
                ? "v_cmpx_gt_i32_e64_dpp"
                : "v_cmpx_gt_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxGtI32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxGtI32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6985,7 +8106,15 @@ VCmpxGtI32Vop3::VCmpxGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i32_e64_dpp"
+          : "v_cmpx_gt_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -6995,7 +8124,7 @@ VCmpxNeI32Vop3::VCmpxNeI32Vop3(const MachineInst *inst)
                ? "v_cmpx_ne_i32_e64_dpp"
                : "v_cmpx_ne_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNeI32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNeI32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7038,7 +8167,15 @@ VCmpxNeI32Vop3::VCmpxNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i32_e64_dpp"
+          : "v_cmpx_ne_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7048,7 +8185,7 @@ VCmpxGeI32Vop3::VCmpxGeI32Vop3(const MachineInst *inst)
                ? "v_cmpx_ge_i32_e64_dpp"
                : "v_cmpx_ge_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxGeI32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxGeI32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7091,7 +8228,15 @@ VCmpxGeI32Vop3::VCmpxGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i32_e64_dpp"
+          : "v_cmpx_ge_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -7101,7 +8246,7 @@ VCmpxLtU32Vop3::VCmpxLtU32Vop3(const MachineInst *inst)
                ? "v_cmpx_lt_u32_e64_dpp"
                : "v_cmpx_lt_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLtU32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLtU32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7144,7 +8289,15 @@ VCmpxLtU32Vop3::VCmpxLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u32_e64_dpp"
+          : "v_cmpx_lt_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7154,7 +8307,7 @@ VCmpxEqU32Vop3::VCmpxEqU32Vop3(const MachineInst *inst)
                ? "v_cmpx_eq_u32_e64_dpp"
                : "v_cmpx_eq_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxEqU32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxEqU32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7197,7 +8350,15 @@ VCmpxEqU32Vop3::VCmpxEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u32_e64_dpp"
+          : "v_cmpx_eq_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7207,7 +8368,7 @@ VCmpxLeU32Vop3::VCmpxLeU32Vop3(const MachineInst *inst)
                ? "v_cmpx_le_u32_e64_dpp"
                : "v_cmpx_le_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLeU32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLeU32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7250,7 +8411,15 @@ VCmpxLeU32Vop3::VCmpxLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u32_e64_dpp"
+          : "v_cmpx_le_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7260,7 +8429,7 @@ VCmpxGtU32Vop3::VCmpxGtU32Vop3(const MachineInst *inst)
                ? "v_cmpx_gt_u32_e64_dpp"
                : "v_cmpx_gt_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxGtU32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxGtU32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7303,7 +8472,15 @@ VCmpxGtU32Vop3::VCmpxGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u32_e64_dpp"
+          : "v_cmpx_gt_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7313,7 +8490,7 @@ VCmpxNeU32Vop3::VCmpxNeU32Vop3(const MachineInst *inst)
                ? "v_cmpx_ne_u32_e64_dpp"
                : "v_cmpx_ne_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNeU32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNeU32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7356,7 +8533,15 @@ VCmpxNeU32Vop3::VCmpxNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u32_e64_dpp"
+          : "v_cmpx_ne_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7366,7 +8551,7 @@ VCmpxGeU32Vop3::VCmpxGeU32Vop3(const MachineInst *inst)
                ? "v_cmpx_ge_u32_e64_dpp"
                : "v_cmpx_ge_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxGeU32Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxGeU32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7409,7 +8594,15 @@ VCmpxGeU32Vop3::VCmpxGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u32_e64_dpp"
+          : "v_cmpx_ge_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7419,7 +8612,7 @@ VCmpxLtI64Vop3::VCmpxLtI64Vop3(const MachineInst *inst)
                ? "v_cmpx_lt_i64_e64_dpp"
                : "v_cmpx_lt_i64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLtI64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLtI64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7440,9 +8633,6 @@ VCmpxLtI64Vop3::VCmpxLtI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -7450,7 +8640,18 @@ VCmpxLtI64Vop3::VCmpxLtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i64_e64_dpp"
+          : "v_cmpx_lt_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support DPP";
   return std::make_unique<VCmpxLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -7460,7 +8661,7 @@ VCmpxEqI64Vop3::VCmpxEqI64Vop3(const MachineInst *inst)
                ? "v_cmpx_eq_i64_e64_dpp"
                : "v_cmpx_eq_i64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxEqI64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxEqI64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7481,9 +8682,6 @@ VCmpxEqI64Vop3::VCmpxEqI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -7491,7 +8689,18 @@ VCmpxEqI64Vop3::VCmpxEqI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i64_e64_dpp"
+          : "v_cmpx_eq_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support DPP";
   return std::make_unique<VCmpxEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -7501,7 +8710,7 @@ VCmpxLeI64Vop3::VCmpxLeI64Vop3(const MachineInst *inst)
                ? "v_cmpx_le_i64_e64_dpp"
                : "v_cmpx_le_i64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLeI64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLeI64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7522,9 +8731,6 @@ VCmpxLeI64Vop3::VCmpxLeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -7532,7 +8738,18 @@ VCmpxLeI64Vop3::VCmpxLeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i64_e64_dpp"
+          : "v_cmpx_le_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support DPP";
   return std::make_unique<VCmpxLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -7542,7 +8759,7 @@ VCmpxGtI64Vop3::VCmpxGtI64Vop3(const MachineInst *inst)
                ? "v_cmpx_gt_i64_e64_dpp"
                : "v_cmpx_gt_i64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxGtI64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxGtI64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7563,9 +8780,6 @@ VCmpxGtI64Vop3::VCmpxGtI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -7573,7 +8787,18 @@ VCmpxGtI64Vop3::VCmpxGtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i64_e64_dpp"
+          : "v_cmpx_gt_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support DPP";
   return std::make_unique<VCmpxGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -7583,7 +8808,7 @@ VCmpxNeI64Vop3::VCmpxNeI64Vop3(const MachineInst *inst)
                ? "v_cmpx_ne_i64_e64_dpp"
                : "v_cmpx_ne_i64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNeI64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNeI64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7604,9 +8829,6 @@ VCmpxNeI64Vop3::VCmpxNeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -7614,7 +8836,18 @@ VCmpxNeI64Vop3::VCmpxNeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i64_e64_dpp"
+          : "v_cmpx_ne_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support DPP";
   return std::make_unique<VCmpxNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -7624,7 +8857,7 @@ VCmpxGeI64Vop3::VCmpxGeI64Vop3(const MachineInst *inst)
                ? "v_cmpx_ge_i64_e64_dpp"
                : "v_cmpx_ge_i64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxGeI64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxGeI64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7645,9 +8878,6 @@ VCmpxGeI64Vop3::VCmpxGeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -7655,7 +8885,18 @@ VCmpxGeI64Vop3::VCmpxGeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i64_e64_dpp"
+          : "v_cmpx_ge_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support DPP";
   return std::make_unique<VCmpxGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -7665,7 +8906,7 @@ VCmpxLtU64Vop3::VCmpxLtU64Vop3(const MachineInst *inst)
                ? "v_cmpx_lt_u64_e64_dpp"
                : "v_cmpx_lt_u64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLtU64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLtU64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7686,9 +8927,6 @@ VCmpxLtU64Vop3::VCmpxLtU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -7696,7 +8934,18 @@ VCmpxLtU64Vop3::VCmpxLtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u64_e64_dpp"
+          : "v_cmpx_lt_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support DPP";
   return std::make_unique<VCmpxLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -7706,7 +8955,7 @@ VCmpxEqU64Vop3::VCmpxEqU64Vop3(const MachineInst *inst)
                ? "v_cmpx_eq_u64_e64_dpp"
                : "v_cmpx_eq_u64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxEqU64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxEqU64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7727,9 +8976,6 @@ VCmpxEqU64Vop3::VCmpxEqU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -7737,7 +8983,18 @@ VCmpxEqU64Vop3::VCmpxEqU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u64_e64_dpp"
+          : "v_cmpx_eq_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support DPP";
   return std::make_unique<VCmpxEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -7747,7 +9004,7 @@ VCmpxLeU64Vop3::VCmpxLeU64Vop3(const MachineInst *inst)
                ? "v_cmpx_le_u64_e64_dpp"
                : "v_cmpx_le_u64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxLeU64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxLeU64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7768,9 +9025,6 @@ VCmpxLeU64Vop3::VCmpxLeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -7778,7 +9032,18 @@ VCmpxLeU64Vop3::VCmpxLeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u64_e64_dpp"
+          : "v_cmpx_le_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support DPP";
   return std::make_unique<VCmpxLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -7788,7 +9053,7 @@ VCmpxGtU64Vop3::VCmpxGtU64Vop3(const MachineInst *inst)
                ? "v_cmpx_gt_u64_e64_dpp"
                : "v_cmpx_gt_u64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxGtU64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxGtU64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7809,9 +9074,6 @@ VCmpxGtU64Vop3::VCmpxGtU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -7819,7 +9081,18 @@ VCmpxGtU64Vop3::VCmpxGtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u64_e64_dpp"
+          : "v_cmpx_gt_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support DPP";
   return std::make_unique<VCmpxGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -7829,7 +9102,7 @@ VCmpxNeU64Vop3::VCmpxNeU64Vop3(const MachineInst *inst)
                ? "v_cmpx_ne_u64_e64_dpp"
                : "v_cmpx_ne_u64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxNeU64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxNeU64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7850,9 +9123,6 @@ VCmpxNeU64Vop3::VCmpxNeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -7860,7 +9130,18 @@ VCmpxNeU64Vop3::VCmpxNeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u64_e64_dpp"
+          : "v_cmpx_ne_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support DPP";
   return std::make_unique<VCmpxNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -7870,7 +9151,7 @@ VCmpxGeU64Vop3::VCmpxGeU64Vop3(const MachineInst *inst)
                ? "v_cmpx_ge_u64_e64_dpp"
                : "v_cmpx_ge_u64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxGeU64Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCmpxGeU64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7891,9 +9172,6 @@ VCmpxGeU64Vop3::VCmpxGeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -7901,7 +9179,18 @@ VCmpxGeU64Vop3::VCmpxGeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u64_e64_dpp"
+          : "v_cmpx_ge_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support DPP";
   return std::make_unique<VCmpxGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -7911,8 +9200,7 @@ VCmpxClassF16Vop3::VCmpxClassF16Vop3(const MachineInst *inst)
                ? "v_cmpx_class_f16_e64_dpp"
                : "v_cmpx_class_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxClassF16Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCmpxClassF16Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7963,7 +9251,16 @@ VCmpxClassF16Vop3::VCmpxClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f16_e64_dpp"
+          : "v_cmpx_class_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -7973,8 +9270,7 @@ VCmpxClassF32Vop3::VCmpxClassF32Vop3(const MachineInst *inst)
                ? "v_cmpx_class_f32_e64_dpp"
                : "v_cmpx_class_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxClassF32Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCmpxClassF32Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8017,7 +9313,16 @@ VCmpxClassF32Vop3::VCmpxClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f32_e64_dpp"
+          : "v_cmpx_class_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -8027,8 +9332,7 @@ VCmpxClassF64Vop3::VCmpxClassF64Vop3(const MachineInst *inst)
                ? "v_cmpx_class_f64_e64_dpp"
                : "v_cmpx_class_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCmpxClassF64Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCmpxClassF64Vop3)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8048,9 +9352,6 @@ VCmpxClassF64Vop3::VCmpxClassF64Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -8058,7 +9359,19 @@ VCmpxClassF64Vop3::VCmpxClassF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f64_e64_dpp"
+          : "v_cmpx_class_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support DPP";
   return std::make_unique<VCmpxClassF64Vop3>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_cvt.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_cvt.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -18,7 +17,7 @@ VCvtI32F64Vop3::VCvtI32F64Vop3(const MachineInst *inst)
                ? "v_cvt_i32_f64_e64_dpp"
                : "v_cvt_i32_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtI32F64Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtI32F64Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -39,14 +38,22 @@ VCvtI32F64Vop3::VCvtI32F64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_I32_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f64_e64_dpp"
+          : "v_cvt_i32_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_I32_F64 does not support DPP8";
   return std::make_unique<VCvtI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -56,7 +63,7 @@ VCvtF64I32Vop3::VCvtF64I32Vop3(const MachineInst *inst)
                ? "v_cvt_f64_i32_e64_dpp"
                : "v_cvt_f64_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF64I32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtF64I32Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -76,14 +83,22 @@ VCvtF64I32Vop3::VCvtF64I32Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_I32 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_i32_e64_dpp"
+          : "v_cvt_f64_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_I32 does not support DPP8";
   return std::make_unique<VCvtF64I32Vop3>(opcode);
 }
 } // namespace detail
@@ -93,7 +108,7 @@ VCvtF32I32Vop3::VCvtF32I32Vop3(const MachineInst *inst)
                ? "v_cvt_f32_i32_e64_dpp"
                : "v_cvt_f32_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF32I32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtF32I32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -126,7 +141,15 @@ VCvtF32I32Vop3::VCvtF32I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_i32_e64_dpp"
+          : "v_cvt_f32_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop3>(opcode);
 }
 } // namespace detail
@@ -136,7 +159,7 @@ VCvtF32U32Vop3::VCvtF32U32Vop3(const MachineInst *inst)
                ? "v_cvt_f32_u32_e64_dpp"
                : "v_cvt_f32_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF32U32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtF32U32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -169,7 +192,15 @@ VCvtF32U32Vop3::VCvtF32U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_u32_e64_dpp"
+          : "v_cvt_f32_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop3>(opcode);
 }
 } // namespace detail
@@ -179,7 +210,7 @@ VCvtU32F32Vop3::VCvtU32F32Vop3(const MachineInst *inst)
                ? "v_cvt_u32_f32_e64_dpp"
                : "v_cvt_u32_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtU32F32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtU32F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -212,7 +243,15 @@ VCvtU32F32Vop3::VCvtU32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f32_e64_dpp"
+          : "v_cvt_u32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -222,7 +261,7 @@ VCvtI32F32Vop3::VCvtI32F32Vop3(const MachineInst *inst)
                ? "v_cvt_i32_f32_e64_dpp"
                : "v_cvt_i32_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtI32F32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtI32F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -255,7 +294,15 @@ VCvtI32F32Vop3::VCvtI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f32_e64_dpp"
+          : "v_cvt_i32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -265,7 +312,7 @@ VCvtF16F32Vop3::VCvtF16F32Vop3(const MachineInst *inst)
                ? "v_cvt_f16_f32_e64_dpp"
                : "v_cvt_f16_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF16F32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtF16F32Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -298,7 +345,15 @@ VCvtF16F32Vop3::VCvtF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_f32_e64_dpp"
+          : "v_cvt_f16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -321,7 +376,7 @@ VCvtF32F16Vop3::VCvtF32F16Vop3(const MachineInst *inst)
                ? "v_cvt_f32_f16_e64_dpp"
                : "v_cvt_f32_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF32F16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtF32F16Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -358,7 +413,15 @@ VCvtF32F16Vop3::VCvtF32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f16_e64_dpp"
+          : "v_cvt_f32_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -368,8 +431,7 @@ VCvtNearestI32F32Vop3::VCvtNearestI32F32Vop3(const MachineInst *inst)
                ? "v_cvt_nearest_i32_f32_e64_dpp"
                : "v_cvt_nearest_i32_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtNearestI32F32Vop3),
-           LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtNearestI32F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -402,7 +464,16 @@ VCvtNearestI32F32Vop3::VCvtNearestI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNearestI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNearestI32F32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_nearest_i32_f32_e64_dpp"
+          : "v_cvt_nearest_i32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNearestI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -412,8 +483,7 @@ VCvtFloorI32F32Vop3::VCvtFloorI32F32Vop3(const MachineInst *inst)
                ? "v_cvt_floor_i32_f32_e64_dpp"
                : "v_cvt_floor_i32_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtFloorI32F32Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VCvtFloorI32F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -446,7 +516,16 @@ VCvtFloorI32F32Vop3::VCvtFloorI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFloorI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtFloorI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_floor_i32_f32_e64_dpp"
+          : "v_cvt_floor_i32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFloorI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -456,8 +535,7 @@ VCvtOffF32I4Vop3::VCvtOffF32I4Vop3(const MachineInst *inst)
                ? "v_cvt_off_f32_i4_e64_dpp"
                : "v_cvt_off_f32_i4",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtOffF32I4Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VCvtOffF32I4Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -490,7 +568,16 @@ VCvtOffF32I4Vop3::VCvtOffF32I4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_off_f32_i4_e64_dpp"
+          : "v_cvt_off_f32_i4",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop3>(opcode);
 }
 } // namespace detail
@@ -500,7 +587,7 @@ VCvtF32F64Vop3::VCvtF32F64Vop3(const MachineInst *inst)
                ? "v_cvt_f32_f64_e64_dpp"
                : "v_cvt_f32_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF32F64Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtF32F64Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -521,14 +608,22 @@ VCvtF32F64Vop3::VCvtF32F64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F32_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f64_e64_dpp"
+          : "v_cvt_f32_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F32_F64 does not support DPP8";
   return std::make_unique<VCvtF32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -538,7 +633,7 @@ VCvtF64F32Vop3::VCvtF64F32Vop3(const MachineInst *inst)
                ? "v_cvt_f64_f32_e64_dpp"
                : "v_cvt_f64_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF64F32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtF64F32Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -558,14 +653,22 @@ VCvtF64F32Vop3::VCvtF64F32Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_F32 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_f32_e64_dpp"
+          : "v_cvt_f64_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support DPP8";
   return std::make_unique<VCvtF64F32Vop3>(opcode);
 }
 } // namespace detail
@@ -575,8 +678,7 @@ VCvtF32Ubyte0Vop3::VCvtF32Ubyte0Vop3(const MachineInst *inst)
                ? "v_cvt_f32_ubyte0_e64_dpp"
                : "v_cvt_f32_ubyte0",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF32Ubyte0Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VCvtF32Ubyte0Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -609,7 +711,16 @@ VCvtF32Ubyte0Vop3::VCvtF32Ubyte0Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte0_e64_dpp"
+          : "v_cvt_f32_ubyte0",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop3>(opcode);
 }
 } // namespace detail
@@ -619,8 +730,7 @@ VCvtF32Ubyte1Vop3::VCvtF32Ubyte1Vop3(const MachineInst *inst)
                ? "v_cvt_f32_ubyte1_e64_dpp"
                : "v_cvt_f32_ubyte1",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF32Ubyte1Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VCvtF32Ubyte1Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -653,7 +763,16 @@ VCvtF32Ubyte1Vop3::VCvtF32Ubyte1Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte1_e64_dpp"
+          : "v_cvt_f32_ubyte1",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop3>(opcode);
 }
 } // namespace detail
@@ -663,8 +782,7 @@ VCvtF32Ubyte2Vop3::VCvtF32Ubyte2Vop3(const MachineInst *inst)
                ? "v_cvt_f32_ubyte2_e64_dpp"
                : "v_cvt_f32_ubyte2",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF32Ubyte2Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VCvtF32Ubyte2Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -697,7 +815,16 @@ VCvtF32Ubyte2Vop3::VCvtF32Ubyte2Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte2_e64_dpp"
+          : "v_cvt_f32_ubyte2",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop3>(opcode);
 }
 } // namespace detail
@@ -707,8 +834,7 @@ VCvtF32Ubyte3Vop3::VCvtF32Ubyte3Vop3(const MachineInst *inst)
                ? "v_cvt_f32_ubyte3_e64_dpp"
                : "v_cvt_f32_ubyte3",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF32Ubyte3Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VCvtF32Ubyte3Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -741,7 +867,16 @@ VCvtF32Ubyte3Vop3::VCvtF32Ubyte3Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte3_e64_dpp"
+          : "v_cvt_f32_ubyte3",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop3>(opcode);
 }
 } // namespace detail
@@ -751,7 +886,7 @@ VCvtU32F64Vop3::VCvtU32F64Vop3(const MachineInst *inst)
                ? "v_cvt_u32_f64_e64_dpp"
                : "v_cvt_u32_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtU32F64Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtU32F64Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -772,14 +907,22 @@ VCvtU32F64Vop3::VCvtU32F64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_U32_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f64_e64_dpp"
+          : "v_cvt_u32_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_U32_F64 does not support DPP8";
   return std::make_unique<VCvtU32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -789,7 +932,7 @@ VCvtF64U32Vop3::VCvtF64U32Vop3(const MachineInst *inst)
                ? "v_cvt_f64_u32_e64_dpp"
                : "v_cvt_f64_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF64U32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtF64U32Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -809,14 +952,22 @@ VCvtF64U32Vop3::VCvtF64U32Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_U32 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_u32_e64_dpp"
+          : "v_cvt_f64_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_U32 does not support DPP8";
   return std::make_unique<VCvtF64U32Vop3>(opcode);
 }
 } // namespace detail
@@ -826,8 +977,7 @@ VFrexpExpI32F64Vop3::VFrexpExpI32F64Vop3(const MachineInst *inst)
                ? "v_frexp_exp_i32_f64_e64_dpp"
                : "v_frexp_exp_i32_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFrexpExpI32F64Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VFrexpExpI32F64Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -848,14 +998,23 @@ VFrexpExpI32F64Vop3::VFrexpExpI32F64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_EXP_I32_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f64_e64_dpp"
+          : "v_frexp_exp_i32_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_EXP_I32_F64 does not support DPP8";
   return std::make_unique<VFrexpExpI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -865,8 +1024,7 @@ VFrexpMantF64Vop3::VFrexpMantF64Vop3(const MachineInst *inst)
                ? "v_frexp_mant_f64_e64_dpp"
                : "v_frexp_mant_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFrexpMantF64Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VFrexpMantF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -887,14 +1045,23 @@ VFrexpMantF64Vop3::VFrexpMantF64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_MANT_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f64_e64_dpp"
+          : "v_frexp_mant_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_MANT_F64 does not support DPP8";
   return std::make_unique<VFrexpMantF64Vop3>(opcode);
 }
 } // namespace detail
@@ -904,8 +1071,7 @@ VFrexpExpI32F32Vop3::VFrexpExpI32F32Vop3(const MachineInst *inst)
                ? "v_frexp_exp_i32_f32_e64_dpp"
                : "v_frexp_exp_i32_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFrexpExpI32F32Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VFrexpExpI32F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -938,7 +1104,16 @@ VFrexpExpI32F32Vop3::VFrexpExpI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f32_e64_dpp"
+          : "v_frexp_exp_i32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -948,8 +1123,7 @@ VFrexpMantF32Vop3::VFrexpMantF32Vop3(const MachineInst *inst)
                ? "v_frexp_mant_f32_e64_dpp"
                : "v_frexp_mant_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFrexpMantF32Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VFrexpMantF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -982,7 +1156,16 @@ VFrexpMantF32Vop3::VFrexpMantF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f32_e64_dpp"
+          : "v_frexp_mant_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop3>(opcode);
 }
 } // namespace detail
@@ -992,7 +1175,7 @@ VCvtF16U16Vop3::VCvtF16U16Vop3(const MachineInst *inst)
                ? "v_cvt_f16_u16_e64_dpp"
                : "v_cvt_f16_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF16U16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtF16U16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1029,7 +1212,15 @@ VCvtF16U16Vop3::VCvtF16U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_u16_e64_dpp"
+          : "v_cvt_f16_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop3>(opcode);
 }
 } // namespace detail
@@ -1052,7 +1243,7 @@ VCvtF16I16Vop3::VCvtF16I16Vop3(const MachineInst *inst)
                ? "v_cvt_f16_i16_e64_dpp"
                : "v_cvt_f16_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF16I16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtF16I16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1089,7 +1280,15 @@ VCvtF16I16Vop3::VCvtF16I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_i16_e64_dpp"
+          : "v_cvt_f16_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop3>(opcode);
 }
 } // namespace detail
@@ -1112,7 +1311,7 @@ VCvtU16F16Vop3::VCvtU16F16Vop3(const MachineInst *inst)
                ? "v_cvt_u16_f16_e64_dpp"
                : "v_cvt_u16_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtU16F16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtU16F16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1149,7 +1348,15 @@ VCvtU16F16Vop3::VCvtU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u16_f16_e64_dpp"
+          : "v_cvt_u16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1172,7 +1379,7 @@ VCvtI16F16Vop3::VCvtI16F16Vop3(const MachineInst *inst)
                ? "v_cvt_i16_f16_e64_dpp"
                : "v_cvt_i16_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtI16F16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtI16F16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1209,7 +1416,15 @@ VCvtI16F16Vop3::VCvtI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i16_f16_e64_dpp"
+          : "v_cvt_i16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1232,8 +1447,7 @@ VFrexpMantF16Vop3::VFrexpMantF16Vop3(const MachineInst *inst)
                ? "v_frexp_mant_f16_e64_dpp"
                : "v_frexp_mant_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFrexpMantF16Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VFrexpMantF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1270,7 +1484,16 @@ VFrexpMantF16Vop3::VFrexpMantF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f16_e64_dpp"
+          : "v_frexp_mant_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1293,8 +1516,7 @@ VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
                ? "v_frexp_exp_i16_f16_e64_dpp"
                : "v_frexp_exp_i16_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFrexpExpI16F16Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VFrexpExpI16F16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1331,7 +1553,16 @@ VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i16_f16_e64_dpp"
+          : "v_frexp_exp_i16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1354,8 +1585,7 @@ VCvtNormI16F16Vop3::VCvtNormI16F16Vop3(const MachineInst *inst)
                ? "v_cvt_norm_i16_f16_e64_dpp"
                : "v_cvt_norm_i16_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtNormI16F16Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VCvtNormI16F16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1392,7 +1622,16 @@ VCvtNormI16F16Vop3::VCvtNormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_i16_f16_e64_dpp"
+          : "v_cvt_norm_i16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1415,8 +1654,7 @@ VCvtNormU16F16Vop3::VCvtNormU16F16Vop3(const MachineInst *inst)
                ? "v_cvt_norm_u16_f16_e64_dpp"
                : "v_cvt_norm_u16_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtNormU16F16Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VCvtNormU16F16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1453,7 +1691,16 @@ VCvtNormU16F16Vop3::VCvtNormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_u16_f16_e64_dpp"
+          : "v_cvt_norm_u16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1476,7 +1723,7 @@ VCvtI32I16Vop3::VCvtI32I16Vop3(const MachineInst *inst)
                ? "v_cvt_i32_i16_e64_dpp"
                : "v_cvt_i32_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtI32I16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtI32I16Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1513,7 +1760,15 @@ VCvtI32I16Vop3::VCvtI32I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_i16_e64_dpp"
+          : "v_cvt_i32_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32I16Vop3>(opcode);
 }
 } // namespace detail
@@ -1523,7 +1778,7 @@ VCvtU32U16Vop3::VCvtU32U16Vop3(const MachineInst *inst)
                ? "v_cvt_u32_u16_e64_dpp"
                : "v_cvt_u32_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtU32U16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtU32U16Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1560,7 +1815,15 @@ VCvtU32U16Vop3::VCvtU32U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_u16_e64_dpp"
+          : "v_cvt_u32_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32U16Vop3>(opcode);
 }
 } // namespace detail
@@ -1570,7 +1833,7 @@ VCvtF32Fp8Vop3::VCvtF32Fp8Vop3(const MachineInst *inst)
                ? "v_cvt_f32_fp8_e64_dpp"
                : "v_cvt_f32_fp8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF32Fp8Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtF32Fp8Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(8, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1603,7 +1866,15 @@ VCvtF32Fp8Vop3::VCvtF32Fp8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Fp8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Fp8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_fp8_e64_dpp"
+          : "v_cvt_f32_fp8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Fp8Vop3>(opcode);
 }
 } // namespace detail
@@ -1613,7 +1884,7 @@ VCvtF32Bf8Vop3::VCvtF32Bf8Vop3(const MachineInst *inst)
                ? "v_cvt_f32_bf8_e64_dpp"
                : "v_cvt_f32_bf8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF32Bf8Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtF32Bf8Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(8, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1646,7 +1917,15 @@ VCvtF32Bf8Vop3::VCvtF32Bf8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Bf8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Bf8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_bf8_e64_dpp"
+          : "v_cvt_f32_bf8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Bf8Vop3>(opcode);
 }
 } // namespace detail
@@ -1656,8 +1935,7 @@ VCvtPkF32Fp8Vop3::VCvtPkF32Fp8Vop3(const MachineInst *inst)
                ? "v_cvt_pk_f32_fp8_e64_dpp"
                : "v_cvt_pk_f32_fp8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkF32Fp8Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VCvtPkF32Fp8Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1672,15 +1950,24 @@ VCvtPkF32Fp8Vop3::VCvtPkF32Fp8Vop3(const MachineInst *inst)
                                (((amdgpu::vop3_opsel(inst_) >> 0) & 1u) * 16u)) &
                               0xFFFFu),
         true);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_PK_F32_FP8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF32Fp8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF32Fp8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_f32_fp8_e64_dpp"
+          : "v_cvt_pk_f32_fp8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_PK_F32_FP8 does not support DPP";
   return std::make_unique<VCvtPkF32Fp8Vop3>(opcode);
 }
 } // namespace detail
@@ -1690,8 +1977,7 @@ VCvtPkF32Bf8Vop3::VCvtPkF32Bf8Vop3(const MachineInst *inst)
                ? "v_cvt_pk_f32_bf8_e64_dpp"
                : "v_cvt_pk_f32_bf8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkF32Bf8Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VCvtPkF32Bf8Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1706,15 +1992,24 @@ VCvtPkF32Bf8Vop3::VCvtPkF32Bf8Vop3(const MachineInst *inst)
                                (((amdgpu::vop3_opsel(inst_) >> 0) & 1u) * 16u)) &
                               0xFFFFu),
         true);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_PK_F32_BF8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF32Bf8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF32Bf8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_f32_bf8_e64_dpp"
+          : "v_cvt_pk_f32_bf8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_PK_F32_BF8 does not support DPP";
   return std::make_unique<VCvtPkF32Bf8Vop3>(opcode);
 }
 } // namespace detail
@@ -1724,7 +2019,7 @@ VCvtF32Bf16Vop3::VCvtF32Bf16Vop3(const MachineInst *inst)
                ? "v_cvt_f32_bf16_e64_dpp"
                : "v_cvt_f32_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF32Bf16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtF32Bf16Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1761,7 +2056,16 @@ VCvtF32Bf16Vop3::VCvtF32Bf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Bf16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_bf16_e64_dpp"
+          : "v_cvt_f32_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -1771,8 +2075,7 @@ VCvtPkF16Fp8Vop3::VCvtPkF16Fp8Vop3(const MachineInst *inst)
                ? "v_cvt_pk_f16_fp8_e64_dpp"
                : "v_cvt_pk_f16_fp8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkF16Fp8Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VCvtPkF16Fp8Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1809,7 +2112,16 @@ VCvtPkF16Fp8Vop3::VCvtPkF16Fp8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF16Fp8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF16Fp8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_f16_fp8_e64_dpp"
+          : "v_cvt_pk_f16_fp8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkF16Fp8Vop3>(opcode);
 }
 } // namespace detail
@@ -1819,8 +2131,7 @@ VCvtPkF16Bf8Vop3::VCvtPkF16Bf8Vop3(const MachineInst *inst)
                ? "v_cvt_pk_f16_bf8_e64_dpp"
                : "v_cvt_pk_f16_bf8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkF16Bf8Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VCvtPkF16Bf8Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1857,7 +2168,16 @@ VCvtPkF16Bf8Vop3::VCvtPkF16Bf8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF16Bf8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF16Bf8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_f16_bf8_e64_dpp"
+          : "v_cvt_pk_f16_bf8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkF16Bf8Vop3>(opcode);
 }
 } // namespace detail
@@ -1867,7 +2187,7 @@ VCvtF16Fp8Vop3::VCvtF16Fp8Vop3(const MachineInst *inst)
                ? "v_cvt_f16_fp8_e64_dpp"
                : "v_cvt_f16_fp8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF16Fp8Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtF16Fp8Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(8, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1900,7 +2220,15 @@ VCvtF16Fp8Vop3::VCvtF16Fp8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16Fp8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16Fp8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_fp8_e64_dpp"
+          : "v_cvt_f16_fp8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16Fp8Vop3>(opcode);
 }
 } // namespace detail
@@ -1923,7 +2251,7 @@ VCvtF16Bf8Vop3::VCvtF16Bf8Vop3(const MachineInst *inst)
                ? "v_cvt_f16_bf8_e64_dpp"
                : "v_cvt_f16_bf8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtF16Bf8Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VCvtF16Bf8Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(8, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1956,7 +2284,15 @@ VCvtF16Bf8Vop3::VCvtF16Bf8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16Bf8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16Bf8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_bf8_e64_dpp"
+          : "v_cvt_f16_bf8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16Bf8Vop3>(opcode);
 }
 } // namespace detail
@@ -1979,8 +2315,7 @@ VCvtPkRtzF16F32Vop3::VCvtPkRtzF16F32Vop3(const MachineInst *inst)
                ? "v_cvt_pk_rtz_f16_f32_e64_dpp"
                : "v_cvt_pk_rtz_f16_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkRtzF16F32Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCvtPkRtzF16F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2020,7 +2355,16 @@ VCvtPkRtzF16F32Vop3::VCvtPkRtzF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkRtzF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkRtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_rtz_f16_f32_e64_dpp"
+          : "v_cvt_pk_rtz_f16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkRtzF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -2030,7 +2374,7 @@ VCvtPkU8F32Vop3::VCvtPkU8F32Vop3(const MachineInst *inst)
                ? "v_cvt_pk_u8_f32_e64_dpp"
                : "v_cvt_pk_u8_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkU8F32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCvtPkU8F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2077,7 +2421,16 @@ VCvtPkU8F32Vop3::VCvtPkU8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_u8_f32_e64_dpp"
+          : "v_cvt_pk_u8_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -2087,8 +2440,7 @@ VCvtScalef32SrPk8Fp4F32Vop3::VCvtScalef32SrPk8Fp4F32Vop3(const MachineInst *inst
                ? "v_cvt_scalef32_sr_pk8_fp4_f32_e64_dpp"
                : "v_cvt_scalef32_sr_pk8_fp4_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk8Fp4F32Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk8Fp4F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2107,9 +2459,6 @@ VCvtScalef32SrPk8Fp4F32Vop3::VCvtScalef32SrPk8Fp4F32Vop3(const MachineInst *inst
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_SR_PK8_FP4_F32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2117,7 +2466,19 @@ VCvtScalef32SrPk8Fp4F32Vop3::VCvtScalef32SrPk8Fp4F32Vop3(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk8Fp4F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk8Fp4F32Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_sr_pk8_fp4_f32_e64_dpp"
+          : "v_cvt_scalef32_sr_pk8_fp4_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_SR_PK8_FP4_F32 does not support DPP";
   return std::make_unique<VCvtScalef32SrPk8Fp4F32Vop3>(opcode);
 }
 } // namespace detail
@@ -2127,8 +2488,7 @@ VCvtScalef32SrPk8Fp8F32Vop3::VCvtScalef32SrPk8Fp8F32Vop3(const MachineInst *inst
                ? "v_cvt_scalef32_sr_pk8_fp8_f32_e64_dpp"
                : "v_cvt_scalef32_sr_pk8_fp8_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk8Fp8F32Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk8Fp8F32Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2147,9 +2507,6 @@ VCvtScalef32SrPk8Fp8F32Vop3::VCvtScalef32SrPk8Fp8F32Vop3(const MachineInst *inst
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_SR_PK8_FP8_F32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2157,7 +2514,19 @@ VCvtScalef32SrPk8Fp8F32Vop3::VCvtScalef32SrPk8Fp8F32Vop3(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk8Fp8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk8Fp8F32Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_sr_pk8_fp8_f32_e64_dpp"
+          : "v_cvt_scalef32_sr_pk8_fp8_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_SR_PK8_FP8_F32 does not support DPP";
   return std::make_unique<VCvtScalef32SrPk8Fp8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -2167,8 +2536,7 @@ VCvtScalef32SrPk8Bf8F32Vop3::VCvtScalef32SrPk8Bf8F32Vop3(const MachineInst *inst
                ? "v_cvt_scalef32_sr_pk8_bf8_f32_e64_dpp"
                : "v_cvt_scalef32_sr_pk8_bf8_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk8Bf8F32Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk8Bf8F32Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2187,9 +2555,6 @@ VCvtScalef32SrPk8Bf8F32Vop3::VCvtScalef32SrPk8Bf8F32Vop3(const MachineInst *inst
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_SR_PK8_BF8_F32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2197,7 +2562,19 @@ VCvtScalef32SrPk8Bf8F32Vop3::VCvtScalef32SrPk8Bf8F32Vop3(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk8Bf8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk8Bf8F32Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_sr_pk8_bf8_f32_e64_dpp"
+          : "v_cvt_scalef32_sr_pk8_bf8_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_SR_PK8_BF8_F32 does not support DPP";
   return std::make_unique<VCvtScalef32SrPk8Bf8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -2207,8 +2584,7 @@ VCvtScalePk8F16Fp4Vop3::VCvtScalePk8F16Fp4Vop3(const MachineInst *inst)
                ? "v_cvt_scale_pk8_f16_fp4_e64_dpp"
                : "v_cvt_scale_pk8_f16_fp4",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalePk8F16Fp4Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalePk8F16Fp4Vop3)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2221,16 +2597,25 @@ VCvtScalePk8F16Fp4Vop3::VCvtScalePk8F16Fp4Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALE_PK8_F16_FP4 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalePk8F16Fp4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalePk8F16Fp4Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scale_pk8_f16_fp4_e64_dpp"
+          : "v_cvt_scale_pk8_f16_fp4",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALE_PK8_F16_FP4 does not support DPP";
   return std::make_unique<VCvtScalePk8F16Fp4Vop3>(opcode);
 }
 } // namespace detail
@@ -2240,8 +2625,7 @@ VCvtScalePk8Bf16Fp4Vop3::VCvtScalePk8Bf16Fp4Vop3(const MachineInst *inst)
                ? "v_cvt_scale_pk8_bf16_fp4_e64_dpp"
                : "v_cvt_scale_pk8_bf16_fp4",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalePk8Bf16Fp4Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalePk8Bf16Fp4Vop3)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2254,16 +2638,25 @@ VCvtScalePk8Bf16Fp4Vop3::VCvtScalePk8Bf16Fp4Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALE_PK8_BF16_FP4 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalePk8Bf16Fp4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalePk8Bf16Fp4Vop3(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scale_pk8_bf16_fp4_e64_dpp"
+          : "v_cvt_scale_pk8_bf16_fp4",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALE_PK8_BF16_FP4 does not support DPP";
   return std::make_unique<VCvtScalePk8Bf16Fp4Vop3>(opcode);
 }
 } // namespace detail
@@ -2273,8 +2666,7 @@ VCvtScalePk8F32Fp4Vop3::VCvtScalePk8F32Fp4Vop3(const MachineInst *inst)
                ? "v_cvt_scale_pk8_f32_fp4_e64_dpp"
                : "v_cvt_scale_pk8_f32_fp4",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalePk8F32Fp4Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalePk8F32Fp4Vop3)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2287,16 +2679,25 @@ VCvtScalePk8F32Fp4Vop3::VCvtScalePk8F32Fp4Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALE_PK8_F32_FP4 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalePk8F32Fp4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalePk8F32Fp4Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scale_pk8_f32_fp4_e64_dpp"
+          : "v_cvt_scale_pk8_f32_fp4",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALE_PK8_F32_FP4 does not support DPP";
   return std::make_unique<VCvtScalePk8F32Fp4Vop3>(opcode);
 }
 } // namespace detail
@@ -2306,8 +2707,7 @@ VCvtScalePk8F16Fp8Vop3::VCvtScalePk8F16Fp8Vop3(const MachineInst *inst)
                ? "v_cvt_scale_pk8_f16_fp8_e64_dpp"
                : "v_cvt_scale_pk8_f16_fp8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalePk8F16Fp8Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalePk8F16Fp8Vop3)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2320,16 +2720,25 @@ VCvtScalePk8F16Fp8Vop3::VCvtScalePk8F16Fp8Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALE_PK8_F16_FP8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalePk8F16Fp8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalePk8F16Fp8Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scale_pk8_f16_fp8_e64_dpp"
+          : "v_cvt_scale_pk8_f16_fp8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALE_PK8_F16_FP8 does not support DPP";
   return std::make_unique<VCvtScalePk8F16Fp8Vop3>(opcode);
 }
 } // namespace detail
@@ -2339,8 +2748,7 @@ VCvtScalePk8Bf16Fp8Vop3::VCvtScalePk8Bf16Fp8Vop3(const MachineInst *inst)
                ? "v_cvt_scale_pk8_bf16_fp8_e64_dpp"
                : "v_cvt_scale_pk8_bf16_fp8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalePk8Bf16Fp8Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalePk8Bf16Fp8Vop3)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2353,16 +2761,25 @@ VCvtScalePk8Bf16Fp8Vop3::VCvtScalePk8Bf16Fp8Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALE_PK8_BF16_FP8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalePk8Bf16Fp8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalePk8Bf16Fp8Vop3(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scale_pk8_bf16_fp8_e64_dpp"
+          : "v_cvt_scale_pk8_bf16_fp8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALE_PK8_BF16_FP8 does not support DPP";
   return std::make_unique<VCvtScalePk8Bf16Fp8Vop3>(opcode);
 }
 } // namespace detail
@@ -2372,8 +2789,7 @@ VCvtScalePk8F32Fp8Vop3::VCvtScalePk8F32Fp8Vop3(const MachineInst *inst)
                ? "v_cvt_scale_pk8_f32_fp8_e64_dpp"
                : "v_cvt_scale_pk8_f32_fp8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalePk8F32Fp8Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalePk8F32Fp8Vop3)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2386,16 +2802,25 @@ VCvtScalePk8F32Fp8Vop3::VCvtScalePk8F32Fp8Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALE_PK8_F32_FP8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalePk8F32Fp8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalePk8F32Fp8Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scale_pk8_f32_fp8_e64_dpp"
+          : "v_cvt_scale_pk8_f32_fp8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALE_PK8_F32_FP8 does not support DPP";
   return std::make_unique<VCvtScalePk8F32Fp8Vop3>(opcode);
 }
 } // namespace detail
@@ -2405,8 +2830,7 @@ VCvtScalePk8F16Bf8Vop3::VCvtScalePk8F16Bf8Vop3(const MachineInst *inst)
                ? "v_cvt_scale_pk8_f16_bf8_e64_dpp"
                : "v_cvt_scale_pk8_f16_bf8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalePk8F16Bf8Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalePk8F16Bf8Vop3)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2419,16 +2843,25 @@ VCvtScalePk8F16Bf8Vop3::VCvtScalePk8F16Bf8Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALE_PK8_F16_BF8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalePk8F16Bf8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalePk8F16Bf8Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scale_pk8_f16_bf8_e64_dpp"
+          : "v_cvt_scale_pk8_f16_bf8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALE_PK8_F16_BF8 does not support DPP";
   return std::make_unique<VCvtScalePk8F16Bf8Vop3>(opcode);
 }
 } // namespace detail
@@ -2438,8 +2871,7 @@ VCvtScalePk8Bf16Bf8Vop3::VCvtScalePk8Bf16Bf8Vop3(const MachineInst *inst)
                ? "v_cvt_scale_pk8_bf16_bf8_e64_dpp"
                : "v_cvt_scale_pk8_bf16_bf8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalePk8Bf16Bf8Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalePk8Bf16Bf8Vop3)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2452,16 +2884,25 @@ VCvtScalePk8Bf16Bf8Vop3::VCvtScalePk8Bf16Bf8Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALE_PK8_BF16_BF8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalePk8Bf16Bf8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalePk8Bf16Bf8Vop3(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scale_pk8_bf16_bf8_e64_dpp"
+          : "v_cvt_scale_pk8_bf16_bf8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALE_PK8_BF16_BF8 does not support DPP";
   return std::make_unique<VCvtScalePk8Bf16Bf8Vop3>(opcode);
 }
 } // namespace detail
@@ -2471,8 +2912,7 @@ VCvtScalePk8F32Bf8Vop3::VCvtScalePk8F32Bf8Vop3(const MachineInst *inst)
                ? "v_cvt_scale_pk8_f32_bf8_e64_dpp"
                : "v_cvt_scale_pk8_f32_bf8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalePk8F32Bf8Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalePk8F32Bf8Vop3)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2485,16 +2925,25 @@ VCvtScalePk8F32Bf8Vop3::VCvtScalePk8F32Bf8Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALE_PK8_F32_BF8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalePk8F32Bf8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalePk8F32Bf8Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scale_pk8_f32_bf8_e64_dpp"
+          : "v_cvt_scale_pk8_f32_bf8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALE_PK8_F32_BF8 does not support DPP";
   return std::make_unique<VCvtScalePk8F32Bf8Vop3>(opcode);
 }
 } // namespace detail
@@ -2504,8 +2953,7 @@ VCvtScalef32Pk8Fp4F32Vop3::VCvtScalef32Pk8Fp4F32Vop3(const MachineInst *inst)
                ? "v_cvt_scalef32_pk8_fp4_f32_e64_dpp"
                : "v_cvt_scalef32_pk8_fp4_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk8Fp4F32Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk8Fp4F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2518,16 +2966,25 @@ VCvtScalef32Pk8Fp4F32Vop3::VCvtScalef32Pk8Fp4F32Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_PK8_FP4_F32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk8Fp4F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk8Fp4F32Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_pk8_fp4_f32_e64_dpp"
+          : "v_cvt_scalef32_pk8_fp4_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_PK8_FP4_F32 does not support DPP";
   return std::make_unique<VCvtScalef32Pk8Fp4F32Vop3>(opcode);
 }
 } // namespace detail
@@ -2537,8 +2994,7 @@ VCvtScalef32Pk8Fp4F16Vop3::VCvtScalef32Pk8Fp4F16Vop3(const MachineInst *inst)
                ? "v_cvt_scalef32_pk8_fp4_f16_e64_dpp"
                : "v_cvt_scalef32_pk8_fp4_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk8Fp4F16Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk8Fp4F16Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2551,16 +3007,25 @@ VCvtScalef32Pk8Fp4F16Vop3::VCvtScalef32Pk8Fp4F16Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_PK8_FP4_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk8Fp4F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk8Fp4F16Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_pk8_fp4_f16_e64_dpp"
+          : "v_cvt_scalef32_pk8_fp4_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_PK8_FP4_F16 does not support DPP";
   return std::make_unique<VCvtScalef32Pk8Fp4F16Vop3>(opcode);
 }
 } // namespace detail
@@ -2570,8 +3035,7 @@ VCvtScalef32Pk8Fp8Bf16Vop3::VCvtScalef32Pk8Fp8Bf16Vop3(const MachineInst *inst)
                ? "v_cvt_scalef32_pk8_fp8_bf16_e64_dpp"
                : "v_cvt_scalef32_pk8_fp8_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk8Fp8Bf16Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk8Fp8Bf16Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2584,16 +3048,25 @@ VCvtScalef32Pk8Fp8Bf16Vop3::VCvtScalef32Pk8Fp8Bf16Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_PK8_FP8_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk8Fp8Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk8Fp8Bf16Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_pk8_fp8_bf16_e64_dpp"
+          : "v_cvt_scalef32_pk8_fp8_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_PK8_FP8_BF16 does not support DPP";
   return std::make_unique<VCvtScalef32Pk8Fp8Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -2603,8 +3076,7 @@ VCvtScalef32Pk8Bf8Bf16Vop3::VCvtScalef32Pk8Bf8Bf16Vop3(const MachineInst *inst)
                ? "v_cvt_scalef32_pk8_bf8_bf16_e64_dpp"
                : "v_cvt_scalef32_pk8_bf8_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk8Bf8Bf16Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk8Bf8Bf16Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2617,16 +3089,25 @@ VCvtScalef32Pk8Bf8Bf16Vop3::VCvtScalef32Pk8Bf8Bf16Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_PK8_BF8_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk8Bf8Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk8Bf8Bf16Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_pk8_bf8_bf16_e64_dpp"
+          : "v_cvt_scalef32_pk8_bf8_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_PK8_BF8_BF16 does not support DPP";
   return std::make_unique<VCvtScalef32Pk8Bf8Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -2636,8 +3117,7 @@ VCvtScalef32Pk8Fp4Bf16Vop3::VCvtScalef32Pk8Fp4Bf16Vop3(const MachineInst *inst)
                ? "v_cvt_scalef32_pk8_fp4_bf16_e64_dpp"
                : "v_cvt_scalef32_pk8_fp4_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk8Fp4Bf16Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk8Fp4Bf16Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2650,16 +3130,25 @@ VCvtScalef32Pk8Fp4Bf16Vop3::VCvtScalef32Pk8Fp4Bf16Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_PK8_FP4_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk8Fp4Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk8Fp4Bf16Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_pk8_fp4_bf16_e64_dpp"
+          : "v_cvt_scalef32_pk8_fp4_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_PK8_FP4_BF16 does not support DPP";
   return std::make_unique<VCvtScalef32Pk8Fp4Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -2669,8 +3158,7 @@ VCvtScalef32SrPk8Fp4F16Vop3::VCvtScalef32SrPk8Fp4F16Vop3(const MachineInst *inst
                ? "v_cvt_scalef32_sr_pk8_fp4_f16_e64_dpp"
                : "v_cvt_scalef32_sr_pk8_fp4_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk8Fp4F16Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk8Fp4F16Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2689,9 +3177,6 @@ VCvtScalef32SrPk8Fp4F16Vop3::VCvtScalef32SrPk8Fp4F16Vop3(const MachineInst *inst
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_SR_PK8_FP4_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2699,7 +3184,19 @@ VCvtScalef32SrPk8Fp4F16Vop3::VCvtScalef32SrPk8Fp4F16Vop3(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk8Fp4F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk8Fp4F16Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_sr_pk8_fp4_f16_e64_dpp"
+          : "v_cvt_scalef32_sr_pk8_fp4_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_SR_PK8_FP4_F16 does not support DPP";
   return std::make_unique<VCvtScalef32SrPk8Fp4F16Vop3>(opcode);
 }
 } // namespace detail
@@ -2709,8 +3206,7 @@ VCvtScalef32SrPk8Fp4Bf16Vop3::VCvtScalef32SrPk8Fp4Bf16Vop3(const MachineInst *in
                ? "v_cvt_scalef32_sr_pk8_fp4_bf16_e64_dpp"
                : "v_cvt_scalef32_sr_pk8_fp4_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk8Fp4Bf16Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk8Fp4Bf16Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2729,9 +3225,6 @@ VCvtScalef32SrPk8Fp4Bf16Vop3::VCvtScalef32SrPk8Fp4Bf16Vop3(const MachineInst *in
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_SR_PK8_FP4_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2739,7 +3232,19 @@ VCvtScalef32SrPk8Fp4Bf16Vop3::VCvtScalef32SrPk8Fp4Bf16Vop3(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk8Fp4Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk8Fp4Bf16Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_sr_pk8_fp4_bf16_e64_dpp"
+          : "v_cvt_scalef32_sr_pk8_fp4_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_SR_PK8_FP4_BF16 does not support DPP";
   return std::make_unique<VCvtScalef32SrPk8Fp4Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -2749,8 +3254,7 @@ VCvtScalef32SrPk8Fp8F16Vop3::VCvtScalef32SrPk8Fp8F16Vop3(const MachineInst *inst
                ? "v_cvt_scalef32_sr_pk8_fp8_f16_e64_dpp"
                : "v_cvt_scalef32_sr_pk8_fp8_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk8Fp8F16Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk8Fp8F16Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2769,9 +3273,6 @@ VCvtScalef32SrPk8Fp8F16Vop3::VCvtScalef32SrPk8Fp8F16Vop3(const MachineInst *inst
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_SR_PK8_FP8_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2779,7 +3280,19 @@ VCvtScalef32SrPk8Fp8F16Vop3::VCvtScalef32SrPk8Fp8F16Vop3(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk8Fp8F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk8Fp8F16Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_sr_pk8_fp8_f16_e64_dpp"
+          : "v_cvt_scalef32_sr_pk8_fp8_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_SR_PK8_FP8_F16 does not support DPP";
   return std::make_unique<VCvtScalef32SrPk8Fp8F16Vop3>(opcode);
 }
 } // namespace detail
@@ -2789,8 +3302,7 @@ VCvtScalef32SrPk8Fp8Bf16Vop3::VCvtScalef32SrPk8Fp8Bf16Vop3(const MachineInst *in
                ? "v_cvt_scalef32_sr_pk8_fp8_bf16_e64_dpp"
                : "v_cvt_scalef32_sr_pk8_fp8_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk8Fp8Bf16Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk8Fp8Bf16Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2809,9 +3321,6 @@ VCvtScalef32SrPk8Fp8Bf16Vop3::VCvtScalef32SrPk8Fp8Bf16Vop3(const MachineInst *in
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_SR_PK8_FP8_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2819,7 +3328,19 @@ VCvtScalef32SrPk8Fp8Bf16Vop3::VCvtScalef32SrPk8Fp8Bf16Vop3(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk8Fp8Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk8Fp8Bf16Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_sr_pk8_fp8_bf16_e64_dpp"
+          : "v_cvt_scalef32_sr_pk8_fp8_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_SR_PK8_FP8_BF16 does not support DPP";
   return std::make_unique<VCvtScalef32SrPk8Fp8Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -2829,8 +3350,7 @@ VCvtScalef32SrPk8Bf8F16Vop3::VCvtScalef32SrPk8Bf8F16Vop3(const MachineInst *inst
                ? "v_cvt_scalef32_sr_pk8_bf8_f16_e64_dpp"
                : "v_cvt_scalef32_sr_pk8_bf8_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk8Bf8F16Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk8Bf8F16Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2849,9 +3369,6 @@ VCvtScalef32SrPk8Bf8F16Vop3::VCvtScalef32SrPk8Bf8F16Vop3(const MachineInst *inst
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_SR_PK8_BF8_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2859,7 +3376,19 @@ VCvtScalef32SrPk8Bf8F16Vop3::VCvtScalef32SrPk8Bf8F16Vop3(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk8Bf8F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk8Bf8F16Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_sr_pk8_bf8_f16_e64_dpp"
+          : "v_cvt_scalef32_sr_pk8_bf8_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_SR_PK8_BF8_F16 does not support DPP";
   return std::make_unique<VCvtScalef32SrPk8Bf8F16Vop3>(opcode);
 }
 } // namespace detail
@@ -2869,8 +3398,7 @@ VCvtScalef32SrPk8Bf8Bf16Vop3::VCvtScalef32SrPk8Bf8Bf16Vop3(const MachineInst *in
                ? "v_cvt_scalef32_sr_pk8_bf8_bf16_e64_dpp"
                : "v_cvt_scalef32_sr_pk8_bf8_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk8Bf8Bf16Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk8Bf8Bf16Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2889,9 +3417,6 @@ VCvtScalef32SrPk8Bf8Bf16Vop3::VCvtScalef32SrPk8Bf8Bf16Vop3(const MachineInst *in
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_SR_PK8_BF8_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2899,7 +3424,19 @@ VCvtScalef32SrPk8Bf8Bf16Vop3::VCvtScalef32SrPk8Bf8Bf16Vop3(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk8Bf8Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk8Bf8Bf16Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_sr_pk8_bf8_bf16_e64_dpp"
+          : "v_cvt_scalef32_sr_pk8_bf8_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_SR_PK8_BF8_BF16 does not support DPP";
   return std::make_unique<VCvtScalef32SrPk8Bf8Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -2909,8 +3446,7 @@ VCvtScalef32Pk8Fp8F32Vop3::VCvtScalef32Pk8Fp8F32Vop3(const MachineInst *inst)
                ? "v_cvt_scalef32_pk8_fp8_f32_e64_dpp"
                : "v_cvt_scalef32_pk8_fp8_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk8Fp8F32Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk8Fp8F32Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2923,16 +3459,25 @@ VCvtScalef32Pk8Fp8F32Vop3::VCvtScalef32Pk8Fp8F32Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_PK8_FP8_F32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk8Fp8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk8Fp8F32Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_pk8_fp8_f32_e64_dpp"
+          : "v_cvt_scalef32_pk8_fp8_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_PK8_FP8_F32 does not support DPP";
   return std::make_unique<VCvtScalef32Pk8Fp8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -2942,8 +3487,7 @@ VCvtScalef32Pk8Fp8F16Vop3::VCvtScalef32Pk8Fp8F16Vop3(const MachineInst *inst)
                ? "v_cvt_scalef32_pk8_fp8_f16_e64_dpp"
                : "v_cvt_scalef32_pk8_fp8_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk8Fp8F16Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk8Fp8F16Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2956,16 +3500,25 @@ VCvtScalef32Pk8Fp8F16Vop3::VCvtScalef32Pk8Fp8F16Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_PK8_FP8_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk8Fp8F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk8Fp8F16Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_pk8_fp8_f16_e64_dpp"
+          : "v_cvt_scalef32_pk8_fp8_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_PK8_FP8_F16 does not support DPP";
   return std::make_unique<VCvtScalef32Pk8Fp8F16Vop3>(opcode);
 }
 } // namespace detail
@@ -2975,8 +3528,7 @@ VCvtScalef32Pk8Bf8F32Vop3::VCvtScalef32Pk8Bf8F32Vop3(const MachineInst *inst)
                ? "v_cvt_scalef32_pk8_bf8_f32_e64_dpp"
                : "v_cvt_scalef32_pk8_bf8_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk8Bf8F32Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk8Bf8F32Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2989,16 +3541,25 @@ VCvtScalef32Pk8Bf8F32Vop3::VCvtScalef32Pk8Bf8F32Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_PK8_BF8_F32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk8Bf8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk8Bf8F32Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_pk8_bf8_f32_e64_dpp"
+          : "v_cvt_scalef32_pk8_bf8_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_PK8_BF8_F32 does not support DPP";
   return std::make_unique<VCvtScalef32Pk8Bf8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3008,8 +3569,7 @@ VCvtScalef32Pk8Bf8F16Vop3::VCvtScalef32Pk8Bf8F16Vop3(const MachineInst *inst)
                ? "v_cvt_scalef32_pk8_bf8_f16_e64_dpp"
                : "v_cvt_scalef32_pk8_bf8_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk8Bf8F16Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk8Bf8F16Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3022,16 +3582,25 @@ VCvtScalef32Pk8Bf8F16Vop3::VCvtScalef32Pk8Bf8F16Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_PK8_BF8_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk8Bf8F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk8Bf8F16Vop3(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_pk8_bf8_f16_e64_dpp"
+          : "v_cvt_scalef32_pk8_bf8_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_PK8_BF8_F16 does not support DPP";
   return std::make_unique<VCvtScalef32Pk8Bf8F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3041,8 +3610,7 @@ VCvtScalePk16F16Fp6Vop3::VCvtScalePk16F16Fp6Vop3(const MachineInst *inst)
                ? "v_cvt_scale_pk16_f16_fp6_e64_dpp"
                : "v_cvt_scale_pk16_f16_fp6",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalePk16F16Fp6Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalePk16F16Fp6Vop3)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(96, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3055,16 +3623,25 @@ VCvtScalePk16F16Fp6Vop3::VCvtScalePk16F16Fp6Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALE_PK16_F16_FP6 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalePk16F16Fp6Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalePk16F16Fp6Vop3(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scale_pk16_f16_fp6_e64_dpp"
+          : "v_cvt_scale_pk16_f16_fp6",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALE_PK16_F16_FP6 does not support DPP";
   return std::make_unique<VCvtScalePk16F16Fp6Vop3>(opcode);
 }
 } // namespace detail
@@ -3074,8 +3651,7 @@ VCvtScalePk16Bf16Fp6Vop3::VCvtScalePk16Bf16Fp6Vop3(const MachineInst *inst)
                ? "v_cvt_scale_pk16_bf16_fp6_e64_dpp"
                : "v_cvt_scale_pk16_bf16_fp6",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalePk16Bf16Fp6Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalePk16Bf16Fp6Vop3)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(96, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3088,16 +3664,25 @@ VCvtScalePk16Bf16Fp6Vop3::VCvtScalePk16Bf16Fp6Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALE_PK16_BF16_FP6 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalePk16Bf16Fp6Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalePk16Bf16Fp6Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scale_pk16_bf16_fp6_e64_dpp"
+          : "v_cvt_scale_pk16_bf16_fp6",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALE_PK16_BF16_FP6 does not support DPP";
   return std::make_unique<VCvtScalePk16Bf16Fp6Vop3>(opcode);
 }
 } // namespace detail
@@ -3107,8 +3692,7 @@ VCvtScalePk16F32Fp6Vop3::VCvtScalePk16F32Fp6Vop3(const MachineInst *inst)
                ? "v_cvt_scale_pk16_f32_fp6_e64_dpp"
                : "v_cvt_scale_pk16_f32_fp6",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalePk16F32Fp6Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalePk16F32Fp6Vop3)),
       vdst(512, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(96, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3121,16 +3705,25 @@ VCvtScalePk16F32Fp6Vop3::VCvtScalePk16F32Fp6Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALE_PK16_F32_FP6 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalePk16F32Fp6Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalePk16F32Fp6Vop3(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scale_pk16_f32_fp6_e64_dpp"
+          : "v_cvt_scale_pk16_f32_fp6",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALE_PK16_F32_FP6 does not support DPP";
   return std::make_unique<VCvtScalePk16F32Fp6Vop3>(opcode);
 }
 } // namespace detail
@@ -3140,8 +3733,7 @@ VCvtScalePk16F16Bf6Vop3::VCvtScalePk16F16Bf6Vop3(const MachineInst *inst)
                ? "v_cvt_scale_pk16_f16_bf6_e64_dpp"
                : "v_cvt_scale_pk16_f16_bf6",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalePk16F16Bf6Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalePk16F16Bf6Vop3)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(96, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3154,16 +3746,25 @@ VCvtScalePk16F16Bf6Vop3::VCvtScalePk16F16Bf6Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALE_PK16_F16_BF6 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalePk16F16Bf6Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalePk16F16Bf6Vop3(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scale_pk16_f16_bf6_e64_dpp"
+          : "v_cvt_scale_pk16_f16_bf6",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALE_PK16_F16_BF6 does not support DPP";
   return std::make_unique<VCvtScalePk16F16Bf6Vop3>(opcode);
 }
 } // namespace detail
@@ -3173,8 +3774,7 @@ VCvtScalePk16Bf16Bf6Vop3::VCvtScalePk16Bf16Bf6Vop3(const MachineInst *inst)
                ? "v_cvt_scale_pk16_bf16_bf6_e64_dpp"
                : "v_cvt_scale_pk16_bf16_bf6",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalePk16Bf16Bf6Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalePk16Bf16Bf6Vop3)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(96, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3187,16 +3787,25 @@ VCvtScalePk16Bf16Bf6Vop3::VCvtScalePk16Bf16Bf6Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALE_PK16_BF16_BF6 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalePk16Bf16Bf6Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalePk16Bf16Bf6Vop3(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scale_pk16_bf16_bf6_e64_dpp"
+          : "v_cvt_scale_pk16_bf16_bf6",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALE_PK16_BF16_BF6 does not support DPP";
   return std::make_unique<VCvtScalePk16Bf16Bf6Vop3>(opcode);
 }
 } // namespace detail
@@ -3206,8 +3815,7 @@ VCvtScalePk16F32Bf6Vop3::VCvtScalePk16F32Bf6Vop3(const MachineInst *inst)
                ? "v_cvt_scale_pk16_f32_bf6_e64_dpp"
                : "v_cvt_scale_pk16_f32_bf6",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalePk16F32Bf6Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalePk16F32Bf6Vop3)),
       vdst(512, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(96, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3220,16 +3828,25 @@ VCvtScalePk16F32Bf6Vop3::VCvtScalePk16F32Bf6Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALE_PK16_F32_BF6 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalePk16F32Bf6Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalePk16F32Bf6Vop3(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scale_pk16_f32_bf6_e64_dpp"
+          : "v_cvt_scale_pk16_f32_bf6",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALE_PK16_F32_BF6 does not support DPP";
   return std::make_unique<VCvtScalePk16F32Bf6Vop3>(opcode);
 }
 } // namespace detail
@@ -3239,8 +3856,7 @@ VCvtScalef32Pk16Fp6F32Vop3::VCvtScalef32Pk16Fp6F32Vop3(const MachineInst *inst)
                ? "v_cvt_scalef32_pk16_fp6_f32_e64_dpp"
                : "v_cvt_scalef32_pk16_fp6_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk16Fp6F32Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk16Fp6F32Vop3)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3253,16 +3869,25 @@ VCvtScalef32Pk16Fp6F32Vop3::VCvtScalef32Pk16Fp6F32Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_PK16_FP6_F32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk16Fp6F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk16Fp6F32Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_pk16_fp6_f32_e64_dpp"
+          : "v_cvt_scalef32_pk16_fp6_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_PK16_FP6_F32 does not support DPP";
   return std::make_unique<VCvtScalef32Pk16Fp6F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3272,8 +3897,7 @@ VCvtScalef32Pk16Bf6F32Vop3::VCvtScalef32Pk16Bf6F32Vop3(const MachineInst *inst)
                ? "v_cvt_scalef32_pk16_bf6_f32_e64_dpp"
                : "v_cvt_scalef32_pk16_bf6_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk16Bf6F32Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk16Bf6F32Vop3)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3286,16 +3910,25 @@ VCvtScalef32Pk16Bf6F32Vop3::VCvtScalef32Pk16Bf6F32Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_PK16_BF6_F32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk16Bf6F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk16Bf6F32Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_pk16_bf6_f32_e64_dpp"
+          : "v_cvt_scalef32_pk16_bf6_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_PK16_BF6_F32 does not support DPP";
   return std::make_unique<VCvtScalef32Pk16Bf6F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3305,8 +3938,7 @@ VCvtScalef32Pk16Fp6F16Vop3::VCvtScalef32Pk16Fp6F16Vop3(const MachineInst *inst)
                ? "v_cvt_scalef32_pk16_fp6_f16_e64_dpp"
                : "v_cvt_scalef32_pk16_fp6_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk16Fp6F16Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk16Fp6F16Vop3)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3319,16 +3951,25 @@ VCvtScalef32Pk16Fp6F16Vop3::VCvtScalef32Pk16Fp6F16Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_PK16_FP6_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk16Fp6F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk16Fp6F16Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_pk16_fp6_f16_e64_dpp"
+          : "v_cvt_scalef32_pk16_fp6_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_PK16_FP6_F16 does not support DPP";
   return std::make_unique<VCvtScalef32Pk16Fp6F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3338,8 +3979,7 @@ VCvtScalef32Pk16Bf6F16Vop3::VCvtScalef32Pk16Bf6F16Vop3(const MachineInst *inst)
                ? "v_cvt_scalef32_pk16_bf6_f16_e64_dpp"
                : "v_cvt_scalef32_pk16_bf6_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk16Bf6F16Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk16Bf6F16Vop3)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3352,16 +3992,25 @@ VCvtScalef32Pk16Bf6F16Vop3::VCvtScalef32Pk16Bf6F16Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_PK16_BF6_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk16Bf6F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk16Bf6F16Vop3(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_pk16_bf6_f16_e64_dpp"
+          : "v_cvt_scalef32_pk16_bf6_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_PK16_BF6_F16 does not support DPP";
   return std::make_unique<VCvtScalef32Pk16Bf6F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3371,8 +4020,7 @@ VCvtScalef32Pk16Fp6Bf16Vop3::VCvtScalef32Pk16Fp6Bf16Vop3(const MachineInst *inst
                ? "v_cvt_scalef32_pk16_fp6_bf16_e64_dpp"
                : "v_cvt_scalef32_pk16_fp6_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk16Fp6Bf16Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk16Fp6Bf16Vop3)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3385,16 +4033,25 @@ VCvtScalef32Pk16Fp6Bf16Vop3::VCvtScalef32Pk16Fp6Bf16Vop3(const MachineInst *inst
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_PK16_FP6_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk16Fp6Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk16Fp6Bf16Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_pk16_fp6_bf16_e64_dpp"
+          : "v_cvt_scalef32_pk16_fp6_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_PK16_FP6_BF16 does not support DPP";
   return std::make_unique<VCvtScalef32Pk16Fp6Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -3404,8 +4061,7 @@ VCvtScalef32Pk16Bf6Bf16Vop3::VCvtScalef32Pk16Bf6Bf16Vop3(const MachineInst *inst
                ? "v_cvt_scalef32_pk16_bf6_bf16_e64_dpp"
                : "v_cvt_scalef32_pk16_bf6_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk16Bf6Bf16Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32Pk16Bf6Bf16Vop3)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3418,16 +4074,25 @@ VCvtScalef32Pk16Bf6Bf16Vop3::VCvtScalef32Pk16Bf6Bf16Vop3(const MachineInst *inst
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_PK16_BF6_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32Pk16Bf6Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32Pk16Bf6Bf16Vop3(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_pk16_bf6_bf16_e64_dpp"
+          : "v_cvt_scalef32_pk16_bf6_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_PK16_BF6_BF16 does not support DPP";
   return std::make_unique<VCvtScalef32Pk16Bf6Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -3437,8 +4102,7 @@ VCvtScalef32SrPk16Fp6F32Vop3::VCvtScalef32SrPk16Fp6F32Vop3(const MachineInst *in
                ? "v_cvt_scalef32_sr_pk16_fp6_f32_e64_dpp"
                : "v_cvt_scalef32_sr_pk16_fp6_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk16Fp6F32Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk16Fp6F32Vop3)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3457,9 +4121,6 @@ VCvtScalef32SrPk16Fp6F32Vop3::VCvtScalef32SrPk16Fp6F32Vop3(const MachineInst *in
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_SR_PK16_FP6_F32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3467,7 +4128,19 @@ VCvtScalef32SrPk16Fp6F32Vop3::VCvtScalef32SrPk16Fp6F32Vop3(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk16Fp6F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk16Fp6F32Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_sr_pk16_fp6_f32_e64_dpp"
+          : "v_cvt_scalef32_sr_pk16_fp6_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_SR_PK16_FP6_F32 does not support DPP";
   return std::make_unique<VCvtScalef32SrPk16Fp6F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3477,8 +4150,7 @@ VCvtScalef32SrPk16Bf6F32Vop3::VCvtScalef32SrPk16Bf6F32Vop3(const MachineInst *in
                ? "v_cvt_scalef32_sr_pk16_bf6_f32_e64_dpp"
                : "v_cvt_scalef32_sr_pk16_bf6_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk16Bf6F32Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk16Bf6F32Vop3)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3497,9 +4169,6 @@ VCvtScalef32SrPk16Bf6F32Vop3::VCvtScalef32SrPk16Bf6F32Vop3(const MachineInst *in
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_SR_PK16_BF6_F32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3507,7 +4176,19 @@ VCvtScalef32SrPk16Bf6F32Vop3::VCvtScalef32SrPk16Bf6F32Vop3(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk16Bf6F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk16Bf6F32Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_sr_pk16_bf6_f32_e64_dpp"
+          : "v_cvt_scalef32_sr_pk16_bf6_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_SR_PK16_BF6_F32 does not support DPP";
   return std::make_unique<VCvtScalef32SrPk16Bf6F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3517,8 +4198,7 @@ VCvtScalef32SrPk16Fp6F16Vop3::VCvtScalef32SrPk16Fp6F16Vop3(const MachineInst *in
                ? "v_cvt_scalef32_sr_pk16_fp6_f16_e64_dpp"
                : "v_cvt_scalef32_sr_pk16_fp6_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk16Fp6F16Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk16Fp6F16Vop3)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3537,9 +4217,6 @@ VCvtScalef32SrPk16Fp6F16Vop3::VCvtScalef32SrPk16Fp6F16Vop3(const MachineInst *in
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_SR_PK16_FP6_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3547,7 +4224,19 @@ VCvtScalef32SrPk16Fp6F16Vop3::VCvtScalef32SrPk16Fp6F16Vop3(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk16Fp6F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk16Fp6F16Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_sr_pk16_fp6_f16_e64_dpp"
+          : "v_cvt_scalef32_sr_pk16_fp6_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_SR_PK16_FP6_F16 does not support DPP";
   return std::make_unique<VCvtScalef32SrPk16Fp6F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3557,8 +4246,7 @@ VCvtScalef32SrPk16Bf6F16Vop3::VCvtScalef32SrPk16Bf6F16Vop3(const MachineInst *in
                ? "v_cvt_scalef32_sr_pk16_bf6_f16_e64_dpp"
                : "v_cvt_scalef32_sr_pk16_bf6_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk16Bf6F16Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk16Bf6F16Vop3)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3577,9 +4265,6 @@ VCvtScalef32SrPk16Bf6F16Vop3::VCvtScalef32SrPk16Bf6F16Vop3(const MachineInst *in
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_SR_PK16_BF6_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3587,7 +4272,19 @@ VCvtScalef32SrPk16Bf6F16Vop3::VCvtScalef32SrPk16Bf6F16Vop3(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk16Bf6F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk16Bf6F16Vop3(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_sr_pk16_bf6_f16_e64_dpp"
+          : "v_cvt_scalef32_sr_pk16_bf6_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_SR_PK16_BF6_F16 does not support DPP";
   return std::make_unique<VCvtScalef32SrPk16Bf6F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3597,8 +4294,7 @@ VCvtScalef32SrPk16Fp6Bf16Vop3::VCvtScalef32SrPk16Fp6Bf16Vop3(const MachineInst *
                ? "v_cvt_scalef32_sr_pk16_fp6_bf16_e64_dpp"
                : "v_cvt_scalef32_sr_pk16_fp6_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk16Fp6Bf16Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk16Fp6Bf16Vop3)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3617,9 +4313,6 @@ VCvtScalef32SrPk16Fp6Bf16Vop3::VCvtScalef32SrPk16Fp6Bf16Vop3(const MachineInst *
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_SR_PK16_FP6_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3627,7 +4320,19 @@ VCvtScalef32SrPk16Fp6Bf16Vop3::VCvtScalef32SrPk16Fp6Bf16Vop3(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk16Fp6Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk16Fp6Bf16Vop3(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_sr_pk16_fp6_bf16_e64_dpp"
+          : "v_cvt_scalef32_sr_pk16_fp6_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_SR_PK16_FP6_BF16 does not support DPP";
   return std::make_unique<VCvtScalef32SrPk16Fp6Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -3637,8 +4342,7 @@ VCvtScalef32SrPk16Bf6Bf16Vop3::VCvtScalef32SrPk16Bf6Bf16Vop3(const MachineInst *
                ? "v_cvt_scalef32_sr_pk16_bf6_bf16_e64_dpp"
                : "v_cvt_scalef32_sr_pk16_bf6_bf16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk16Bf6Bf16Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCvtScalef32SrPk16Bf6Bf16Vop3)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3657,9 +4361,6 @@ VCvtScalef32SrPk16Bf6Bf16Vop3::VCvtScalef32SrPk16Bf6Bf16Vop3(const MachineInst *
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_SCALEF32_SR_PK16_BF6_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3667,7 +4368,19 @@ VCvtScalef32SrPk16Bf6Bf16Vop3::VCvtScalef32SrPk16Bf6Bf16Vop3(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtScalef32SrPk16Bf6Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtScalef32SrPk16Bf6Bf16Vop3(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_scalef32_sr_pk16_bf6_bf16_e64_dpp"
+          : "v_cvt_scalef32_sr_pk16_bf6_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_SCALEF32_SR_PK16_BF6_BF16 does not support DPP";
   return std::make_unique<VCvtScalef32SrPk16Bf6Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -3677,8 +4390,7 @@ VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
                ? "v_cvt_pk_i16_f32_e64_dpp"
                : "v_cvt_pk_i16_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkI16F32Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCvtPkI16F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3718,7 +4430,16 @@ VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkI16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkI16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_i16_f32_e64_dpp"
+          : "v_cvt_pk_i16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkI16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3728,8 +4449,7 @@ VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
                ? "v_cvt_pk_u16_f32_e64_dpp"
                : "v_cvt_pk_u16_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkU16F32Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCvtPkU16F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3769,7 +4489,16 @@ VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_u16_f32_e64_dpp"
+          : "v_cvt_pk_u16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3779,7 +4508,7 @@ VPackB32F16Vop3::VPackB32F16Vop3(const MachineInst *inst)
                ? "v_pack_b32_f16_e64_dpp"
                : "v_pack_b32_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPackB32F16Vop3), LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VPackB32F16Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3827,7 +4556,16 @@ VPackB32F16Vop3::VPackB32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_pack_b32_f16_e64_dpp"
+          : "v_pack_b32_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPackB32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3837,8 +4575,7 @@ VCvtPkNormI16F16Vop3::VCvtPkNormI16F16Vop3(const MachineInst *inst)
                ? "v_cvt_pk_norm_i16_f16_e64_dpp"
                : "v_cvt_pk_norm_i16_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkNormI16F16Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtPkNormI16F16Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3886,7 +4623,16 @@ VCvtPkNormI16F16Vop3::VCvtPkNormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkNormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkNormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_norm_i16_f16_e64_dpp"
+          : "v_cvt_pk_norm_i16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkNormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3896,8 +4642,7 @@ VCvtPkNormU16F16Vop3::VCvtPkNormU16F16Vop3(const MachineInst *inst)
                ? "v_cvt_pk_norm_u16_f16_e64_dpp"
                : "v_cvt_pk_norm_u16_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkNormU16F16Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtPkNormU16F16Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3945,7 +4690,16 @@ VCvtPkNormU16F16Vop3::VCvtPkNormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkNormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkNormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_norm_u16_f16_e64_dpp"
+          : "v_cvt_pk_norm_u16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkNormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3955,8 +4709,7 @@ VCvtPkNormI16F32Vop3::VCvtPkNormI16F32Vop3(const MachineInst *inst)
                ? "v_cvt_pk_norm_i16_f32_e64_dpp"
                : "v_cvt_pk_norm_i16_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkNormI16F32Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtPkNormI16F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3996,7 +4749,16 @@ VCvtPkNormI16F32Vop3::VCvtPkNormI16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkNormI16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkNormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_norm_i16_f32_e64_dpp"
+          : "v_cvt_pk_norm_i16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkNormI16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4006,8 +4768,7 @@ VCvtPkNormU16F32Vop3::VCvtPkNormU16F32Vop3(const MachineInst *inst)
                ? "v_cvt_pk_norm_u16_f32_e64_dpp"
                : "v_cvt_pk_norm_u16_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkNormU16F32Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VCvtPkNormU16F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4047,7 +4808,16 @@ VCvtPkNormU16F32Vop3::VCvtPkNormU16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkNormU16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkNormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_norm_u16_f32_e64_dpp"
+          : "v_cvt_pk_norm_u16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkNormU16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4057,8 +4827,7 @@ VCvtPkU16U32Vop3::VCvtPkU16U32Vop3(const MachineInst *inst)
                ? "v_cvt_pk_u16_u32_e64_dpp"
                : "v_cvt_pk_u16_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkU16U32Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCvtPkU16U32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4098,7 +4867,16 @@ VCvtPkU16U32Vop3::VCvtPkU16U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_u16_u32_e64_dpp"
+          : "v_cvt_pk_u16_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU16U32Vop3>(opcode);
 }
 } // namespace detail
@@ -4108,8 +4886,7 @@ VCvtPkI16I32Vop3::VCvtPkI16I32Vop3(const MachineInst *inst)
                ? "v_cvt_pk_i16_i32_e64_dpp"
                : "v_cvt_pk_i16_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkI16I32Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCvtPkI16I32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4149,7 +4926,16 @@ VCvtPkI16I32Vop3::VCvtPkI16I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_i16_i32_e64_dpp"
+          : "v_cvt_pk_i16_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkI16I32Vop3>(opcode);
 }
 } // namespace detail
@@ -4159,8 +4945,7 @@ VCvtPkFp8F32Vop3::VCvtPkFp8F32Vop3(const MachineInst *inst)
                ? "v_cvt_pk_fp8_f32_e64_dpp"
                : "v_cvt_pk_fp8_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkFp8F32Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCvtPkFp8F32Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4200,7 +4985,16 @@ VCvtPkFp8F32Vop3::VCvtPkFp8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkFp8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkFp8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_fp8_f32_e64_dpp"
+          : "v_cvt_pk_fp8_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkFp8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4223,8 +5017,7 @@ VCvtPkBf8F32Vop3::VCvtPkBf8F32Vop3(const MachineInst *inst)
                ? "v_cvt_pk_bf8_f32_e64_dpp"
                : "v_cvt_pk_bf8_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkBf8F32Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCvtPkBf8F32Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4264,7 +5057,16 @@ VCvtPkBf8F32Vop3::VCvtPkBf8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkBf8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkBf8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_bf8_f32_e64_dpp"
+          : "v_cvt_pk_bf8_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkBf8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4287,8 +5089,7 @@ VCvtSrFp8F32Vop3::VCvtSrFp8F32Vop3(const MachineInst *inst)
                ? "v_cvt_sr_fp8_f32_e64_dpp"
                : "v_cvt_sr_fp8_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtSrFp8F32Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCvtSrFp8F32Vop3)),
       vdst(8, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4328,7 +5129,16 @@ VCvtSrFp8F32Vop3::VCvtSrFp8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtSrFp8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtSrFp8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_sr_fp8_f32_e64_dpp"
+          : "v_cvt_sr_fp8_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtSrFp8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4351,8 +5161,7 @@ VCvtSrBf8F32Vop3::VCvtSrBf8F32Vop3(const MachineInst *inst)
                ? "v_cvt_sr_bf8_f32_e64_dpp"
                : "v_cvt_sr_bf8_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtSrBf8F32Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCvtSrBf8F32Vop3)),
       vdst(8, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4392,7 +5201,16 @@ VCvtSrBf8F32Vop3::VCvtSrBf8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtSrBf8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtSrBf8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_sr_bf8_f32_e64_dpp"
+          : "v_cvt_sr_bf8_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtSrBf8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4415,8 +5233,7 @@ VCvtPkBf16F32Vop3::VCvtPkBf16F32Vop3(const MachineInst *inst)
                ? "v_cvt_pk_bf16_f32_e64_dpp"
                : "v_cvt_pk_bf16_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkBf16F32Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCvtPkBf16F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4456,7 +5273,16 @@ VCvtPkBf16F32Vop3::VCvtPkBf16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkBf16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkBf16F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_bf16_f32_e64_dpp"
+          : "v_cvt_pk_bf16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkBf16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4466,8 +5292,7 @@ VCvtSrPkBf16F32Vop3::VCvtSrPkBf16F32Vop3(const MachineInst *inst)
                ? "v_cvt_sr_pk_bf16_f32_e64_dpp"
                : "v_cvt_sr_pk_bf16_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtSrPkBf16F32Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCvtSrPkBf16F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4514,7 +5339,16 @@ VCvtSrPkBf16F32Vop3::VCvtSrPkBf16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtSrPkBf16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtSrPkBf16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_sr_pk_bf16_f32_e64_dpp"
+          : "v_cvt_sr_pk_bf16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtSrPkBf16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4524,8 +5358,7 @@ VCvtPkF16F32Vop3::VCvtPkF16F32Vop3(const MachineInst *inst)
                ? "v_cvt_pk_f16_f32_e64_dpp"
                : "v_cvt_pk_f16_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkF16F32Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCvtPkF16F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4565,7 +5398,16 @@ VCvtPkF16F32Vop3::VCvtPkF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_f16_f32_e64_dpp"
+          : "v_cvt_pk_f16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4575,7 +5417,7 @@ VCvtSrPkF16F32Vop3::VCvtSrPkF16F32Vop3(const MachineInst *inst)
                ? "v_cvt_sr_pk_f16_f32_e64_dpp"
                : "v_cvt_sr_pk_f16_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtSrPkF16F32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCvtSrPkF16F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4622,7 +5464,16 @@ VCvtSrPkF16F32Vop3::VCvtSrPkF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtSrPkF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtSrPkF16F32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_sr_pk_f16_f32_e64_dpp"
+          : "v_cvt_sr_pk_f16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtSrPkF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4632,8 +5483,7 @@ VCvtPkFp8F16Vop3::VCvtPkFp8F16Vop3(const MachineInst *inst)
                ? "v_cvt_pk_fp8_f16_e64_dpp"
                : "v_cvt_pk_fp8_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkFp8F16Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VCvtPkFp8F16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_NOINLINE, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4666,7 +5516,16 @@ VCvtPkFp8F16Vop3::VCvtPkFp8F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkFp8F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkFp8F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_fp8_f16_e64_dpp"
+          : "v_cvt_pk_fp8_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkFp8F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4689,8 +5548,7 @@ VCvtPkBf8F16Vop3::VCvtPkBf8F16Vop3(const MachineInst *inst)
                ? "v_cvt_pk_bf8_f16_e64_dpp"
                : "v_cvt_pk_bf8_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtPkBf8F16Vop3), LiteralSupport::Literal32,
-           1),
+           selected_exec_fn(InstructionExecutionId::VCvtPkBf8F16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_NOINLINE, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4723,7 +5581,16 @@ VCvtPkBf8F16Vop3::VCvtPkBf8F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkBf8F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkBf8F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_bf8_f16_e64_dpp"
+          : "v_cvt_pk_bf8_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkBf8F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4746,8 +5613,7 @@ VCvtSrFp8F16Vop3::VCvtSrFp8F16Vop3(const MachineInst *inst)
                ? "v_cvt_sr_fp8_f16_e64_dpp"
                : "v_cvt_sr_fp8_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtSrFp8F16Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCvtSrFp8F16Vop3)),
       vdst(8, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4791,7 +5657,16 @@ VCvtSrFp8F16Vop3::VCvtSrFp8F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtSrFp8F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtSrFp8F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_sr_fp8_f16_e64_dpp"
+          : "v_cvt_sr_fp8_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtSrFp8F16Vop3>(opcode);
 }
 } // namespace detail
@@ -4814,8 +5689,7 @@ VCvtSrBf8F16Vop3::VCvtSrBf8F16Vop3(const MachineInst *inst)
                ? "v_cvt_sr_bf8_f16_e64_dpp"
                : "v_cvt_sr_bf8_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCvtSrBf8F16Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VCvtSrBf8F16Vop3)),
       vdst(8, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4859,7 +5733,16 @@ VCvtSrBf8F16Vop3::VCvtSrBf8F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtSrBf8F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtSrBf8F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_sr_bf8_f16_e64_dpp"
+          : "v_cvt_sr_bf8_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtSrBf8F16Vop3>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_data.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_data.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -18,7 +17,7 @@ VMovB32Vop3::VMovB32Vop3(const MachineInst *inst)
                ? "v_mov_b32_e64_dpp"
                : "v_mov_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMovB32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VMovB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -51,7 +50,15 @@ VMovB32Vop3::VMovB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mov_b32_e64_dpp"
+          : "v_mov_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop3>(opcode);
 }
 } // namespace detail
@@ -61,22 +68,30 @@ VReadfirstlaneB32Vop3::VReadfirstlaneB32Vop3(const MachineInst *inst)
                ? "v_readfirstlane_b32_e64_dpp"
                : "v_readfirstlane_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VReadfirstlaneB32Vop3), LiteralSupport::None,
-           1),
+           selected_exec_fn(InstructionExecutionId::VReadfirstlaneB32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_readfirstlane_b32_e64_dpp"
+          : "v_readfirstlane_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::None, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support DPP";
   return std::make_unique<VReadfirstlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -86,7 +101,7 @@ VMovB16Vop3::VMovB16Vop3(const MachineInst *inst)
                ? "v_mov_b16_e64_dpp"
                : "v_mov_b16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMovB16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VMovB16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -123,7 +138,15 @@ VMovB16Vop3::VMovB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mov_b16_e64_dpp"
+          : "v_mov_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB16Vop3>(opcode);
 }
 } // namespace detail
@@ -145,7 +168,7 @@ VMovB64Vop3::VMovB64Vop3(const MachineInst *inst)
                ? "v_mov_b64_e64_dpp"
                : "v_mov_b64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMovB64Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VMovB64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -166,14 +189,22 @@ VMovB64Vop3::VMovB64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MOV_B64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mov_b64_e64_dpp"
+          : "v_mov_b64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MOV_B64 does not support DPP8";
   return std::make_unique<VMovB64Vop3>(opcode);
 }
 } // namespace detail
@@ -183,7 +214,7 @@ VMovreldB32Vop3::VMovreldB32Vop3(const MachineInst *inst)
                ? "v_movreld_b32_e64_dpp"
                : "v_movreld_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMovreldB32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VMovreldB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -219,7 +250,16 @@ VMovreldB32Vop3::VMovreldB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovreldB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovreldB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_movreld_b32_e64_dpp"
+          : "v_movreld_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovreldB32Vop3>(opcode);
 }
 } // namespace detail
@@ -229,7 +269,7 @@ VMovrelsB32Vop3::VMovrelsB32Vop3(const MachineInst *inst)
                ? "v_movrels_b32_e64_dpp"
                : "v_movrels_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMovrelsB32Vop3), LiteralSupport::None, 1),
+           selected_exec_fn(InstructionExecutionId::VMovrelsB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -261,7 +301,16 @@ VMovrelsB32Vop3::VMovrelsB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_movrels_b32_e64_dpp"
+          : "v_movrels_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::None, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsB32Vop3>(opcode);
 }
 } // namespace detail
@@ -271,8 +320,7 @@ VPermlane16SwapB32Vop3::VPermlane16SwapB32Vop3(const MachineInst *inst)
                ? "v_permlane16_swap_b32_e64_dpp"
                : "v_permlane16_swap_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPermlane16SwapB32Vop3), LiteralSupport::None,
-           0),
+           selected_exec_fn(InstructionExecutionId::VPermlane16SwapB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -281,15 +329,24 @@ VPermlane16SwapB32Vop3::VPermlane16SwapB32Vop3(const MachineInst *inst)
   src_operands_[1] = &src0;
   num_src_ = 2;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANE16_SWAP_B32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlane16SwapB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlane16SwapB32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_permlane16_swap_b32_e64_dpp"
+          : "v_permlane16_swap_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::None, 0);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE16_SWAP_B32 does not support DPP";
   return std::make_unique<VPermlane16SwapB32Vop3>(opcode);
 }
 } // namespace detail
@@ -299,7 +356,7 @@ VCndmaskB32Vop3::VCndmaskB32Vop3(const MachineInst *inst)
                ? "v_cndmask_b32_e64_dpp"
                : "v_cndmask_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCndmaskB32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCndmaskB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -341,7 +398,16 @@ VCndmaskB32Vop3::VCndmaskB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cndmask_b32_e64_dpp"
+          : "v_cndmask_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop3>(opcode);
 }
 } // namespace detail
@@ -351,7 +417,7 @@ VCubeidF32Vop3::VCubeidF32Vop3(const MachineInst *inst)
                ? "v_cubeid_f32_e64_dpp"
                : "v_cubeid_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCubeidF32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCubeidF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -398,7 +464,15 @@ VCubeidF32Vop3::VCubeidF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cubeid_f32_e64_dpp"
+          : "v_cubeid_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubeidF32Vop3>(opcode);
 }
 } // namespace detail
@@ -408,7 +482,7 @@ VCubescF32Vop3::VCubescF32Vop3(const MachineInst *inst)
                ? "v_cubesc_f32_e64_dpp"
                : "v_cubesc_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCubescF32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCubescF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -455,7 +529,15 @@ VCubescF32Vop3::VCubescF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cubesc_f32_e64_dpp"
+          : "v_cubesc_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubescF32Vop3>(opcode);
 }
 } // namespace detail
@@ -465,7 +547,7 @@ VCubetcF32Vop3::VCubetcF32Vop3(const MachineInst *inst)
                ? "v_cubetc_f32_e64_dpp"
                : "v_cubetc_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCubetcF32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCubetcF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -512,7 +594,15 @@ VCubetcF32Vop3::VCubetcF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cubetc_f32_e64_dpp"
+          : "v_cubetc_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubetcF32Vop3>(opcode);
 }
 } // namespace detail
@@ -522,7 +612,7 @@ VCubemaF32Vop3::VCubemaF32Vop3(const MachineInst *inst)
                ? "v_cubema_f32_e64_dpp"
                : "v_cubema_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCubemaF32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCubemaF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -569,7 +659,15 @@ VCubemaF32Vop3::VCubemaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cubema_f32_e64_dpp"
+          : "v_cubema_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubemaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -579,7 +677,7 @@ VPermPk16B4U4Vop3::VPermPk16B4U4Vop3(const MachineInst *inst)
                ? "v_perm_pk16_b4_u4_e64_dpp"
                : "v_perm_pk16_b4_u4",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPermPk16B4U4Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VPermPk16B4U4Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -603,9 +701,6 @@ VPermPk16B4U4Vop3::VPermPk16B4U4Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERM_PK16_B4_U4 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -613,7 +708,19 @@ VPermPk16B4U4Vop3::VPermPk16B4U4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermPk16B4U4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermPk16B4U4Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_perm_pk16_b4_u4_e64_dpp"
+          : "v_perm_pk16_b4_u4",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERM_PK16_B4_U4 does not support DPP";
   return std::make_unique<VPermPk16B4U4Vop3>(opcode);
 }
 } // namespace detail
@@ -623,7 +730,7 @@ VPermPk16B6U4Vop3::VPermPk16B6U4Vop3(const MachineInst *inst)
                ? "v_perm_pk16_b6_u4_e64_dpp"
                : "v_perm_pk16_b6_u4",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPermPk16B6U4Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VPermPk16B6U4Vop3)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -648,9 +755,6 @@ VPermPk16B6U4Vop3::VPermPk16B6U4Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERM_PK16_B6_U4 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -658,7 +762,19 @@ VPermPk16B6U4Vop3::VPermPk16B6U4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermPk16B6U4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermPk16B6U4Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_perm_pk16_b6_u4_e64_dpp"
+          : "v_perm_pk16_b6_u4",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERM_PK16_B6_U4 does not support DPP";
   return std::make_unique<VPermPk16B6U4Vop3>(opcode);
 }
 } // namespace detail
@@ -668,7 +784,7 @@ VPermPk16B8U4Vop3::VPermPk16B8U4Vop3(const MachineInst *inst)
                ? "v_perm_pk16_b8_u4_e64_dpp"
                : "v_perm_pk16_b8_u4",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPermPk16B8U4Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VPermPk16B8U4Vop3)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -694,9 +810,6 @@ VPermPk16B8U4Vop3::VPermPk16B8U4Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERM_PK16_B8_U4 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -704,7 +817,19 @@ VPermPk16B8U4Vop3::VPermPk16B8U4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermPk16B8U4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermPk16B8U4Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_perm_pk16_b8_u4_e64_dpp"
+          : "v_perm_pk16_b8_u4",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERM_PK16_B8_U4 does not support DPP";
   return std::make_unique<VPermPk16B8U4Vop3>(opcode);
 }
 } // namespace detail
@@ -714,7 +839,7 @@ VPermB32Vop3::VPermB32Vop3(const MachineInst *inst)
                ? "v_perm_b32_e64_dpp"
                : "v_perm_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPermB32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VPermB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -761,7 +886,15 @@ VPermB32Vop3::VPermB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_perm_b32_e64_dpp"
+          : "v_perm_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPermB32Vop3>(opcode);
 }
 } // namespace detail
@@ -771,7 +904,7 @@ VPermlane16B32Vop3::VPermlane16B32Vop3(const MachineInst *inst)
                ? "v_permlane16_b32_e64_dpp"
                : "v_permlane16_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPermlane16B32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VPermlane16B32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -790,15 +923,24 @@ VPermlane16B32Vop3::VPermlane16B32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANE16_B32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlane16B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlane16B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_permlane16_b32_e64_dpp"
+          : "v_permlane16_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE16_B32 does not support DPP";
   return std::make_unique<VPermlane16B32Vop3>(opcode);
 }
 } // namespace detail
@@ -808,8 +950,7 @@ VPermlanex16B32Vop3::VPermlanex16B32Vop3(const MachineInst *inst)
                ? "v_permlanex16_b32_e64_dpp"
                : "v_permlanex16_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPermlanex16B32Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VPermlanex16B32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -828,15 +969,24 @@ VPermlanex16B32Vop3::VPermlanex16B32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANEX16_B32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlanex16B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlanex16B32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_permlanex16_b32_e64_dpp"
+          : "v_permlanex16_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANEX16_B32 does not support DPP";
   return std::make_unique<VPermlanex16B32Vop3>(opcode);
 }
 } // namespace detail
@@ -846,7 +996,7 @@ VCndmaskB16Vop3::VCndmaskB16Vop3(const MachineInst *inst)
                ? "v_cndmask_b16_e64_dpp"
                : "v_cndmask_b16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VCndmaskB16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VCndmaskB16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -896,7 +1046,16 @@ VCndmaskB16Vop3::VCndmaskB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cndmask_b16_e64_dpp"
+          : "v_cndmask_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB16Vop3>(opcode);
 }
 } // namespace detail
@@ -919,8 +1078,7 @@ VPermlaneBcastB32Vop3::VPermlaneBcastB32Vop3(const MachineInst *inst)
                ? "v_permlane_bcast_b32_e64_dpp"
                : "v_permlane_bcast_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPermlaneBcastB32Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VPermlaneBcastB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -939,15 +1097,24 @@ VPermlaneBcastB32Vop3::VPermlaneBcastB32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANE_BCAST_B32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlaneBcastB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlaneBcastB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_permlane_bcast_b32_e64_dpp"
+          : "v_permlane_bcast_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE_BCAST_B32 does not support DPP";
   return std::make_unique<VPermlaneBcastB32Vop3>(opcode);
 }
 } // namespace detail
@@ -957,7 +1124,7 @@ VPermlaneUpB32Vop3::VPermlaneUpB32Vop3(const MachineInst *inst)
                ? "v_permlane_up_b32_e64_dpp"
                : "v_permlane_up_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPermlaneUpB32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VPermlaneUpB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -976,15 +1143,24 @@ VPermlaneUpB32Vop3::VPermlaneUpB32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANE_UP_B32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlaneUpB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlaneUpB32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_permlane_up_b32_e64_dpp"
+          : "v_permlane_up_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE_UP_B32 does not support DPP";
   return std::make_unique<VPermlaneUpB32Vop3>(opcode);
 }
 } // namespace detail
@@ -994,8 +1170,7 @@ VPermlaneDownB32Vop3::VPermlaneDownB32Vop3(const MachineInst *inst)
                ? "v_permlane_down_b32_e64_dpp"
                : "v_permlane_down_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPermlaneDownB32Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VPermlaneDownB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1014,15 +1189,24 @@ VPermlaneDownB32Vop3::VPermlaneDownB32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANE_DOWN_B32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlaneDownB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlaneDownB32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_permlane_down_b32_e64_dpp"
+          : "v_permlane_down_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE_DOWN_B32 does not support DPP";
   return std::make_unique<VPermlaneDownB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1032,8 +1216,7 @@ VPermlaneXorB32Vop3::VPermlaneXorB32Vop3(const MachineInst *inst)
                ? "v_permlane_xor_b32_e64_dpp"
                : "v_permlane_xor_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPermlaneXorB32Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VPermlaneXorB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1052,15 +1235,24 @@ VPermlaneXorB32Vop3::VPermlaneXorB32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANE_XOR_B32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlaneXorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlaneXorB32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_permlane_xor_b32_e64_dpp"
+          : "v_permlane_xor_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE_XOR_B32 does not support DPP";
   return std::make_unique<VPermlaneXorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1070,8 +1262,7 @@ VPermlane16VarB32Vop3::VPermlane16VarB32Vop3(const MachineInst *inst)
                ? "v_permlane16_var_b32_e64_dpp"
                : "v_permlane16_var_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPermlane16VarB32Vop3), LiteralSupport::None,
-           2),
+           selected_exec_fn(InstructionExecutionId::VPermlane16VarB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1080,16 +1271,25 @@ VPermlane16VarB32Vop3::VPermlane16VarB32Vop3(const MachineInst *inst)
   src_operands_[1] = &src1;
   num_src_ = 2;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANE16_VAR_B32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlane16VarB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlane16VarB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_permlane16_var_b32_e64_dpp"
+          : "v_permlane16_var_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::None, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE16_VAR_B32 does not support DPP";
   return std::make_unique<VPermlane16VarB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1099,8 +1299,7 @@ VPermlanex16VarB32Vop3::VPermlanex16VarB32Vop3(const MachineInst *inst)
                ? "v_permlanex16_var_b32_e64_dpp"
                : "v_permlanex16_var_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPermlanex16VarB32Vop3), LiteralSupport::None,
-           2),
+           selected_exec_fn(InstructionExecutionId::VPermlanex16VarB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1109,16 +1308,25 @@ VPermlanex16VarB32Vop3::VPermlanex16VarB32Vop3(const MachineInst *inst)
   src_operands_[1] = &src1;
   num_src_ = 2;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANEX16_VAR_B32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlanex16VarB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlanex16VarB32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_permlanex16_var_b32_e64_dpp"
+          : "v_permlanex16_var_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::None, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANEX16_VAR_B32 does not support DPP";
   return std::make_unique<VPermlanex16VarB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1128,8 +1336,7 @@ VPermlaneIdxGenB32Vop3::VPermlaneIdxGenB32Vop3(const MachineInst *inst)
                ? "v_permlane_idx_gen_b32_e64_dpp"
                : "v_permlane_idx_gen_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPermlaneIdxGenB32Vop3),
-           LiteralSupport::Literal32, 2),
+           selected_exec_fn(InstructionExecutionId::VPermlaneIdxGenB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1142,15 +1349,24 @@ VPermlaneIdxGenB32Vop3::VPermlaneIdxGenB32Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANE_IDX_GEN_B32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlaneIdxGenB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlaneIdxGenB32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_permlane_idx_gen_b32_e64_dpp"
+          : "v_permlane_idx_gen_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE_IDX_GEN_B32 does not support DPP";
   return std::make_unique<VPermlaneIdxGenB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1160,7 +1376,7 @@ VReadlaneB32Vop3::VReadlaneB32Vop3(const MachineInst *inst)
                ? "v_readlane_b32_e64_dpp"
                : "v_readlane_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VReadlaneB32Vop3), LiteralSupport::None, 2),
+           selected_exec_fn(InstructionExecutionId::VReadlaneB32Vop3)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC_LANESEL, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1169,14 +1385,23 @@ VReadlaneB32Vop3::VReadlaneB32Vop3(const MachineInst *inst)
   src_operands_[1] = &src1;
   num_src_ = 2;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_READLANE_B32 does not support DPP", "");
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_readlane_b32_e64_dpp"
+          : "v_readlane_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::None, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_READLANE_B32 does not support DPP";
   return std::make_unique<VReadlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1186,8 +1411,7 @@ VWritelaneB32Vop3::VWritelaneB32Vop3(const MachineInst *inst)
                ? "v_writelane_b32_e64_dpp"
                : "v_writelane_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VWritelaneB32Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VWritelaneB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC_LANESEL, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1201,14 +1425,23 @@ VWritelaneB32Vop3::VWritelaneB32Vop3(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WRITELANE_B32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_writelane_b32_e64_dpp"
+          : "v_writelane_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_WRITELANE_B32 does not support DPP";
   return std::make_unique<VWritelaneB32Vop3>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_misc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_misc.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -18,13 +17,21 @@ VNopVop3::VNopVop3(const MachineInst *inst)
                ? "v_nop_e64_dpp"
                : "v_nop",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VNopVop3), LiteralSupport::None, 0) {
+           selected_exec_fn(InstructionExecutionId::VNopVop3)) {
   num_src_ = 0;
   num_dst_ = 0;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode) {
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_nop_e64_dpp"
+          : "v_nop",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::None, 0);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop3>(opcode);
 }
 } // namespace detail
@@ -34,13 +41,21 @@ VPipeflushVop3::VPipeflushVop3(const MachineInst *inst)
                ? "v_pipeflush_e64_dpp"
                : "v_pipeflush",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPipeflushVop3), LiteralSupport::None, 0) {
+           selected_exec_fn(InstructionExecutionId::VPipeflushVop3)) {
   num_src_ = 0;
   num_dst_ = 0;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPipeflushVop3(const MachineInst *opcode) {
+DecodeResult decodeVPipeflushVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_pipeflush_e64_dpp"
+          : "v_pipeflush",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::None, 0);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPipeflushVop3>(opcode);
 }
 } // namespace detail
@@ -50,7 +65,7 @@ VMovrelsdB32Vop3::VMovrelsdB32Vop3(const MachineInst *inst)
                ? "v_movrelsd_b32_e64_dpp"
                : "v_movrelsd_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMovrelsdB32Vop3), LiteralSupport::None, 1),
+           selected_exec_fn(InstructionExecutionId::VMovrelsdB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -82,7 +97,16 @@ VMovrelsdB32Vop3::VMovrelsdB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsdB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_b32_e64_dpp"
+          : "v_movrelsd_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::None, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsdB32Vop3>(opcode);
 }
 } // namespace detail
@@ -92,7 +116,7 @@ VMovrelsd2B32Vop3::VMovrelsd2B32Vop3(const MachineInst *inst)
                ? "v_movrelsd_2_b32_e64_dpp"
                : "v_movrelsd_2_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMovrelsd2B32Vop3), LiteralSupport::None, 1),
+           selected_exec_fn(InstructionExecutionId::VMovrelsd2B32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -124,7 +148,16 @@ VMovrelsd2B32Vop3::VMovrelsd2B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsd2B32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_2_b32_e64_dpp"
+          : "v_movrelsd_2_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::None, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsd2B32Vop3>(opcode);
 }
 } // namespace detail
@@ -134,7 +167,7 @@ VPrngB32Vop3::VPrngB32Vop3(const MachineInst *inst)
                ? "v_prng_b32_e64_dpp"
                : "v_prng_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VPrngB32Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VPrngB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -167,7 +200,15 @@ VPrngB32Vop3::VPrngB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPrngB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPrngB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_prng_b32_e64_dpp"
+          : "v_prng_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPrngB32Vop3>(opcode);
 }
 } // namespace detail
@@ -177,7 +218,7 @@ VSatPkU8I16Vop3::VSatPkU8I16Vop3(const MachineInst *inst)
                ? "v_sat_pk_u8_i16_e64_dpp"
                : "v_sat_pk_u8_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSatPkU8I16Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSatPkU8I16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -210,7 +251,16 @@ VSatPkU8I16Vop3::VSatPkU8I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sat_pk_u8_i16_e64_dpp"
+          : "v_sat_pk_u8_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop3>(opcode);
 }
 } // namespace detail
@@ -233,7 +283,7 @@ VSatPk4I4I8Vop3::VSatPk4I4I8Vop3(const MachineInst *inst)
                ? "v_sat_pk4_i4_i8_e64_dpp"
                : "v_sat_pk4_i4_i8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSatPk4I4I8Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSatPk4I4I8Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -266,7 +316,16 @@ VSatPk4I4I8Vop3::VSatPk4I4I8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPk4I4I8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSatPk4I4I8Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sat_pk4_i4_i8_e64_dpp"
+          : "v_sat_pk4_i4_i8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPk4I4I8Vop3>(opcode);
 }
 } // namespace detail
@@ -289,7 +348,7 @@ VSatPk4U4U8Vop3::VSatPk4U4U8Vop3(const MachineInst *inst)
                ? "v_sat_pk4_u4_u8_e64_dpp"
                : "v_sat_pk4_u4_u8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSatPk4U4U8Vop3), LiteralSupport::Literal32, 1),
+           selected_exec_fn(InstructionExecutionId::VSatPk4U4U8Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -322,7 +381,16 @@ VSatPk4U4U8Vop3::VSatPk4U4U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPk4U4U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSatPk4U4U8Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sat_pk4_u4_u8_e64_dpp"
+          : "v_sat_pk4_u4_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 1);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPk4U4U8Vop3>(opcode);
 }
 } // namespace detail
@@ -345,7 +413,7 @@ VMullitF32Vop3::VMullitF32Vop3(const MachineInst *inst)
                ? "v_mullit_f32_e64_dpp"
                : "v_mullit_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMullitF32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMullitF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -392,7 +460,15 @@ VMullitF32Vop3::VMullitF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMullitF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMullitF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mullit_f32_e64_dpp"
+          : "v_mullit_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMullitF32Vop3>(opcode);
 }
 } // namespace detail
@@ -402,7 +478,7 @@ VQsadPkU16U8Vop3::VQsadPkU16U8Vop3(const MachineInst *inst)
                ? "v_qsad_pk_u16_u8_e64_dpp"
                : "v_qsad_pk_u16_u8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VQsadPkU16U8Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VQsadPkU16U8Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -427,9 +503,6 @@ VQsadPkU16U8Vop3::VQsadPkU16U8Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_QSAD_PK_U16_U8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -437,7 +510,19 @@ VQsadPkU16U8Vop3::VQsadPkU16U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_qsad_pk_u16_u8_e64_dpp"
+          : "v_qsad_pk_u16_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_QSAD_PK_U16_U8 does not support DPP";
   return std::make_unique<VQsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -447,7 +532,7 @@ VMqsadPkU16U8Vop3::VMqsadPkU16U8Vop3(const MachineInst *inst)
                ? "v_mqsad_pk_u16_u8_e64_dpp"
                : "v_mqsad_pk_u16_u8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMqsadPkU16U8Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMqsadPkU16U8Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -472,9 +557,6 @@ VMqsadPkU16U8Vop3::VMqsadPkU16U8Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MQSAD_PK_U16_U8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -482,7 +564,19 @@ VMqsadPkU16U8Vop3::VMqsadPkU16U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mqsad_pk_u16_u8_e64_dpp"
+          : "v_mqsad_pk_u16_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MQSAD_PK_U16_U8 does not support DPP";
   return std::make_unique<VMqsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -492,7 +586,7 @@ VMqsadU32U8Vop3::VMqsadU32U8Vop3(const MachineInst *inst)
                ? "v_mqsad_u32_u8_e64_dpp"
                : "v_mqsad_u32_u8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMqsadU32U8Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMqsadU32U8Vop3)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -512,9 +606,6 @@ VMqsadU32U8Vop3::VMqsadU32U8Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MQSAD_U32_U8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -522,7 +613,19 @@ VMqsadU32U8Vop3::VMqsadU32U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mqsad_u32_u8_e64_dpp"
+          : "v_mqsad_u32_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MQSAD_U32_U8 does not support DPP";
   return std::make_unique<VMqsadU32U8Vop3>(opcode);
 }
 } // namespace detail
@@ -532,8 +635,7 @@ VTrigPreopF64Vop3::VTrigPreopF64Vop3(const MachineInst *inst)
                ? "v_trig_preop_f64_e64_dpp"
                : "v_trig_preop_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VTrigPreopF64Vop3), LiteralSupport::Literal32,
-           2),
+           selected_exec_fn(InstructionExecutionId::VTrigPreopF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -551,16 +653,25 @@ VTrigPreopF64Vop3::VTrigPreopF64Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_TRIG_PREOP_F64 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_trig_preop_f64_e64_dpp"
+          : "v_trig_preop_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32, 2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_TRIG_PREOP_F64 does not support DPP";
   return std::make_unique<VTrigPreopF64Vop3>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_ternary.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_ternary.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -18,7 +17,7 @@ VFmaDx9ZeroF32Vop3::VFmaDx9ZeroF32Vop3(const MachineInst *inst)
                ? "v_fma_dx9_zero_f32_e64_dpp"
                : "v_fma_dx9_zero_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFmaDx9ZeroF32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VFmaDx9ZeroF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -65,7 +64,16 @@ VFmaDx9ZeroF32Vop3::VFmaDx9ZeroF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaDx9ZeroF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaDx9ZeroF32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fma_dx9_zero_f32_e64_dpp"
+          : "v_fma_dx9_zero_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaDx9ZeroF32Vop3>(opcode);
 }
 } // namespace detail
@@ -75,7 +83,7 @@ VMadI32I24Vop3::VMadI32I24Vop3(const MachineInst *inst)
                ? "v_mad_i32_i24_e64_dpp"
                : "v_mad_i32_i24",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMadI32I24Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMadI32I24Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -122,7 +130,15 @@ VMadI32I24Vop3::VMadI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_i32_i24_e64_dpp"
+          : "v_mad_i32_i24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -132,7 +148,7 @@ VMadU32U24Vop3::VMadU32U24Vop3(const MachineInst *inst)
                ? "v_mad_u32_u24_e64_dpp"
                : "v_mad_u32_u24",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMadU32U24Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMadU32U24Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -179,7 +195,15 @@ VMadU32U24Vop3::VMadU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_u32_u24_e64_dpp"
+          : "v_mad_u32_u24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -189,7 +213,7 @@ VBfeU32Vop3::VBfeU32Vop3(const MachineInst *inst)
                ? "v_bfe_u32_e64_dpp"
                : "v_bfe_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VBfeU32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VBfeU32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -236,7 +260,15 @@ VBfeU32Vop3::VBfeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfe_u32_e64_dpp"
+          : "v_bfe_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -246,7 +278,7 @@ VBfeI32Vop3::VBfeI32Vop3(const MachineInst *inst)
                ? "v_bfe_i32_e64_dpp"
                : "v_bfe_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VBfeI32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VBfeI32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -293,7 +325,15 @@ VBfeI32Vop3::VBfeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfe_i32_e64_dpp"
+          : "v_bfe_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -303,7 +343,7 @@ VBfiB32Vop3::VBfiB32Vop3(const MachineInst *inst)
                ? "v_bfi_b32_e64_dpp"
                : "v_bfi_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VBfiB32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VBfiB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -350,7 +390,15 @@ VBfiB32Vop3::VBfiB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfi_b32_e64_dpp"
+          : "v_bfi_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfiB32Vop3>(opcode);
 }
 } // namespace detail
@@ -360,7 +408,7 @@ VFmaF32Vop3::VFmaF32Vop3(const MachineInst *inst)
                ? "v_fma_f32_e64_dpp"
                : "v_fma_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFmaF32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VFmaF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -407,7 +455,15 @@ VFmaF32Vop3::VFmaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fma_f32_e64_dpp"
+          : "v_fma_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -417,7 +473,7 @@ VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
                ? "v_fma_f64_e64_dpp"
                : "v_fma_f64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFmaF64Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VFmaF64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -452,8 +508,6 @@ VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMA_F64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -461,7 +515,17 @@ VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fma_f64_e64_dpp"
+          : "v_fma_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMA_F64 does not support DPP8";
   return std::make_unique<VFmaF64Vop3>(opcode);
 }
 } // namespace detail
@@ -471,7 +535,7 @@ VLerpU8Vop3::VLerpU8Vop3(const MachineInst *inst)
                ? "v_lerp_u8_e64_dpp"
                : "v_lerp_u8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VLerpU8Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VLerpU8Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -518,7 +582,15 @@ VLerpU8Vop3::VLerpU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lerp_u8_e64_dpp"
+          : "v_lerp_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLerpU8Vop3>(opcode);
 }
 } // namespace detail
@@ -528,7 +600,7 @@ VAlignbitB32Vop3::VAlignbitB32Vop3(const MachineInst *inst)
                ? "v_alignbit_b32_e64_dpp"
                : "v_alignbit_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAlignbitB32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VAlignbitB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -579,7 +651,16 @@ VAlignbitB32Vop3::VAlignbitB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_alignbit_b32_e64_dpp"
+          : "v_alignbit_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbitB32Vop3>(opcode);
 }
 } // namespace detail
@@ -589,7 +670,7 @@ VAlignbyteB32Vop3::VAlignbyteB32Vop3(const MachineInst *inst)
                ? "v_alignbyte_b32_e64_dpp"
                : "v_alignbyte_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAlignbyteB32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VAlignbyteB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -640,7 +721,16 @@ VAlignbyteB32Vop3::VAlignbyteB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_alignbyte_b32_e64_dpp"
+          : "v_alignbyte_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbyteB32Vop3>(opcode);
 }
 } // namespace detail
@@ -650,7 +740,7 @@ VMin3I32Vop3::VMin3I32Vop3(const MachineInst *inst)
                ? "v_min3_i32_e64_dpp"
                : "v_min3_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMin3I32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMin3I32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -697,7 +787,15 @@ VMin3I32Vop3::VMin3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_i32_e64_dpp"
+          : "v_min3_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -707,7 +805,7 @@ VMin3U32Vop3::VMin3U32Vop3(const MachineInst *inst)
                ? "v_min3_u32_e64_dpp"
                : "v_min3_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMin3U32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMin3U32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -754,7 +852,15 @@ VMin3U32Vop3::VMin3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_u32_e64_dpp"
+          : "v_min3_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -764,7 +870,7 @@ VMax3I32Vop3::VMax3I32Vop3(const MachineInst *inst)
                ? "v_max3_i32_e64_dpp"
                : "v_max3_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMax3I32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMax3I32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -811,7 +917,15 @@ VMax3I32Vop3::VMax3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_i32_e64_dpp"
+          : "v_max3_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -821,7 +935,7 @@ VMax3U32Vop3::VMax3U32Vop3(const MachineInst *inst)
                ? "v_max3_u32_e64_dpp"
                : "v_max3_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMax3U32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMax3U32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -868,7 +982,15 @@ VMax3U32Vop3::VMax3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_u32_e64_dpp"
+          : "v_max3_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -878,7 +1000,7 @@ VMed3I32Vop3::VMed3I32Vop3(const MachineInst *inst)
                ? "v_med3_i32_e64_dpp"
                : "v_med3_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMed3I32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMed3I32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -925,7 +1047,15 @@ VMed3I32Vop3::VMed3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_i32_e64_dpp"
+          : "v_med3_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -935,7 +1065,7 @@ VMed3U32Vop3::VMed3U32Vop3(const MachineInst *inst)
                ? "v_med3_u32_e64_dpp"
                : "v_med3_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMed3U32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMed3U32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -982,7 +1112,15 @@ VMed3U32Vop3::VMed3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_u32_e64_dpp"
+          : "v_med3_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -992,7 +1130,7 @@ VSadU8Vop3::VSadU8Vop3(const MachineInst *inst)
                ? "v_sad_u8_e64_dpp"
                : "v_sad_u8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSadU8Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VSadU8Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1039,7 +1177,15 @@ VSadU8Vop3::VSadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sad_u8_e64_dpp"
+          : "v_sad_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -1049,7 +1195,7 @@ VSadHiU8Vop3::VSadHiU8Vop3(const MachineInst *inst)
                ? "v_sad_hi_u8_e64_dpp"
                : "v_sad_hi_u8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSadHiU8Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VSadHiU8Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1096,7 +1242,15 @@ VSadHiU8Vop3::VSadHiU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sad_hi_u8_e64_dpp"
+          : "v_sad_hi_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadHiU8Vop3>(opcode);
 }
 } // namespace detail
@@ -1106,7 +1260,7 @@ VSadU16Vop3::VSadU16Vop3(const MachineInst *inst)
                ? "v_sad_u16_e64_dpp"
                : "v_sad_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSadU16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VSadU16Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1153,7 +1307,15 @@ VSadU16Vop3::VSadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sad_u16_e64_dpp"
+          : "v_sad_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -1163,7 +1325,7 @@ VSadU32Vop3::VSadU32Vop3(const MachineInst *inst)
                ? "v_sad_u32_e64_dpp"
                : "v_sad_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VSadU32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VSadU32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1210,7 +1372,15 @@ VSadU32Vop3::VSadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sad_u32_e64_dpp"
+          : "v_sad_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -1220,7 +1390,7 @@ VMin3NumF32Vop3::VMin3NumF32Vop3(const MachineInst *inst)
                ? "v_min3_num_f32_e64_dpp"
                : "v_min3_num_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMin3NumF32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMin3NumF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1267,7 +1437,16 @@ VMin3NumF32Vop3::VMin3NumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3NumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3NumF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_num_f32_e64_dpp"
+          : "v_min3_num_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3NumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1277,7 +1456,7 @@ VMax3NumF32Vop3::VMax3NumF32Vop3(const MachineInst *inst)
                ? "v_max3_num_f32_e64_dpp"
                : "v_max3_num_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMax3NumF32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMax3NumF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1324,7 +1503,16 @@ VMax3NumF32Vop3::VMax3NumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3NumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3NumF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_num_f32_e64_dpp"
+          : "v_max3_num_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3NumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1334,7 +1522,7 @@ VMin3NumF16Vop3::VMin3NumF16Vop3(const MachineInst *inst)
                ? "v_min3_num_f16_e64_dpp"
                : "v_min3_num_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMin3NumF16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMin3NumF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1393,7 +1581,16 @@ VMin3NumF16Vop3::VMin3NumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3NumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3NumF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_num_f16_e64_dpp"
+          : "v_min3_num_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3NumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1416,7 +1613,7 @@ VMax3NumF16Vop3::VMax3NumF16Vop3(const MachineInst *inst)
                ? "v_max3_num_f16_e64_dpp"
                : "v_max3_num_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMax3NumF16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMax3NumF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1475,7 +1672,16 @@ VMax3NumF16Vop3::VMax3NumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3NumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3NumF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_num_f16_e64_dpp"
+          : "v_max3_num_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3NumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1498,7 +1704,7 @@ VMinimum3F32Vop3::VMinimum3F32Vop3(const MachineInst *inst)
                ? "v_minimum3_f32_e64_dpp"
                : "v_minimum3_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinimum3F32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMinimum3F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1545,7 +1751,16 @@ VMinimum3F32Vop3::VMinimum3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinimum3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinimum3F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minimum3_f32_e64_dpp"
+          : "v_minimum3_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinimum3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -1555,7 +1770,7 @@ VMaximum3F32Vop3::VMaximum3F32Vop3(const MachineInst *inst)
                ? "v_maximum3_f32_e64_dpp"
                : "v_maximum3_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaximum3F32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMaximum3F32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1602,7 +1817,16 @@ VMaximum3F32Vop3::VMaximum3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaximum3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaximum3F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maximum3_f32_e64_dpp"
+          : "v_maximum3_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaximum3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -1612,7 +1836,7 @@ VMinimum3F16Vop3::VMinimum3F16Vop3(const MachineInst *inst)
                ? "v_minimum3_f16_e64_dpp"
                : "v_minimum3_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinimum3F16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMinimum3F16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1671,7 +1895,16 @@ VMinimum3F16Vop3::VMinimum3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinimum3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinimum3F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minimum3_f16_e64_dpp"
+          : "v_minimum3_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinimum3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1694,7 +1927,7 @@ VMaximum3F16Vop3::VMaximum3F16Vop3(const MachineInst *inst)
                ? "v_maximum3_f16_e64_dpp"
                : "v_maximum3_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaximum3F16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMaximum3F16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1753,7 +1986,16 @@ VMaximum3F16Vop3::VMaximum3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaximum3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaximum3F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maximum3_f16_e64_dpp"
+          : "v_maximum3_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaximum3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1776,7 +2018,7 @@ VMed3NumF32Vop3::VMed3NumF32Vop3(const MachineInst *inst)
                ? "v_med3_num_f32_e64_dpp"
                : "v_med3_num_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMed3NumF32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMed3NumF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1823,7 +2065,16 @@ VMed3NumF32Vop3::VMed3NumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3NumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3NumF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_num_f32_e64_dpp"
+          : "v_med3_num_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3NumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1833,7 +2084,7 @@ VMed3NumF16Vop3::VMed3NumF16Vop3(const MachineInst *inst)
                ? "v_med3_num_f16_e64_dpp"
                : "v_med3_num_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMed3NumF16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMed3NumF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1892,7 +2143,16 @@ VMed3NumF16Vop3::VMed3NumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3NumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3NumF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_num_f16_e64_dpp"
+          : "v_med3_num_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3NumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1915,7 +2175,7 @@ VMadU32Vop3::VMadU32Vop3(const MachineInst *inst)
                ? "v_mad_u32_e64_dpp"
                : "v_mad_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMadU32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMadU32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1947,8 +2207,6 @@ VMadU32Vop3::VMadU32Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAD_U32 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -1956,7 +2214,17 @@ VMadU32Vop3::VMadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_u32_e64_dpp"
+          : "v_mad_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MAD_U32 does not support DPP8";
   return std::make_unique<VMadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -1966,7 +2234,7 @@ VMsadU8Vop3::VMsadU8Vop3(const MachineInst *inst)
                ? "v_msad_u8_e64_dpp"
                : "v_msad_u8",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMsadU8Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMsadU8Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2013,7 +2281,15 @@ VMsadU8Vop3::VMsadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_msad_u8_e64_dpp"
+          : "v_msad_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMsadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -2023,7 +2299,7 @@ VXor3B32Vop3::VXor3B32Vop3(const MachineInst *inst)
                ? "v_xor3_b32_e64_dpp"
                : "v_xor3_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VXor3B32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VXor3B32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2070,7 +2346,15 @@ VXor3B32Vop3::VXor3B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXor3B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXor3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xor3_b32_e64_dpp"
+          : "v_xor3_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXor3B32Vop3>(opcode);
 }
 } // namespace detail
@@ -2080,7 +2364,7 @@ VMadU16Vop3::VMadU16Vop3(const MachineInst *inst)
                ? "v_mad_u16_e64_dpp"
                : "v_mad_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMadU16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMadU16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2139,7 +2423,15 @@ VMadU16Vop3::VMadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_u16_e64_dpp"
+          : "v_mad_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -2161,7 +2453,7 @@ VXadU32Vop3::VXadU32Vop3(const MachineInst *inst)
                ? "v_xad_u32_e64_dpp"
                : "v_xad_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VXadU32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VXadU32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2208,7 +2500,15 @@ VXadU32Vop3::VXadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xad_u32_e64_dpp"
+          : "v_xad_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2218,7 +2518,7 @@ VLshlAddU32Vop3::VLshlAddU32Vop3(const MachineInst *inst)
                ? "v_lshl_add_u32_e64_dpp"
                : "v_lshl_add_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VLshlAddU32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VLshlAddU32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2265,7 +2565,16 @@ VLshlAddU32Vop3::VLshlAddU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshl_add_u32_e64_dpp"
+          : "v_lshl_add_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlAddU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2275,7 +2584,7 @@ VAddLshlU32Vop3::VAddLshlU32Vop3(const MachineInst *inst)
                ? "v_add_lshl_u32_e64_dpp"
                : "v_add_lshl_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAddLshlU32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VAddLshlU32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2322,7 +2631,16 @@ VAddLshlU32Vop3::VAddLshlU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_lshl_u32_e64_dpp"
+          : "v_add_lshl_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddLshlU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2332,7 +2650,7 @@ VFmaF16Vop3::VFmaF16Vop3(const MachineInst *inst)
                ? "v_fma_f16_e64_dpp"
                : "v_fma_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VFmaF16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VFmaF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2391,7 +2709,15 @@ VFmaF16Vop3::VFmaF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fma_f16_e64_dpp"
+          : "v_fma_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2413,7 +2739,7 @@ VMin3I16Vop3::VMin3I16Vop3(const MachineInst *inst)
                ? "v_min3_i16_e64_dpp"
                : "v_min3_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMin3I16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMin3I16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2472,7 +2798,15 @@ VMin3I16Vop3::VMin3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_i16_e64_dpp"
+          : "v_min3_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -2494,7 +2828,7 @@ VMin3U16Vop3::VMin3U16Vop3(const MachineInst *inst)
                ? "v_min3_u16_e64_dpp"
                : "v_min3_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMin3U16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMin3U16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2553,7 +2887,15 @@ VMin3U16Vop3::VMin3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_u16_e64_dpp"
+          : "v_min3_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -2575,7 +2917,7 @@ VMax3I16Vop3::VMax3I16Vop3(const MachineInst *inst)
                ? "v_max3_i16_e64_dpp"
                : "v_max3_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMax3I16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMax3I16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2634,7 +2976,15 @@ VMax3I16Vop3::VMax3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_i16_e64_dpp"
+          : "v_max3_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -2656,7 +3006,7 @@ VMax3U16Vop3::VMax3U16Vop3(const MachineInst *inst)
                ? "v_max3_u16_e64_dpp"
                : "v_max3_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMax3U16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMax3U16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2715,7 +3065,15 @@ VMax3U16Vop3::VMax3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_u16_e64_dpp"
+          : "v_max3_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -2737,7 +3095,7 @@ VMed3I16Vop3::VMed3I16Vop3(const MachineInst *inst)
                ? "v_med3_i16_e64_dpp"
                : "v_med3_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMed3I16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMed3I16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2796,7 +3154,15 @@ VMed3I16Vop3::VMed3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_i16_e64_dpp"
+          : "v_med3_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -2818,7 +3184,7 @@ VMed3U16Vop3::VMed3U16Vop3(const MachineInst *inst)
                ? "v_med3_u16_e64_dpp"
                : "v_med3_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMed3U16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMed3U16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2877,7 +3243,15 @@ VMed3U16Vop3::VMed3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_u16_e64_dpp"
+          : "v_med3_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -2899,7 +3273,7 @@ VLshlAddU64Vop3::VLshlAddU64Vop3(const MachineInst *inst)
                ? "v_lshl_add_u64_e64_dpp"
                : "v_lshl_add_u64",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VLshlAddU64Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VLshlAddU64Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2933,8 +3307,6 @@ VLshlAddU64Vop3::VLshlAddU64Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_LSHL_ADD_U64 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2942,7 +3314,18 @@ VLshlAddU64Vop3::VLshlAddU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlAddU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlAddU64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshl_add_u64_e64_dpp"
+          : "v_lshl_add_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_LSHL_ADD_U64 does not support DPP8";
   return std::make_unique<VLshlAddU64Vop3>(opcode);
 }
 } // namespace detail
@@ -2952,7 +3335,7 @@ VMadI16Vop3::VMadI16Vop3(const MachineInst *inst)
                ? "v_mad_i16_e64_dpp"
                : "v_mad_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMadI16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMadI16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3011,7 +3394,15 @@ VMadI16Vop3::VMadI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_i16_e64_dpp"
+          : "v_mad_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI16Vop3>(opcode);
 }
 } // namespace detail
@@ -3033,7 +3424,7 @@ VAdd3U32Vop3::VAdd3U32Vop3(const MachineInst *inst)
                ? "v_add3_u32_e64_dpp"
                : "v_add3_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAdd3U32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VAdd3U32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3080,7 +3471,15 @@ VAdd3U32Vop3::VAdd3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add3_u32_e64_dpp"
+          : "v_add3_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAdd3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3090,7 +3489,7 @@ VLshlOrB32Vop3::VLshlOrB32Vop3(const MachineInst *inst)
                ? "v_lshl_or_b32_e64_dpp"
                : "v_lshl_or_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VLshlOrB32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VLshlOrB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3137,7 +3536,15 @@ VLshlOrB32Vop3::VLshlOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshl_or_b32_e64_dpp"
+          : "v_lshl_or_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3147,7 +3554,7 @@ VAndOrB32Vop3::VAndOrB32Vop3(const MachineInst *inst)
                ? "v_and_or_b32_e64_dpp"
                : "v_and_or_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAndOrB32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VAndOrB32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3194,7 +3601,15 @@ VAndOrB32Vop3::VAndOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_and_or_b32_e64_dpp"
+          : "v_and_or_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3204,7 +3619,7 @@ VOr3B32Vop3::VOr3B32Vop3(const MachineInst *inst)
                ? "v_or3_b32_e64_dpp"
                : "v_or3_b32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VOr3B32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VOr3B32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3251,7 +3666,15 @@ VOr3B32Vop3::VOr3B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_or3_b32_e64_dpp"
+          : "v_or3_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOr3B32Vop3>(opcode);
 }
 } // namespace detail
@@ -3261,7 +3684,7 @@ VMadU32U16Vop3::VMadU32U16Vop3(const MachineInst *inst)
                ? "v_mad_u32_u16_e64_dpp"
                : "v_mad_u32_u16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMadU32U16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMadU32U16Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3316,7 +3739,15 @@ VMadU32U16Vop3::VMadU32U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_u32_u16_e64_dpp"
+          : "v_mad_u32_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3326,7 +3757,7 @@ VMadI32I16Vop3::VMadI32I16Vop3(const MachineInst *inst)
                ? "v_mad_i32_i16_e64_dpp"
                : "v_mad_i32_i16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMadI32I16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMadI32I16Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3381,7 +3812,15 @@ VMadI32I16Vop3::VMadI32I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_i32_i16_e64_dpp"
+          : "v_mad_i32_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3391,7 +3830,7 @@ VAddMaxI32Vop3::VAddMaxI32Vop3(const MachineInst *inst)
                ? "v_add_max_i32_e64_dpp"
                : "v_add_max_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAddMaxI32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VAddMaxI32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3438,7 +3877,15 @@ VAddMaxI32Vop3::VAddMaxI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddMaxI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_max_i32_e64_dpp"
+          : "v_add_max_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddMaxI32Vop3>(opcode);
 }
 } // namespace detail
@@ -3448,7 +3895,7 @@ VAddMaxU32Vop3::VAddMaxU32Vop3(const MachineInst *inst)
                ? "v_add_max_u32_e64_dpp"
                : "v_add_max_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAddMaxU32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VAddMaxU32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3495,7 +3942,15 @@ VAddMaxU32Vop3::VAddMaxU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddMaxU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_max_u32_e64_dpp"
+          : "v_add_max_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddMaxU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3505,7 +3960,7 @@ VAddMinI32Vop3::VAddMinI32Vop3(const MachineInst *inst)
                ? "v_add_min_i32_e64_dpp"
                : "v_add_min_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAddMinI32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VAddMinI32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3552,7 +4007,15 @@ VAddMinI32Vop3::VAddMinI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddMinI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_min_i32_e64_dpp"
+          : "v_add_min_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddMinI32Vop3>(opcode);
 }
 } // namespace detail
@@ -3562,7 +4025,7 @@ VAddMinU32Vop3::VAddMinU32Vop3(const MachineInst *inst)
                ? "v_add_min_u32_e64_dpp"
                : "v_add_min_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAddMinU32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VAddMinU32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3609,7 +4072,15 @@ VAddMinU32Vop3::VAddMinU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddMinU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_min_u32_e64_dpp"
+          : "v_add_min_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddMinU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3619,7 +4090,7 @@ VMaxminU32Vop3::VMaxminU32Vop3(const MachineInst *inst)
                ? "v_maxmin_u32_e64_dpp"
                : "v_maxmin_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaxminU32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMaxminU32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3666,7 +4137,15 @@ VMaxminU32Vop3::VMaxminU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxminU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxminU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maxmin_u32_e64_dpp"
+          : "v_maxmin_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxminU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3676,7 +4155,7 @@ VMinmaxU32Vop3::VMinmaxU32Vop3(const MachineInst *inst)
                ? "v_minmax_u32_e64_dpp"
                : "v_minmax_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinmaxU32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMinmaxU32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3723,7 +4202,15 @@ VMinmaxU32Vop3::VMinmaxU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinmaxU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinmaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minmax_u32_e64_dpp"
+          : "v_minmax_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinmaxU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3733,7 +4220,7 @@ VMaxminI32Vop3::VMaxminI32Vop3(const MachineInst *inst)
                ? "v_maxmin_i32_e64_dpp"
                : "v_maxmin_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaxminI32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMaxminI32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3780,7 +4267,15 @@ VMaxminI32Vop3::VMaxminI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxminI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxminI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maxmin_i32_e64_dpp"
+          : "v_maxmin_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxminI32Vop3>(opcode);
 }
 } // namespace detail
@@ -3790,7 +4285,7 @@ VMinmaxI32Vop3::VMinmaxI32Vop3(const MachineInst *inst)
                ? "v_minmax_i32_e64_dpp"
                : "v_minmax_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinmaxI32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMinmaxI32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3837,7 +4332,15 @@ VMinmaxI32Vop3::VMinmaxI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinmaxI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinmaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minmax_i32_e64_dpp"
+          : "v_minmax_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinmaxI32Vop3>(opcode);
 }
 } // namespace detail
@@ -3847,7 +4350,7 @@ VMinmaxNumF32Vop3::VMinmaxNumF32Vop3(const MachineInst *inst)
                ? "v_minmax_num_f32_e64_dpp"
                : "v_minmax_num_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinmaxNumF32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMinmaxNumF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3894,7 +4397,16 @@ VMinmaxNumF32Vop3::VMinmaxNumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinmaxNumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinmaxNumF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minmax_num_f32_e64_dpp"
+          : "v_minmax_num_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinmaxNumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3904,7 +4416,7 @@ VMaxminNumF32Vop3::VMaxminNumF32Vop3(const MachineInst *inst)
                ? "v_maxmin_num_f32_e64_dpp"
                : "v_maxmin_num_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaxminNumF32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMaxminNumF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3951,7 +4463,16 @@ VMaxminNumF32Vop3::VMaxminNumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxminNumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxminNumF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maxmin_num_f32_e64_dpp"
+          : "v_maxmin_num_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxminNumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3961,7 +4482,7 @@ VMinmaxNumF16Vop3::VMinmaxNumF16Vop3(const MachineInst *inst)
                ? "v_minmax_num_f16_e64_dpp"
                : "v_minmax_num_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinmaxNumF16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMinmaxNumF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4020,7 +4541,16 @@ VMinmaxNumF16Vop3::VMinmaxNumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinmaxNumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinmaxNumF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minmax_num_f16_e64_dpp"
+          : "v_minmax_num_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinmaxNumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4043,7 +4573,7 @@ VMaxminNumF16Vop3::VMaxminNumF16Vop3(const MachineInst *inst)
                ? "v_maxmin_num_f16_e64_dpp"
                : "v_maxmin_num_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaxminNumF16Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMaxminNumF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4102,7 +4632,16 @@ VMaxminNumF16Vop3::VMaxminNumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxminNumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxminNumF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maxmin_num_f16_e64_dpp"
+          : "v_maxmin_num_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxminNumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4125,8 +4664,7 @@ VMinimummaximumF32Vop3::VMinimummaximumF32Vop3(const MachineInst *inst)
                ? "v_minimummaximum_f32_e64_dpp"
                : "v_minimummaximum_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinimummaximumF32Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMinimummaximumF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4173,7 +4711,16 @@ VMinimummaximumF32Vop3::VMinimummaximumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinimummaximumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinimummaximumF32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minimummaximum_f32_e64_dpp"
+          : "v_minimummaximum_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinimummaximumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4183,8 +4730,7 @@ VMaximumminimumF32Vop3::VMaximumminimumF32Vop3(const MachineInst *inst)
                ? "v_maximumminimum_f32_e64_dpp"
                : "v_maximumminimum_f32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaximumminimumF32Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMaximumminimumF32Vop3)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4231,7 +4777,16 @@ VMaximumminimumF32Vop3::VMaximumminimumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaximumminimumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaximumminimumF32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maximumminimum_f32_e64_dpp"
+          : "v_maximumminimum_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaximumminimumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4241,8 +4796,7 @@ VMinimummaximumF16Vop3::VMinimummaximumF16Vop3(const MachineInst *inst)
                ? "v_minimummaximum_f16_e64_dpp"
                : "v_minimummaximum_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMinimummaximumF16Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMinimummaximumF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4301,7 +4855,16 @@ VMinimummaximumF16Vop3::VMinimummaximumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinimummaximumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinimummaximumF16Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minimummaximum_f16_e64_dpp"
+          : "v_minimummaximum_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinimummaximumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4324,8 +4887,7 @@ VMaximumminimumF16Vop3::VMaximumminimumF16Vop3(const MachineInst *inst)
                ? "v_maximumminimum_f16_e64_dpp"
                : "v_maximumminimum_f16",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMaximumminimumF16Vop3),
-           LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMaximumminimumF16Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4384,7 +4946,16 @@ VMaximumminimumF16Vop3::VMaximumminimumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaximumminimumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaximumminimumF16Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maximumminimum_f16_e64_dpp"
+          : "v_maximumminimum_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaximumminimumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4407,7 +4978,7 @@ VAshrPkI8I32Vop3::VAshrPkI8I32Vop3(const MachineInst *inst)
                ? "v_ashr_pk_i8_i32_e64_dpp"
                : "v_ashr_pk_i8_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAshrPkI8I32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VAshrPkI8I32Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4454,7 +5025,16 @@ VAshrPkI8I32Vop3::VAshrPkI8I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrPkI8I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrPkI8I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ashr_pk_i8_i32_e64_dpp"
+          : "v_ashr_pk_i8_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrPkI8I32Vop3>(opcode);
 }
 } // namespace detail
@@ -4477,7 +5057,7 @@ VAshrPkU8I32Vop3::VAshrPkU8I32Vop3(const MachineInst *inst)
                ? "v_ashr_pk_u8_i32_e64_dpp"
                : "v_ashr_pk_u8_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VAshrPkU8I32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VAshrPkU8I32Vop3)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4524,7 +5104,16 @@ VAshrPkU8I32Vop3::VAshrPkU8I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrPkU8I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrPkU8I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ashr_pk_u8_i32_e64_dpp"
+          : "v_ashr_pk_u8_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrPkU8I32Vop3>(opcode);
 }
 } // namespace detail
@@ -4547,7 +5136,7 @@ VMadNcU64U32Vop3::VMadNcU64U32Vop3(const MachineInst *inst)
                ? "v_mad_nc_u64_u32_e64_dpp"
                : "v_mad_nc_u64_u32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMadNcU64U32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMadNcU64U32Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4580,8 +5169,6 @@ VMadNcU64U32Vop3::VMadNcU64U32Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAD_NC_U64_U32 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -4589,7 +5176,18 @@ VMadNcU64U32Vop3::VMadNcU64U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadNcU64U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadNcU64U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_nc_u64_u32_e64_dpp"
+          : "v_mad_nc_u64_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MAD_NC_U64_U32 does not support DPP8";
   return std::make_unique<VMadNcU64U32Vop3>(opcode);
 }
 } // namespace detail
@@ -4599,7 +5197,7 @@ VMadNcI64I32Vop3::VMadNcI64I32Vop3(const MachineInst *inst)
                ? "v_mad_nc_i64_i32_e64_dpp"
                : "v_mad_nc_i64_i32",
            reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(InstructionExecutionId::VMadNcI64I32Vop3), LiteralSupport::Literal32),
+           selected_exec_fn(InstructionExecutionId::VMadNcI64I32Vop3)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4632,8 +5230,6 @@ VMadNcI64I32Vop3::VMadNcI64I32Vop3(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAD_NC_I64_I32 does not support DPP8", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -4641,7 +5237,18 @@ VMadNcI64I32Vop3::VMadNcI64I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadNcI64I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadNcI64I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_nc_i64_i32_e64_dpp"
+          : "v_mad_nc_i64_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MAD_NC_I64_I32 does not support DPP8";
   return std::make_unique<VMadNcI64I32Vop3>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3p.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -106,7 +105,7 @@ VPkMadI16Vop3p::VPkMadI16Vop3p(const MachineInst *inst)
                 ? "v_pk_mad_i16_e64_dpp"
                 : "v_pk_mad_i16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMadI16Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VPkMadI16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -129,9 +128,6 @@ VPkMadI16Vop3p::VPkMadI16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAD_I16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -139,7 +135,19 @@ VPkMadI16Vop3p::VPkMadI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_mad_i16_e64_dpp"
+          : "v_pk_mad_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAD_I16 does not support DPP";
   return std::make_unique<VPkMadI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -149,8 +157,7 @@ VPkMulLoU16Vop3p::VPkMulLoU16Vop3p(const MachineInst *inst)
                 ? "v_pk_mul_lo_u16_e64_dpp"
                 : "v_pk_mul_lo_u16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMulLoU16Vop3p), LiteralSupport::Literal32,
-            2),
+            selected_exec_fn(InstructionExecutionId::VPkMulLoU16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -167,16 +174,27 @@ VPkMulLoU16Vop3p::VPkMulLoU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MUL_LO_U16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_mul_lo_u16_e64_dpp"
+          : "v_pk_mul_lo_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MUL_LO_U16 does not support DPP";
   return std::make_unique<VPkMulLoU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -186,7 +204,7 @@ VPkAddI16Vop3p::VPkAddI16Vop3p(const MachineInst *inst)
                 ? "v_pk_add_i16_e64_dpp"
                 : "v_pk_add_i16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkAddI16Vop3p), LiteralSupport::Literal32, 2),
+            selected_exec_fn(InstructionExecutionId::VPkAddI16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -203,16 +221,26 @@ VPkAddI16Vop3p::VPkAddI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ADD_I16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_add_i16_e64_dpp"
+          : "v_pk_add_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ADD_I16 does not support DPP";
   return std::make_unique<VPkAddI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -222,7 +250,7 @@ VPkSubI16Vop3p::VPkSubI16Vop3p(const MachineInst *inst)
                 ? "v_pk_sub_i16_e64_dpp"
                 : "v_pk_sub_i16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkSubI16Vop3p), LiteralSupport::Literal32, 2),
+            selected_exec_fn(InstructionExecutionId::VPkSubI16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -239,16 +267,26 @@ VPkSubI16Vop3p::VPkSubI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_SUB_I16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_sub_i16_e64_dpp"
+          : "v_pk_sub_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_SUB_I16 does not support DPP";
   return std::make_unique<VPkSubI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -258,8 +296,7 @@ VPkLshlrevB16Vop3p::VPkLshlrevB16Vop3p(const MachineInst *inst)
                 ? "v_pk_lshlrev_b16_e64_dpp"
                 : "v_pk_lshlrev_b16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkLshlrevB16Vop3p), LiteralSupport::Literal32,
-            2),
+            selected_exec_fn(InstructionExecutionId::VPkLshlrevB16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -276,16 +313,27 @@ VPkLshlrevB16Vop3p::VPkLshlrevB16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_LSHLREV_B16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_lshlrev_b16_e64_dpp"
+          : "v_pk_lshlrev_b16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_LSHLREV_B16 does not support DPP";
   return std::make_unique<VPkLshlrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -295,8 +343,7 @@ VPkLshrrevB16Vop3p::VPkLshrrevB16Vop3p(const MachineInst *inst)
                 ? "v_pk_lshrrev_b16_e64_dpp"
                 : "v_pk_lshrrev_b16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkLshrrevB16Vop3p), LiteralSupport::Literal32,
-            2),
+            selected_exec_fn(InstructionExecutionId::VPkLshrrevB16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -313,16 +360,27 @@ VPkLshrrevB16Vop3p::VPkLshrrevB16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_LSHRREV_B16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_lshrrev_b16_e64_dpp"
+          : "v_pk_lshrrev_b16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_LSHRREV_B16 does not support DPP";
   return std::make_unique<VPkLshrrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -332,8 +390,7 @@ VPkAshrrevI16Vop3p::VPkAshrrevI16Vop3p(const MachineInst *inst)
                 ? "v_pk_ashrrev_i16_e64_dpp"
                 : "v_pk_ashrrev_i16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkAshrrevI16Vop3p), LiteralSupport::Literal32,
-            2),
+            selected_exec_fn(InstructionExecutionId::VPkAshrrevI16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -350,16 +407,27 @@ VPkAshrrevI16Vop3p::VPkAshrrevI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ASHRREV_I16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_ashrrev_i16_e64_dpp"
+          : "v_pk_ashrrev_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ASHRREV_I16 does not support DPP";
   return std::make_unique<VPkAshrrevI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -369,7 +437,7 @@ VPkMaxI16Vop3p::VPkMaxI16Vop3p(const MachineInst *inst)
                 ? "v_pk_max_i16_e64_dpp"
                 : "v_pk_max_i16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMaxI16Vop3p), LiteralSupport::Literal32, 2),
+            selected_exec_fn(InstructionExecutionId::VPkMaxI16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -386,16 +454,26 @@ VPkMaxI16Vop3p::VPkMaxI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAX_I16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_max_i16_e64_dpp"
+          : "v_pk_max_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAX_I16 does not support DPP";
   return std::make_unique<VPkMaxI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -405,7 +483,7 @@ VPkMinI16Vop3p::VPkMinI16Vop3p(const MachineInst *inst)
                 ? "v_pk_min_i16_e64_dpp"
                 : "v_pk_min_i16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMinI16Vop3p), LiteralSupport::Literal32, 2),
+            selected_exec_fn(InstructionExecutionId::VPkMinI16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -422,16 +500,26 @@ VPkMinI16Vop3p::VPkMinI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MIN_I16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_min_i16_e64_dpp"
+          : "v_pk_min_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MIN_I16 does not support DPP";
   return std::make_unique<VPkMinI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -441,7 +529,7 @@ VPkMadU16Vop3p::VPkMadU16Vop3p(const MachineInst *inst)
                 ? "v_pk_mad_u16_e64_dpp"
                 : "v_pk_mad_u16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMadU16Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VPkMadU16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -464,9 +552,6 @@ VPkMadU16Vop3p::VPkMadU16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAD_U16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -474,7 +559,19 @@ VPkMadU16Vop3p::VPkMadU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_mad_u16_e64_dpp"
+          : "v_pk_mad_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAD_U16 does not support DPP";
   return std::make_unique<VPkMadU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -484,7 +581,7 @@ VPkAddU16Vop3p::VPkAddU16Vop3p(const MachineInst *inst)
                 ? "v_pk_add_u16_e64_dpp"
                 : "v_pk_add_u16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkAddU16Vop3p), LiteralSupport::Literal32, 2),
+            selected_exec_fn(InstructionExecutionId::VPkAddU16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -501,16 +598,26 @@ VPkAddU16Vop3p::VPkAddU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ADD_U16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_add_u16_e64_dpp"
+          : "v_pk_add_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ADD_U16 does not support DPP";
   return std::make_unique<VPkAddU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -520,7 +627,7 @@ VPkSubU16Vop3p::VPkSubU16Vop3p(const MachineInst *inst)
                 ? "v_pk_sub_u16_e64_dpp"
                 : "v_pk_sub_u16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkSubU16Vop3p), LiteralSupport::Literal32, 2),
+            selected_exec_fn(InstructionExecutionId::VPkSubU16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -537,16 +644,26 @@ VPkSubU16Vop3p::VPkSubU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_SUB_U16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_sub_u16_e64_dpp"
+          : "v_pk_sub_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_SUB_U16 does not support DPP";
   return std::make_unique<VPkSubU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -556,7 +673,7 @@ VPkMaxU16Vop3p::VPkMaxU16Vop3p(const MachineInst *inst)
                 ? "v_pk_max_u16_e64_dpp"
                 : "v_pk_max_u16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMaxU16Vop3p), LiteralSupport::Literal32, 2),
+            selected_exec_fn(InstructionExecutionId::VPkMaxU16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -573,16 +690,26 @@ VPkMaxU16Vop3p::VPkMaxU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAX_U16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_max_u16_e64_dpp"
+          : "v_pk_max_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAX_U16 does not support DPP";
   return std::make_unique<VPkMaxU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -592,7 +719,7 @@ VPkMinU16Vop3p::VPkMinU16Vop3p(const MachineInst *inst)
                 ? "v_pk_min_u16_e64_dpp"
                 : "v_pk_min_u16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMinU16Vop3p), LiteralSupport::Literal32, 2),
+            selected_exec_fn(InstructionExecutionId::VPkMinU16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -609,16 +736,26 @@ VPkMinU16Vop3p::VPkMinU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MIN_U16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_min_u16_e64_dpp"
+          : "v_pk_min_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MIN_U16 does not support DPP";
   return std::make_unique<VPkMinU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -628,7 +765,7 @@ VPkFmaF16Vop3p::VPkFmaF16Vop3p(const MachineInst *inst)
                 ? "v_pk_fma_f16_e64_dpp"
                 : "v_pk_fma_f16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkFmaF16Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VPkFmaF16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -651,9 +788,6 @@ VPkFmaF16Vop3p::VPkFmaF16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_FMA_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -661,7 +795,19 @@ VPkFmaF16Vop3p::VPkFmaF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_fma_f16_e64_dpp"
+          : "v_pk_fma_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_FMA_F16 does not support DPP";
   return std::make_unique<VPkFmaF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -671,7 +817,7 @@ VPkAddF16Vop3p::VPkAddF16Vop3p(const MachineInst *inst)
                 ? "v_pk_add_f16_e64_dpp"
                 : "v_pk_add_f16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkAddF16Vop3p), LiteralSupport::Literal32, 2),
+            selected_exec_fn(InstructionExecutionId::VPkAddF16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -688,16 +834,26 @@ VPkAddF16Vop3p::VPkAddF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ADD_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_add_f16_e64_dpp"
+          : "v_pk_add_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ADD_F16 does not support DPP";
   return std::make_unique<VPkAddF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -707,7 +863,7 @@ VPkMulF16Vop3p::VPkMulF16Vop3p(const MachineInst *inst)
                 ? "v_pk_mul_f16_e64_dpp"
                 : "v_pk_mul_f16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMulF16Vop3p), LiteralSupport::Literal32, 2),
+            selected_exec_fn(InstructionExecutionId::VPkMulF16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -724,16 +880,26 @@ VPkMulF16Vop3p::VPkMulF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MUL_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_mul_f16_e64_dpp"
+          : "v_pk_mul_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MUL_F16 does not support DPP";
   return std::make_unique<VPkMulF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -743,7 +909,7 @@ VPkFmaBf16Vop3p::VPkFmaBf16Vop3p(const MachineInst *inst)
                 ? "v_pk_fma_bf16_e64_dpp"
                 : "v_pk_fma_bf16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkFmaBf16Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VPkFmaBf16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -766,9 +932,6 @@ VPkFmaBf16Vop3p::VPkFmaBf16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_FMA_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -776,7 +939,20 @@ VPkFmaBf16Vop3p::VPkFmaBf16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmaBf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkFmaBf16Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_fma_bf16_e64_dpp"
+          : "v_pk_fma_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_FMA_BF16 does not support DPP";
   return std::make_unique<VPkFmaBf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -786,7 +962,7 @@ VPkAddMaxI16Vop3p::VPkAddMaxI16Vop3p(const MachineInst *inst)
                 ? "v_pk_add_max_i16_e64_dpp"
                 : "v_pk_add_max_i16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkAddMaxI16Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VPkAddMaxI16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -809,9 +985,6 @@ VPkAddMaxI16Vop3p::VPkAddMaxI16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ADD_MAX_I16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -819,7 +992,20 @@ VPkAddMaxI16Vop3p::VPkAddMaxI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddMaxI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddMaxI16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_add_max_i16_e64_dpp"
+          : "v_pk_add_max_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ADD_MAX_I16 does not support DPP";
   return std::make_unique<VPkAddMaxI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -829,7 +1015,7 @@ VPkAddMaxU16Vop3p::VPkAddMaxU16Vop3p(const MachineInst *inst)
                 ? "v_pk_add_max_u16_e64_dpp"
                 : "v_pk_add_max_u16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkAddMaxU16Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VPkAddMaxU16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -852,9 +1038,6 @@ VPkAddMaxU16Vop3p::VPkAddMaxU16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ADD_MAX_U16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -862,7 +1045,20 @@ VPkAddMaxU16Vop3p::VPkAddMaxU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddMaxU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddMaxU16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_add_max_u16_e64_dpp"
+          : "v_pk_add_max_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ADD_MAX_U16 does not support DPP";
   return std::make_unique<VPkAddMaxU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -872,7 +1068,7 @@ VDot4I32Iu8Vop3p::VDot4I32Iu8Vop3p(const MachineInst *inst)
                 ? "v_dot4_i32_iu8_e64_dpp"
                 : "v_dot4_i32_iu8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VDot4I32Iu8Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VDot4I32Iu8Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -895,9 +1091,6 @@ VDot4I32Iu8Vop3p::VDot4I32Iu8Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT4_I32_IU8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -905,7 +1098,20 @@ VDot4I32Iu8Vop3p::VDot4I32Iu8Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4I32Iu8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4I32Iu8Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot4_i32_iu8_e64_dpp"
+          : "v_dot4_i32_iu8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT4_I32_IU8 does not support DPP";
   return std::make_unique<VDot4I32Iu8Vop3p>(opcode);
 }
 } // namespace detail
@@ -915,7 +1121,7 @@ VDot4U32U8Vop3p::VDot4U32U8Vop3p(const MachineInst *inst)
                 ? "v_dot4_u32_u8_e64_dpp"
                 : "v_dot4_u32_u8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VDot4U32U8Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VDot4U32U8Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -938,9 +1144,6 @@ VDot4U32U8Vop3p::VDot4U32U8Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT4_U32_U8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -948,7 +1151,20 @@ VDot4U32U8Vop3p::VDot4U32U8Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot4_u32_u8_e64_dpp"
+          : "v_dot4_u32_u8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT4_U32_U8 does not support DPP";
   return std::make_unique<VDot4U32U8Vop3p>(opcode);
 }
 } // namespace detail
@@ -958,7 +1174,7 @@ VDot8I32Iu4Vop3p::VDot8I32Iu4Vop3p(const MachineInst *inst)
                 ? "v_dot8_i32_iu4_e64_dpp"
                 : "v_dot8_i32_iu4",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VDot8I32Iu4Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VDot8I32Iu4Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -981,9 +1197,6 @@ VDot8I32Iu4Vop3p::VDot8I32Iu4Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT8_I32_IU4 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -991,7 +1204,20 @@ VDot8I32Iu4Vop3p::VDot8I32Iu4Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8I32Iu4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8I32Iu4Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot8_i32_iu4_e64_dpp"
+          : "v_dot8_i32_iu4",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT8_I32_IU4 does not support DPP";
   return std::make_unique<VDot8I32Iu4Vop3p>(opcode);
 }
 } // namespace detail
@@ -1001,7 +1227,7 @@ VDot8U32U4Vop3p::VDot8U32U4Vop3p(const MachineInst *inst)
                 ? "v_dot8_u32_u4_e64_dpp"
                 : "v_dot8_u32_u4",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VDot8U32U4Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VDot8U32U4Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1024,9 +1250,6 @@ VDot8U32U4Vop3p::VDot8U32U4Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT8_U32_U4 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -1034,7 +1257,20 @@ VDot8U32U4Vop3p::VDot8U32U4Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot8_u32_u4_e64_dpp"
+          : "v_dot8_u32_u4",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT8_U32_U4 does not support DPP";
   return std::make_unique<VDot8U32U4Vop3p>(opcode);
 }
 } // namespace detail
@@ -1044,8 +1280,7 @@ VPkMinNumF16Vop3p::VPkMinNumF16Vop3p(const MachineInst *inst)
                 ? "v_pk_min_num_f16_e64_dpp"
                 : "v_pk_min_num_f16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMinNumF16Vop3p), LiteralSupport::Literal32,
-            2),
+            selected_exec_fn(InstructionExecutionId::VPkMinNumF16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1062,16 +1297,27 @@ VPkMinNumF16Vop3p::VPkMinNumF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MIN_NUM_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinNumF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinNumF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_min_num_f16_e64_dpp"
+          : "v_pk_min_num_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MIN_NUM_F16 does not support DPP";
   return std::make_unique<VPkMinNumF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1081,8 +1327,7 @@ VPkMaxNumF16Vop3p::VPkMaxNumF16Vop3p(const MachineInst *inst)
                 ? "v_pk_max_num_f16_e64_dpp"
                 : "v_pk_max_num_f16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMaxNumF16Vop3p), LiteralSupport::Literal32,
-            2),
+            selected_exec_fn(InstructionExecutionId::VPkMaxNumF16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1099,16 +1344,27 @@ VPkMaxNumF16Vop3p::VPkMaxNumF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAX_NUM_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxNumF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxNumF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_max_num_f16_e64_dpp"
+          : "v_pk_max_num_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAX_NUM_F16 does not support DPP";
   return std::make_unique<VPkMaxNumF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1118,8 +1374,7 @@ VPkMinimumF16Vop3p::VPkMinimumF16Vop3p(const MachineInst *inst)
                 ? "v_pk_minimum_f16_e64_dpp"
                 : "v_pk_minimum_f16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMinimumF16Vop3p), LiteralSupport::Literal32,
-            2),
+            selected_exec_fn(InstructionExecutionId::VPkMinimumF16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1136,16 +1391,27 @@ VPkMinimumF16Vop3p::VPkMinimumF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MINIMUM_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinimumF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinimumF16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_minimum_f16_e64_dpp"
+          : "v_pk_minimum_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MINIMUM_F16 does not support DPP";
   return std::make_unique<VPkMinimumF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1155,8 +1421,7 @@ VPkMaximumF16Vop3p::VPkMaximumF16Vop3p(const MachineInst *inst)
                 ? "v_pk_maximum_f16_e64_dpp"
                 : "v_pk_maximum_f16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMaximumF16Vop3p), LiteralSupport::Literal32,
-            2),
+            selected_exec_fn(InstructionExecutionId::VPkMaximumF16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1173,16 +1438,27 @@ VPkMaximumF16Vop3p::VPkMaximumF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAXIMUM_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaximumF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaximumF16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_maximum_f16_e64_dpp"
+          : "v_pk_maximum_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAXIMUM_F16 does not support DPP";
   return std::make_unique<VPkMaximumF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1192,7 +1468,7 @@ VPkFmaF32Vop3p::VPkFmaF32Vop3p(const MachineInst *inst)
                 ? "v_pk_fma_f32_e64_dpp"
                 : "v_pk_fma_f32",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkFmaF32Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VPkFmaF32Vop3p)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1218,9 +1494,6 @@ VPkFmaF32Vop3p::VPkFmaF32Vop3p(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::Replicate32);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_FMA_F32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -1228,7 +1501,19 @@ VPkFmaF32Vop3p::VPkFmaF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmaF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkFmaF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_fma_f32_e64_dpp"
+          : "v_pk_fma_f32",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_FMA_F32 does not support DPP";
   return std::make_unique<VPkFmaF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -1238,7 +1523,7 @@ VFmaMixF32Vop3p::VFmaMixF32Vop3p(const MachineInst *inst)
                 ? "v_fma_mix_f32_e64_dpp"
                 : "v_fma_mix_f32",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VFmaMixF32Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VFmaMixF32Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1285,7 +1570,16 @@ VFmaMixF32Vop3p::VFmaMixF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixF32Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_fma_mix_f32_e64_dpp"
+          : "v_fma_mix_f32",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -1295,7 +1589,7 @@ VFmaMixloF16Vop3p::VFmaMixloF16Vop3p(const MachineInst *inst)
                 ? "v_fma_mixlo_f16_e64_dpp"
                 : "v_fma_mixlo_f16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VFmaMixloF16Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VFmaMixloF16Vop3p)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1343,7 +1637,16 @@ VFmaMixloF16Vop3p::VFmaMixloF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixloF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_fma_mixlo_f16_e64_dpp"
+          : "v_fma_mixlo_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixloF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1366,7 +1669,7 @@ VFmaMixhiF16Vop3p::VFmaMixhiF16Vop3p(const MachineInst *inst)
                 ? "v_fma_mixhi_f16_e64_dpp"
                 : "v_fma_mixhi_f16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VFmaMixhiF16Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VFmaMixhiF16Vop3p)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1414,7 +1717,16 @@ VFmaMixhiF16Vop3p::VFmaMixhiF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixhiF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_fma_mixhi_f16_e64_dpp"
+          : "v_fma_mixhi_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixhiF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1437,8 +1749,7 @@ VPkAddBf16Vop3p::VPkAddBf16Vop3p(const MachineInst *inst)
                 ? "v_pk_add_bf16_e64_dpp"
                 : "v_pk_add_bf16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkAddBf16Vop3p), LiteralSupport::Literal32,
-            2),
+            selected_exec_fn(InstructionExecutionId::VPkAddBf16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1455,16 +1766,27 @@ VPkAddBf16Vop3p::VPkAddBf16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ADD_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddBf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddBf16Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_add_bf16_e64_dpp"
+          : "v_pk_add_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ADD_BF16 does not support DPP";
   return std::make_unique<VPkAddBf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1474,7 +1796,7 @@ VPkMulF32Vop3p::VPkMulF32Vop3p(const MachineInst *inst)
                 ? "v_pk_mul_f32_e64_dpp"
                 : "v_pk_mul_f32",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMulF32Vop3p), LiteralSupport::Literal32, 2),
+            selected_exec_fn(InstructionExecutionId::VPkMulF32Vop3p)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1493,16 +1815,26 @@ VPkMulF32Vop3p::VPkMulF32Vop3p(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::Replicate32);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MUL_F32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_mul_f32_e64_dpp"
+          : "v_pk_mul_f32",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MUL_F32 does not support DPP";
   return std::make_unique<VPkMulF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -1512,7 +1844,7 @@ VPkAddF32Vop3p::VPkAddF32Vop3p(const MachineInst *inst)
                 ? "v_pk_add_f32_e64_dpp"
                 : "v_pk_add_f32",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkAddF32Vop3p), LiteralSupport::Literal32, 2),
+            selected_exec_fn(InstructionExecutionId::VPkAddF32Vop3p)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1531,16 +1863,26 @@ VPkAddF32Vop3p::VPkAddF32Vop3p(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::Replicate32);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ADD_F32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_add_f32_e64_dpp"
+          : "v_pk_add_f32",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ADD_F32 does not support DPP";
   return std::make_unique<VPkAddF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -1550,8 +1892,7 @@ VPkMulBf16Vop3p::VPkMulBf16Vop3p(const MachineInst *inst)
                 ? "v_pk_mul_bf16_e64_dpp"
                 : "v_pk_mul_bf16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMulBf16Vop3p), LiteralSupport::Literal32,
-            2),
+            selected_exec_fn(InstructionExecutionId::VPkMulBf16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1568,16 +1909,27 @@ VPkMulBf16Vop3p::VPkMulBf16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MUL_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulBf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulBf16Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_mul_bf16_e64_dpp"
+          : "v_pk_mul_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MUL_BF16 does not support DPP";
   return std::make_unique<VPkMulBf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1587,8 +1939,7 @@ VPkMinNumBf16Vop3p::VPkMinNumBf16Vop3p(const MachineInst *inst)
                 ? "v_pk_min_num_bf16_e64_dpp"
                 : "v_pk_min_num_bf16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMinNumBf16Vop3p), LiteralSupport::Literal32,
-            2),
+            selected_exec_fn(InstructionExecutionId::VPkMinNumBf16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1605,16 +1956,27 @@ VPkMinNumBf16Vop3p::VPkMinNumBf16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MIN_NUM_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinNumBf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinNumBf16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_min_num_bf16_e64_dpp"
+          : "v_pk_min_num_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MIN_NUM_BF16 does not support DPP";
   return std::make_unique<VPkMinNumBf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1624,8 +1986,7 @@ VPkMaxNumBf16Vop3p::VPkMaxNumBf16Vop3p(const MachineInst *inst)
                 ? "v_pk_max_num_bf16_e64_dpp"
                 : "v_pk_max_num_bf16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMaxNumBf16Vop3p), LiteralSupport::Literal32,
-            2),
+            selected_exec_fn(InstructionExecutionId::VPkMaxNumBf16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1642,16 +2003,27 @@ VPkMaxNumBf16Vop3p::VPkMaxNumBf16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAX_NUM_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxNumBf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxNumBf16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_max_num_bf16_e64_dpp"
+          : "v_pk_max_num_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32,
+      2);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAX_NUM_BF16 does not support DPP";
   return std::make_unique<VPkMaxNumBf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1661,7 +2033,7 @@ VPkAddMinI16Vop3p::VPkAddMinI16Vop3p(const MachineInst *inst)
                 ? "v_pk_add_min_i16_e64_dpp"
                 : "v_pk_add_min_i16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkAddMinI16Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VPkAddMinI16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1684,9 +2056,6 @@ VPkAddMinI16Vop3p::VPkAddMinI16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ADD_MIN_I16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -1694,7 +2063,20 @@ VPkAddMinI16Vop3p::VPkAddMinI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddMinI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddMinI16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_add_min_i16_e64_dpp"
+          : "v_pk_add_min_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ADD_MIN_I16 does not support DPP";
   return std::make_unique<VPkAddMinI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1704,7 +2086,7 @@ VPkAddMinU16Vop3p::VPkAddMinU16Vop3p(const MachineInst *inst)
                 ? "v_pk_add_min_u16_e64_dpp"
                 : "v_pk_add_min_u16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkAddMinU16Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VPkAddMinU16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1727,9 +2109,6 @@ VPkAddMinU16Vop3p::VPkAddMinU16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ADD_MIN_U16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -1737,7 +2116,20 @@ VPkAddMinU16Vop3p::VPkAddMinU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddMinU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddMinU16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_add_min_u16_e64_dpp"
+          : "v_pk_add_min_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ADD_MIN_U16 does not support DPP";
   return std::make_unique<VPkAddMinU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1747,7 +2139,7 @@ VPkMax3I16Vop3p::VPkMax3I16Vop3p(const MachineInst *inst)
                 ? "v_pk_max3_i16_e64_dpp"
                 : "v_pk_max3_i16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMax3I16Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VPkMax3I16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1770,9 +2162,6 @@ VPkMax3I16Vop3p::VPkMax3I16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAX3_I16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -1780,7 +2169,20 @@ VPkMax3I16Vop3p::VPkMax3I16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMax3I16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMax3I16Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_max3_i16_e64_dpp"
+          : "v_pk_max3_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAX3_I16 does not support DPP";
   return std::make_unique<VPkMax3I16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1790,7 +2192,7 @@ VPkMax3U16Vop3p::VPkMax3U16Vop3p(const MachineInst *inst)
                 ? "v_pk_max3_u16_e64_dpp"
                 : "v_pk_max3_u16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMax3U16Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VPkMax3U16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1813,9 +2215,6 @@ VPkMax3U16Vop3p::VPkMax3U16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAX3_U16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -1823,7 +2222,20 @@ VPkMax3U16Vop3p::VPkMax3U16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMax3U16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMax3U16Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_max3_u16_e64_dpp"
+          : "v_pk_max3_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAX3_U16 does not support DPP";
   return std::make_unique<VPkMax3U16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1833,7 +2245,7 @@ VPkMin3I16Vop3p::VPkMin3I16Vop3p(const MachineInst *inst)
                 ? "v_pk_min3_i16_e64_dpp"
                 : "v_pk_min3_i16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMin3I16Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VPkMin3I16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1856,9 +2268,6 @@ VPkMin3I16Vop3p::VPkMin3I16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MIN3_I16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -1866,7 +2275,20 @@ VPkMin3I16Vop3p::VPkMin3I16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMin3I16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMin3I16Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_min3_i16_e64_dpp"
+          : "v_pk_min3_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MIN3_I16 does not support DPP";
   return std::make_unique<VPkMin3I16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1876,7 +2298,7 @@ VPkMin3U16Vop3p::VPkMin3U16Vop3p(const MachineInst *inst)
                 ? "v_pk_min3_u16_e64_dpp"
                 : "v_pk_min3_u16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMin3U16Vop3p), LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VPkMin3U16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1899,9 +2321,6 @@ VPkMin3U16Vop3p::VPkMin3U16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MIN3_U16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -1909,7 +2328,20 @@ VPkMin3U16Vop3p::VPkMin3U16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMin3U16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMin3U16Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_min3_u16_e64_dpp"
+          : "v_pk_min3_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MIN3_U16 does not support DPP";
   return std::make_unique<VPkMin3U16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1919,8 +2351,7 @@ VWmmaF3216x16x128F8f6f4Vop3p::VWmmaF3216x16x128F8f6f4Vop3p(const MachineInst *in
                 ? "v_wmma_f32_16x16x128_f8f6f4_e64_dpp"
                 : "v_wmma_f32_16x16x128_f8f6f4",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x128F8f6f4Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x128F8f6f4Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(gfx1250_matrix_fmt_operand_size_bits(reinterpret_cast<const OpEncoding *>(inst)->opsel,
                                                 16, 128),
@@ -1938,9 +2369,6 @@ VWmmaF3216x16x128F8f6f4Vop3p::VWmmaF3216x16x128F8f6f4Vop3p(const MachineInst *in
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X128_F8F6F4 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -1948,7 +2376,20 @@ VWmmaF3216x16x128F8f6f4Vop3p::VWmmaF3216x16x128F8f6f4Vop3p(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x128F8f6f4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x128F8f6f4Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x128_f8f6f4_e64_dpp"
+          : "v_wmma_f32_16x16x128_f8f6f4",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X128_F8F6F4 does not support DPP";
   return std::make_unique<VWmmaF3216x16x128F8f6f4Vop3p>(opcode);
 }
 } // namespace detail
@@ -1965,8 +2406,7 @@ VPkMinimum3F16Vop3p::VPkMinimum3F16Vop3p(const MachineInst *inst)
                 ? "v_pk_minimum3_f16_e64_dpp"
                 : "v_pk_minimum3_f16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMinimum3F16Vop3p),
-            LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VPkMinimum3F16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1989,9 +2429,6 @@ VPkMinimum3F16Vop3p::VPkMinimum3F16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MINIMUM3_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -1999,7 +2436,20 @@ VPkMinimum3F16Vop3p::VPkMinimum3F16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinimum3F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinimum3F16Vop3p(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_minimum3_f16_e64_dpp"
+          : "v_pk_minimum3_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MINIMUM3_F16 does not support DPP";
   return std::make_unique<VPkMinimum3F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -2009,8 +2459,7 @@ VPkMaximum3F16Vop3p::VPkMaximum3F16Vop3p(const MachineInst *inst)
                 ? "v_pk_maximum3_f16_e64_dpp"
                 : "v_pk_maximum3_f16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMaximum3F16Vop3p),
-            LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VPkMaximum3F16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2033,9 +2482,6 @@ VPkMaximum3F16Vop3p::VPkMaximum3F16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAXIMUM3_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2043,7 +2489,20 @@ VPkMaximum3F16Vop3p::VPkMaximum3F16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaximum3F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaximum3F16Vop3p(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_maximum3_f16_e64_dpp"
+          : "v_pk_maximum3_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAXIMUM3_F16 does not support DPP";
   return std::make_unique<VPkMaximum3F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -2053,8 +2512,7 @@ VPkMin3NumF16Vop3p::VPkMin3NumF16Vop3p(const MachineInst *inst)
                 ? "v_pk_min3_num_f16_e64_dpp"
                 : "v_pk_min3_num_f16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMin3NumF16Vop3p),
-            LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VPkMin3NumF16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2077,9 +2535,6 @@ VPkMin3NumF16Vop3p::VPkMin3NumF16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MIN3_NUM_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2087,7 +2542,20 @@ VPkMin3NumF16Vop3p::VPkMin3NumF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMin3NumF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMin3NumF16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_min3_num_f16_e64_dpp"
+          : "v_pk_min3_num_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MIN3_NUM_F16 does not support DPP";
   return std::make_unique<VPkMin3NumF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -2097,8 +2565,7 @@ VPkMax3NumF16Vop3p::VPkMax3NumF16Vop3p(const MachineInst *inst)
                 ? "v_pk_max3_num_f16_e64_dpp"
                 : "v_pk_max3_num_f16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VPkMax3NumF16Vop3p),
-            LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VPkMax3NumF16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2121,9 +2588,6 @@ VPkMax3NumF16Vop3p::VPkMax3NumF16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAX3_NUM_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2131,7 +2595,20 @@ VPkMax3NumF16Vop3p::VPkMax3NumF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMax3NumF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMax3NumF16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_max3_num_f16_e64_dpp"
+          : "v_pk_max3_num_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAX3_NUM_F16 does not support DPP";
   return std::make_unique<VPkMax3NumF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -2141,8 +2618,7 @@ VFmaMixF32Bf16Vop3p::VFmaMixF32Bf16Vop3p(const MachineInst *inst)
                 ? "v_fma_mix_f32_bf16_e64_dpp"
                 : "v_fma_mix_f32_bf16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VFmaMixF32Bf16Vop3p),
-            LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VFmaMixF32Bf16Vop3p)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2189,7 +2665,16 @@ VFmaMixF32Bf16Vop3p::VFmaMixF32Bf16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixF32Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixF32Bf16Vop3p(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_fma_mix_f32_bf16_e64_dpp"
+          : "v_fma_mix_f32_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixF32Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -2199,8 +2684,7 @@ VFmaMixloBf16Vop3p::VFmaMixloBf16Vop3p(const MachineInst *inst)
                 ? "v_fma_mixlo_bf16_e64_dpp"
                 : "v_fma_mixlo_bf16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VFmaMixloBf16Vop3p),
-            LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VFmaMixloBf16Vop3p)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2248,7 +2732,16 @@ VFmaMixloBf16Vop3p::VFmaMixloBf16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixloBf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixloBf16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_fma_mixlo_bf16_e64_dpp"
+          : "v_fma_mixlo_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixloBf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -2271,8 +2764,7 @@ VFmaMixhiBf16Vop3p::VFmaMixhiBf16Vop3p(const MachineInst *inst)
                 ? "v_fma_mixhi_bf16_e64_dpp"
                 : "v_fma_mixhi_bf16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VFmaMixhiBf16Vop3p),
-            LiteralSupport::Literal32),
+            selected_exec_fn(InstructionExecutionId::VFmaMixhiBf16Vop3p)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2320,7 +2812,16 @@ VFmaMixhiBf16Vop3p::VFmaMixhiBf16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixhiBf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixhiBf16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_fma_mixhi_bf16_e64_dpp"
+          : "v_fma_mixhi_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::Literal32);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixhiBf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -2343,8 +2844,7 @@ VWmmaF3216x16x4F32Vop3p::VWmmaF3216x16x4F32Vop3p(const MachineInst *inst)
                 ? "v_wmma_f32_16x16x4_f32_e64_dpp"
                 : "v_wmma_f32_16x16x4_f32",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x4F32Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x4F32Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2356,9 +2856,6 @@ VWmmaF3216x16x4F32Vop3p::VWmmaF3216x16x4F32Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X4_F32 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2366,7 +2863,20 @@ VWmmaF3216x16x4F32Vop3p::VWmmaF3216x16x4F32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x4F32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x4F32Vop3p(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x4_f32_e64_dpp"
+          : "v_wmma_f32_16x16x4_f32",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X4_F32 does not support DPP";
   return std::make_unique<VWmmaF3216x16x4F32Vop3p>(opcode);
 }
 } // namespace detail
@@ -2376,8 +2886,7 @@ VWmmaF3216x16x32F16Vop3p::VWmmaF3216x16x32F16Vop3p(const MachineInst *inst)
                 ? "v_wmma_f32_16x16x32_f16_e64_dpp"
                 : "v_wmma_f32_16x16x32_f16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x32F16Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x32F16Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2389,9 +2898,6 @@ VWmmaF3216x16x32F16Vop3p::VWmmaF3216x16x32F16Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X32_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2399,7 +2905,20 @@ VWmmaF3216x16x32F16Vop3p::VWmmaF3216x16x32F16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x32F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x32F16Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x32_f16_e64_dpp"
+          : "v_wmma_f32_16x16x32_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X32_F16 does not support DPP";
   return std::make_unique<VWmmaF3216x16x32F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -2409,8 +2928,7 @@ VWmmaF1616x16x32F16Vop3p::VWmmaF1616x16x32F16Vop3p(const MachineInst *inst)
                 ? "v_wmma_f16_16x16x32_f16_e64_dpp"
                 : "v_wmma_f16_16x16x32_f16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF1616x16x32F16Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF1616x16x32F16Vop3p)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2422,9 +2940,6 @@ VWmmaF1616x16x32F16Vop3p::VWmmaF1616x16x32F16Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F16_16X16X32_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2432,7 +2947,20 @@ VWmmaF1616x16x32F16Vop3p::VWmmaF1616x16x32F16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x32F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF1616x16x32F16Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f16_16x16x32_f16_e64_dpp"
+          : "v_wmma_f16_16x16x32_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F16_16X16X32_F16 does not support DPP";
   return std::make_unique<VWmmaF1616x16x32F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -2442,8 +2970,7 @@ VWmmaF3216x16x32Bf16Vop3p::VWmmaF3216x16x32Bf16Vop3p(const MachineInst *inst)
                 ? "v_wmma_f32_16x16x32_bf16_e64_dpp"
                 : "v_wmma_f32_16x16x32_bf16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x32Bf16Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x32Bf16Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2455,9 +2982,6 @@ VWmmaF3216x16x32Bf16Vop3p::VWmmaF3216x16x32Bf16Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X32_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2465,7 +2989,20 @@ VWmmaF3216x16x32Bf16Vop3p::VWmmaF3216x16x32Bf16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x32Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x32Bf16Vop3p(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x32_bf16_e64_dpp"
+          : "v_wmma_f32_16x16x32_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X32_BF16 does not support DPP";
   return std::make_unique<VWmmaF3216x16x32Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -2475,8 +3012,7 @@ VWmmaBf1616x16x32Bf16Vop3p::VWmmaBf1616x16x32Bf16Vop3p(const MachineInst *inst)
                 ? "v_wmma_bf16_16x16x32_bf16_e64_dpp"
                 : "v_wmma_bf16_16x16x32_bf16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaBf1616x16x32Bf16Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaBf1616x16x32Bf16Vop3p)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2488,9 +3024,6 @@ VWmmaBf1616x16x32Bf16Vop3p::VWmmaBf1616x16x32Bf16Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_BF16_16X16X32_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2498,7 +3031,20 @@ VWmmaBf1616x16x32Bf16Vop3p::VWmmaBf1616x16x32Bf16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaBf1616x16x32Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaBf1616x16x32Bf16Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_bf16_16x16x32_bf16_e64_dpp"
+          : "v_wmma_bf16_16x16x32_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_BF16_16X16X32_BF16 does not support DPP";
   return std::make_unique<VWmmaBf1616x16x32Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -2508,8 +3054,7 @@ VWmmaBf16f3216x16x32Bf16Vop3p::VWmmaBf16f3216x16x32Bf16Vop3p(const MachineInst *
                 ? "v_wmma_bf16f32_16x16x32_bf16_e64_dpp"
                 : "v_wmma_bf16f32_16x16x32_bf16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaBf16f3216x16x32Bf16Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaBf16f3216x16x32Bf16Vop3p)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2521,9 +3066,6 @@ VWmmaBf16f3216x16x32Bf16Vop3p::VWmmaBf16f3216x16x32Bf16Vop3p(const MachineInst *
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_BF16F32_16X16X32_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2531,7 +3073,20 @@ VWmmaBf16f3216x16x32Bf16Vop3p::VWmmaBf16f3216x16x32Bf16Vop3p(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaBf16f3216x16x32Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaBf16f3216x16x32Bf16Vop3p(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_bf16f32_16x16x32_bf16_e64_dpp"
+          : "v_wmma_bf16f32_16x16x32_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_BF16F32_16X16X32_BF16 does not support DPP";
   return std::make_unique<VWmmaBf16f3216x16x32Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -2541,8 +3096,7 @@ VSwmmacF3216x16x64F16Vop3p::VSwmmacF3216x16x64F16Vop3p(const MachineInst *inst)
                 ? "v_swmmac_f32_16x16x64_f16_e64_dpp"
                 : "v_swmmac_f32_16x16x64_f16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VSwmmacF3216x16x64F16Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VSwmmacF3216x16x64F16Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2553,9 +3107,6 @@ VSwmmacF3216x16x64F16Vop3p::VSwmmacF3216x16x64F16Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_F32_16X16X64_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2563,7 +3114,20 @@ VSwmmacF3216x16x64F16Vop3p::VSwmmacF3216x16x64F16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x64F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacF3216x16x64F16Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_f32_16x16x64_f16_e64_dpp"
+          : "v_swmmac_f32_16x16x64_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_F32_16X16X64_F16 does not support DPP";
   return std::make_unique<VSwmmacF3216x16x64F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -2582,8 +3146,7 @@ VSwmmacF3216x16x64Bf16Vop3p::VSwmmacF3216x16x64Bf16Vop3p(const MachineInst *inst
                 ? "v_swmmac_f32_16x16x64_bf16_e64_dpp"
                 : "v_swmmac_f32_16x16x64_bf16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VSwmmacF3216x16x64Bf16Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VSwmmacF3216x16x64Bf16Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2594,9 +3157,6 @@ VSwmmacF3216x16x64Bf16Vop3p::VSwmmacF3216x16x64Bf16Vop3p(const MachineInst *inst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_F32_16X16X64_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2604,7 +3164,20 @@ VSwmmacF3216x16x64Bf16Vop3p::VSwmmacF3216x16x64Bf16Vop3p(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x64Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacF3216x16x64Bf16Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_f32_16x16x64_bf16_e64_dpp"
+          : "v_swmmac_f32_16x16x64_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_F32_16X16X64_BF16 does not support DPP";
   return std::make_unique<VSwmmacF3216x16x64Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -2623,8 +3196,7 @@ VSwmmacF1616x16x64F16Vop3p::VSwmmacF1616x16x64F16Vop3p(const MachineInst *inst)
                 ? "v_swmmac_f16_16x16x64_f16_e64_dpp"
                 : "v_swmmac_f16_16x16x64_f16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VSwmmacF1616x16x64F16Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VSwmmacF1616x16x64F16Vop3p)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2635,9 +3207,6 @@ VSwmmacF1616x16x64F16Vop3p::VSwmmacF1616x16x64F16Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_F16_16X16X64_F16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2645,7 +3214,20 @@ VSwmmacF1616x16x64F16Vop3p::VSwmmacF1616x16x64F16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacF1616x16x64F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacF1616x16x64F16Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_f16_16x16x64_f16_e64_dpp"
+          : "v_swmmac_f16_16x16x64_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_F16_16X16X64_F16 does not support DPP";
   return std::make_unique<VSwmmacF1616x16x64F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -2664,8 +3246,7 @@ VSwmmacBf1616x16x64Bf16Vop3p::VSwmmacBf1616x16x64Bf16Vop3p(const MachineInst *in
                 ? "v_swmmac_bf16_16x16x64_bf16_e64_dpp"
                 : "v_swmmac_bf16_16x16x64_bf16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VSwmmacBf1616x16x64Bf16Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VSwmmacBf1616x16x64Bf16Vop3p)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2676,9 +3257,6 @@ VSwmmacBf1616x16x64Bf16Vop3p::VSwmmacBf1616x16x64Bf16Vop3p(const MachineInst *in
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_BF16_16X16X64_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2686,7 +3264,20 @@ VSwmmacBf1616x16x64Bf16Vop3p::VSwmmacBf1616x16x64Bf16Vop3p(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacBf1616x16x64Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacBf1616x16x64Bf16Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_bf16_16x16x64_bf16_e64_dpp"
+          : "v_swmmac_bf16_16x16x64_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_BF16_16X16X64_BF16 does not support DPP";
   return std::make_unique<VSwmmacBf1616x16x64Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -2705,8 +3296,7 @@ VSwmmacBf16f3216x16x64Bf16Vop3p::VSwmmacBf16f3216x16x64Bf16Vop3p(const MachineIn
                 ? "v_swmmac_bf16f32_16x16x64_bf16_e64_dpp"
                 : "v_swmmac_bf16f32_16x16x64_bf16",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VSwmmacBf16f3216x16x64Bf16Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VSwmmacBf16f3216x16x64Bf16Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2717,9 +3307,6 @@ VSwmmacBf16f3216x16x64Bf16Vop3p::VSwmmacBf16f3216x16x64Bf16Vop3p(const MachineIn
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_BF16F32_16X16X64_BF16 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2727,7 +3314,20 @@ VSwmmacBf16f3216x16x64Bf16Vop3p::VSwmmacBf16f3216x16x64Bf16Vop3p(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacBf16f3216x16x64Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacBf16f3216x16x64Bf16Vop3p(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_bf16f32_16x16x64_bf16_e64_dpp"
+          : "v_swmmac_bf16f32_16x16x64_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_BF16F32_16X16X64_BF16 does not support DPP";
   return std::make_unique<VSwmmacBf16f3216x16x64Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -2746,8 +3346,7 @@ VWmmaF3216x16x64Fp8Fp8Vop3p::VWmmaF3216x16x64Fp8Fp8Vop3p(const MachineInst *inst
                 ? "v_wmma_f32_16x16x64_fp8_fp8_e64_dpp"
                 : "v_wmma_f32_16x16x64_fp8_fp8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x64Fp8Fp8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x64Fp8Fp8Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2759,9 +3358,6 @@ VWmmaF3216x16x64Fp8Fp8Vop3p::VWmmaF3216x16x64Fp8Fp8Vop3p(const MachineInst *inst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X64_FP8_FP8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2769,7 +3365,20 @@ VWmmaF3216x16x64Fp8Fp8Vop3p::VWmmaF3216x16x64Fp8Fp8Vop3p(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x64Fp8Fp8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x64Fp8Fp8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x64_fp8_fp8_e64_dpp"
+          : "v_wmma_f32_16x16x64_fp8_fp8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X64_FP8_FP8 does not support DPP";
   return std::make_unique<VWmmaF3216x16x64Fp8Fp8Vop3p>(opcode);
 }
 } // namespace detail
@@ -2779,8 +3388,7 @@ VWmmaF3216x16x64Fp8Bf8Vop3p::VWmmaF3216x16x64Fp8Bf8Vop3p(const MachineInst *inst
                 ? "v_wmma_f32_16x16x64_fp8_bf8_e64_dpp"
                 : "v_wmma_f32_16x16x64_fp8_bf8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x64Fp8Bf8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x64Fp8Bf8Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2792,9 +3400,6 @@ VWmmaF3216x16x64Fp8Bf8Vop3p::VWmmaF3216x16x64Fp8Bf8Vop3p(const MachineInst *inst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X64_FP8_BF8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2802,7 +3407,20 @@ VWmmaF3216x16x64Fp8Bf8Vop3p::VWmmaF3216x16x64Fp8Bf8Vop3p(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x64Fp8Bf8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x64Fp8Bf8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x64_fp8_bf8_e64_dpp"
+          : "v_wmma_f32_16x16x64_fp8_bf8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X64_FP8_BF8 does not support DPP";
   return std::make_unique<VWmmaF3216x16x64Fp8Bf8Vop3p>(opcode);
 }
 } // namespace detail
@@ -2812,8 +3430,7 @@ VWmmaF3216x16x64Bf8Fp8Vop3p::VWmmaF3216x16x64Bf8Fp8Vop3p(const MachineInst *inst
                 ? "v_wmma_f32_16x16x64_bf8_fp8_e64_dpp"
                 : "v_wmma_f32_16x16x64_bf8_fp8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x64Bf8Fp8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x64Bf8Fp8Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2825,9 +3442,6 @@ VWmmaF3216x16x64Bf8Fp8Vop3p::VWmmaF3216x16x64Bf8Fp8Vop3p(const MachineInst *inst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X64_BF8_FP8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2835,7 +3449,20 @@ VWmmaF3216x16x64Bf8Fp8Vop3p::VWmmaF3216x16x64Bf8Fp8Vop3p(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x64Bf8Fp8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x64Bf8Fp8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x64_bf8_fp8_e64_dpp"
+          : "v_wmma_f32_16x16x64_bf8_fp8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X64_BF8_FP8 does not support DPP";
   return std::make_unique<VWmmaF3216x16x64Bf8Fp8Vop3p>(opcode);
 }
 } // namespace detail
@@ -2845,8 +3472,7 @@ VWmmaF3216x16x64Bf8Bf8Vop3p::VWmmaF3216x16x64Bf8Bf8Vop3p(const MachineInst *inst
                 ? "v_wmma_f32_16x16x64_bf8_bf8_e64_dpp"
                 : "v_wmma_f32_16x16x64_bf8_bf8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x64Bf8Bf8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x64Bf8Bf8Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2858,9 +3484,6 @@ VWmmaF3216x16x64Bf8Bf8Vop3p::VWmmaF3216x16x64Bf8Bf8Vop3p(const MachineInst *inst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X64_BF8_BF8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2868,7 +3491,20 @@ VWmmaF3216x16x64Bf8Bf8Vop3p::VWmmaF3216x16x64Bf8Bf8Vop3p(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x64Bf8Bf8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x64Bf8Bf8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x64_bf8_bf8_e64_dpp"
+          : "v_wmma_f32_16x16x64_bf8_bf8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X64_BF8_BF8 does not support DPP";
   return std::make_unique<VWmmaF3216x16x64Bf8Bf8Vop3p>(opcode);
 }
 } // namespace detail
@@ -2878,8 +3514,7 @@ VWmmaF1616x16x64Fp8Fp8Vop3p::VWmmaF1616x16x64Fp8Fp8Vop3p(const MachineInst *inst
                 ? "v_wmma_f16_16x16x64_fp8_fp8_e64_dpp"
                 : "v_wmma_f16_16x16x64_fp8_fp8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF1616x16x64Fp8Fp8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF1616x16x64Fp8Fp8Vop3p)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2891,9 +3526,6 @@ VWmmaF1616x16x64Fp8Fp8Vop3p::VWmmaF1616x16x64Fp8Fp8Vop3p(const MachineInst *inst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F16_16X16X64_FP8_FP8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2901,7 +3533,20 @@ VWmmaF1616x16x64Fp8Fp8Vop3p::VWmmaF1616x16x64Fp8Fp8Vop3p(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x64Fp8Fp8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF1616x16x64Fp8Fp8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f16_16x16x64_fp8_fp8_e64_dpp"
+          : "v_wmma_f16_16x16x64_fp8_fp8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F16_16X16X64_FP8_FP8 does not support DPP";
   return std::make_unique<VWmmaF1616x16x64Fp8Fp8Vop3p>(opcode);
 }
 } // namespace detail
@@ -2911,8 +3556,7 @@ VWmmaF1616x16x64Fp8Bf8Vop3p::VWmmaF1616x16x64Fp8Bf8Vop3p(const MachineInst *inst
                 ? "v_wmma_f16_16x16x64_fp8_bf8_e64_dpp"
                 : "v_wmma_f16_16x16x64_fp8_bf8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF1616x16x64Fp8Bf8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF1616x16x64Fp8Bf8Vop3p)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2924,9 +3568,6 @@ VWmmaF1616x16x64Fp8Bf8Vop3p::VWmmaF1616x16x64Fp8Bf8Vop3p(const MachineInst *inst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F16_16X16X64_FP8_BF8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2934,7 +3575,20 @@ VWmmaF1616x16x64Fp8Bf8Vop3p::VWmmaF1616x16x64Fp8Bf8Vop3p(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x64Fp8Bf8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF1616x16x64Fp8Bf8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f16_16x16x64_fp8_bf8_e64_dpp"
+          : "v_wmma_f16_16x16x64_fp8_bf8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F16_16X16X64_FP8_BF8 does not support DPP";
   return std::make_unique<VWmmaF1616x16x64Fp8Bf8Vop3p>(opcode);
 }
 } // namespace detail
@@ -2944,8 +3598,7 @@ VWmmaF1616x16x64Bf8Fp8Vop3p::VWmmaF1616x16x64Bf8Fp8Vop3p(const MachineInst *inst
                 ? "v_wmma_f16_16x16x64_bf8_fp8_e64_dpp"
                 : "v_wmma_f16_16x16x64_bf8_fp8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF1616x16x64Bf8Fp8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF1616x16x64Bf8Fp8Vop3p)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2957,9 +3610,6 @@ VWmmaF1616x16x64Bf8Fp8Vop3p::VWmmaF1616x16x64Bf8Fp8Vop3p(const MachineInst *inst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F16_16X16X64_BF8_FP8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -2967,7 +3617,20 @@ VWmmaF1616x16x64Bf8Fp8Vop3p::VWmmaF1616x16x64Bf8Fp8Vop3p(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x64Bf8Fp8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF1616x16x64Bf8Fp8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f16_16x16x64_bf8_fp8_e64_dpp"
+          : "v_wmma_f16_16x16x64_bf8_fp8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F16_16X16X64_BF8_FP8 does not support DPP";
   return std::make_unique<VWmmaF1616x16x64Bf8Fp8Vop3p>(opcode);
 }
 } // namespace detail
@@ -2977,8 +3640,7 @@ VWmmaF1616x16x64Bf8Bf8Vop3p::VWmmaF1616x16x64Bf8Bf8Vop3p(const MachineInst *inst
                 ? "v_wmma_f16_16x16x64_bf8_bf8_e64_dpp"
                 : "v_wmma_f16_16x16x64_bf8_bf8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF1616x16x64Bf8Bf8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF1616x16x64Bf8Bf8Vop3p)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2990,9 +3652,6 @@ VWmmaF1616x16x64Bf8Bf8Vop3p::VWmmaF1616x16x64Bf8Bf8Vop3p(const MachineInst *inst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F16_16X16X64_BF8_BF8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3000,7 +3659,20 @@ VWmmaF1616x16x64Bf8Bf8Vop3p::VWmmaF1616x16x64Bf8Bf8Vop3p(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x64Bf8Bf8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF1616x16x64Bf8Bf8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f16_16x16x64_bf8_bf8_e64_dpp"
+          : "v_wmma_f16_16x16x64_bf8_bf8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F16_16X16X64_BF8_BF8 does not support DPP";
   return std::make_unique<VWmmaF1616x16x64Bf8Bf8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3010,8 +3682,7 @@ VWmmaI3216x16x64Iu8Vop3p::VWmmaI3216x16x64Iu8Vop3p(const MachineInst *inst)
                 ? "v_wmma_i32_16x16x64_iu8_e64_dpp"
                 : "v_wmma_i32_16x16x64_iu8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaI3216x16x64Iu8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaI3216x16x64Iu8Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3023,9 +3694,6 @@ VWmmaI3216x16x64Iu8Vop3p::VWmmaI3216x16x64Iu8Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_I32_16X16X64_IU8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3033,7 +3701,20 @@ VWmmaI3216x16x64Iu8Vop3p::VWmmaI3216x16x64Iu8Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaI3216x16x64Iu8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaI3216x16x64Iu8Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_i32_16x16x64_iu8_e64_dpp"
+          : "v_wmma_i32_16x16x64_iu8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_I32_16X16X64_IU8 does not support DPP";
   return std::make_unique<VWmmaI3216x16x64Iu8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3043,8 +3724,7 @@ VSwmmacF3216x16x128Fp8Fp8Vop3p::VSwmmacF3216x16x128Fp8Fp8Vop3p(const MachineInst
                 ? "v_swmmac_f32_16x16x128_fp8_fp8_e64_dpp"
                 : "v_swmmac_f32_16x16x128_fp8_fp8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VSwmmacF3216x16x128Fp8Fp8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VSwmmacF3216x16x128Fp8Fp8Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3055,9 +3735,6 @@ VSwmmacF3216x16x128Fp8Fp8Vop3p::VSwmmacF3216x16x128Fp8Fp8Vop3p(const MachineInst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_F32_16X16X128_FP8_FP8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3065,7 +3742,20 @@ VSwmmacF3216x16x128Fp8Fp8Vop3p::VSwmmacF3216x16x128Fp8Fp8Vop3p(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x128Fp8Fp8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacF3216x16x128Fp8Fp8Vop3p(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_f32_16x16x128_fp8_fp8_e64_dpp"
+          : "v_swmmac_f32_16x16x128_fp8_fp8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_F32_16X16X128_FP8_FP8 does not support DPP";
   return std::make_unique<VSwmmacF3216x16x128Fp8Fp8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3084,8 +3774,7 @@ VSwmmacF3216x16x128Fp8Bf8Vop3p::VSwmmacF3216x16x128Fp8Bf8Vop3p(const MachineInst
                 ? "v_swmmac_f32_16x16x128_fp8_bf8_e64_dpp"
                 : "v_swmmac_f32_16x16x128_fp8_bf8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VSwmmacF3216x16x128Fp8Bf8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VSwmmacF3216x16x128Fp8Bf8Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3096,9 +3785,6 @@ VSwmmacF3216x16x128Fp8Bf8Vop3p::VSwmmacF3216x16x128Fp8Bf8Vop3p(const MachineInst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_F32_16X16X128_FP8_BF8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3106,7 +3792,20 @@ VSwmmacF3216x16x128Fp8Bf8Vop3p::VSwmmacF3216x16x128Fp8Bf8Vop3p(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x128Fp8Bf8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacF3216x16x128Fp8Bf8Vop3p(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_f32_16x16x128_fp8_bf8_e64_dpp"
+          : "v_swmmac_f32_16x16x128_fp8_bf8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_F32_16X16X128_FP8_BF8 does not support DPP";
   return std::make_unique<VSwmmacF3216x16x128Fp8Bf8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3125,8 +3824,7 @@ VSwmmacF3216x16x128Bf8Fp8Vop3p::VSwmmacF3216x16x128Bf8Fp8Vop3p(const MachineInst
                 ? "v_swmmac_f32_16x16x128_bf8_fp8_e64_dpp"
                 : "v_swmmac_f32_16x16x128_bf8_fp8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VSwmmacF3216x16x128Bf8Fp8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VSwmmacF3216x16x128Bf8Fp8Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3137,9 +3835,6 @@ VSwmmacF3216x16x128Bf8Fp8Vop3p::VSwmmacF3216x16x128Bf8Fp8Vop3p(const MachineInst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_F32_16X16X128_BF8_FP8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3147,7 +3842,20 @@ VSwmmacF3216x16x128Bf8Fp8Vop3p::VSwmmacF3216x16x128Bf8Fp8Vop3p(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x128Bf8Fp8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacF3216x16x128Bf8Fp8Vop3p(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_f32_16x16x128_bf8_fp8_e64_dpp"
+          : "v_swmmac_f32_16x16x128_bf8_fp8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_F32_16X16X128_BF8_FP8 does not support DPP";
   return std::make_unique<VSwmmacF3216x16x128Bf8Fp8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3166,8 +3874,7 @@ VSwmmacF3216x16x128Bf8Bf8Vop3p::VSwmmacF3216x16x128Bf8Bf8Vop3p(const MachineInst
                 ? "v_swmmac_f32_16x16x128_bf8_bf8_e64_dpp"
                 : "v_swmmac_f32_16x16x128_bf8_bf8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VSwmmacF3216x16x128Bf8Bf8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VSwmmacF3216x16x128Bf8Bf8Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3178,9 +3885,6 @@ VSwmmacF3216x16x128Bf8Bf8Vop3p::VSwmmacF3216x16x128Bf8Bf8Vop3p(const MachineInst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_F32_16X16X128_BF8_BF8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3188,7 +3892,20 @@ VSwmmacF3216x16x128Bf8Bf8Vop3p::VSwmmacF3216x16x128Bf8Bf8Vop3p(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x128Bf8Bf8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacF3216x16x128Bf8Bf8Vop3p(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_f32_16x16x128_bf8_bf8_e64_dpp"
+          : "v_swmmac_f32_16x16x128_bf8_bf8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_F32_16X16X128_BF8_BF8 does not support DPP";
   return std::make_unique<VSwmmacF3216x16x128Bf8Bf8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3207,8 +3924,7 @@ VSwmmacF1616x16x128Fp8Fp8Vop3p::VSwmmacF1616x16x128Fp8Fp8Vop3p(const MachineInst
                 ? "v_swmmac_f16_16x16x128_fp8_fp8_e64_dpp"
                 : "v_swmmac_f16_16x16x128_fp8_fp8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VSwmmacF1616x16x128Fp8Fp8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VSwmmacF1616x16x128Fp8Fp8Vop3p)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3219,9 +3935,6 @@ VSwmmacF1616x16x128Fp8Fp8Vop3p::VSwmmacF1616x16x128Fp8Fp8Vop3p(const MachineInst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_F16_16X16X128_FP8_FP8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3229,7 +3942,20 @@ VSwmmacF1616x16x128Fp8Fp8Vop3p::VSwmmacF1616x16x128Fp8Fp8Vop3p(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacF1616x16x128Fp8Fp8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacF1616x16x128Fp8Fp8Vop3p(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_f16_16x16x128_fp8_fp8_e64_dpp"
+          : "v_swmmac_f16_16x16x128_fp8_fp8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_F16_16X16X128_FP8_FP8 does not support DPP";
   return std::make_unique<VSwmmacF1616x16x128Fp8Fp8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3248,8 +3974,7 @@ VSwmmacF1616x16x128Fp8Bf8Vop3p::VSwmmacF1616x16x128Fp8Bf8Vop3p(const MachineInst
                 ? "v_swmmac_f16_16x16x128_fp8_bf8_e64_dpp"
                 : "v_swmmac_f16_16x16x128_fp8_bf8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VSwmmacF1616x16x128Fp8Bf8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VSwmmacF1616x16x128Fp8Bf8Vop3p)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3260,9 +3985,6 @@ VSwmmacF1616x16x128Fp8Bf8Vop3p::VSwmmacF1616x16x128Fp8Bf8Vop3p(const MachineInst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_F16_16X16X128_FP8_BF8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3270,7 +3992,20 @@ VSwmmacF1616x16x128Fp8Bf8Vop3p::VSwmmacF1616x16x128Fp8Bf8Vop3p(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacF1616x16x128Fp8Bf8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacF1616x16x128Fp8Bf8Vop3p(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_f16_16x16x128_fp8_bf8_e64_dpp"
+          : "v_swmmac_f16_16x16x128_fp8_bf8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_F16_16X16X128_FP8_BF8 does not support DPP";
   return std::make_unique<VSwmmacF1616x16x128Fp8Bf8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3289,8 +4024,7 @@ VSwmmacF1616x16x128Bf8Fp8Vop3p::VSwmmacF1616x16x128Bf8Fp8Vop3p(const MachineInst
                 ? "v_swmmac_f16_16x16x128_bf8_fp8_e64_dpp"
                 : "v_swmmac_f16_16x16x128_bf8_fp8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VSwmmacF1616x16x128Bf8Fp8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VSwmmacF1616x16x128Bf8Fp8Vop3p)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3301,9 +4035,6 @@ VSwmmacF1616x16x128Bf8Fp8Vop3p::VSwmmacF1616x16x128Bf8Fp8Vop3p(const MachineInst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_F16_16X16X128_BF8_FP8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3311,7 +4042,20 @@ VSwmmacF1616x16x128Bf8Fp8Vop3p::VSwmmacF1616x16x128Bf8Fp8Vop3p(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacF1616x16x128Bf8Fp8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacF1616x16x128Bf8Fp8Vop3p(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_f16_16x16x128_bf8_fp8_e64_dpp"
+          : "v_swmmac_f16_16x16x128_bf8_fp8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_F16_16X16X128_BF8_FP8 does not support DPP";
   return std::make_unique<VSwmmacF1616x16x128Bf8Fp8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3330,8 +4074,7 @@ VSwmmacF1616x16x128Bf8Bf8Vop3p::VSwmmacF1616x16x128Bf8Bf8Vop3p(const MachineInst
                 ? "v_swmmac_f16_16x16x128_bf8_bf8_e64_dpp"
                 : "v_swmmac_f16_16x16x128_bf8_bf8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VSwmmacF1616x16x128Bf8Bf8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VSwmmacF1616x16x128Bf8Bf8Vop3p)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3342,9 +4085,6 @@ VSwmmacF1616x16x128Bf8Bf8Vop3p::VSwmmacF1616x16x128Bf8Bf8Vop3p(const MachineInst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_F16_16X16X128_BF8_BF8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3352,7 +4092,20 @@ VSwmmacF1616x16x128Bf8Bf8Vop3p::VSwmmacF1616x16x128Bf8Bf8Vop3p(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacF1616x16x128Bf8Bf8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacF1616x16x128Bf8Bf8Vop3p(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_f16_16x16x128_bf8_bf8_e64_dpp"
+          : "v_swmmac_f16_16x16x128_bf8_bf8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_F16_16X16X128_BF8_BF8 does not support DPP";
   return std::make_unique<VSwmmacF1616x16x128Bf8Bf8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3371,8 +4124,7 @@ VSwmmacI3216x16x128Iu8Vop3p::VSwmmacI3216x16x128Iu8Vop3p(const MachineInst *inst
                 ? "v_swmmac_i32_16x16x128_iu8_e64_dpp"
                 : "v_swmmac_i32_16x16x128_iu8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VSwmmacI3216x16x128Iu8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VSwmmacI3216x16x128Iu8Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3383,9 +4135,6 @@ VSwmmacI3216x16x128Iu8Vop3p::VSwmmacI3216x16x128Iu8Vop3p(const MachineInst *inst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_I32_16X16X128_IU8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3393,7 +4142,20 @@ VSwmmacI3216x16x128Iu8Vop3p::VSwmmacI3216x16x128Iu8Vop3p(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacI3216x16x128Iu8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacI3216x16x128Iu8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_i32_16x16x128_iu8_e64_dpp"
+          : "v_swmmac_i32_16x16x128_iu8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_I32_16X16X128_IU8 does not support DPP";
   return std::make_unique<VSwmmacI3216x16x128Iu8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3412,8 +4174,7 @@ VWmmaF3216x16x128Fp8Fp8Vop3p::VWmmaF3216x16x128Fp8Fp8Vop3p(const MachineInst *in
                 ? "v_wmma_f32_16x16x128_fp8_fp8_e64_dpp"
                 : "v_wmma_f32_16x16x128_fp8_fp8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x128Fp8Fp8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x128Fp8Fp8Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3424,18 +4185,6 @@ VWmmaF3216x16x128Fp8Fp8Vop3p::VWmmaF3216x16x128Fp8Fp8Vop3p(const MachineInst *in
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (!((reinterpret_cast<const OpEncoding *>(inst)->src2 >= 0 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 124) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 128 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 208) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 240 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 248) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 256 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 511)))
-    throw util::InvalidInst("V_WMMA_F32_16X16X128_FP8_FP8 has an invalid accumulator selector", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X128_FP8_FP8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3443,7 +4192,29 @@ VWmmaF3216x16x128Fp8Fp8Vop3p::VWmmaF3216x16x128Fp8Fp8Vop3p(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x128Fp8Fp8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x128Fp8Fp8Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x128_fp8_fp8_e64_dpp"
+          : "v_wmma_f32_16x16x128_fp8_fp8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (!((reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 0 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 124) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 128 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 208) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 240 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 248) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 256 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 511))) [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X128_FP8_FP8 has an invalid accumulator selector";
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X128_FP8_FP8 does not support DPP";
   return std::make_unique<VWmmaF3216x16x128Fp8Fp8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3453,8 +4224,7 @@ VWmmaF3216x16x128Fp8Bf8Vop3p::VWmmaF3216x16x128Fp8Bf8Vop3p(const MachineInst *in
                 ? "v_wmma_f32_16x16x128_fp8_bf8_e64_dpp"
                 : "v_wmma_f32_16x16x128_fp8_bf8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x128Fp8Bf8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x128Fp8Bf8Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3465,18 +4235,6 @@ VWmmaF3216x16x128Fp8Bf8Vop3p::VWmmaF3216x16x128Fp8Bf8Vop3p(const MachineInst *in
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (!((reinterpret_cast<const OpEncoding *>(inst)->src2 >= 0 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 124) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 128 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 208) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 240 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 248) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 256 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 511)))
-    throw util::InvalidInst("V_WMMA_F32_16X16X128_FP8_BF8 has an invalid accumulator selector", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X128_FP8_BF8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3484,7 +4242,29 @@ VWmmaF3216x16x128Fp8Bf8Vop3p::VWmmaF3216x16x128Fp8Bf8Vop3p(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x128Fp8Bf8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x128Fp8Bf8Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x128_fp8_bf8_e64_dpp"
+          : "v_wmma_f32_16x16x128_fp8_bf8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (!((reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 0 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 124) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 128 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 208) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 240 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 248) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 256 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 511))) [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X128_FP8_BF8 has an invalid accumulator selector";
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X128_FP8_BF8 does not support DPP";
   return std::make_unique<VWmmaF3216x16x128Fp8Bf8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3494,8 +4274,7 @@ VWmmaF3216x16x128Bf8Fp8Vop3p::VWmmaF3216x16x128Bf8Fp8Vop3p(const MachineInst *in
                 ? "v_wmma_f32_16x16x128_bf8_fp8_e64_dpp"
                 : "v_wmma_f32_16x16x128_bf8_fp8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x128Bf8Fp8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x128Bf8Fp8Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3506,18 +4285,6 @@ VWmmaF3216x16x128Bf8Fp8Vop3p::VWmmaF3216x16x128Bf8Fp8Vop3p(const MachineInst *in
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (!((reinterpret_cast<const OpEncoding *>(inst)->src2 >= 0 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 124) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 128 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 208) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 240 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 248) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 256 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 511)))
-    throw util::InvalidInst("V_WMMA_F32_16X16X128_BF8_FP8 has an invalid accumulator selector", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X128_BF8_FP8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3525,7 +4292,29 @@ VWmmaF3216x16x128Bf8Fp8Vop3p::VWmmaF3216x16x128Bf8Fp8Vop3p(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x128Bf8Fp8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x128Bf8Fp8Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x128_bf8_fp8_e64_dpp"
+          : "v_wmma_f32_16x16x128_bf8_fp8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (!((reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 0 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 124) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 128 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 208) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 240 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 248) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 256 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 511))) [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X128_BF8_FP8 has an invalid accumulator selector";
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X128_BF8_FP8 does not support DPP";
   return std::make_unique<VWmmaF3216x16x128Bf8Fp8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3535,8 +4324,7 @@ VWmmaF3216x16x128Bf8Bf8Vop3p::VWmmaF3216x16x128Bf8Bf8Vop3p(const MachineInst *in
                 ? "v_wmma_f32_16x16x128_bf8_bf8_e64_dpp"
                 : "v_wmma_f32_16x16x128_bf8_bf8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x128Bf8Bf8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF3216x16x128Bf8Bf8Vop3p)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3547,18 +4335,6 @@ VWmmaF3216x16x128Bf8Bf8Vop3p::VWmmaF3216x16x128Bf8Bf8Vop3p(const MachineInst *in
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (!((reinterpret_cast<const OpEncoding *>(inst)->src2 >= 0 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 124) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 128 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 208) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 240 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 248) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 256 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 511)))
-    throw util::InvalidInst("V_WMMA_F32_16X16X128_BF8_BF8 has an invalid accumulator selector", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X128_BF8_BF8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3566,7 +4342,29 @@ VWmmaF3216x16x128Bf8Bf8Vop3p::VWmmaF3216x16x128Bf8Bf8Vop3p(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x128Bf8Bf8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x128Bf8Bf8Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x128_bf8_bf8_e64_dpp"
+          : "v_wmma_f32_16x16x128_bf8_bf8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (!((reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 0 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 124) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 128 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 208) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 240 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 248) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 256 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 511))) [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X128_BF8_BF8 has an invalid accumulator selector";
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X128_BF8_BF8 does not support DPP";
   return std::make_unique<VWmmaF3216x16x128Bf8Bf8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3576,8 +4374,7 @@ VWmmaF1616x16x128Fp8Fp8Vop3p::VWmmaF1616x16x128Fp8Fp8Vop3p(const MachineInst *in
                 ? "v_wmma_f16_16x16x128_fp8_fp8_e64_dpp"
                 : "v_wmma_f16_16x16x128_fp8_fp8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF1616x16x128Fp8Fp8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF1616x16x128Fp8Fp8Vop3p)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3588,18 +4385,6 @@ VWmmaF1616x16x128Fp8Fp8Vop3p::VWmmaF1616x16x128Fp8Fp8Vop3p(const MachineInst *in
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (!((reinterpret_cast<const OpEncoding *>(inst)->src2 >= 0 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 124) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 128 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 208) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 240 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 248) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 256 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 511)))
-    throw util::InvalidInst("V_WMMA_F16_16X16X128_FP8_FP8 has an invalid accumulator selector", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F16_16X16X128_FP8_FP8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3607,7 +4392,29 @@ VWmmaF1616x16x128Fp8Fp8Vop3p::VWmmaF1616x16x128Fp8Fp8Vop3p(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x128Fp8Fp8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF1616x16x128Fp8Fp8Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f16_16x16x128_fp8_fp8_e64_dpp"
+          : "v_wmma_f16_16x16x128_fp8_fp8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (!((reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 0 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 124) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 128 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 208) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 240 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 248) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 256 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 511))) [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F16_16X16X128_FP8_FP8 has an invalid accumulator selector";
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F16_16X16X128_FP8_FP8 does not support DPP";
   return std::make_unique<VWmmaF1616x16x128Fp8Fp8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3617,8 +4424,7 @@ VWmmaF1616x16x128Fp8Bf8Vop3p::VWmmaF1616x16x128Fp8Bf8Vop3p(const MachineInst *in
                 ? "v_wmma_f16_16x16x128_fp8_bf8_e64_dpp"
                 : "v_wmma_f16_16x16x128_fp8_bf8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF1616x16x128Fp8Bf8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF1616x16x128Fp8Bf8Vop3p)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3629,18 +4435,6 @@ VWmmaF1616x16x128Fp8Bf8Vop3p::VWmmaF1616x16x128Fp8Bf8Vop3p(const MachineInst *in
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (!((reinterpret_cast<const OpEncoding *>(inst)->src2 >= 0 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 124) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 128 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 208) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 240 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 248) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 256 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 511)))
-    throw util::InvalidInst("V_WMMA_F16_16X16X128_FP8_BF8 has an invalid accumulator selector", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F16_16X16X128_FP8_BF8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3648,7 +4442,29 @@ VWmmaF1616x16x128Fp8Bf8Vop3p::VWmmaF1616x16x128Fp8Bf8Vop3p(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x128Fp8Bf8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF1616x16x128Fp8Bf8Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f16_16x16x128_fp8_bf8_e64_dpp"
+          : "v_wmma_f16_16x16x128_fp8_bf8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (!((reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 0 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 124) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 128 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 208) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 240 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 248) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 256 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 511))) [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F16_16X16X128_FP8_BF8 has an invalid accumulator selector";
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F16_16X16X128_FP8_BF8 does not support DPP";
   return std::make_unique<VWmmaF1616x16x128Fp8Bf8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3658,8 +4474,7 @@ VWmmaF1616x16x128Bf8Fp8Vop3p::VWmmaF1616x16x128Bf8Fp8Vop3p(const MachineInst *in
                 ? "v_wmma_f16_16x16x128_bf8_fp8_e64_dpp"
                 : "v_wmma_f16_16x16x128_bf8_fp8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF1616x16x128Bf8Fp8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF1616x16x128Bf8Fp8Vop3p)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3670,18 +4485,6 @@ VWmmaF1616x16x128Bf8Fp8Vop3p::VWmmaF1616x16x128Bf8Fp8Vop3p(const MachineInst *in
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (!((reinterpret_cast<const OpEncoding *>(inst)->src2 >= 0 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 124) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 128 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 208) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 240 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 248) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 256 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 511)))
-    throw util::InvalidInst("V_WMMA_F16_16X16X128_BF8_FP8 has an invalid accumulator selector", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F16_16X16X128_BF8_FP8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3689,7 +4492,29 @@ VWmmaF1616x16x128Bf8Fp8Vop3p::VWmmaF1616x16x128Bf8Fp8Vop3p(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x128Bf8Fp8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF1616x16x128Bf8Fp8Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f16_16x16x128_bf8_fp8_e64_dpp"
+          : "v_wmma_f16_16x16x128_bf8_fp8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (!((reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 0 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 124) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 128 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 208) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 240 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 248) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 256 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 511))) [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F16_16X16X128_BF8_FP8 has an invalid accumulator selector";
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F16_16X16X128_BF8_FP8 does not support DPP";
   return std::make_unique<VWmmaF1616x16x128Bf8Fp8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3699,8 +4524,7 @@ VWmmaF1616x16x128Bf8Bf8Vop3p::VWmmaF1616x16x128Bf8Bf8Vop3p(const MachineInst *in
                 ? "v_wmma_f16_16x16x128_bf8_bf8_e64_dpp"
                 : "v_wmma_f16_16x16x128_bf8_bf8",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF1616x16x128Bf8Bf8Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF1616x16x128Bf8Bf8Vop3p)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3711,18 +4535,6 @@ VWmmaF1616x16x128Bf8Bf8Vop3p::VWmmaF1616x16x128Bf8Bf8Vop3p(const MachineInst *in
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (!((reinterpret_cast<const OpEncoding *>(inst)->src2 >= 0 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 124) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 128 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 208) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 240 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 248) ||
-        (reinterpret_cast<const OpEncoding *>(inst)->src2 >= 256 &&
-         reinterpret_cast<const OpEncoding *>(inst)->src2 <= 511)))
-    throw util::InvalidInst("V_WMMA_F16_16X16X128_BF8_BF8 has an invalid accumulator selector", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F16_16X16X128_BF8_BF8 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3730,7 +4542,29 @@ VWmmaF1616x16x128Bf8Bf8Vop3p::VWmmaF1616x16x128Bf8Bf8Vop3p(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x128Bf8Bf8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF1616x16x128Bf8Bf8Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f16_16x16x128_bf8_bf8_e64_dpp"
+          : "v_wmma_f16_16x16x128_bf8_bf8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (!((reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 0 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 124) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 128 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 208) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 240 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 248) ||
+        (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 >= 256 &&
+         reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src2 <= 511))) [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F16_16X16X128_BF8_BF8 has an invalid accumulator selector";
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F16_16X16X128_BF8_BF8 does not support DPP";
   return std::make_unique<VWmmaF1616x16x128Bf8Bf8Vop3p>(opcode);
 }
 } // namespace detail
@@ -3740,8 +4574,7 @@ VWmmaF3232x16x128F4Vop3p::VWmmaF3232x16x128F4Vop3p(const MachineInst *inst)
                 ? "v_wmma_f32_32x16x128_f4_e64_dpp"
                 : "v_wmma_f32_32x16x128_f4",
             reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(InstructionExecutionId::VWmmaF3232x16x128F4Vop3p),
-            LiteralSupport::None),
+            selected_exec_fn(InstructionExecutionId::VWmmaF3232x16x128F4Vop3p)),
       vdst(512, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3753,9 +4586,6 @@ VWmmaF3232x16x128F4Vop3p::VWmmaF3232x16x128F4Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_32X16X128_F4 does not support DPP", "");
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
@@ -3763,14 +4593,27 @@ VWmmaF3232x16x128F4Vop3p::VWmmaF3232x16x128F4Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3232x16x128F4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3232x16x128F4Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_32x16x128_f4_e64_dpp"
+          : "v_wmma_f32_32x16x128_f4",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error, LiteralSupport::None);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_32X16X128_F4 does not support DPP";
   return std::make_unique<VWmmaF3232x16x128F4Vop3p>(opcode);
 }
 } // namespace detail
 
 VWmmaScaleF32Vop3px2::VWmmaScaleF32Vop3px2(const MachineInst *inst)
     : Vop3p(gfx1250_scaled_wmma_mnemonic(inst), reinterpret_cast<const OpEncoding *>(inst + 2),
-            selected_exec_fn(InstructionExecutionId::VWmmaScaleF32Vop3px2), LiteralSupport::Both, 3,
+            selected_exec_fn(InstructionExecutionId::VWmmaScaleF32Vop3px2),
             Vop3p::ExtensionDecodePolicy::Skip),
       vdst(gfx1250_scaled_wmma_dst_size_bits(inst), OperandType::OPR_VGPR,
            reinterpret_cast<const OpEncoding *>(inst + 2)->vdst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vopc_cmp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vopc_cmp.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vopc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -64,7 +63,15 @@ VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f16_dpp"
+          : "v_cmp_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -120,7 +127,15 @@ VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f16_dpp"
+          : "v_cmp_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -176,7 +191,15 @@ VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f16_dpp"
+          : "v_cmp_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -232,7 +255,15 @@ VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f16_dpp"
+          : "v_cmp_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -288,7 +319,15 @@ VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f16_dpp"
+          : "v_cmp_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -344,7 +383,15 @@ VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f16_dpp"
+          : "v_cmp_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -400,7 +447,15 @@ VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f16_dpp"
+          : "v_cmp_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -456,7 +511,15 @@ VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f16_dpp"
+          : "v_cmp_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -512,7 +575,15 @@ VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f16_dpp"
+          : "v_cmp_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -568,7 +639,15 @@ VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f16_dpp"
+          : "v_cmp_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -624,7 +703,15 @@ VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f16_dpp"
+          : "v_cmp_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -680,7 +767,15 @@ VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f16_dpp"
+          : "v_cmp_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -736,7 +831,15 @@ VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f16_dpp"
+          : "v_cmp_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -792,7 +895,15 @@ VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f16_dpp"
+          : "v_cmp_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -845,7 +956,15 @@ VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f32_dpp"
+          : "v_cmp_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -898,7 +1017,15 @@ VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f32_dpp"
+          : "v_cmp_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -951,7 +1078,15 @@ VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f32_dpp"
+          : "v_cmp_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1004,7 +1139,15 @@ VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f32_dpp"
+          : "v_cmp_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1057,7 +1200,15 @@ VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f32_dpp"
+          : "v_cmp_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1110,7 +1261,15 @@ VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f32_dpp"
+          : "v_cmp_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1163,7 +1322,15 @@ VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f32_dpp"
+          : "v_cmp_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1216,7 +1383,15 @@ VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f32_dpp"
+          : "v_cmp_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1269,7 +1444,15 @@ VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f32_dpp"
+          : "v_cmp_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1322,7 +1505,15 @@ VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f32_dpp"
+          : "v_cmp_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1375,7 +1566,15 @@ VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f32_dpp"
+          : "v_cmp_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1428,7 +1627,15 @@ VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f32_dpp"
+          : "v_cmp_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1481,7 +1688,15 @@ VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f32_dpp"
+          : "v_cmp_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1534,7 +1749,15 @@ VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f32_dpp"
+          : "v_cmp_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1565,16 +1788,24 @@ VCmpLtF64Vopc::VCmpLtF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f64_dpp"
+          : "v_cmp_lt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support DPP";
   return std::make_unique<VCmpLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1605,16 +1836,24 @@ VCmpEqF64Vopc::VCmpEqF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f64_dpp"
+          : "v_cmp_eq_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support DPP";
   return std::make_unique<VCmpEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1645,16 +1884,24 @@ VCmpLeF64Vopc::VCmpLeF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f64_dpp"
+          : "v_cmp_le_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support DPP";
   return std::make_unique<VCmpLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1685,16 +1932,24 @@ VCmpGtF64Vopc::VCmpGtF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f64_dpp"
+          : "v_cmp_gt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support DPP";
   return std::make_unique<VCmpGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1725,16 +1980,24 @@ VCmpLgF64Vopc::VCmpLgF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LG_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f64_dpp"
+          : "v_cmp_lg_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support DPP";
   return std::make_unique<VCmpLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1765,16 +2028,24 @@ VCmpGeF64Vopc::VCmpGeF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f64_dpp"
+          : "v_cmp_ge_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support DPP";
   return std::make_unique<VCmpGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1805,16 +2076,24 @@ VCmpOF64Vopc::VCmpOF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_O_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f64_dpp"
+          : "v_cmp_o_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support DPP";
   return std::make_unique<VCmpOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1845,16 +2124,24 @@ VCmpUF64Vopc::VCmpUF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_U_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f64_dpp"
+          : "v_cmp_u_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support DPP";
   return std::make_unique<VCmpUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1885,16 +2172,24 @@ VCmpNgeF64Vopc::VCmpNgeF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f64_dpp"
+          : "v_cmp_nge_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support DPP";
   return std::make_unique<VCmpNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1925,16 +2220,24 @@ VCmpNlgF64Vopc::VCmpNlgF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f64_dpp"
+          : "v_cmp_nlg_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support DPP";
   return std::make_unique<VCmpNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1965,16 +2268,24 @@ VCmpNgtF64Vopc::VCmpNgtF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f64_dpp"
+          : "v_cmp_ngt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support DPP";
   return std::make_unique<VCmpNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2005,16 +2316,24 @@ VCmpNleF64Vopc::VCmpNleF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f64_dpp"
+          : "v_cmp_nle_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support DPP";
   return std::make_unique<VCmpNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2045,16 +2364,24 @@ VCmpNeqF64Vopc::VCmpNeqF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f64_dpp"
+          : "v_cmp_neq_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support DPP";
   return std::make_unique<VCmpNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2085,16 +2412,24 @@ VCmpNltF64Vopc::VCmpNltF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f64_dpp"
+          : "v_cmp_nlt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support DPP";
   return std::make_unique<VCmpNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2150,7 +2485,15 @@ VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i16_dpp"
+          : "v_cmp_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2206,7 +2549,15 @@ VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i16_dpp"
+          : "v_cmp_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2262,7 +2613,15 @@ VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i16_dpp"
+          : "v_cmp_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2318,7 +2677,15 @@ VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i16_dpp"
+          : "v_cmp_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2374,7 +2741,15 @@ VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i16_dpp"
+          : "v_cmp_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2430,7 +2805,15 @@ VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i16_dpp"
+          : "v_cmp_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2486,7 +2869,15 @@ VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u16_dpp"
+          : "v_cmp_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2542,7 +2933,15 @@ VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u16_dpp"
+          : "v_cmp_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2598,7 +2997,15 @@ VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u16_dpp"
+          : "v_cmp_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2654,7 +3061,15 @@ VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u16_dpp"
+          : "v_cmp_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2710,7 +3125,15 @@ VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u16_dpp"
+          : "v_cmp_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2766,7 +3189,15 @@ VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u16_dpp"
+          : "v_cmp_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2819,7 +3250,15 @@ VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i32_dpp"
+          : "v_cmp_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2872,7 +3311,15 @@ VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i32_dpp"
+          : "v_cmp_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2925,7 +3372,15 @@ VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i32_dpp"
+          : "v_cmp_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2978,7 +3433,15 @@ VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i32_dpp"
+          : "v_cmp_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3031,7 +3494,15 @@ VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i32_dpp"
+          : "v_cmp_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3084,7 +3555,15 @@ VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i32_dpp"
+          : "v_cmp_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3137,7 +3616,15 @@ VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u32_dpp"
+          : "v_cmp_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3190,7 +3677,15 @@ VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u32_dpp"
+          : "v_cmp_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3243,7 +3738,15 @@ VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u32_dpp"
+          : "v_cmp_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3296,7 +3799,15 @@ VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u32_dpp"
+          : "v_cmp_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3349,7 +3860,15 @@ VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u32_dpp"
+          : "v_cmp_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3402,7 +3921,15 @@ VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u32_dpp"
+          : "v_cmp_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3433,16 +3960,24 @@ VCmpLtI64Vopc::VCmpLtI64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i64_dpp"
+          : "v_cmp_lt_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support DPP";
   return std::make_unique<VCmpLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3473,16 +4008,24 @@ VCmpEqI64Vopc::VCmpEqI64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i64_dpp"
+          : "v_cmp_eq_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support DPP";
   return std::make_unique<VCmpEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3513,16 +4056,24 @@ VCmpLeI64Vopc::VCmpLeI64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i64_dpp"
+          : "v_cmp_le_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support DPP";
   return std::make_unique<VCmpLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3553,16 +4104,24 @@ VCmpGtI64Vopc::VCmpGtI64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i64_dpp"
+          : "v_cmp_gt_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support DPP";
   return std::make_unique<VCmpGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3593,16 +4152,24 @@ VCmpNeI64Vopc::VCmpNeI64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i64_dpp"
+          : "v_cmp_ne_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support DPP";
   return std::make_unique<VCmpNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3633,16 +4200,24 @@ VCmpGeI64Vopc::VCmpGeI64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i64_dpp"
+          : "v_cmp_ge_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support DPP";
   return std::make_unique<VCmpGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3673,16 +4248,24 @@ VCmpLtU64Vopc::VCmpLtU64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u64_dpp"
+          : "v_cmp_lt_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support DPP";
   return std::make_unique<VCmpLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3713,16 +4296,24 @@ VCmpEqU64Vopc::VCmpEqU64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u64_dpp"
+          : "v_cmp_eq_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support DPP";
   return std::make_unique<VCmpEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3753,16 +4344,24 @@ VCmpLeU64Vopc::VCmpLeU64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u64_dpp"
+          : "v_cmp_le_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support DPP";
   return std::make_unique<VCmpLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3793,16 +4392,24 @@ VCmpGtU64Vopc::VCmpGtU64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u64_dpp"
+          : "v_cmp_gt_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support DPP";
   return std::make_unique<VCmpGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3833,16 +4440,24 @@ VCmpNeU64Vopc::VCmpNeU64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u64_dpp"
+          : "v_cmp_ne_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support DPP";
   return std::make_unique<VCmpNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3873,16 +4488,24 @@ VCmpGeU64Vopc::VCmpGeU64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u64_dpp"
+          : "v_cmp_ge_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support DPP";
   return std::make_unique<VCmpGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3938,7 +4561,16 @@ VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f16_dpp"
+          : "v_cmp_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3991,7 +4623,16 @@ VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f32_dpp"
+          : "v_cmp_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4022,16 +4663,25 @@ VCmpClassF64Vopc::VCmpClassF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   vsrc1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f64_dpp"
+          : "v_cmp_class_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support DPP";
   return std::make_unique<VCmpClassF64Vopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vopc_cmpx.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vopc_cmpx.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vopc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -68,7 +67,15 @@ VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f16_dpp"
+          : "v_cmpx_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -128,7 +135,15 @@ VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f16_dpp"
+          : "v_cmpx_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -188,7 +203,15 @@ VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f16_dpp"
+          : "v_cmpx_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -248,7 +271,15 @@ VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f16_dpp"
+          : "v_cmpx_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -308,7 +339,15 @@ VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f16_dpp"
+          : "v_cmpx_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -368,7 +407,15 @@ VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f16_dpp"
+          : "v_cmpx_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -428,7 +475,15 @@ VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f16_dpp"
+          : "v_cmpx_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -488,7 +543,15 @@ VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f16_dpp"
+          : "v_cmpx_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -548,7 +611,16 @@ VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f16_dpp"
+          : "v_cmpx_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -608,7 +680,16 @@ VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f16_dpp"
+          : "v_cmpx_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -668,7 +749,16 @@ VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f16_dpp"
+          : "v_cmpx_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -728,7 +818,16 @@ VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f16_dpp"
+          : "v_cmpx_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -788,7 +887,16 @@ VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f16_dpp"
+          : "v_cmpx_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -848,7 +956,16 @@ VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f16_dpp"
+          : "v_cmpx_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -905,7 +1022,15 @@ VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f32_dpp"
+          : "v_cmpx_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -962,7 +1087,15 @@ VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f32_dpp"
+          : "v_cmpx_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1019,7 +1152,15 @@ VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f32_dpp"
+          : "v_cmpx_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1076,7 +1217,15 @@ VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f32_dpp"
+          : "v_cmpx_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1133,7 +1282,15 @@ VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f32_dpp"
+          : "v_cmpx_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1190,7 +1347,15 @@ VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f32_dpp"
+          : "v_cmpx_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1247,7 +1412,15 @@ VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f32_dpp"
+          : "v_cmpx_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1304,7 +1477,15 @@ VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f32_dpp"
+          : "v_cmpx_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1361,7 +1542,16 @@ VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f32_dpp"
+          : "v_cmpx_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1418,7 +1608,16 @@ VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f32_dpp"
+          : "v_cmpx_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1475,7 +1674,16 @@ VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f32_dpp"
+          : "v_cmpx_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1532,7 +1740,16 @@ VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f32_dpp"
+          : "v_cmpx_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1589,7 +1806,16 @@ VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f32_dpp"
+          : "v_cmpx_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1646,7 +1872,16 @@ VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f32_dpp"
+          : "v_cmpx_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1679,9 +1914,6 @@ VCmpxLtF64Vopc::VCmpxLtF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -1690,7 +1922,18 @@ VCmpxLtF64Vopc::VCmpxLtF64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f64_dpp"
+          : "v_cmpx_lt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support DPP";
   return std::make_unique<VCmpxLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1723,9 +1966,6 @@ VCmpxEqF64Vopc::VCmpxEqF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -1734,7 +1974,18 @@ VCmpxEqF64Vopc::VCmpxEqF64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f64_dpp"
+          : "v_cmpx_eq_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support DPP";
   return std::make_unique<VCmpxEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1767,9 +2018,6 @@ VCmpxLeF64Vopc::VCmpxLeF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -1778,7 +2026,18 @@ VCmpxLeF64Vopc::VCmpxLeF64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f64_dpp"
+          : "v_cmpx_le_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support DPP";
   return std::make_unique<VCmpxLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1811,9 +2070,6 @@ VCmpxGtF64Vopc::VCmpxGtF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -1822,7 +2078,18 @@ VCmpxGtF64Vopc::VCmpxGtF64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f64_dpp"
+          : "v_cmpx_gt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support DPP";
   return std::make_unique<VCmpxGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1855,9 +2122,6 @@ VCmpxLgF64Vopc::VCmpxLgF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -1866,7 +2130,18 @@ VCmpxLgF64Vopc::VCmpxLgF64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f64_dpp"
+          : "v_cmpx_lg_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support DPP";
   return std::make_unique<VCmpxLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1899,9 +2174,6 @@ VCmpxGeF64Vopc::VCmpxGeF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -1910,7 +2182,18 @@ VCmpxGeF64Vopc::VCmpxGeF64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f64_dpp"
+          : "v_cmpx_ge_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support DPP";
   return std::make_unique<VCmpxGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1943,9 +2226,6 @@ VCmpxOF64Vopc::VCmpxOF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_O_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -1954,7 +2234,18 @@ VCmpxOF64Vopc::VCmpxOF64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f64_dpp"
+          : "v_cmpx_o_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support DPP";
   return std::make_unique<VCmpxOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1987,9 +2278,6 @@ VCmpxUF64Vopc::VCmpxUF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_U_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -1998,7 +2286,18 @@ VCmpxUF64Vopc::VCmpxUF64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f64_dpp"
+          : "v_cmpx_u_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support DPP";
   return std::make_unique<VCmpxUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2031,9 +2330,6 @@ VCmpxNgeF64Vopc::VCmpxNgeF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -2042,7 +2338,19 @@ VCmpxNgeF64Vopc::VCmpxNgeF64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f64_dpp"
+          : "v_cmpx_nge_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support DPP";
   return std::make_unique<VCmpxNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2075,9 +2383,6 @@ VCmpxNlgF64Vopc::VCmpxNlgF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -2086,7 +2391,19 @@ VCmpxNlgF64Vopc::VCmpxNlgF64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f64_dpp"
+          : "v_cmpx_nlg_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support DPP";
   return std::make_unique<VCmpxNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2119,9 +2436,6 @@ VCmpxNgtF64Vopc::VCmpxNgtF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -2130,7 +2444,19 @@ VCmpxNgtF64Vopc::VCmpxNgtF64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f64_dpp"
+          : "v_cmpx_ngt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support DPP";
   return std::make_unique<VCmpxNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2163,9 +2489,6 @@ VCmpxNleF64Vopc::VCmpxNleF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -2174,7 +2497,19 @@ VCmpxNleF64Vopc::VCmpxNleF64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f64_dpp"
+          : "v_cmpx_nle_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support DPP";
   return std::make_unique<VCmpxNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2207,9 +2542,6 @@ VCmpxNeqF64Vopc::VCmpxNeqF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -2218,7 +2550,19 @@ VCmpxNeqF64Vopc::VCmpxNeqF64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f64_dpp"
+          : "v_cmpx_neq_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support DPP";
   return std::make_unique<VCmpxNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2251,9 +2595,6 @@ VCmpxNltF64Vopc::VCmpxNltF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -2262,7 +2603,19 @@ VCmpxNltF64Vopc::VCmpxNltF64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f64_dpp"
+          : "v_cmpx_nlt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support DPP";
   return std::make_unique<VCmpxNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2322,7 +2675,15 @@ VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i16_dpp"
+          : "v_cmpx_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2382,7 +2743,15 @@ VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i16_dpp"
+          : "v_cmpx_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2442,7 +2811,15 @@ VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i16_dpp"
+          : "v_cmpx_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2502,7 +2879,15 @@ VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i16_dpp"
+          : "v_cmpx_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2562,7 +2947,15 @@ VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i16_dpp"
+          : "v_cmpx_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2622,7 +3015,15 @@ VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i16_dpp"
+          : "v_cmpx_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2682,7 +3083,15 @@ VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u16_dpp"
+          : "v_cmpx_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2742,7 +3151,15 @@ VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u16_dpp"
+          : "v_cmpx_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2802,7 +3219,15 @@ VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u16_dpp"
+          : "v_cmpx_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2862,7 +3287,15 @@ VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u16_dpp"
+          : "v_cmpx_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2922,7 +3355,15 @@ VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u16_dpp"
+          : "v_cmpx_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2982,7 +3423,15 @@ VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u16_dpp"
+          : "v_cmpx_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -3039,7 +3488,15 @@ VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i32_dpp"
+          : "v_cmpx_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3096,7 +3553,15 @@ VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i32_dpp"
+          : "v_cmpx_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3153,7 +3618,15 @@ VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i32_dpp"
+          : "v_cmpx_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3210,7 +3683,15 @@ VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i32_dpp"
+          : "v_cmpx_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3267,7 +3748,15 @@ VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i32_dpp"
+          : "v_cmpx_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3324,7 +3813,15 @@ VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i32_dpp"
+          : "v_cmpx_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3381,7 +3878,15 @@ VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u32_dpp"
+          : "v_cmpx_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3438,7 +3943,15 @@ VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u32_dpp"
+          : "v_cmpx_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3495,7 +4008,15 @@ VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u32_dpp"
+          : "v_cmpx_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3552,7 +4073,15 @@ VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u32_dpp"
+          : "v_cmpx_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3609,7 +4138,15 @@ VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u32_dpp"
+          : "v_cmpx_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3666,7 +4203,15 @@ VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u32_dpp"
+          : "v_cmpx_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3699,9 +4244,6 @@ VCmpxLtI64Vopc::VCmpxLtI64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -3710,7 +4252,18 @@ VCmpxLtI64Vopc::VCmpxLtI64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i64_dpp"
+          : "v_cmpx_lt_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support DPP";
   return std::make_unique<VCmpxLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3743,9 +4296,6 @@ VCmpxEqI64Vopc::VCmpxEqI64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -3754,7 +4304,18 @@ VCmpxEqI64Vopc::VCmpxEqI64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i64_dpp"
+          : "v_cmpx_eq_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support DPP";
   return std::make_unique<VCmpxEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3787,9 +4348,6 @@ VCmpxLeI64Vopc::VCmpxLeI64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -3798,7 +4356,18 @@ VCmpxLeI64Vopc::VCmpxLeI64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i64_dpp"
+          : "v_cmpx_le_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support DPP";
   return std::make_unique<VCmpxLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3831,9 +4400,6 @@ VCmpxGtI64Vopc::VCmpxGtI64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -3842,7 +4408,18 @@ VCmpxGtI64Vopc::VCmpxGtI64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i64_dpp"
+          : "v_cmpx_gt_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support DPP";
   return std::make_unique<VCmpxGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3875,9 +4452,6 @@ VCmpxNeI64Vopc::VCmpxNeI64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -3886,7 +4460,18 @@ VCmpxNeI64Vopc::VCmpxNeI64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i64_dpp"
+          : "v_cmpx_ne_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support DPP";
   return std::make_unique<VCmpxNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3919,9 +4504,6 @@ VCmpxGeI64Vopc::VCmpxGeI64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -3930,7 +4512,18 @@ VCmpxGeI64Vopc::VCmpxGeI64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i64_dpp"
+          : "v_cmpx_ge_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support DPP";
   return std::make_unique<VCmpxGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3963,9 +4556,6 @@ VCmpxLtU64Vopc::VCmpxLtU64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -3974,7 +4564,18 @@ VCmpxLtU64Vopc::VCmpxLtU64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u64_dpp"
+          : "v_cmpx_lt_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support DPP";
   return std::make_unique<VCmpxLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -4007,9 +4608,6 @@ VCmpxEqU64Vopc::VCmpxEqU64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -4018,7 +4616,18 @@ VCmpxEqU64Vopc::VCmpxEqU64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u64_dpp"
+          : "v_cmpx_eq_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support DPP";
   return std::make_unique<VCmpxEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -4051,9 +4660,6 @@ VCmpxLeU64Vopc::VCmpxLeU64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -4062,7 +4668,18 @@ VCmpxLeU64Vopc::VCmpxLeU64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u64_dpp"
+          : "v_cmpx_le_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support DPP";
   return std::make_unique<VCmpxLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -4095,9 +4712,6 @@ VCmpxGtU64Vopc::VCmpxGtU64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -4106,7 +4720,18 @@ VCmpxGtU64Vopc::VCmpxGtU64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u64_dpp"
+          : "v_cmpx_gt_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support DPP";
   return std::make_unique<VCmpxGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -4139,9 +4764,6 @@ VCmpxNeU64Vopc::VCmpxNeU64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -4150,7 +4772,18 @@ VCmpxNeU64Vopc::VCmpxNeU64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u64_dpp"
+          : "v_cmpx_ne_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support DPP";
   return std::make_unique<VCmpxNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -4183,9 +4816,6 @@ VCmpxGeU64Vopc::VCmpxGeU64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -4194,7 +4824,18 @@ VCmpxGeU64Vopc::VCmpxGeU64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u64_dpp"
+          : "v_cmpx_ge_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support DPP";
   return std::make_unique<VCmpxGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -4254,7 +4895,16 @@ VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f16_dpp"
+          : "v_cmpx_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4311,7 +4961,16 @@ VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f32_dpp"
+          : "v_cmpx_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4344,9 +5003,6 @@ VCmpxClassF64Vopc::VCmpxClassF64Vopc(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
@@ -4355,7 +5011,19 @@ VCmpxClassF64Vopc::VCmpxClassF64Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f64_dpp"
+          : "v_cmpx_class_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support DPP";
   return std::make_unique<VCmpxClassF64Vopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vopd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vopd.cpp
@@ -136,6 +136,43 @@ bool Vopd::is_float64_op(uint16_t op) {
   }
 }
 
+Result Vopd::validate_encoding(const MachineInst *inst, const util::DiagnosticEmitter &emit_error) {
+  const auto *words = reinterpret_cast<const uint32_t *>(inst);
+  const uint32_t word0 = words[0];
+  const uint32_t word1 = words[1];
+  if ((word0 >> 24) == 0xCF) {
+    const uint16_t opx = static_cast<uint16_t>((word0 >> 18) & 0x3F);
+    const uint16_t opy = static_cast<uint16_t>((word0 >> 12) & 0x3F);
+    if (!is_valid_opcode(opx, kVopd3XOpcodeMask)) [[unlikely]]
+      return emit_error.emit() << "invalid VOPD3 X opcode";
+    if (!is_valid_opcode(opy, kVopd3YOpcodeMask)) [[unlikely]]
+      return emit_error.emit() << "invalid VOPD3 Y opcode";
+    const uint16_t srcx0 = static_cast<uint16_t>(word0 & 0x1FF);
+    const uint16_t srcy0 = static_cast<uint16_t>(word1 & 0x1FF);
+    if (srcx0 == 254 || srcx0 == 255 || srcy0 == 254 || srcy0 == 255) [[unlikely]]
+      return emit_error.emit() << "VOPD3 does not support literal selectors";
+    const uint32_t word2 = words[2];
+    const uint16_t vdstx = static_cast<uint16_t>(word2 & 0xFF);
+    const uint16_t vdsty = static_cast<uint16_t>((word2 >> 24) & 0xFF);
+    const uint32_t x_end = vdstx + (is_float64_op(opx) ? 2 : 1);
+    const uint32_t y_end = vdsty + (is_float64_op(opy) ? 2 : 1);
+    if (vdstx < y_end && vdsty < x_end) [[unlikely]]
+      return emit_error.emit() << "VOPD3 destination ranges overlap";
+    return Result::success();
+  }
+  const uint16_t opx = static_cast<uint16_t>((word0 >> 22) & 0xF);
+  const uint16_t opy = static_cast<uint16_t>((word0 >> 17) & 0x1F);
+  if (!is_valid_opcode(opx, kVopdXOpcodeMask)) [[unlikely]]
+    return emit_error.emit() << "invalid VOPD X opcode";
+  if (!is_valid_opcode(opy, kVopdYOpcodeMask)) [[unlikely]]
+    return emit_error.emit() << "invalid VOPD Y opcode";
+  const uint16_t srcx0 = static_cast<uint16_t>(word0 & 0x1FF);
+  const uint16_t srcy0 = static_cast<uint16_t>(word1 & 0x1FF);
+  if (srcx0 == 254 || srcy0 == 254) [[unlikely]]
+    return emit_error.emit() << "VOPD does not support 64-bit literals";
+  return Result::success();
+}
+
 Vopd::Vopd(const MachineInst *inst)
     : IsaInstruction<Isa>("vopd", selected_exec_fn(InstructionExecutionId::Vopd)),
       dstx_(32, OperandType::OPR_VGPR, 0), dsty_(32, OperandType::OPR_VGPR, 0),
@@ -154,14 +191,8 @@ Vopd::Vopd(const MachineInst *inst)
     word2_ = words[2];
     opx_ = static_cast<uint16_t>((word0_ >> 18) & 0x3F);
     opy_ = static_cast<uint16_t>((word0_ >> 12) & 0x3F);
-    if (!is_valid_opcode(opx_, kVopd3XOpcodeMask))
-      throw util::InvalidInst("invalid VOPD3 X opcode", "");
-    if (!is_valid_opcode(opy_, kVopd3YOpcodeMask))
-      throw util::InvalidInst("invalid VOPD3 Y opcode", "");
     uint16_t srcx0 = static_cast<uint16_t>(word0_ & 0x1FF);
     uint16_t srcy0 = static_cast<uint16_t>(word1_ & 0x1FF);
-    if (srcx0 == 254 || srcx0 == 255 || srcy0 == 254 || srcy0 == 255)
-      throw util::InvalidInst("VOPD3 does not support literal selectors", "");
     negx_ = static_cast<uint8_t>((word1_ >> 9) & 0x7);
     negy_ = static_cast<uint8_t>((word1_ >> 12) & 0x7);
     uint16_t vsrcx1 = static_cast<uint16_t>((word1_ >> 16) & 0xFF);
@@ -173,10 +204,6 @@ Vopd::Vopd(const MachineInst *inst)
 
     uint32_t x_bits = is_float64_op(opx_) ? 64 : 32;
     uint32_t y_bits = is_float64_op(opy_) ? 64 : 32;
-    const uint32_t x_end = vdstx + x_bits / 32;
-    const uint32_t y_end = vdsty + y_bits / 32;
-    if (vdstx < y_end && vdsty < x_end)
-      throw util::InvalidInst("VOPD3 destination ranges overlap", "");
     dstx_ = Operand(x_bits, OperandType::OPR_VGPR, vdstx);
     dsty_ = Operand(y_bits, OperandType::OPR_VGPR, vdsty);
     srcx0_ = make_src0(x_bits, true, false, 0, srcx0);
@@ -192,16 +219,10 @@ Vopd::Vopd(const MachineInst *inst)
     encoding_id_ = 0x32;
     opx_ = static_cast<uint16_t>((word0_ >> 22) & 0xF);
     opy_ = static_cast<uint16_t>((word0_ >> 17) & 0x1F);
-    if (!is_valid_opcode(opx_, kVopdXOpcodeMask))
-      throw util::InvalidInst("invalid VOPD X opcode", "");
-    if (!is_valid_opcode(opy_, kVopdYOpcodeMask))
-      throw util::InvalidInst("invalid VOPD Y opcode", "");
     uint16_t srcx0 = static_cast<uint16_t>(word0_ & 0x1FF);
     uint16_t vsrcx1 = static_cast<uint16_t>((word0_ >> 9) & 0xFF);
     uint16_t srcy0 = static_cast<uint16_t>(word1_ & 0x1FF);
     uint16_t vsrcy1 = static_cast<uint16_t>((word1_ >> 9) & 0xFF);
-    if (srcx0 == 254 || srcy0 == 254)
-      throw util::InvalidInst("VOPD does not support 64-bit literals", "");
     uint16_t vdstx = static_cast<uint16_t>((word1_ >> 24) & 0xFF);
     uint16_t vdsty_hi = static_cast<uint16_t>((word1_ >> 17) & 0x7F);
     uint16_t vdsty = static_cast<uint16_t>((vdsty_hi << 1) | ((~vdstx) & 1u));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vopd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vopd.h
@@ -9,6 +9,7 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/encodings.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/operand.h"
+#include "rocjitsu/isa/decode_result.h"
 #include <cstdint>
 #include <string>
 
@@ -18,6 +19,8 @@ namespace cdna5 {
 class Vopd : public IsaInstruction<Isa> {
 public:
   explicit Vopd(const MachineInst *inst);
+  static Result validate_encoding(const MachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error);
   void execute_impl(amdgpu::Wavefront &wf);
 
 private:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vscratch.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vscratch.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vscratch.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -33,7 +32,12 @@ ScratchLoadU8Vscratch::ScratchLoadU8Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadU8Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadU8Vscratch(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_u8", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadU8Vscratch>(opcode);
 }
 } // namespace detail
@@ -58,7 +62,12 @@ ScratchLoadI8Vscratch::ScratchLoadI8Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadI8Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadI8Vscratch(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_i8", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadI8Vscratch>(opcode);
 }
 } // namespace detail
@@ -83,7 +92,12 @@ ScratchLoadU16Vscratch::ScratchLoadU16Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadU16Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadU16Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_u16", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadU16Vscratch>(opcode);
 }
 } // namespace detail
@@ -108,7 +122,12 @@ ScratchLoadI16Vscratch::ScratchLoadI16Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadI16Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadI16Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_i16", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadI16Vscratch>(opcode);
 }
 } // namespace detail
@@ -133,7 +152,12 @@ ScratchLoadB32Vscratch::ScratchLoadB32Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadB32Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadB32Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_b32", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadB32Vscratch>(opcode);
 }
 } // namespace detail
@@ -158,7 +182,12 @@ ScratchLoadB64Vscratch::ScratchLoadB64Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadB64Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadB64Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_b64", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadB64Vscratch>(opcode);
 }
 } // namespace detail
@@ -183,7 +212,12 @@ ScratchLoadB96Vscratch::ScratchLoadB96Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadB96Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadB96Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_b96", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadB96Vscratch>(opcode);
 }
 } // namespace detail
@@ -208,7 +242,12 @@ ScratchLoadB128Vscratch::ScratchLoadB128Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadB128Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadB128Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_b128", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadB128Vscratch>(opcode);
 }
 } // namespace detail
@@ -233,7 +272,12 @@ ScratchStoreB8Vscratch::ScratchStoreB8Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchStoreB8Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchStoreB8Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_store_b8", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchStoreB8Vscratch>(opcode);
 }
 } // namespace detail
@@ -258,7 +302,12 @@ ScratchStoreB16Vscratch::ScratchStoreB16Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchStoreB16Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchStoreB16Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_store_b16", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchStoreB16Vscratch>(opcode);
 }
 } // namespace detail
@@ -283,7 +332,12 @@ ScratchStoreB32Vscratch::ScratchStoreB32Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchStoreB32Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchStoreB32Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_store_b32", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchStoreB32Vscratch>(opcode);
 }
 } // namespace detail
@@ -308,7 +362,12 @@ ScratchStoreB64Vscratch::ScratchStoreB64Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchStoreB64Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchStoreB64Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_store_b64", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchStoreB64Vscratch>(opcode);
 }
 } // namespace detail
@@ -333,7 +392,12 @@ ScratchStoreB96Vscratch::ScratchStoreB96Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchStoreB96Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchStoreB96Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_store_b96", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchStoreB96Vscratch>(opcode);
 }
 } // namespace detail
@@ -358,7 +422,12 @@ ScratchStoreB128Vscratch::ScratchStoreB128Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchStoreB128Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchStoreB128Vscratch(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_store_b128", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchStoreB128Vscratch>(opcode);
 }
 } // namespace detail
@@ -383,7 +452,12 @@ ScratchLoadD16U8Vscratch::ScratchLoadD16U8Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadD16U8Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadD16U8Vscratch(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_d16_u8", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadD16U8Vscratch>(opcode);
 }
 } // namespace detail
@@ -421,7 +495,12 @@ ScratchLoadD16I8Vscratch::ScratchLoadD16I8Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadD16I8Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadD16I8Vscratch(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_d16_i8", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadD16I8Vscratch>(opcode);
 }
 } // namespace detail
@@ -459,7 +538,12 @@ ScratchLoadD16B16Vscratch::ScratchLoadD16B16Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadD16B16Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadD16B16Vscratch(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_d16_b16", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadD16B16Vscratch>(opcode);
 }
 } // namespace detail
@@ -497,7 +581,12 @@ ScratchLoadD16HiU8Vscratch::ScratchLoadD16HiU8Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadD16HiU8Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadD16HiU8Vscratch(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_d16_hi_u8", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadD16HiU8Vscratch>(opcode);
 }
 } // namespace detail
@@ -535,7 +624,12 @@ ScratchLoadD16HiI8Vscratch::ScratchLoadD16HiI8Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadD16HiI8Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadD16HiI8Vscratch(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_d16_hi_i8", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadD16HiI8Vscratch>(opcode);
 }
 } // namespace detail
@@ -573,7 +667,13 @@ ScratchLoadD16HiB16Vscratch::ScratchLoadD16HiB16Vscratch(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadD16HiB16Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadD16HiB16Vscratch(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_d16_hi_b16", reinterpret_cast<const Vscratch::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadD16HiB16Vscratch>(opcode);
 }
 } // namespace detail
@@ -611,7 +711,13 @@ ScratchStoreD16HiB8Vscratch::ScratchStoreD16HiB8Vscratch(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchStoreD16HiB8Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchStoreD16HiB8Vscratch(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_store_d16_hi_b8", reinterpret_cast<const Vscratch::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchStoreD16HiB8Vscratch>(opcode);
 }
 } // namespace detail
@@ -636,7 +742,13 @@ ScratchStoreD16HiB16Vscratch::ScratchStoreD16HiB16Vscratch(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchStoreD16HiB16Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchStoreD16HiB16Vscratch(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_store_d16_hi_b16", reinterpret_cast<const Vscratch::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchStoreD16HiB16Vscratch>(opcode);
 }
 } // namespace detail
@@ -663,7 +775,12 @@ ScratchLoadBlockVscratch::ScratchLoadBlockVscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadBlockVscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadBlockVscratch(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_block", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadBlockVscratch>(opcode);
 }
 } // namespace detail
@@ -690,7 +807,12 @@ ScratchStoreBlockVscratch::ScratchStoreBlockVscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchStoreBlockVscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchStoreBlockVscratch(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_store_block", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchStoreBlockVscratch>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/decoder.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/decoder.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/vop3p.h"
-#include "util/except.h"
 #include <array>
 #include <bit>
 #include <format>
@@ -15,1426 +14,1922 @@ namespace rocjitsu {
 namespace rdna1 {
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicFcmpswapMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicFcmpswapX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicFmaxMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicFmaxX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicFminMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicFminX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSminMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUminMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferGl0InvMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferGl1InvMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSbyteMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadShortD16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSshortMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUbyteMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUshortMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreByteMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreShortMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAppendDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsBpermuteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsConsumeDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsBarrierDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsInitDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaBrDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaPDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaVDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsNopDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrderedCountDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPermuteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2st64B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2st64B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadAddtidB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB128Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB96Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI8D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU16D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU16D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU8D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSwizzleB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrapRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2st64B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2st64B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteAddtidB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB128Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB16D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB96Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeExpExp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicFcmpswapFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicFcmpswapX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicFmaxFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicFmaxX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicFminFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicFminX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSminFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSminX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUminFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUminX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordx2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordx3Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordx4Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSbyteFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadShortD16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadShortD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSshortFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUbyteFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUshortFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreByteD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreByteFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordx2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordx3Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordx4Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreShortD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreShortFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicAddMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicAndMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicCmpswapMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicDecMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicFcmpswapMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicFmaxMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicFminMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicIncMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicOrMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSmaxMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSminMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSubMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSwapMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicUmaxMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicUminMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicXorMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4BClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4BClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4BMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4BOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CBClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CBClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CBMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CBOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4COMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4ClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4ClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4OMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4hMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4hPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather8hPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGetLodMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGetResinfoMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadBy2Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadBy4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipBy2Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipBy4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipPck2Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipPck4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipPckSgnMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadPck2Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadPck4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadPckSgnMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageMsaaLoadMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdClG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdClOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdClG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdClOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreBy2Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreBy4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipBy2Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipBy4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipPck2Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipPck4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStorePck2Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStorePck4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStorePckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddcU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn1SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn1WrexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn1WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2WrexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtcProbeBufferSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtcProbeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBarrierSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCallB64Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbguserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClauseSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkEqI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkEqU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGeI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGeU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGtI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGtU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLeI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLeU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLgI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLgU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLtI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLtU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCodeEndSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDenormModeSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf0I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf0I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf1I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf1I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32I64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetWaveidInWorkgroupSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetpcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGl1InvSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSInstPrefetchSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMemrealtimeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMemtimeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsd2B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn1SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRfeB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRoundModeSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchLoadDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetkillSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetpcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubbU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubvectorLoopBeginSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubvectorLoopEndSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSwappcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTtracedataImmSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSVersionSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitIdleSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntDepctrSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntExpcntSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntLgkmcntSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntVmcntSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntVscntSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClrexcpVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClrexcpVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormI16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormU16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkrtzF16F32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2F32F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2I32I16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2U32U16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4I32I8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8I32I4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhI32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhU32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfblB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfblB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixhiF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixloF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaakF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaakF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmamkF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmamkF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpMovF32Vintrp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpMovF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP1F32Vintrp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP1F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP1llF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP1lvF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2F32Vintrp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMacF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMacF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMacLegacyF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMacLegacyF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadLegacyF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadakF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadmkF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovreldB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovreldB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLegacyF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLegacyF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMullitF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlane16B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlanex16B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPipeflushVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPipeflushVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwaprelB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXor3B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode);
+DecodeResult decodeBufferAtomicAddMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicFcmpswapMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicFcmpswapX2Mubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicFmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicFmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicFminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicFminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrMubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferGl0InvMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferGl1InvMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXMubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadShortD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreByteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreShortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAppendDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsBpermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsConsumeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsBarrierDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsInitDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaBrDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaPDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaVDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsNopDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrderedCountDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2st64B32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2st64B64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadAddtidB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI8D16HiDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU16D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU16D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU8D16HiDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSwizzleB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrapRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2st64B32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2st64B64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteAddtidB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB16D16HiDs(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB8D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchgRtnB32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchgRtnB64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeExpExp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapFlat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicFcmpswapFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicFcmpswapX2Flat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicFmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicFmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicFminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicFminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrX2Flat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordx2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordx3Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordx4Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadShortD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadShortD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreByteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreByteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordx2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordx3Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordx4Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreShortD16HiFlat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreShortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicAddMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicAndMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicCmpswapMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicDecMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicFcmpswapMimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicFmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicFminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicIncMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicOrMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSubMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSwapMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicUmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicUminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicXorMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4BClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4BClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4BMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4BOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CBClMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CBClOMimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CBMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CBOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLzMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLzOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4COMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4ClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4ClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4Mimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4OMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4hMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4hPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather8hPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGetLodMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGetResinfoMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadBy2Mimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadBy4Mimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipBy2Mimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipBy4Mimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipPck2Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipPck4Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipPckMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipPckSgnMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadPck2Mimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadPck4Mimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadPckMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadPckSgnMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageMsaaLoadMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdClG16Mimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdClMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdClOG16Mimg(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdClOMimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdOG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClOG16Mimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDOG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdClG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdClOG16Mimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdOG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleClMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleClOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClOG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDG16Mimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDOG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLzMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLzOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleOMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreBy2Mimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreBy4Mimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipBy2Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipBy4Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipPck2Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipPck4Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStorePck2Mimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStorePck4Mimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStorePckMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddcU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn1SaveexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn1WrexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn1WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2SaveexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2WrexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtcProbeBufferSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtcProbeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBarrierSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx16Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx4Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx8Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCallB64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysSopp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbguserSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClauseSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkEqI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkEqU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLgI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLgU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCodeEndSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDenormModeSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf0I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf0I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf1I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf1I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32I64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetWaveidInWorkgroupSmem(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGl1InvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSInstPrefetchSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx16Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx4Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx8Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMemrealtimeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMemtimeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsd2B32Sop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrSaveexecB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn1SaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2SaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRfeB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRoundModeSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchLoadDwordSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchLoadDwordx2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSScratchLoadDwordx4Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetkillSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubbU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubvectorLoopBeginSopk(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubvectorLoopEndSopk(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSwappcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTtracedataImmSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSVersionSopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitIdleSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntDepctrSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntExpcntSopk(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntLgkmcntSopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntVmcntSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntVscntSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoCiU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClrexcpVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClrexcpVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFlrI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFlrI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkrtzF16F32Vop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtRpiI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtRpiI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2F32F16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2I32I16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2U32U16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cF32F16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cF32F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4I32I8Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4cI32I8Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4cI32I8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8I32I4Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhU32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfblB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfblB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmamkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmamkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpMovF32Vintrp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpMovF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP1F32Vintrp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP1F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP1llF16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP1lvF16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2F32Vintrp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMacLegacyF32Vop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMacLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadmkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovreldB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovreldB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsd2B32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsd2B32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsdB32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsdB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLegacyF32Vop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMullitF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlane16B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlanex16B32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPipeflushVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPipeflushVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoCiU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoCiU32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevNcU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevNcU32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwaprelB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXor3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 } // namespace detail
 
 struct DecoderImpl {
 public:
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 
 private:
-  using DecodeFunc = std::unique_ptr<Instruction> (*)(const MachineInst *);
-  static std::unique_ptr<Instruction> decodeInvalid(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopp(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVintrp(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3p(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeDs(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeFlat(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMubuf(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMtbuf(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMimg(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSmem(const MachineInst *opcode);
+  using DecodeFunc = DecodeResult (*)(const MachineInst *, const DecodeErrorEmitter &);
+  static DecodeResult decodeInvalid(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVintrp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMtbuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
   static const std::array<DecodeFunc, 512> primary_decode_table;
   static const std::array<DecodeFunc, 256> sub_decode_vopc;
   static const std::array<DecodeFunc, 256> sub_decode_vop1;
@@ -1452,88 +1947,102 @@ private:
   static const std::array<DecodeFunc, 256> sub_decode_smem;
 };
 
-std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
-  return DecoderImpl::decode(opcode);
+DecodeResult Decoder::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  return DecoderImpl::decode(opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decode(const MachineInst *opcode) {
+DecodeResult DecoderImpl::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
   Sop1MachineInst op = std::bit_cast<decltype(op)>(*opcode);
-  return primary_decode_table[op.encoding](opcode);
+  return primary_decode_table[op.encoding](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decodeInvalid(const MachineInst *opcode) {
-  throw util::InvalidInst(std::format("{:X}", *opcode));
-  return nullptr;
+DecodeResult DecoderImpl::decodeInvalid(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  return emit_error.emit() << "Invalid instruction opcode: " << std::format("{:X}", *opcode);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vopc[op.op](opcode);
+  return sub_decode_vopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop1[op.op](opcode);
+  return sub_decode_vop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sop1[op.op](opcode);
+  return sub_decode_sop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopc[op.op](opcode);
+  return sub_decode_sopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopp(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopp::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopp[op.op](opcode);
+  return sub_decode_sopp[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVintrp(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVintrp(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
   Vintrp::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vintrp[op.op](opcode);
+  return sub_decode_vintrp[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3p(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3p(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Vop3p::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3p[op.op](opcode);
+  return sub_decode_vop3p[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop3::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3[op.op](opcode);
+  return sub_decode_vop3[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeDs(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeDs(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
   Ds::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_ds[op.op](opcode);
+  return sub_decode_ds[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeFlat(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeFlat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Flat::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_flat[op.op](opcode);
+  return sub_decode_flat[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMubuf(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Mubuf::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mubuf[op.op](opcode);
+  return sub_decode_mubuf[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMtbuf(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMtbuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Mtbuf::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mtbuf[op.op](opcode);
+  return sub_decode_mtbuf[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMimg(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Mimg::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mimg[op.op](opcode);
+  return sub_decode_mimg[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSmem(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Smem::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_smem[op.op](opcode);
+  return sub_decode_smem[op.op](opcode, emit_error);
 }
 
 const std::array<DecoderImpl::DecodeFunc, 512> DecoderImpl::primary_decode_table = {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/decoder.h
@@ -8,6 +8,7 @@
 #define ROCJITSU_ISA_ARCH_AMDGPU_RDNA1_DECODER_H_
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/machine_insts.h"
+#include "rocjitsu/isa/decode_result.h"
 #include <array>
 #include <cstddef>
 #include <memory>
@@ -21,7 +22,7 @@ namespace rdna1 {
 class Decoder {
 public:
   static constexpr std::size_t kMaxInstructionWords = 3;
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 };
 
 } // namespace rdna1

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/ds.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/ds.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/ds.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -31,7 +30,11 @@ DsAddU32Ds::DsAddU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU32Ds>(opcode);
 }
 } // namespace detail
@@ -54,7 +57,11 @@ DsSubU32Ds::DsSubU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU32Ds>(opcode);
 }
 } // namespace detail
@@ -77,7 +84,11 @@ DsRsubU32Ds::DsRsubU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU32Ds>(opcode);
 }
 } // namespace detail
@@ -100,7 +111,11 @@ DsIncU32Ds::DsIncU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU32Ds>(opcode);
 }
 } // namespace detail
@@ -123,7 +138,11 @@ DsDecU32Ds::DsDecU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU32Ds>(opcode);
 }
 } // namespace detail
@@ -146,7 +165,11 @@ DsMinI32Ds::DsMinI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI32Ds>(opcode);
 }
 } // namespace detail
@@ -169,7 +192,11 @@ DsMaxI32Ds::DsMaxI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI32Ds>(opcode);
 }
 } // namespace detail
@@ -192,7 +219,11 @@ DsMinU32Ds::DsMinU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU32Ds>(opcode);
 }
 } // namespace detail
@@ -215,7 +246,11 @@ DsMaxU32Ds::DsMaxU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU32Ds>(opcode);
 }
 } // namespace detail
@@ -238,7 +273,11 @@ DsAndB32Ds::DsAndB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB32Ds>(opcode);
 }
 } // namespace detail
@@ -261,7 +300,11 @@ DsOrB32Ds::DsOrB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB32Ds>(opcode);
 }
 } // namespace detail
@@ -284,7 +327,11 @@ DsXorB32Ds::DsXorB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB32Ds>(opcode);
 }
 } // namespace detail
@@ -309,7 +356,11 @@ DsMskorB32Ds::DsMskorB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB32Ds>(opcode);
 }
 } // namespace detail
@@ -330,7 +381,11 @@ DsWriteB32Ds::DsWriteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB32Ds>(opcode);
 }
 } // namespace detail
@@ -353,7 +408,11 @@ DsWrite2B32Ds::DsWrite2B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2B32Ds>(opcode);
 }
 } // namespace detail
@@ -376,7 +435,12 @@ DsWrite2st64B32Ds::DsWrite2st64B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2st64B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2st64B32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2st64_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2st64B32Ds>(opcode);
 }
 } // namespace detail
@@ -401,7 +465,11 @@ DsCmpstB32Ds::DsCmpstB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstB32Ds>(opcode);
 }
 } // namespace detail
@@ -426,7 +494,11 @@ DsCmpstF32Ds::DsCmpstF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstF32Ds>(opcode);
 }
 } // namespace detail
@@ -449,7 +521,11 @@ DsMinF32Ds::DsMinF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinF32Ds>(opcode);
 }
 } // namespace detail
@@ -472,7 +548,11 @@ DsMaxF32Ds::DsMaxF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxF32Ds>(opcode);
 }
 } // namespace detail
@@ -485,7 +565,11 @@ DsNopDs::DsNopDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsNopDs(const MachineInst *opcode) {
+DecodeResult decodeDsNopDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Ds::validate_encoding("ds_nop", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsNopDs>(opcode);
 }
 } // namespace detail
@@ -508,7 +592,11 @@ DsAddF32Ds::DsAddF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddF32Ds>(opcode);
 }
 } // namespace detail
@@ -521,7 +609,12 @@ DsGwsSemaReleaseAllDs::DsGwsSemaReleaseAllDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_release_all", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaReleaseAllDs>(opcode);
 }
 } // namespace detail
@@ -536,7 +629,11 @@ DsGwsInitDs::DsGwsInitDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsInitDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsInitDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_init", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsInitDs>(opcode);
 }
 } // namespace detail
@@ -549,7 +646,11 @@ DsGwsSemaVDs::DsGwsSemaVDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaVDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaVDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_v", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaVDs>(opcode);
 }
 } // namespace detail
@@ -564,7 +665,11 @@ DsGwsSemaBrDs::DsGwsSemaBrDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaBrDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaBrDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_br", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaBrDs>(opcode);
 }
 } // namespace detail
@@ -577,7 +682,11 @@ DsGwsSemaPDs::DsGwsSemaPDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaPDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaPDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_p", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaPDs>(opcode);
 }
 } // namespace detail
@@ -592,7 +701,11 @@ DsGwsBarrierDs::DsGwsBarrierDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsBarrierDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsBarrierDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_barrier", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsBarrierDs>(opcode);
 }
 } // namespace detail
@@ -613,7 +726,11 @@ DsWriteB8Ds::DsWriteB8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB8Ds>(opcode);
 }
 } // namespace detail
@@ -634,7 +751,11 @@ DsWriteB16Ds::DsWriteB16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB16Ds>(opcode);
 }
 } // namespace detail
@@ -659,7 +780,11 @@ DsAddRtnU32Ds::DsAddRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -684,7 +809,11 @@ DsSubRtnU32Ds::DsSubRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -709,7 +838,11 @@ DsRsubRtnU32Ds::DsRsubRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -734,7 +867,11 @@ DsIncRtnU32Ds::DsIncRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -759,7 +896,11 @@ DsDecRtnU32Ds::DsDecRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -784,7 +925,11 @@ DsMinRtnI32Ds::DsMinRtnI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI32Ds>(opcode);
 }
 } // namespace detail
@@ -809,7 +954,11 @@ DsMaxRtnI32Ds::DsMaxRtnI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI32Ds>(opcode);
 }
 } // namespace detail
@@ -834,7 +983,11 @@ DsMinRtnU32Ds::DsMinRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -859,7 +1012,11 @@ DsMaxRtnU32Ds::DsMaxRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -884,7 +1041,11 @@ DsAndRtnB32Ds::DsAndRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -909,7 +1070,11 @@ DsOrRtnB32Ds::DsOrRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -934,7 +1099,11 @@ DsXorRtnB32Ds::DsXorRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -961,7 +1130,12 @@ DsMskorRtnB32Ds::DsMskorRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -986,7 +1160,12 @@ DsWrxchgRtnB32Ds::DsWrxchgRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchgRtnB32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchgRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1013,7 +1192,12 @@ DsWrxchg2RtnB32Ds::DsWrxchg2RtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2RtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1040,7 +1224,12 @@ DsWrxchg2st64RtnB32Ds::DsWrxchg2st64RtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2st64_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2st64RtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1067,7 +1256,12 @@ DsCmpstRtnB32Ds::DsCmpstRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1094,7 +1288,12 @@ DsCmpstRtnF32Ds::DsCmpstRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnF32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1119,7 +1318,11 @@ DsMinRtnF32Ds::DsMinRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1144,7 +1347,11 @@ DsMaxRtnF32Ds::DsMaxRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1170,7 +1377,11 @@ DsWrapRtnB32Ds::DsWrapRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrapRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrapRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrap_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrapRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1187,7 +1398,11 @@ DsSwizzleB32Ds::DsSwizzleB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSwizzleB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSwizzleB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_swizzle_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSwizzleB32Ds>(opcode);
 }
 } // namespace detail
@@ -1208,7 +1423,11 @@ DsReadB32Ds::DsReadB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB32Ds>(opcode);
 }
 } // namespace detail
@@ -1229,7 +1448,11 @@ DsRead2B32Ds::DsRead2B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2B32Ds>(opcode);
 }
 } // namespace detail
@@ -1250,7 +1473,12 @@ DsRead2st64B32Ds::DsRead2st64B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2st64B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2st64B32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2st64_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2st64B32Ds>(opcode);
 }
 } // namespace detail
@@ -1271,7 +1499,11 @@ DsReadI8Ds::DsReadI8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadI8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI8Ds>(opcode);
 }
 } // namespace detail
@@ -1298,7 +1530,11 @@ DsReadU8Ds::DsReadU8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU8Ds>(opcode);
 }
 } // namespace detail
@@ -1325,7 +1561,11 @@ DsReadI16Ds::DsReadI16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadI16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI16Ds>(opcode);
 }
 } // namespace detail
@@ -1352,7 +1592,11 @@ DsReadU16Ds::DsReadU16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU16Ds>(opcode);
 }
 } // namespace detail
@@ -1379,7 +1623,11 @@ DsConsumeDs::DsConsumeDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsConsumeDs(const MachineInst *opcode) {
+DecodeResult decodeDsConsumeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_consume", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsConsumeDs>(opcode);
 }
 } // namespace detail
@@ -1400,7 +1648,11 @@ DsAppendDs::DsAppendDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAppendDs(const MachineInst *opcode) {
+DecodeResult decodeDsAppendDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_append", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAppendDs>(opcode);
 }
 } // namespace detail
@@ -1420,7 +1672,12 @@ DsOrderedCountDs::DsOrderedCountDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrderedCountDs(const MachineInst *opcode) {
+DecodeResult decodeDsOrderedCountDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_ordered_count", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrderedCountDs>(opcode);
 }
 } // namespace detail
@@ -1443,7 +1700,11 @@ DsAddU64Ds::DsAddU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU64Ds>(opcode);
 }
 } // namespace detail
@@ -1466,7 +1727,11 @@ DsSubU64Ds::DsSubU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU64Ds>(opcode);
 }
 } // namespace detail
@@ -1489,7 +1754,11 @@ DsRsubU64Ds::DsRsubU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU64Ds>(opcode);
 }
 } // namespace detail
@@ -1512,7 +1781,11 @@ DsIncU64Ds::DsIncU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU64Ds>(opcode);
 }
 } // namespace detail
@@ -1535,7 +1808,11 @@ DsDecU64Ds::DsDecU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU64Ds>(opcode);
 }
 } // namespace detail
@@ -1558,7 +1835,11 @@ DsMinI64Ds::DsMinI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI64Ds>(opcode);
 }
 } // namespace detail
@@ -1581,7 +1862,11 @@ DsMaxI64Ds::DsMaxI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI64Ds>(opcode);
 }
 } // namespace detail
@@ -1604,7 +1889,11 @@ DsMinU64Ds::DsMinU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU64Ds>(opcode);
 }
 } // namespace detail
@@ -1627,7 +1916,11 @@ DsMaxU64Ds::DsMaxU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU64Ds>(opcode);
 }
 } // namespace detail
@@ -1650,7 +1943,11 @@ DsAndB64Ds::DsAndB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB64Ds>(opcode);
 }
 } // namespace detail
@@ -1673,7 +1970,11 @@ DsOrB64Ds::DsOrB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB64Ds>(opcode);
 }
 } // namespace detail
@@ -1696,7 +1997,11 @@ DsXorB64Ds::DsXorB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB64Ds>(opcode);
 }
 } // namespace detail
@@ -1721,7 +2026,11 @@ DsMskorB64Ds::DsMskorB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB64Ds>(opcode);
 }
 } // namespace detail
@@ -1742,7 +2051,11 @@ DsWriteB64Ds::DsWriteB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB64Ds>(opcode);
 }
 } // namespace detail
@@ -1765,7 +2078,11 @@ DsWrite2B64Ds::DsWrite2B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2B64Ds>(opcode);
 }
 } // namespace detail
@@ -1788,7 +2105,12 @@ DsWrite2st64B64Ds::DsWrite2st64B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2st64B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2st64B64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2st64_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2st64B64Ds>(opcode);
 }
 } // namespace detail
@@ -1813,7 +2135,11 @@ DsCmpstB64Ds::DsCmpstB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstB64Ds>(opcode);
 }
 } // namespace detail
@@ -1838,7 +2164,11 @@ DsCmpstF64Ds::DsCmpstF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstF64Ds>(opcode);
 }
 } // namespace detail
@@ -1861,7 +2191,11 @@ DsMinF64Ds::DsMinF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinF64Ds>(opcode);
 }
 } // namespace detail
@@ -1884,7 +2218,11 @@ DsMaxF64Ds::DsMaxF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxF64Ds>(opcode);
 }
 } // namespace detail
@@ -1909,7 +2247,11 @@ DsAddRtnF32Ds::DsAddRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1934,7 +2276,11 @@ DsAddRtnU64Ds::DsAddRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -1959,7 +2305,11 @@ DsSubRtnU64Ds::DsSubRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -1984,7 +2334,11 @@ DsRsubRtnU64Ds::DsRsubRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2009,7 +2363,11 @@ DsIncRtnU64Ds::DsIncRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2034,7 +2392,11 @@ DsDecRtnU64Ds::DsDecRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2059,7 +2421,11 @@ DsMinRtnI64Ds::DsMinRtnI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI64Ds>(opcode);
 }
 } // namespace detail
@@ -2084,7 +2450,11 @@ DsMaxRtnI64Ds::DsMaxRtnI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI64Ds>(opcode);
 }
 } // namespace detail
@@ -2109,7 +2479,11 @@ DsMinRtnU64Ds::DsMinRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2134,7 +2508,11 @@ DsMaxRtnU64Ds::DsMaxRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2159,7 +2537,11 @@ DsAndRtnB64Ds::DsAndRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2184,7 +2566,11 @@ DsOrRtnB64Ds::DsOrRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2209,7 +2595,11 @@ DsXorRtnB64Ds::DsXorRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2236,7 +2626,12 @@ DsMskorRtnB64Ds::DsMskorRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2261,7 +2656,12 @@ DsWrxchgRtnB64Ds::DsWrxchgRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchgRtnB64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchgRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2288,7 +2688,12 @@ DsWrxchg2RtnB64Ds::DsWrxchg2RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2315,7 +2720,12 @@ DsWrxchg2st64RtnB64Ds::DsWrxchg2st64RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2st64_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2st64RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2342,7 +2752,12 @@ DsCmpstRtnB64Ds::DsCmpstRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnB64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2369,7 +2784,12 @@ DsCmpstRtnF64Ds::DsCmpstRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnF64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -2394,7 +2814,11 @@ DsMinRtnF64Ds::DsMinRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -2419,7 +2843,11 @@ DsMaxRtnF64Ds::DsMaxRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -2440,7 +2868,11 @@ DsReadB64Ds::DsReadB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB64Ds>(opcode);
 }
 } // namespace detail
@@ -2461,7 +2893,11 @@ DsRead2B64Ds::DsRead2B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2B64Ds>(opcode);
 }
 } // namespace detail
@@ -2482,7 +2918,12 @@ DsRead2st64B64Ds::DsRead2st64B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2st64B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2st64B64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2st64_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2st64B64Ds>(opcode);
 }
 } // namespace detail
@@ -2507,7 +2948,12 @@ DsCondxchg32RtnB64Ds::DsCondxchg32RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_condxchg32_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCondxchg32RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2528,7 +2974,12 @@ DsWriteB8D16HiDs::DsWriteB8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB8D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2549,7 +3000,12 @@ DsWriteB16D16HiDs::DsWriteB16D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB16D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB16D16HiDs(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b16_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB16D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2570,7 +3026,11 @@ DsReadU8D16Ds::DsReadU8D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU8D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u8_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU8D16Ds>(opcode);
 }
 } // namespace detail
@@ -2597,7 +3057,12 @@ DsReadU8D16HiDs::DsReadU8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsReadU8D16HiDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2624,7 +3089,11 @@ DsReadI8D16Ds::DsReadI8D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI8D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i8_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI8D16Ds>(opcode);
 }
 } // namespace detail
@@ -2651,7 +3120,12 @@ DsReadI8D16HiDs::DsReadI8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsReadI8D16HiDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2678,7 +3152,11 @@ DsReadU16D16Ds::DsReadU16D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU16D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU16D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u16_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU16D16Ds>(opcode);
 }
 } // namespace detail
@@ -2705,7 +3183,12 @@ DsReadU16D16HiDs::DsReadU16D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU16D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsReadU16D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u16_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU16D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2732,7 +3215,12 @@ DsWriteAddtidB32Ds::DsWriteAddtidB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteAddtidB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteAddtidB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_addtid_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteAddtidB32Ds>(opcode);
 }
 } // namespace detail
@@ -2753,7 +3241,12 @@ DsReadAddtidB32Ds::DsReadAddtidB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadAddtidB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadAddtidB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_addtid_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadAddtidB32Ds>(opcode);
 }
 } // namespace detail
@@ -2772,7 +3265,11 @@ DsPermuteB32Ds::DsPermuteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPermuteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsPermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_permute_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPermuteB32Ds>(opcode);
 }
 } // namespace detail
@@ -2791,7 +3288,12 @@ DsBpermuteB32Ds::DsBpermuteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsBpermuteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsBpermuteB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_bpermute_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsBpermuteB32Ds>(opcode);
 }
 } // namespace detail
@@ -2812,7 +3314,11 @@ DsWriteB96Ds::DsWriteB96Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB96Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b96", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB96Ds>(opcode);
 }
 } // namespace detail
@@ -2833,7 +3339,11 @@ DsWriteB128Ds::DsWriteB128Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB128Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b128", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB128Ds>(opcode);
 }
 } // namespace detail
@@ -2854,7 +3364,11 @@ DsReadB96Ds::DsReadB96Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB96Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b96", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB96Ds>(opcode);
 }
 } // namespace detail
@@ -2875,7 +3389,11 @@ DsReadB128Ds::DsReadB128Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB128Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b128", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB128Ds>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/encodings.h
@@ -10,6 +10,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna1/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
+#include "rocjitsu/isa/decode_result.h"
 #include "rocjitsu/isa/instruction.h"
 #include <array>
 #include <cstdint>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/exp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/exp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/exp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -33,7 +32,11 @@ ExpExp::ExpExp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeExpExp(const MachineInst *opcode) {
+DecodeResult decodeExpExp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Exp::validate_encoding("exp", reinterpret_cast<const Exp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ExpExp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/flat.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/flat.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/flat.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -40,7 +39,12 @@ FlatLoadUbyteFlat::FlatLoadUbyteFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUbyteFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ubyte", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUbyteFlat>(opcode);
 }
 } // namespace detail
@@ -72,7 +76,12 @@ FlatLoadSbyteFlat::FlatLoadSbyteFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSbyteFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sbyte", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSbyteFlat>(opcode);
 }
 } // namespace detail
@@ -104,7 +113,12 @@ FlatLoadUshortFlat::FlatLoadUshortFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUshortFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ushort", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUshortFlat>(opcode);
 }
 } // namespace detail
@@ -136,7 +150,12 @@ FlatLoadSshortFlat::FlatLoadSshortFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSshortFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sshort", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSshortFlat>(opcode);
 }
 } // namespace detail
@@ -168,7 +187,12 @@ FlatLoadDwordFlat::FlatLoadDwordFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dword", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordFlat>(opcode);
 }
 } // namespace detail
@@ -200,7 +224,12 @@ FlatLoadDwordx2Flat::FlatLoadDwordx2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordx2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordx2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dwordx2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordx2Flat>(opcode);
 }
 } // namespace detail
@@ -232,7 +261,12 @@ FlatLoadDwordx4Flat::FlatLoadDwordx4Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordx4Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordx4Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dwordx4", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordx4Flat>(opcode);
 }
 } // namespace detail
@@ -264,7 +298,12 @@ FlatLoadDwordx3Flat::FlatLoadDwordx3Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordx3Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordx3Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dwordx3", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordx3Flat>(opcode);
 }
 } // namespace detail
@@ -296,7 +335,12 @@ FlatStoreByteFlat::FlatStoreByteFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreByteFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreByteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_byte", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreByteFlat>(opcode);
 }
 } // namespace detail
@@ -328,7 +372,12 @@ FlatStoreByteD16HiFlat::FlatStoreByteD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreByteD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreByteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_byte_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreByteD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -360,7 +409,12 @@ FlatStoreShortFlat::FlatStoreShortFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreShortFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreShortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_short", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreShortFlat>(opcode);
 }
 } // namespace detail
@@ -392,7 +446,12 @@ FlatStoreShortD16HiFlat::FlatStoreShortD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreShortD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreShortD16HiFlat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_short_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreShortD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -424,7 +483,12 @@ FlatStoreDwordFlat::FlatStoreDwordFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dword", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordFlat>(opcode);
 }
 } // namespace detail
@@ -456,7 +520,12 @@ FlatStoreDwordx2Flat::FlatStoreDwordx2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordx2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordx2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dwordx2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordx2Flat>(opcode);
 }
 } // namespace detail
@@ -488,7 +557,12 @@ FlatStoreDwordx4Flat::FlatStoreDwordx4Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordx4Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordx4Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dwordx4", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordx4Flat>(opcode);
 }
 } // namespace detail
@@ -520,7 +594,12 @@ FlatStoreDwordx3Flat::FlatStoreDwordx3Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordx3Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordx3Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dwordx3", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordx3Flat>(opcode);
 }
 } // namespace detail
@@ -552,7 +631,12 @@ FlatLoadUbyteD16Flat::FlatLoadUbyteD16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ubyte_d16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUbyteD16Flat>(opcode);
 }
 } // namespace detail
@@ -591,7 +675,12 @@ FlatLoadUbyteD16HiFlat::FlatLoadUbyteD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ubyte_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUbyteD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -630,7 +719,12 @@ FlatLoadSbyteD16Flat::FlatLoadSbyteD16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sbyte_d16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSbyteD16Flat>(opcode);
 }
 } // namespace detail
@@ -669,7 +763,12 @@ FlatLoadSbyteD16HiFlat::FlatLoadSbyteD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sbyte_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSbyteD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -708,7 +807,12 @@ FlatLoadShortD16Flat::FlatLoadShortD16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadShortD16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadShortD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_short_d16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadShortD16Flat>(opcode);
 }
 } // namespace detail
@@ -747,7 +851,12 @@ FlatLoadShortD16HiFlat::FlatLoadShortD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadShortD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadShortD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_short_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadShortD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -789,7 +898,12 @@ FlatAtomicSwapFlat::FlatAtomicSwapFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_swap", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapFlat>(opcode);
 }
 } // namespace detail
@@ -824,7 +938,12 @@ FlatAtomicCmpswapFlat::FlatAtomicCmpswapFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapFlat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_cmpswap", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapFlat>(opcode);
 }
 } // namespace detail
@@ -859,7 +978,12 @@ FlatAtomicAddFlat::FlatAtomicAddFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddFlat>(opcode);
 }
 } // namespace detail
@@ -894,7 +1018,12 @@ FlatAtomicSubFlat::FlatAtomicSubFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_sub", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubFlat>(opcode);
 }
 } // namespace detail
@@ -929,7 +1058,12 @@ FlatAtomicSminFlat::FlatAtomicSminFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSminFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smin", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSminFlat>(opcode);
 }
 } // namespace detail
@@ -964,7 +1098,12 @@ FlatAtomicUminFlat::FlatAtomicUminFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUminFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umin", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUminFlat>(opcode);
 }
 } // namespace detail
@@ -999,7 +1138,12 @@ FlatAtomicSmaxFlat::FlatAtomicSmaxFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smax", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSmaxFlat>(opcode);
 }
 } // namespace detail
@@ -1034,7 +1178,12 @@ FlatAtomicUmaxFlat::FlatAtomicUmaxFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umax", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUmaxFlat>(opcode);
 }
 } // namespace detail
@@ -1069,7 +1218,12 @@ FlatAtomicAndFlat::FlatAtomicAndFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_and", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndFlat>(opcode);
 }
 } // namespace detail
@@ -1104,7 +1258,12 @@ FlatAtomicOrFlat::FlatAtomicOrFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_or", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrFlat>(opcode);
 }
 } // namespace detail
@@ -1139,7 +1298,12 @@ FlatAtomicXorFlat::FlatAtomicXorFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_xor", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorFlat>(opcode);
 }
 } // namespace detail
@@ -1174,7 +1338,12 @@ FlatAtomicIncFlat::FlatAtomicIncFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_inc", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncFlat>(opcode);
 }
 } // namespace detail
@@ -1209,7 +1378,12 @@ FlatAtomicDecFlat::FlatAtomicDecFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_dec", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecFlat>(opcode);
 }
 } // namespace detail
@@ -1244,7 +1418,12 @@ FlatAtomicFcmpswapFlat::FlatAtomicFcmpswapFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicFcmpswapFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicFcmpswapFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_fcmpswap", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicFcmpswapFlat>(opcode);
 }
 } // namespace detail
@@ -1279,7 +1458,12 @@ FlatAtomicFminFlat::FlatAtomicFminFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicFminFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicFminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_fmin", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicFminFlat>(opcode);
 }
 } // namespace detail
@@ -1314,7 +1498,12 @@ FlatAtomicFmaxFlat::FlatAtomicFmaxFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicFmaxFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicFmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_fmax", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicFmaxFlat>(opcode);
 }
 } // namespace detail
@@ -1349,7 +1538,12 @@ FlatAtomicSwapX2Flat::FlatAtomicSwapX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_swap_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapX2Flat>(opcode);
 }
 } // namespace detail
@@ -1384,7 +1578,12 @@ FlatAtomicCmpswapX2Flat::FlatAtomicCmpswapX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_cmpswap_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapX2Flat>(opcode);
 }
 } // namespace detail
@@ -1419,7 +1618,12 @@ FlatAtomicAddX2Flat::FlatAtomicAddX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddX2Flat>(opcode);
 }
 } // namespace detail
@@ -1454,7 +1658,12 @@ FlatAtomicSubX2Flat::FlatAtomicSubX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_sub_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubX2Flat>(opcode);
 }
 } // namespace detail
@@ -1489,7 +1698,12 @@ FlatAtomicSminX2Flat::FlatAtomicSminX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSminX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smin_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSminX2Flat>(opcode);
 }
 } // namespace detail
@@ -1524,7 +1738,12 @@ FlatAtomicUminX2Flat::FlatAtomicUminX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUminX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umin_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUminX2Flat>(opcode);
 }
 } // namespace detail
@@ -1559,7 +1778,12 @@ FlatAtomicSmaxX2Flat::FlatAtomicSmaxX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smax_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSmaxX2Flat>(opcode);
 }
 } // namespace detail
@@ -1594,7 +1818,12 @@ FlatAtomicUmaxX2Flat::FlatAtomicUmaxX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umax_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUmaxX2Flat>(opcode);
 }
 } // namespace detail
@@ -1629,7 +1858,12 @@ FlatAtomicAndX2Flat::FlatAtomicAndX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_and_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndX2Flat>(opcode);
 }
 } // namespace detail
@@ -1664,7 +1898,12 @@ FlatAtomicOrX2Flat::FlatAtomicOrX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrX2Flat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_or_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrX2Flat>(opcode);
 }
 } // namespace detail
@@ -1699,7 +1938,12 @@ FlatAtomicXorX2Flat::FlatAtomicXorX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_xor_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorX2Flat>(opcode);
 }
 } // namespace detail
@@ -1734,7 +1978,12 @@ FlatAtomicIncX2Flat::FlatAtomicIncX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_inc_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncX2Flat>(opcode);
 }
 } // namespace detail
@@ -1769,7 +2018,12 @@ FlatAtomicDecX2Flat::FlatAtomicDecX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_dec_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecX2Flat>(opcode);
 }
 } // namespace detail
@@ -1804,7 +2058,12 @@ FlatAtomicFcmpswapX2Flat::FlatAtomicFcmpswapX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicFcmpswapX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicFcmpswapX2Flat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_fcmpswap_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicFcmpswapX2Flat>(opcode);
 }
 } // namespace detail
@@ -1839,7 +2098,12 @@ FlatAtomicFminX2Flat::FlatAtomicFminX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicFminX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicFminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_fmin_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicFminX2Flat>(opcode);
 }
 } // namespace detail
@@ -1874,7 +2138,12 @@ FlatAtomicFmaxX2Flat::FlatAtomicFmaxX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicFmaxX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicFmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_fmax_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicFmaxX2Flat>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/mimg.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/mimg.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/mimg.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -26,7 +25,11 @@ ImageLoadMimg::ImageLoadMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMimg>(opcode);
 }
 } // namespace detail
@@ -45,7 +48,12 @@ ImageLoadMipMimg::ImageLoadMipMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipMimg>(opcode);
 }
 } // namespace detail
@@ -64,7 +72,12 @@ ImageLoadPckMimg::ImageLoadPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadPckMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadPckMimg>(opcode);
 }
 } // namespace detail
@@ -83,7 +96,12 @@ ImageLoadPckSgnMimg::ImageLoadPckSgnMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadPckSgnMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadPckSgnMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_pck_sgn", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadPckSgnMimg>(opcode);
 }
 } // namespace detail
@@ -102,7 +120,12 @@ ImageLoadMipPckMimg::ImageLoadMipPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipPckMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipPckMimg>(opcode);
 }
 } // namespace detail
@@ -121,7 +144,12 @@ ImageLoadMipPckSgnMimg::ImageLoadMipPckSgnMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipPckSgnMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipPckSgnMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_pck_sgn", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipPckSgnMimg>(opcode);
 }
 } // namespace detail
@@ -140,7 +168,11 @@ ImageStoreMimg::ImageStoreMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMimg>(opcode);
 }
 } // namespace detail
@@ -159,7 +191,12 @@ ImageStoreMipMimg::ImageStoreMipMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipMimg>(opcode);
 }
 } // namespace detail
@@ -178,7 +215,12 @@ ImageStorePckMimg::ImageStorePckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStorePckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStorePckMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStorePckMimg>(opcode);
 }
 } // namespace detail
@@ -197,7 +239,12 @@ ImageStoreMipPckMimg::ImageStoreMipPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipPckMimg>(opcode);
 }
 } // namespace detail
@@ -216,7 +263,12 @@ ImageGetResinfoMimg::ImageGetResinfoMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGetResinfoMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGetResinfoMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_get_resinfo", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGetResinfoMimg>(opcode);
 }
 } // namespace detail
@@ -236,7 +288,12 @@ ImageAtomicSwapMimg::ImageAtomicSwapMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSwapMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSwapMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_swap", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSwapMimg>(opcode);
 }
 } // namespace detail
@@ -256,7 +313,12 @@ ImageAtomicCmpswapMimg::ImageAtomicCmpswapMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicCmpswapMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicCmpswapMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_cmpswap", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicCmpswapMimg>(opcode);
 }
 } // namespace detail
@@ -276,7 +338,12 @@ ImageAtomicAddMimg::ImageAtomicAddMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicAddMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicAddMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_add", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicAddMimg>(opcode);
 }
 } // namespace detail
@@ -296,7 +363,12 @@ ImageAtomicSubMimg::ImageAtomicSubMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSubMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSubMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_sub", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSubMimg>(opcode);
 }
 } // namespace detail
@@ -316,7 +388,12 @@ ImageAtomicSminMimg::ImageAtomicSminMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSminMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_smin", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSminMimg>(opcode);
 }
 } // namespace detail
@@ -336,7 +413,12 @@ ImageAtomicUminMimg::ImageAtomicUminMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicUminMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicUminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_umin", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicUminMimg>(opcode);
 }
 } // namespace detail
@@ -356,7 +438,12 @@ ImageAtomicSmaxMimg::ImageAtomicSmaxMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSmaxMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_smax", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSmaxMimg>(opcode);
 }
 } // namespace detail
@@ -376,7 +463,12 @@ ImageAtomicUmaxMimg::ImageAtomicUmaxMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicUmaxMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicUmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_umax", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicUmaxMimg>(opcode);
 }
 } // namespace detail
@@ -396,7 +488,12 @@ ImageAtomicAndMimg::ImageAtomicAndMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicAndMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicAndMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_and", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicAndMimg>(opcode);
 }
 } // namespace detail
@@ -416,7 +513,12 @@ ImageAtomicOrMimg::ImageAtomicOrMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicOrMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicOrMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_or", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicOrMimg>(opcode);
 }
 } // namespace detail
@@ -436,7 +538,12 @@ ImageAtomicXorMimg::ImageAtomicXorMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicXorMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicXorMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_xor", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicXorMimg>(opcode);
 }
 } // namespace detail
@@ -456,7 +563,12 @@ ImageAtomicIncMimg::ImageAtomicIncMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicIncMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicIncMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_inc", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicIncMimg>(opcode);
 }
 } // namespace detail
@@ -476,7 +588,12 @@ ImageAtomicDecMimg::ImageAtomicDecMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicDecMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicDecMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_dec", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicDecMimg>(opcode);
 }
 } // namespace detail
@@ -496,7 +613,12 @@ ImageAtomicFcmpswapMimg::ImageAtomicFcmpswapMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicFcmpswapMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicFcmpswapMimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_fcmpswap", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicFcmpswapMimg>(opcode);
 }
 } // namespace detail
@@ -516,7 +638,12 @@ ImageAtomicFminMimg::ImageAtomicFminMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicFminMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicFminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_fmin", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicFminMimg>(opcode);
 }
 } // namespace detail
@@ -536,7 +663,12 @@ ImageAtomicFmaxMimg::ImageAtomicFmaxMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicFmaxMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicFmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_fmax", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicFmaxMimg>(opcode);
 }
 } // namespace detail
@@ -557,7 +689,12 @@ ImageSampleMimg::ImageSampleMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleMimg(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleMimg>(opcode);
 }
 } // namespace detail
@@ -578,7 +715,12 @@ ImageSampleClMimg::ImageSampleClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleClMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleClMimg>(opcode);
 }
 } // namespace detail
@@ -599,7 +741,12 @@ ImageSampleDMimg::ImageSampleDMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDMimg>(opcode);
 }
 } // namespace detail
@@ -620,7 +767,12 @@ ImageSampleDClMimg::ImageSampleDClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClMimg>(opcode);
 }
 } // namespace detail
@@ -641,7 +793,12 @@ ImageSampleLMimg::ImageSampleLMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLMimg>(opcode);
 }
 } // namespace detail
@@ -662,7 +819,12 @@ ImageSampleBMimg::ImageSampleBMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBMimg>(opcode);
 }
 } // namespace detail
@@ -683,7 +845,12 @@ ImageSampleBClMimg::ImageSampleBClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBClMimg>(opcode);
 }
 } // namespace detail
@@ -704,7 +871,12 @@ ImageSampleLzMimg::ImageSampleLzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLzMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLzMimg>(opcode);
 }
 } // namespace detail
@@ -725,7 +897,12 @@ ImageSampleCMimg::ImageSampleCMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCMimg>(opcode);
 }
 } // namespace detail
@@ -746,7 +923,12 @@ ImageSampleCClMimg::ImageSampleCClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCClMimg>(opcode);
 }
 } // namespace detail
@@ -767,7 +949,12 @@ ImageSampleCDMimg::ImageSampleCDMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDMimg>(opcode);
 }
 } // namespace detail
@@ -788,7 +975,12 @@ ImageSampleCDClMimg::ImageSampleCDClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClMimg>(opcode);
 }
 } // namespace detail
@@ -809,7 +1001,12 @@ ImageSampleCLMimg::ImageSampleCLMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLMimg>(opcode);
 }
 } // namespace detail
@@ -830,7 +1027,12 @@ ImageSampleCBMimg::ImageSampleCBMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBMimg>(opcode);
 }
 } // namespace detail
@@ -851,7 +1053,12 @@ ImageSampleCBClMimg::ImageSampleCBClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBClMimg>(opcode);
 }
 } // namespace detail
@@ -872,7 +1079,12 @@ ImageSampleCLzMimg::ImageSampleCLzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLzMimg>(opcode);
 }
 } // namespace detail
@@ -893,7 +1105,12 @@ ImageSampleOMimg::ImageSampleOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleOMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleOMimg>(opcode);
 }
 } // namespace detail
@@ -914,7 +1131,12 @@ ImageSampleClOMimg::ImageSampleClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleClOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleClOMimg>(opcode);
 }
 } // namespace detail
@@ -935,7 +1157,12 @@ ImageSampleDOMimg::ImageSampleDOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDOMimg>(opcode);
 }
 } // namespace detail
@@ -956,7 +1183,12 @@ ImageSampleDClOMimg::ImageSampleDClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClOMimg>(opcode);
 }
 } // namespace detail
@@ -977,7 +1209,12 @@ ImageSampleLOMimg::ImageSampleLOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_l_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLOMimg>(opcode);
 }
 } // namespace detail
@@ -998,7 +1235,12 @@ ImageSampleBOMimg::ImageSampleBOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBOMimg>(opcode);
 }
 } // namespace detail
@@ -1019,7 +1261,12 @@ ImageSampleBClOMimg::ImageSampleBClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBClOMimg>(opcode);
 }
 } // namespace detail
@@ -1040,7 +1287,12 @@ ImageSampleLzOMimg::ImageSampleLzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLzOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLzOMimg>(opcode);
 }
 } // namespace detail
@@ -1061,7 +1313,12 @@ ImageSampleCOMimg::ImageSampleCOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCOMimg>(opcode);
 }
 } // namespace detail
@@ -1082,7 +1339,12 @@ ImageSampleCClOMimg::ImageSampleCClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCClOMimg>(opcode);
 }
 } // namespace detail
@@ -1103,7 +1365,12 @@ ImageSampleCDOMimg::ImageSampleCDOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDOMimg>(opcode);
 }
 } // namespace detail
@@ -1124,7 +1391,12 @@ ImageSampleCDClOMimg::ImageSampleCDClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClOMimg>(opcode);
 }
 } // namespace detail
@@ -1145,7 +1417,12 @@ ImageSampleCLOMimg::ImageSampleCLOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_l_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLOMimg>(opcode);
 }
 } // namespace detail
@@ -1166,7 +1443,12 @@ ImageSampleCBOMimg::ImageSampleCBOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBOMimg>(opcode);
 }
 } // namespace detail
@@ -1187,7 +1469,12 @@ ImageSampleCBClOMimg::ImageSampleCBClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBClOMimg>(opcode);
 }
 } // namespace detail
@@ -1208,7 +1495,12 @@ ImageSampleCLzOMimg::ImageSampleCLzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLzOMimg>(opcode);
 }
 } // namespace detail
@@ -1229,7 +1521,12 @@ ImageGather4Mimg::ImageGather4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4Mimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4Mimg>(opcode);
 }
 } // namespace detail
@@ -1250,7 +1547,12 @@ ImageGather4ClMimg::ImageGather4ClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4ClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4ClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4ClMimg>(opcode);
 }
 } // namespace detail
@@ -1269,7 +1571,12 @@ ImageLoadBy2Mimg::ImageLoadBy2Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadBy2Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadBy2Mimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_by2", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadBy2Mimg>(opcode);
 }
 } // namespace detail
@@ -1288,7 +1595,12 @@ ImageLoadBy4Mimg::ImageLoadBy4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadBy4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadBy4Mimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_by4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadBy4Mimg>(opcode);
 }
 } // namespace detail
@@ -1309,7 +1621,12 @@ ImageGather4LMimg::ImageGather4LMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LMimg>(opcode);
 }
 } // namespace detail
@@ -1330,7 +1647,12 @@ ImageGather4BMimg::ImageGather4BMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4BMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4BMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4BMimg>(opcode);
 }
 } // namespace detail
@@ -1351,7 +1673,12 @@ ImageGather4BClMimg::ImageGather4BClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4BClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4BClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4BClMimg>(opcode);
 }
 } // namespace detail
@@ -1372,7 +1699,12 @@ ImageGather4LzMimg::ImageGather4LzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LzMimg>(opcode);
 }
 } // namespace detail
@@ -1393,7 +1725,12 @@ ImageGather4CMimg::ImageGather4CMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CMimg>(opcode);
 }
 } // namespace detail
@@ -1414,7 +1751,12 @@ ImageGather4CClMimg::ImageGather4CClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CClMimg>(opcode);
 }
 } // namespace detail
@@ -1433,7 +1775,12 @@ ImageLoadMipBy2Mimg::ImageLoadMipBy2Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipBy2Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipBy2Mimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_by2", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipBy2Mimg>(opcode);
 }
 } // namespace detail
@@ -1452,7 +1799,12 @@ ImageLoadMipBy4Mimg::ImageLoadMipBy4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipBy4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipBy4Mimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_by4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipBy4Mimg>(opcode);
 }
 } // namespace detail
@@ -1473,7 +1825,12 @@ ImageGather4CLMimg::ImageGather4CLMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLMimg>(opcode);
 }
 } // namespace detail
@@ -1494,7 +1851,12 @@ ImageGather4CBMimg::ImageGather4CBMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CBMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CBMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CBMimg>(opcode);
 }
 } // namespace detail
@@ -1515,7 +1877,12 @@ ImageGather4CBClMimg::ImageGather4CBClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CBClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CBClMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CBClMimg>(opcode);
 }
 } // namespace detail
@@ -1536,7 +1903,12 @@ ImageGather4CLzMimg::ImageGather4CLzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLzMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLzMimg>(opcode);
 }
 } // namespace detail
@@ -1557,7 +1929,12 @@ ImageGather4OMimg::ImageGather4OMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4OMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4OMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4OMimg>(opcode);
 }
 } // namespace detail
@@ -1578,7 +1955,12 @@ ImageGather4ClOMimg::ImageGather4ClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4ClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4ClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4ClOMimg>(opcode);
 }
 } // namespace detail
@@ -1597,7 +1979,12 @@ ImageStoreBy2Mimg::ImageStoreBy2Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreBy2Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreBy2Mimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_by2", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreBy2Mimg>(opcode);
 }
 } // namespace detail
@@ -1616,7 +2003,12 @@ ImageStoreBy4Mimg::ImageStoreBy4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreBy4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreBy4Mimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_by4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreBy4Mimg>(opcode);
 }
 } // namespace detail
@@ -1637,7 +2029,12 @@ ImageGather4LOMimg::ImageGather4LOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_l_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LOMimg>(opcode);
 }
 } // namespace detail
@@ -1658,7 +2055,12 @@ ImageGather4BOMimg::ImageGather4BOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4BOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4BOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_b_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4BOMimg>(opcode);
 }
 } // namespace detail
@@ -1679,7 +2081,12 @@ ImageGather4BClOMimg::ImageGather4BClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4BClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4BClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_b_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4BClOMimg>(opcode);
 }
 } // namespace detail
@@ -1700,7 +2107,12 @@ ImageGather4LzOMimg::ImageGather4LzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LzOMimg>(opcode);
 }
 } // namespace detail
@@ -1721,7 +2133,12 @@ ImageGather4COMimg::ImageGather4COMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4COMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4COMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4COMimg>(opcode);
 }
 } // namespace detail
@@ -1742,7 +2159,12 @@ ImageGather4CClOMimg::ImageGather4CClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CClOMimg>(opcode);
 }
 } // namespace detail
@@ -1761,7 +2183,12 @@ ImageStoreMipBy2Mimg::ImageStoreMipBy2Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipBy2Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipBy2Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip_by2", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipBy2Mimg>(opcode);
 }
 } // namespace detail
@@ -1780,7 +2207,12 @@ ImageStoreMipBy4Mimg::ImageStoreMipBy4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipBy4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipBy4Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip_by4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipBy4Mimg>(opcode);
 }
 } // namespace detail
@@ -1801,7 +2233,12 @@ ImageGather4CLOMimg::ImageGather4CLOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_l_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLOMimg>(opcode);
 }
 } // namespace detail
@@ -1822,7 +2259,12 @@ ImageGather4CBOMimg::ImageGather4CBOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CBOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CBOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_b_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CBOMimg>(opcode);
 }
 } // namespace detail
@@ -1843,7 +2285,12 @@ ImageGather4CBClOMimg::ImageGather4CBClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CBClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CBClOMimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_b_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CBClOMimg>(opcode);
 }
 } // namespace detail
@@ -1864,7 +2311,12 @@ ImageGather4CLzOMimg::ImageGather4CLzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLzOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLzOMimg>(opcode);
 }
 } // namespace detail
@@ -1885,7 +2337,12 @@ ImageGetLodMimg::ImageGetLodMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGetLodMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGetLodMimg(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_get_lod", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGetLodMimg>(opcode);
 }
 } // namespace detail
@@ -1906,7 +2363,12 @@ ImageGather4hMimg::ImageGather4hMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4hMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4hMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4h", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4hMimg>(opcode);
 }
 } // namespace detail
@@ -1927,7 +2389,12 @@ ImageGather4hPckMimg::ImageGather4hPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4hPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4hPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4h_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4hPckMimg>(opcode);
 }
 } // namespace detail
@@ -1948,7 +2415,12 @@ ImageGather8hPckMimg::ImageGather8hPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather8hPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather8hPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather8h_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather8hPckMimg>(opcode);
 }
 } // namespace detail
@@ -1969,7 +2441,12 @@ ImageSampleCdMimg::ImageSampleCdMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdMimg>(opcode);
 }
 } // namespace detail
@@ -1990,7 +2467,12 @@ ImageSampleCdClMimg::ImageSampleCdClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdClMimg>(opcode);
 }
 } // namespace detail
@@ -2011,7 +2493,12 @@ ImageSampleCCdMimg::ImageSampleCCdMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdMimg>(opcode);
 }
 } // namespace detail
@@ -2032,7 +2519,12 @@ ImageSampleCCdClMimg::ImageSampleCCdClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdClMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdClMimg>(opcode);
 }
 } // namespace detail
@@ -2053,7 +2545,12 @@ ImageSampleCdOMimg::ImageSampleCdOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdOMimg>(opcode);
 }
 } // namespace detail
@@ -2074,7 +2571,12 @@ ImageSampleCdClOMimg::ImageSampleCdClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdClOMimg>(opcode);
 }
 } // namespace detail
@@ -2095,7 +2597,12 @@ ImageSampleCCdOMimg::ImageSampleCCdOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdOMimg>(opcode);
 }
 } // namespace detail
@@ -2116,7 +2623,12 @@ ImageSampleCCdClOMimg::ImageSampleCCdClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdClOMimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdClOMimg>(opcode);
 }
 } // namespace detail
@@ -2135,7 +2647,12 @@ ImageLoadPck2Mimg::ImageLoadPck2Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadPck2Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadPck2Mimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_pck2", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadPck2Mimg>(opcode);
 }
 } // namespace detail
@@ -2154,7 +2671,12 @@ ImageLoadPck4Mimg::ImageLoadPck4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadPck4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadPck4Mimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_pck4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadPck4Mimg>(opcode);
 }
 } // namespace detail
@@ -2173,7 +2695,12 @@ ImageLoadMipPck2Mimg::ImageLoadMipPck2Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipPck2Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipPck2Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_pck2", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipPck2Mimg>(opcode);
 }
 } // namespace detail
@@ -2192,7 +2719,12 @@ ImageLoadMipPck4Mimg::ImageLoadMipPck4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipPck4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipPck4Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_pck4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipPck4Mimg>(opcode);
 }
 } // namespace detail
@@ -2211,7 +2743,12 @@ ImageStorePck2Mimg::ImageStorePck2Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStorePck2Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageStorePck2Mimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_pck2", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStorePck2Mimg>(opcode);
 }
 } // namespace detail
@@ -2230,7 +2767,12 @@ ImageStorePck4Mimg::ImageStorePck4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStorePck4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageStorePck4Mimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_pck4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStorePck4Mimg>(opcode);
 }
 } // namespace detail
@@ -2249,7 +2791,12 @@ ImageStoreMipPck2Mimg::ImageStoreMipPck2Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipPck2Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipPck2Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip_pck2", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipPck2Mimg>(opcode);
 }
 } // namespace detail
@@ -2268,7 +2815,12 @@ ImageStoreMipPck4Mimg::ImageStoreMipPck4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipPck4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipPck4Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip_pck4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipPck4Mimg>(opcode);
 }
 } // namespace detail
@@ -2287,7 +2839,12 @@ ImageMsaaLoadMimg::ImageMsaaLoadMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageMsaaLoadMimg(const MachineInst *opcode) {
+DecodeResult decodeImageMsaaLoadMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_msaa_load", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageMsaaLoadMimg>(opcode);
 }
 } // namespace detail
@@ -2308,7 +2865,12 @@ ImageSampleDG16Mimg::ImageSampleDG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDG16Mimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2329,7 +2891,12 @@ ImageSampleDClG16Mimg::ImageSampleDClG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_cl_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2350,7 +2917,12 @@ ImageSampleCDG16Mimg::ImageSampleCDG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2371,7 +2943,12 @@ ImageSampleCDClG16Mimg::ImageSampleCDClG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_cl_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2392,7 +2969,12 @@ ImageSampleDOG16Mimg::ImageSampleDOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDOG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2413,7 +2995,12 @@ ImageSampleDClOG16Mimg::ImageSampleDClOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClOG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_cl_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2434,7 +3021,12 @@ ImageSampleCDOG16Mimg::ImageSampleCDOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDOG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2455,7 +3047,12 @@ ImageSampleCDClOG16Mimg::ImageSampleCDClOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClOG16Mimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_cl_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2476,7 +3073,12 @@ ImageSampleCdG16Mimg::ImageSampleCdG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2497,7 +3099,12 @@ ImageSampleCdClG16Mimg::ImageSampleCdClG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdClG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdClG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd_cl_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdClG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2518,7 +3125,12 @@ ImageSampleCCdG16Mimg::ImageSampleCCdG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2539,7 +3151,12 @@ ImageSampleCCdClG16Mimg::ImageSampleCCdClG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdClG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdClG16Mimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd_cl_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdClG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2560,7 +3177,12 @@ ImageSampleCdOG16Mimg::ImageSampleCdOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdOG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2581,7 +3203,12 @@ ImageSampleCdClOG16Mimg::ImageSampleCdClOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdClOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdClOG16Mimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd_cl_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdClOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2602,7 +3229,12 @@ ImageSampleCCdOG16Mimg::ImageSampleCCdOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdOG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2623,7 +3255,12 @@ ImageSampleCCdClOG16Mimg::ImageSampleCCdClOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdClOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdClOG16Mimg(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd_cl_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdClOG16Mimg>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/mtbuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/mtbuf.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/mtbuf.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -43,7 +42,12 @@ TbufferLoadFormatXMtbuf::TbufferLoadFormatXMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -68,7 +72,12 @@ TbufferLoadFormatXyMtbuf::TbufferLoadFormatXyMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xy", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -93,7 +102,12 @@ TbufferLoadFormatXyzMtbuf::TbufferLoadFormatXyzMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xyz", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -118,7 +132,12 @@ TbufferLoadFormatXyzwMtbuf::TbufferLoadFormatXyzwMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xyzw", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -143,7 +162,12 @@ TbufferStoreFormatXMtbuf::TbufferStoreFormatXMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -168,7 +192,12 @@ TbufferStoreFormatXyMtbuf::TbufferStoreFormatXyMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xy", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -193,7 +222,12 @@ TbufferStoreFormatXyzMtbuf::TbufferStoreFormatXyzMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xyz", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -218,7 +252,12 @@ TbufferStoreFormatXyzwMtbuf::TbufferStoreFormatXyzwMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xyzw", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -243,7 +282,12 @@ TbufferLoadFormatD16XMtbuf::TbufferLoadFormatD16XMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_d16_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XMtbuf>(opcode);
 }
 } // namespace detail
@@ -274,7 +318,13 @@ TbufferLoadFormatD16XyMtbuf::TbufferLoadFormatD16XyMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_format_d16_xy",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XyMtbuf>(opcode);
 }
 } // namespace detail
@@ -299,7 +349,13 @@ TbufferLoadFormatD16XyzMtbuf::TbufferLoadFormatD16XyzMtbuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_format_d16_xyz",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -330,7 +386,13 @@ TbufferLoadFormatD16XyzwMtbuf::TbufferLoadFormatD16XyzwMtbuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_format_d16_xyzw",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -355,7 +417,13 @@ TbufferStoreFormatD16XMtbuf::TbufferStoreFormatD16XMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_x",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XMtbuf>(opcode);
 }
 } // namespace detail
@@ -380,7 +448,13 @@ TbufferStoreFormatD16XyMtbuf::TbufferStoreFormatD16XyMtbuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_xy",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XyMtbuf>(opcode);
 }
 } // namespace detail
@@ -405,7 +479,13 @@ TbufferStoreFormatD16XyzMtbuf::TbufferStoreFormatD16XyzMtbuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_xyz",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -430,7 +510,13 @@ TbufferStoreFormatD16XyzwMtbuf::TbufferStoreFormatD16XyzwMtbuf(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_xyzw",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XyzwMtbuf>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/mubuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/mubuf.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/mubuf.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -43,7 +42,12 @@ BufferLoadFormatXMubuf::BufferLoadFormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXMubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -68,7 +72,12 @@ BufferLoadFormatXyMubuf::BufferLoadFormatXyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -93,7 +102,12 @@ BufferLoadFormatXyzMubuf::BufferLoadFormatXyzMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xyz", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -118,7 +132,12 @@ BufferLoadFormatXyzwMubuf::BufferLoadFormatXyzwMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xyzw", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -143,7 +162,12 @@ BufferStoreFormatXMubuf::BufferStoreFormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -168,7 +192,12 @@ BufferStoreFormatXyMubuf::BufferStoreFormatXyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -193,7 +222,12 @@ BufferStoreFormatXyzMubuf::BufferStoreFormatXyzMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xyz", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -218,7 +252,12 @@ BufferStoreFormatXyzwMubuf::BufferStoreFormatXyzwMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xyzw", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -243,7 +282,12 @@ BufferLoadUbyteMubuf::BufferLoadUbyteMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUbyteMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ubyte", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUbyteMubuf>(opcode);
 }
 } // namespace detail
@@ -268,7 +312,12 @@ BufferLoadSbyteMubuf::BufferLoadSbyteMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSbyteMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sbyte", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSbyteMubuf>(opcode);
 }
 } // namespace detail
@@ -293,7 +342,12 @@ BufferLoadUshortMubuf::BufferLoadUshortMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUshortMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ushort", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUshortMubuf>(opcode);
 }
 } // namespace detail
@@ -318,7 +372,12 @@ BufferLoadSshortMubuf::BufferLoadSshortMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSshortMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sshort", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSshortMubuf>(opcode);
 }
 } // namespace detail
@@ -343,7 +402,12 @@ BufferLoadDwordMubuf::BufferLoadDwordMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dword", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordMubuf>(opcode);
 }
 } // namespace detail
@@ -368,7 +432,12 @@ BufferLoadDwordx2Mubuf::BufferLoadDwordx2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dwordx2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordx2Mubuf>(opcode);
 }
 } // namespace detail
@@ -393,7 +462,12 @@ BufferLoadDwordx4Mubuf::BufferLoadDwordx4Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dwordx4", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordx4Mubuf>(opcode);
 }
 } // namespace detail
@@ -418,7 +492,12 @@ BufferLoadDwordx3Mubuf::BufferLoadDwordx3Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dwordx3", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordx3Mubuf>(opcode);
 }
 } // namespace detail
@@ -443,7 +522,12 @@ BufferStoreByteMubuf::BufferStoreByteMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreByteMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreByteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_byte", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreByteMubuf>(opcode);
 }
 } // namespace detail
@@ -468,7 +552,12 @@ BufferStoreByteD16HiMubuf::BufferStoreByteD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_byte_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreByteD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -493,7 +582,12 @@ BufferStoreShortMubuf::BufferStoreShortMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreShortMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreShortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_short", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreShortMubuf>(opcode);
 }
 } // namespace detail
@@ -518,7 +612,12 @@ BufferStoreShortD16HiMubuf::BufferStoreShortD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_short_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreShortD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -543,7 +642,12 @@ BufferStoreDwordMubuf::BufferStoreDwordMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dword", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordMubuf>(opcode);
 }
 } // namespace detail
@@ -568,7 +672,12 @@ BufferStoreDwordx2Mubuf::BufferStoreDwordx2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dwordx2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordx2Mubuf>(opcode);
 }
 } // namespace detail
@@ -593,7 +702,12 @@ BufferStoreDwordx4Mubuf::BufferStoreDwordx4Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dwordx4", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordx4Mubuf>(opcode);
 }
 } // namespace detail
@@ -618,7 +732,12 @@ BufferStoreDwordx3Mubuf::BufferStoreDwordx3Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dwordx3", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordx3Mubuf>(opcode);
 }
 } // namespace detail
@@ -643,7 +762,12 @@ BufferLoadUbyteD16Mubuf::BufferLoadUbyteD16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ubyte_d16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUbyteD16Mubuf>(opcode);
 }
 } // namespace detail
@@ -675,7 +799,12 @@ BufferLoadUbyteD16HiMubuf::BufferLoadUbyteD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ubyte_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUbyteD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -707,7 +836,12 @@ BufferLoadSbyteD16Mubuf::BufferLoadSbyteD16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sbyte_d16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSbyteD16Mubuf>(opcode);
 }
 } // namespace detail
@@ -739,7 +873,12 @@ BufferLoadSbyteD16HiMubuf::BufferLoadSbyteD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sbyte_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSbyteD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -771,7 +910,12 @@ BufferLoadShortD16Mubuf::BufferLoadShortD16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadShortD16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadShortD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_short_d16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadShortD16Mubuf>(opcode);
 }
 } // namespace detail
@@ -803,7 +947,12 @@ BufferLoadShortD16HiMubuf::BufferLoadShortD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_short_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadShortD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -835,7 +984,13 @@ BufferLoadFormatD16HiXMubuf::BufferLoadFormatD16HiXMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_format_d16_hi_x",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16HiXMubuf>(opcode);
 }
 } // namespace detail
@@ -867,7 +1022,13 @@ BufferStoreFormatD16HiXMubuf::BufferStoreFormatD16HiXMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_hi_x",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16HiXMubuf>(opcode);
 }
 } // namespace detail
@@ -894,7 +1055,12 @@ BufferAtomicSwapMubuf::BufferAtomicSwapMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_swap", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapMubuf>(opcode);
 }
 } // namespace detail
@@ -922,7 +1088,12 @@ BufferAtomicCmpswapMubuf::BufferAtomicCmpswapMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_cmpswap", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapMubuf>(opcode);
 }
 } // namespace detail
@@ -949,7 +1120,12 @@ BufferAtomicAddMubuf::BufferAtomicAddMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddMubuf>(opcode);
 }
 } // namespace detail
@@ -976,7 +1152,12 @@ BufferAtomicSubMubuf::BufferAtomicSubMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_sub", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubMubuf>(opcode);
 }
 } // namespace detail
@@ -1003,7 +1184,12 @@ BufferAtomicSminMubuf::BufferAtomicSminMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSminMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smin", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSminMubuf>(opcode);
 }
 } // namespace detail
@@ -1030,7 +1216,12 @@ BufferAtomicUminMubuf::BufferAtomicUminMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUminMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umin", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUminMubuf>(opcode);
 }
 } // namespace detail
@@ -1057,7 +1248,12 @@ BufferAtomicSmaxMubuf::BufferAtomicSmaxMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smax", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSmaxMubuf>(opcode);
 }
 } // namespace detail
@@ -1084,7 +1280,12 @@ BufferAtomicUmaxMubuf::BufferAtomicUmaxMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umax", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUmaxMubuf>(opcode);
 }
 } // namespace detail
@@ -1111,7 +1312,12 @@ BufferAtomicAndMubuf::BufferAtomicAndMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_and", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndMubuf>(opcode);
 }
 } // namespace detail
@@ -1138,7 +1344,12 @@ BufferAtomicOrMubuf::BufferAtomicOrMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrMubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_or", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrMubuf>(opcode);
 }
 } // namespace detail
@@ -1165,7 +1376,12 @@ BufferAtomicXorMubuf::BufferAtomicXorMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_xor", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorMubuf>(opcode);
 }
 } // namespace detail
@@ -1192,7 +1408,12 @@ BufferAtomicIncMubuf::BufferAtomicIncMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_inc", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncMubuf>(opcode);
 }
 } // namespace detail
@@ -1219,7 +1440,12 @@ BufferAtomicDecMubuf::BufferAtomicDecMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_dec", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecMubuf>(opcode);
 }
 } // namespace detail
@@ -1247,7 +1473,12 @@ BufferAtomicFcmpswapMubuf::BufferAtomicFcmpswapMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicFcmpswapMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicFcmpswapMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_fcmpswap", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicFcmpswapMubuf>(opcode);
 }
 } // namespace detail
@@ -1274,7 +1505,12 @@ BufferAtomicFminMubuf::BufferAtomicFminMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicFminMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicFminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_fmin", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicFminMubuf>(opcode);
 }
 } // namespace detail
@@ -1301,7 +1537,12 @@ BufferAtomicFmaxMubuf::BufferAtomicFmaxMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicFmaxMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicFmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_fmax", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicFmaxMubuf>(opcode);
 }
 } // namespace detail
@@ -1328,7 +1569,12 @@ BufferAtomicSwapX2Mubuf::BufferAtomicSwapX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_swap_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1356,7 +1602,12 @@ BufferAtomicCmpswapX2Mubuf::BufferAtomicCmpswapX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_cmpswap_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1383,7 +1634,12 @@ BufferAtomicAddX2Mubuf::BufferAtomicAddX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1410,7 +1666,12 @@ BufferAtomicSubX2Mubuf::BufferAtomicSubX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_sub_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1437,7 +1698,12 @@ BufferAtomicSminX2Mubuf::BufferAtomicSminX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smin_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSminX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1464,7 +1730,12 @@ BufferAtomicUminX2Mubuf::BufferAtomicUminX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umin_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUminX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1491,7 +1762,12 @@ BufferAtomicSmaxX2Mubuf::BufferAtomicSmaxX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smax_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSmaxX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1518,7 +1794,12 @@ BufferAtomicUmaxX2Mubuf::BufferAtomicUmaxX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umax_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUmaxX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1545,7 +1826,12 @@ BufferAtomicAndX2Mubuf::BufferAtomicAndX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_and_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1572,7 +1858,12 @@ BufferAtomicOrX2Mubuf::BufferAtomicOrX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_or_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1599,7 +1890,12 @@ BufferAtomicXorX2Mubuf::BufferAtomicXorX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_xor_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1626,7 +1922,12 @@ BufferAtomicIncX2Mubuf::BufferAtomicIncX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_inc_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1653,7 +1954,12 @@ BufferAtomicDecX2Mubuf::BufferAtomicDecX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_dec_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1681,7 +1987,12 @@ BufferAtomicFcmpswapX2Mubuf::BufferAtomicFcmpswapX2Mubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicFcmpswapX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicFcmpswapX2Mubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_fcmpswap_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicFcmpswapX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1708,7 +2019,12 @@ BufferAtomicFminX2Mubuf::BufferAtomicFminX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicFminX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicFminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_fmin_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicFminX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1735,7 +2051,12 @@ BufferAtomicFmaxX2Mubuf::BufferAtomicFmaxX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicFmaxX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicFmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_fmax_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicFmaxX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1748,7 +2069,12 @@ BufferGl0InvMubuf::BufferGl0InvMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferGl0InvMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferGl0InvMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_gl0_inv", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferGl0InvMubuf>(opcode);
 }
 } // namespace detail
@@ -1761,7 +2087,12 @@ BufferGl1InvMubuf::BufferGl1InvMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferGl1InvMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferGl1InvMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_gl1_inv", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferGl1InvMubuf>(opcode);
 }
 } // namespace detail
@@ -1786,7 +2117,12 @@ BufferLoadFormatD16XMubuf::BufferLoadFormatD16XMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_d16_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XMubuf>(opcode);
 }
 } // namespace detail
@@ -1818,7 +2154,12 @@ BufferLoadFormatD16XyMubuf::BufferLoadFormatD16XyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_d16_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XyMubuf>(opcode);
 }
 } // namespace detail
@@ -1843,7 +2184,13 @@ BufferLoadFormatD16XyzMubuf::BufferLoadFormatD16XyzMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_format_d16_xyz",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XyzMubuf>(opcode);
 }
 } // namespace detail
@@ -1875,7 +2222,13 @@ BufferLoadFormatD16XyzwMubuf::BufferLoadFormatD16XyzwMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_format_d16_xyzw",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -1900,7 +2253,12 @@ BufferStoreFormatD16XMubuf::BufferStoreFormatD16XMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_d16_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XMubuf>(opcode);
 }
 } // namespace detail
@@ -1925,7 +2283,13 @@ BufferStoreFormatD16XyMubuf::BufferStoreFormatD16XyMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_xy",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XyMubuf>(opcode);
 }
 } // namespace detail
@@ -1950,7 +2314,13 @@ BufferStoreFormatD16XyzMubuf::BufferStoreFormatD16XyzMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_xyz",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XyzMubuf>(opcode);
 }
 } // namespace detail
@@ -1975,7 +2345,13 @@ BufferStoreFormatD16XyzwMubuf::BufferStoreFormatD16XyzwMubuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_xyzw",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XyzwMubuf>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/operand.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/operand.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/scalar_static_resolve.h"
-#include "util/except.h"
 #include <format>
 #include <optional>
 #include <stdexcept>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/smem.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/smem.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/smem.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -35,7 +34,11 @@ SLoadDwordSmem::SLoadDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordSmem>(opcode);
 }
 } // namespace detail
@@ -56,7 +59,12 @@ SLoadDwordx2Smem::SLoadDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -77,7 +85,12 @@ SLoadDwordx4Smem::SLoadDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx4Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -98,7 +111,12 @@ SLoadDwordx8Smem::SLoadDwordx8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx8Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx8Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx8Smem>(opcode);
 }
 } // namespace detail
@@ -119,7 +137,12 @@ SLoadDwordx16Smem::SLoadDwordx16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx16Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx16Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx16Smem>(opcode);
 }
 } // namespace detail
@@ -140,7 +163,12 @@ SScratchLoadDwordSmem::SScratchLoadDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchLoadDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSScratchLoadDwordSmem(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_load_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchLoadDwordSmem>(opcode);
 }
 } // namespace detail
@@ -161,7 +189,12 @@ SScratchLoadDwordx2Smem::SScratchLoadDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSScratchLoadDwordx2Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_load_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchLoadDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -182,7 +215,12 @@ SScratchLoadDwordx4Smem::SScratchLoadDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSScratchLoadDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSScratchLoadDwordx4Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_scratch_load_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SScratchLoadDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -203,7 +241,12 @@ SBufferLoadDwordSmem::SBufferLoadDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordSmem>(opcode);
 }
 } // namespace detail
@@ -224,7 +267,12 @@ SBufferLoadDwordx2Smem::SBufferLoadDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -245,7 +293,12 @@ SBufferLoadDwordx4Smem::SBufferLoadDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx4Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -266,7 +319,12 @@ SBufferLoadDwordx8Smem::SBufferLoadDwordx8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx8Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx8Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx8Smem>(opcode);
 }
 } // namespace detail
@@ -287,7 +345,12 @@ SBufferLoadDwordx16Smem::SBufferLoadDwordx16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx16Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx16Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx16Smem>(opcode);
 }
 } // namespace detail
@@ -300,7 +363,11 @@ SGl1InvSmem::SGl1InvSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGl1InvSmem(const MachineInst *opcode) {
+DecodeResult decodeSGl1InvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_gl1_inv", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGl1InvSmem>(opcode);
 }
 } // namespace detail
@@ -313,7 +380,11 @@ SDcacheInvSmem::SDcacheInvSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_inv", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheInvSmem>(opcode);
 }
 } // namespace detail
@@ -328,7 +399,11 @@ SMemtimeSmem::SMemtimeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMemtimeSmem(const MachineInst *opcode) {
+DecodeResult decodeSMemtimeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_memtime", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMemtimeSmem>(opcode);
 }
 } // namespace detail
@@ -343,7 +418,12 @@ SMemrealtimeSmem::SMemrealtimeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMemrealtimeSmem(const MachineInst *opcode) {
+DecodeResult decodeSMemrealtimeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_memrealtime", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMemrealtimeSmem>(opcode);
 }
 } // namespace detail
@@ -363,7 +443,11 @@ SAtcProbeSmem::SAtcProbeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtcProbeSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtcProbeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atc_probe", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtcProbeSmem>(opcode);
 }
 } // namespace detail
@@ -383,7 +467,12 @@ SAtcProbeBufferSmem::SAtcProbeBufferSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtcProbeBufferSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtcProbeBufferSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atc_probe_buffer", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtcProbeBufferSmem>(opcode);
 }
 } // namespace detail
@@ -398,7 +487,12 @@ SGetWaveidInWorkgroupSmem::SGetWaveidInWorkgroupSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetWaveidInWorkgroupSmem(const MachineInst *opcode) {
+DecodeResult decodeSGetWaveidInWorkgroupSmem(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_get_waveid_in_workgroup", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetWaveidInWorkgroupSmem>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/sop1.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/sop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -29,7 +28,11 @@ SMovB32Sop1::SMovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -52,7 +55,11 @@ SMovB64Sop1::SMovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -78,7 +85,11 @@ SCmovB32Sop1::SCmovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -105,7 +116,11 @@ SCmovB64Sop1::SCmovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -129,7 +144,11 @@ SNotB32Sop1::SNotB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB32Sop1>(opcode);
 }
 } // namespace detail
@@ -154,7 +173,11 @@ SNotB64Sop1::SNotB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB64Sop1>(opcode);
 }
 } // namespace detail
@@ -178,7 +201,11 @@ SWqmB32Sop1::SWqmB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB32Sop1>(opcode);
 }
 } // namespace detail
@@ -203,7 +230,11 @@ SWqmB64Sop1::SWqmB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB64Sop1>(opcode);
 }
 } // namespace detail
@@ -224,7 +255,11 @@ SBrevB32Sop1::SBrevB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB32Sop1>(opcode);
 }
 } // namespace detail
@@ -246,7 +281,11 @@ SBrevB64Sop1::SBrevB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB64Sop1>(opcode);
 }
 } // namespace detail
@@ -270,7 +309,12 @@ SBcnt0I32B32Sop1::SBcnt0I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -295,7 +339,12 @@ SBcnt0I32B64Sop1::SBcnt0I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -319,7 +368,12 @@ SBcnt1I32B32Sop1::SBcnt1I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -344,7 +398,12 @@ SBcnt1I32B64Sop1::SBcnt1I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -365,7 +424,11 @@ SFf0I32B32Sop1::SFf0I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf0I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf0I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff0_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf0I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -387,7 +450,11 @@ SFf0I32B64Sop1::SFf0I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf0I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf0I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff0_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf0I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -408,7 +475,11 @@ SFf1I32B32Sop1::SFf1I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf1I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf1I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff1_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf1I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -430,7 +501,11 @@ SFf1I32B64Sop1::SFf1I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf1I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf1I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff1_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf1I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -451,7 +526,12 @@ SFlbitI32B32Sop1::SFlbitI32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -473,7 +553,12 @@ SFlbitI32B64Sop1::SFlbitI32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -494,7 +579,11 @@ SFlbitI32Sop1::SFlbitI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32Sop1>(opcode);
 }
 } // namespace detail
@@ -516,7 +605,12 @@ SFlbitI32I64Sop1::SFlbitI32I64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32I64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32I64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32_i64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32I64Sop1>(opcode);
 }
 } // namespace detail
@@ -538,7 +632,11 @@ SSextI32I8Sop1::SSextI32I8Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i8", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I8Sop1>(opcode);
 }
 } // namespace detail
@@ -560,7 +658,12 @@ SSextI32I16Sop1::SSextI32I16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I16Sop1>(opcode);
 }
 } // namespace detail
@@ -582,7 +685,12 @@ SBitset0B32Sop1::SBitset0B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B32Sop1>(opcode);
 }
 } // namespace detail
@@ -604,7 +712,12 @@ SBitset0B64Sop1::SBitset0B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B64Sop1>(opcode);
 }
 } // namespace detail
@@ -626,7 +739,12 @@ SBitset1B32Sop1::SBitset1B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B32Sop1>(opcode);
 }
 } // namespace detail
@@ -648,7 +766,12 @@ SBitset1B64Sop1::SBitset1B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B64Sop1>(opcode);
 }
 } // namespace detail
@@ -666,7 +789,11 @@ SGetpcB64Sop1::SGetpcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetpcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSGetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_getpc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetpcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -685,7 +812,11 @@ SSetpcB64Sop1::SSetpcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetpcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_setpc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetpcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -708,7 +839,11 @@ SSwappcB64Sop1::SSwappcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSwappcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSwappcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_swappc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSwappcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -726,7 +861,11 @@ SRfeB64Sop1::SRfeB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRfeB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSRfeB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_rfe_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRfeB64Sop1>(opcode);
 }
 } // namespace detail
@@ -758,7 +897,12 @@ SAndSaveexecB64Sop1::SAndSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -791,7 +935,12 @@ SOrSaveexecB64Sop1::SOrSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -823,7 +972,12 @@ SXorSaveexecB64Sop1::SXorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -855,7 +1009,12 @@ SAndn2SaveexecB64Sop1::SAndn2SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn2_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -887,7 +1046,12 @@ SOrn2SaveexecB64Sop1::SOrn2SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_orn2_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -919,7 +1083,12 @@ SNandSaveexecB64Sop1::SNandSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nand_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -951,7 +1120,12 @@ SNorSaveexecB64Sop1::SNorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -983,7 +1157,12 @@ SXnorSaveexecB64Sop1::SXnorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xnor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1007,7 +1186,12 @@ SQuadmaskB32Sop1::SQuadmaskB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1032,7 +1216,12 @@ SQuadmaskB64Sop1::SQuadmaskB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1052,7 +1241,12 @@ SMovrelsB32Sop1::SMovrelsB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrels_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1072,7 +1266,12 @@ SMovrelsB64Sop1::SMovrelsB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrels_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1096,7 +1295,12 @@ SMovreldB32Sop1::SMovreldB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1121,7 +1325,12 @@ SMovreldB64Sop1::SMovreldB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1145,7 +1354,11 @@ SAbsI32Sop1::SAbsI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_abs_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsI32Sop1>(opcode);
 }
 } // namespace detail
@@ -1177,7 +1390,12 @@ SAndn1SaveexecB64Sop1::SAndn1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1209,7 +1427,12 @@ SOrn1SaveexecB64Sop1::SOrn1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_orn1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1241,7 +1464,12 @@ SAndn1WrexecB64Sop1::SAndn1WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn1WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn1WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn1_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn1WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1273,7 +1501,12 @@ SAndn2WrexecB64Sop1::SAndn2WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn2WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn2_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1294,7 +1527,12 @@ SBitreplicateB64B32Sop1::SBitreplicateB64B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitreplicate_b64_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitreplicateB64B32Sop1>(opcode);
 }
 } // namespace detail
@@ -1325,7 +1563,12 @@ SAndSaveexecB32Sop1::SAndSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1357,7 +1600,12 @@ SOrSaveexecB32Sop1::SOrSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrSaveexecB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1388,7 +1636,12 @@ SXorSaveexecB32Sop1::SXorSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xor_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1419,7 +1672,12 @@ SAndn2SaveexecB32Sop1::SAndn2SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn2SaveexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn2_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1450,7 +1708,12 @@ SOrn2SaveexecB32Sop1::SOrn2SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrn2SaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_orn2_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1481,7 +1744,12 @@ SNandSaveexecB32Sop1::SNandSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNandSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nand_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1512,7 +1780,12 @@ SNorSaveexecB32Sop1::SNorSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nor_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1543,7 +1816,12 @@ SXnorSaveexecB32Sop1::SXnorSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXnorSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xnor_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1574,7 +1852,12 @@ SAndn1SaveexecB32Sop1::SAndn1SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn1SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn1SaveexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn1_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn1SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1605,7 +1888,12 @@ SOrn1SaveexecB32Sop1::SOrn1SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn1SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrn1SaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_orn1_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn1SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1636,7 +1924,12 @@ SAndn1WrexecB32Sop1::SAndn1WrexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn1WrexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn1WrexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn1_wrexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn1WrexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1667,7 +1960,12 @@ SAndn2WrexecB32Sop1::SAndn2WrexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2WrexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn2WrexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn2_wrexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2WrexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1687,7 +1985,12 @@ SMovrelsd2B32Sop1::SMovrelsd2B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsd2B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsd2B32Sop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrelsd_2_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsd2B32Sop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/sop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/sop2.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/sop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -37,7 +36,11 @@ SAddU32Sop2::SAddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -67,7 +70,11 @@ SSubU32Sop2::SSubU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubU32Sop2>(opcode);
 }
 } // namespace detail
@@ -97,7 +104,11 @@ SAddI32Sop2::SAddI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddI32Sop2>(opcode);
 }
 } // namespace detail
@@ -127,7 +138,11 @@ SSubI32Sop2::SSubI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubI32Sop2>(opcode);
 }
 } // namespace detail
@@ -160,7 +175,11 @@ SAddcU32Sop2::SAddcU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddcU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddcU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_addc_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddcU32Sop2>(opcode);
 }
 } // namespace detail
@@ -193,7 +212,11 @@ SSubbU32Sop2::SSubbU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubbU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubbU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_subb_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubbU32Sop2>(opcode);
 }
 } // namespace detail
@@ -223,7 +246,11 @@ SMinI32Sop2::SMinI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinI32Sop2>(opcode);
 }
 } // namespace detail
@@ -253,7 +280,11 @@ SMinU32Sop2::SMinU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinU32Sop2>(opcode);
 }
 } // namespace detail
@@ -283,7 +314,11 @@ SMaxI32Sop2::SMaxI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxI32Sop2>(opcode);
 }
 } // namespace detail
@@ -313,7 +348,11 @@ SMaxU32Sop2::SMaxU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxU32Sop2>(opcode);
 }
 } // namespace detail
@@ -343,7 +382,12 @@ SCselectB32Sop2::SCselectB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCselectB32Sop2>(opcode);
 }
 } // namespace detail
@@ -375,7 +419,12 @@ SCselectB64Sop2::SCselectB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCselectB64Sop2>(opcode);
 }
 } // namespace detail
@@ -405,7 +454,11 @@ SAndB32Sop2::SAndB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndB32Sop2>(opcode);
 }
 } // namespace detail
@@ -437,7 +490,11 @@ SAndB64Sop2::SAndB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndB64Sop2>(opcode);
 }
 } // namespace detail
@@ -468,7 +525,11 @@ SOrB32Sop2::SOrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -501,7 +562,11 @@ SOrB64Sop2::SOrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -531,7 +596,11 @@ SXorB32Sop2::SXorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -563,7 +632,11 @@ SXorB64Sop2::SXorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -593,7 +666,11 @@ SAndn2B32Sop2::SAndn2B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_andn2_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2B32Sop2>(opcode);
 }
 } // namespace detail
@@ -625,7 +702,11 @@ SAndn2B64Sop2::SAndn2B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_andn2_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2B64Sop2>(opcode);
 }
 } // namespace detail
@@ -655,7 +736,11 @@ SOrn2B32Sop2::SOrn2B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_orn2_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2B32Sop2>(opcode);
 }
 } // namespace detail
@@ -687,7 +772,11 @@ SOrn2B64Sop2::SOrn2B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_orn2_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2B64Sop2>(opcode);
 }
 } // namespace detail
@@ -717,7 +806,11 @@ SNandB32Sop2::SNandB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandB32Sop2>(opcode);
 }
 } // namespace detail
@@ -749,7 +842,11 @@ SNandB64Sop2::SNandB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandB64Sop2>(opcode);
 }
 } // namespace detail
@@ -779,7 +876,11 @@ SNorB32Sop2::SNorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -811,7 +912,11 @@ SNorB64Sop2::SNorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -841,7 +946,11 @@ SXnorB32Sop2::SXnorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -873,7 +982,11 @@ SXnorB64Sop2::SXnorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -903,7 +1016,11 @@ SLshlB32Sop2::SLshlB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshlB32Sop2>(opcode);
 }
 } // namespace detail
@@ -934,7 +1051,11 @@ SLshlB64Sop2::SLshlB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshlB64Sop2>(opcode);
 }
 } // namespace detail
@@ -964,7 +1085,11 @@ SLshrB32Sop2::SLshrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -995,7 +1120,11 @@ SLshrB64Sop2::SLshrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1025,7 +1154,11 @@ SAshrI32Sop2::SAshrI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAshrI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1056,7 +1189,11 @@ SAshrI64Sop2::SAshrI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAshrI64Sop2>(opcode);
 }
 } // namespace detail
@@ -1083,7 +1220,11 @@ SBfmB32Sop2::SBfmB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfmB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1110,7 +1251,11 @@ SBfmB64Sop2::SBfmB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfmB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1137,7 +1282,11 @@ SMulI32Sop2::SMulI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1167,7 +1316,11 @@ SBfeU32Sop2::SBfeU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1197,7 +1350,11 @@ SBfeI32Sop2::SBfeI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1228,7 +1385,11 @@ SBfeU64Sop2::SBfeU64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeU64Sop2>(opcode);
 }
 } // namespace detail
@@ -1259,7 +1420,11 @@ SBfeI64Sop2::SBfeI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeI64Sop2>(opcode);
 }
 } // namespace detail
@@ -1289,7 +1454,12 @@ SAbsdiffI32Sop2::SAbsdiffI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_absdiff_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsdiffI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1319,7 +1489,12 @@ SLshl1AddU32Sop2::SLshl1AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl1_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl1AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1349,7 +1524,12 @@ SLshl2AddU32Sop2::SLshl2AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl2_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl2AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1379,7 +1559,12 @@ SLshl3AddU32Sop2::SLshl3AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl3_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl3AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1409,7 +1594,12 @@ SLshl4AddU32Sop2::SLshl4AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl4_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl4AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1438,7 +1628,12 @@ SPackLlB32B16Sop2::SPackLlB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_ll_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackLlB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1466,7 +1661,12 @@ SPackLhB32B16Sop2::SPackLhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_lh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackLhB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1493,7 +1693,12 @@ SPackHhB32B16Sop2::SPackHhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_hh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackHhB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1520,7 +1725,11 @@ SMulHiU32Sop2::SMulHiU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulHiU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1547,7 +1756,11 @@ SMulHiI32Sop2::SMulHiI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulHiI32Sop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/sopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/sopc.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/sopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -35,7 +34,11 @@ SCmpEqI32Sopc::SCmpEqI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqI32Sopc>(opcode);
 }
 } // namespace detail
@@ -63,7 +66,11 @@ SCmpLgI32Sopc::SCmpLgI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgI32Sopc>(opcode);
 }
 } // namespace detail
@@ -91,7 +98,11 @@ SCmpGtI32Sopc::SCmpGtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -119,7 +130,11 @@ SCmpGeI32Sopc::SCmpGeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -147,7 +162,11 @@ SCmpLtI32Sopc::SCmpLtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -175,7 +194,11 @@ SCmpLeI32Sopc::SCmpLeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -203,7 +226,11 @@ SCmpEqU32Sopc::SCmpEqU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqU32Sopc>(opcode);
 }
 } // namespace detail
@@ -231,7 +258,11 @@ SCmpLgU32Sopc::SCmpLgU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgU32Sopc>(opcode);
 }
 } // namespace detail
@@ -259,7 +290,11 @@ SCmpGtU32Sopc::SCmpGtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -287,7 +322,11 @@ SCmpGeU32Sopc::SCmpGeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -315,7 +354,11 @@ SCmpLtU32Sopc::SCmpLtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -343,7 +386,11 @@ SCmpLeU32Sopc::SCmpLeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -371,7 +418,12 @@ SBitcmp0B32Sopc::SBitcmp0B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp0B32Sopc>(opcode);
 }
 } // namespace detail
@@ -399,7 +451,12 @@ SBitcmp1B32Sopc::SBitcmp1B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp1B32Sopc>(opcode);
 }
 } // namespace detail
@@ -428,7 +485,12 @@ SBitcmp0B64Sopc::SBitcmp0B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp0B64Sopc>(opcode);
 }
 } // namespace detail
@@ -457,7 +519,12 @@ SBitcmp1B64Sopc::SBitcmp1B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp1B64Sopc>(opcode);
 }
 } // namespace detail
@@ -487,7 +554,11 @@ SCmpEqU64Sopc::SCmpEqU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqU64Sopc>(opcode);
 }
 } // namespace detail
@@ -517,7 +588,11 @@ SCmpLgU64Sopc::SCmpLgU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgU64Sopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/sopk.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -24,7 +23,11 @@ SMovkI32Sopk::SMovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_movk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -39,7 +42,11 @@ SVersionSopk::SVersionSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSVersionSopk(const MachineInst *opcode) {
+DecodeResult decodeSVersionSopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_version", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SVersionSopk>(opcode);
 }
 } // namespace detail
@@ -61,7 +68,11 @@ SCmovkI32Sopk::SCmovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmovk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -81,7 +92,11 @@ SCmpkEqI32Sopk::SCmpkEqI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkEqI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkEqI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_eq_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkEqI32Sopk>(opcode);
 }
 } // namespace detail
@@ -101,7 +116,11 @@ SCmpkLgI32Sopk::SCmpkLgI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLgI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLgI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lg_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLgI32Sopk>(opcode);
 }
 } // namespace detail
@@ -121,7 +140,11 @@ SCmpkGtI32Sopk::SCmpkGtI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGtI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_gt_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGtI32Sopk>(opcode);
 }
 } // namespace detail
@@ -141,7 +164,11 @@ SCmpkGeI32Sopk::SCmpkGeI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGeI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_ge_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGeI32Sopk>(opcode);
 }
 } // namespace detail
@@ -161,7 +188,11 @@ SCmpkLtI32Sopk::SCmpkLtI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLtI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lt_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLtI32Sopk>(opcode);
 }
 } // namespace detail
@@ -181,7 +212,11 @@ SCmpkLeI32Sopk::SCmpkLeI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLeI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_le_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLeI32Sopk>(opcode);
 }
 } // namespace detail
@@ -201,7 +236,11 @@ SCmpkEqU32Sopk::SCmpkEqU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkEqU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkEqU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_eq_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkEqU32Sopk>(opcode);
 }
 } // namespace detail
@@ -221,7 +260,11 @@ SCmpkLgU32Sopk::SCmpkLgU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLgU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLgU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lg_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLgU32Sopk>(opcode);
 }
 } // namespace detail
@@ -241,7 +284,11 @@ SCmpkGtU32Sopk::SCmpkGtU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGtU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_gt_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGtU32Sopk>(opcode);
 }
 } // namespace detail
@@ -261,7 +308,11 @@ SCmpkGeU32Sopk::SCmpkGeU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGeU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_ge_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGeU32Sopk>(opcode);
 }
 } // namespace detail
@@ -281,7 +332,11 @@ SCmpkLtU32Sopk::SCmpkLtU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLtU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lt_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLtU32Sopk>(opcode);
 }
 } // namespace detail
@@ -301,7 +356,11 @@ SCmpkLeU32Sopk::SCmpkLeU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLeU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_le_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLeU32Sopk>(opcode);
 }
 } // namespace detail
@@ -322,7 +381,11 @@ SAddkI32Sopk::SAddkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSAddkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_addk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -340,7 +403,11 @@ SMulkI32Sopk::SMulkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_mulk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -357,7 +424,11 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_getreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -374,7 +445,11 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -399,7 +474,12 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_imm32_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregImm32B32Sopk>(opcode);
 }
 } // namespace detail
@@ -428,7 +508,11 @@ SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCallB64Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCallB64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_call_b64", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCallB64Sopk>(opcode);
 }
 } // namespace detail
@@ -451,7 +535,12 @@ SWaitcntVscntSopk::SWaitcntVscntSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntVscntSopk(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntVscntSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_waitcnt_vscnt", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntVscntSopk>(opcode);
 }
 } // namespace detail
@@ -469,7 +558,12 @@ SWaitcntVmcntSopk::SWaitcntVmcntSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntVmcntSopk(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntVmcntSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_waitcnt_vmcnt", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntVmcntSopk>(opcode);
 }
 } // namespace detail
@@ -487,7 +581,12 @@ SWaitcntExpcntSopk::SWaitcntExpcntSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntExpcntSopk(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntExpcntSopk(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_waitcnt_expcnt", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntExpcntSopk>(opcode);
 }
 } // namespace detail
@@ -505,7 +604,12 @@ SWaitcntLgkmcntSopk::SWaitcntLgkmcntSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntLgkmcntSopk(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntLgkmcntSopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_waitcnt_lgkmcnt", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntLgkmcntSopk>(opcode);
 }
 } // namespace detail
@@ -529,7 +633,12 @@ SSubvectorLoopBeginSopk::SSubvectorLoopBeginSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubvectorLoopBeginSopk(const MachineInst *opcode) {
+DecodeResult decodeSSubvectorLoopBeginSopk(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_subvector_loop_begin", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubvectorLoopBeginSopk>(opcode);
 }
 } // namespace detail
@@ -553,7 +662,12 @@ SSubvectorLoopEndSopk::SSubvectorLoopEndSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubvectorLoopEndSopk(const MachineInst *opcode) {
+DecodeResult decodeSSubvectorLoopEndSopk(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_subvector_loop_end", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubvectorLoopEndSopk>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/sopp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/sopp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/sopp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -22,7 +21,11 @@ SNopSopp::SNopSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode) {
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_nop", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNopSopp>(opcode);
 }
 } // namespace detail
@@ -36,7 +39,11 @@ SEndpgmSopp::SEndpgmSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSopp>(opcode);
 }
 } // namespace detail
@@ -53,7 +60,11 @@ SBranchSopp::SBranchSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode) {
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_branch", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBranchSopp>(opcode);
 }
 } // namespace detail
@@ -71,7 +82,11 @@ SWakeupSopp::SWakeupSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode) {
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wakeup", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWakeupSopp>(opcode);
 }
 } // namespace detail
@@ -91,7 +106,12 @@ SCbranchScc0Sopp::SCbranchScc0Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc0", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc0Sopp>(opcode);
 }
 } // namespace detail
@@ -116,7 +136,12 @@ SCbranchScc1Sopp::SCbranchScc1Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc1", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc1Sopp>(opcode);
 }
 } // namespace detail
@@ -141,7 +166,12 @@ SCbranchVcczSopp::SCbranchVcczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVcczSopp>(opcode);
 }
 } // namespace detail
@@ -166,7 +196,12 @@ SCbranchVccnzSopp::SCbranchVccnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVccnzSopp>(opcode);
 }
 } // namespace detail
@@ -191,7 +226,12 @@ SCbranchExeczSopp::SCbranchExeczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExeczSopp>(opcode);
 }
 } // namespace detail
@@ -216,7 +256,12 @@ SCbranchExecnzSopp::SCbranchExecnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExecnzSopp>(opcode);
 }
 } // namespace detail
@@ -235,7 +280,11 @@ SBarrierSopp::SBarrierSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBarrierSopp(const MachineInst *opcode) {
+DecodeResult decodeSBarrierSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_barrier", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBarrierSopp>(opcode);
 }
 } // namespace detail
@@ -250,7 +299,11 @@ SSetkillSopp::SSetkillSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetkillSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetkillSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setkill", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetkillSopp>(opcode);
 }
 } // namespace detail
@@ -266,7 +319,11 @@ SWaitcntSopp::SWaitcntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_waitcnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntSopp>(opcode);
 }
 } // namespace detail
@@ -281,7 +338,11 @@ SSethaltSopp::SSethaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sethalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSethaltSopp>(opcode);
 }
 } // namespace detail
@@ -296,7 +357,11 @@ SSleepSopp::SSleepSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode) {
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sleep", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSleepSopp>(opcode);
 }
 } // namespace detail
@@ -311,7 +376,11 @@ SSetprioSopp::SSetprioSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setprio", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetprioSopp>(opcode);
 }
 } // namespace detail
@@ -329,7 +398,11 @@ SSendmsgSopp::SSendmsgSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsg", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsgSopp>(opcode);
 }
 } // namespace detail
@@ -347,7 +420,12 @@ SSendmsghaltSopp::SSendmsghaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsghalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsghaltSopp>(opcode);
 }
 } // namespace detail
@@ -362,7 +440,11 @@ STrapSopp::STrapSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode) {
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_trap", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STrapSopp>(opcode);
 }
 } // namespace detail
@@ -375,7 +457,11 @@ SIcacheInvSopp::SIcacheInvSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode) {
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_icache_inv", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIcacheInvSopp>(opcode);
 }
 } // namespace detail
@@ -390,7 +476,12 @@ SIncperflevelSopp::SIncperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_incperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIncperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -405,7 +496,12 @@ SDecperflevelSopp::SDecperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_decperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDecperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -421,7 +517,12 @@ STtracedataSopp::STtracedataSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode) {
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_ttracedata", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STtracedataSopp>(opcode);
 }
 } // namespace detail
@@ -436,7 +537,12 @@ SCbranchCdbgsysSopp::SCbranchCdbgsysSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysSopp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysSopp>(opcode);
 }
 } // namespace detail
@@ -451,7 +557,12 @@ SCbranchCdbguserSopp::SCbranchCdbguserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbguserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbguserSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbguser", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbguserSopp>(opcode);
 }
 } // namespace detail
@@ -466,7 +577,12 @@ SCbranchCdbgsysOrUserSopp::SCbranchCdbgsysOrUserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys_or_user", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysOrUserSopp>(opcode);
 }
 } // namespace detail
@@ -481,7 +597,12 @@ SCbranchCdbgsysAndUserSopp::SCbranchCdbgsysAndUserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys_and_user", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysAndUserSopp>(opcode);
 }
 } // namespace detail
@@ -495,7 +616,12 @@ SEndpgmSavedSopp::SEndpgmSavedSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm_saved", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSavedSopp>(opcode);
 }
 } // namespace detail
@@ -509,7 +635,12 @@ SEndpgmOrderedPsDoneSopp::SEndpgmOrderedPsDoneSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm_ordered_ps_done", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmOrderedPsDoneSopp>(opcode);
 }
 } // namespace detail
@@ -522,7 +653,11 @@ SCodeEndSopp::SCodeEndSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCodeEndSopp(const MachineInst *opcode) {
+DecodeResult decodeSCodeEndSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_code_end", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCodeEndSopp>(opcode);
 }
 } // namespace detail
@@ -537,7 +672,12 @@ SInstPrefetchSopp::SInstPrefetchSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSInstPrefetchSopp(const MachineInst *opcode) {
+DecodeResult decodeSInstPrefetchSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_inst_prefetch", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SInstPrefetchSopp>(opcode);
 }
 } // namespace detail
@@ -552,7 +692,11 @@ SClauseSopp::SClauseSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClauseSopp(const MachineInst *opcode) {
+DecodeResult decodeSClauseSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_clause", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClauseSopp>(opcode);
 }
 } // namespace detail
@@ -566,7 +710,11 @@ SWaitIdleSopp::SWaitIdleSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitIdleSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitIdleSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_idle", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitIdleSopp>(opcode);
 }
 } // namespace detail
@@ -583,7 +731,12 @@ SWaitcntDepctrSopp::SWaitcntDepctrSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntDepctrSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntDepctrSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_waitcnt_depctr", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntDepctrSopp>(opcode);
 }
 } // namespace detail
@@ -598,7 +751,11 @@ SRoundModeSopp::SRoundModeSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRoundModeSopp(const MachineInst *opcode) {
+DecodeResult decodeSRoundModeSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_round_mode", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRoundModeSopp>(opcode);
 }
 } // namespace detail
@@ -613,7 +770,12 @@ SDenormModeSopp::SDenormModeSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDenormModeSopp(const MachineInst *opcode) {
+DecodeResult decodeSDenormModeSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_denorm_mode", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDenormModeSopp>(opcode);
 }
 } // namespace detail
@@ -631,7 +793,12 @@ STtracedataImmSopp::STtracedataImmSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTtracedataImmSopp(const MachineInst *opcode) {
+DecodeResult decodeSTtracedataImmSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_ttracedata_imm", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STtracedataImmSopp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/vintrp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/vintrp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/vintrp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -29,7 +28,12 @@ VInterpP1F32Vintrp::VInterpP1F32Vintrp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP1F32Vintrp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP1F32Vintrp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vintrp::validate_encoding(
+      "v_interp_p1_f32", reinterpret_cast<const Vintrp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP1F32Vintrp>(opcode);
 }
 } // namespace detail
@@ -52,7 +56,12 @@ VInterpP2F32Vintrp::VInterpP2F32Vintrp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2F32Vintrp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2F32Vintrp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vintrp::validate_encoding(
+      "v_interp_p2_f32", reinterpret_cast<const Vintrp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2F32Vintrp>(opcode);
 }
 } // namespace detail
@@ -74,7 +83,12 @@ VInterpMovF32Vintrp::VInterpMovF32Vintrp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpMovF32Vintrp(const MachineInst *opcode) {
+DecodeResult decodeVInterpMovF32Vintrp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vintrp::validate_encoding(
+      "v_interp_mov_f32", reinterpret_cast<const Vintrp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpMovF32Vintrp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/vop1.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/vop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -23,7 +22,15 @@ VNopVop1::VNopVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode) {
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_nop_dpp"
+          : "v_nop_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop1>(opcode);
 }
 } // namespace detail
@@ -83,7 +90,16 @@ VMovB32Vop1::VMovB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mov_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_mov_b32_dpp"
+          : "v_mov_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop1>(opcode);
 }
 } // namespace detail
@@ -100,15 +116,24 @@ VReadfirstlaneB32Vop1::VReadfirstlaneB32Vop1(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_readfirstlane_b32_dpp"
+          : "v_readfirstlane_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support SDWA";
   return std::make_unique<VReadfirstlaneB32Vop1>(opcode);
 }
 } // namespace detail
@@ -130,15 +155,23 @@ VCvtI32F64Vop1::VCvtI32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_I32_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_I32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f64_dpp"
+          : "v_cvt_i32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_I32_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_I32_F64 does not support SDWA";
   return std::make_unique<VCvtI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -159,15 +192,23 @@ VCvtF64I32Vop1::VCvtF64I32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_I32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F64_I32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_i32_dpp"
+          : "v_cvt_f64_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_I32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_I32 does not support SDWA";
   return std::make_unique<VCvtF64I32Vop1>(opcode);
 }
 } // namespace detail
@@ -228,7 +269,17 @@ VCvtF32I32Vop1::VCvtF32I32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_i32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_i32_dpp"
+          : "v_cvt_f32_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop1>(opcode);
 }
 } // namespace detail
@@ -289,7 +340,17 @@ VCvtF32U32Vop1::VCvtF32U32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_u32_dpp"
+          : "v_cvt_f32_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop1>(opcode);
 }
 } // namespace detail
@@ -350,7 +411,17 @@ VCvtU32F32Vop1::VCvtU32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_u32_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f32_dpp"
+          : "v_cvt_u32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -411,7 +482,17 @@ VCvtI32F32Vop1::VCvtI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_i32_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f32_dpp"
+          : "v_cvt_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -472,7 +553,17 @@ VCvtF16F32Vop1::VCvtF16F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f16_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_f32_dpp"
+          : "v_cvt_f16_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop1>(opcode);
 }
 } // namespace detail
@@ -540,7 +631,17 @@ VCvtF32F16Vop1::VCvtF32F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f16_dpp"
+          : "v_cvt_f32_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop1>(opcode);
 }
 } // namespace detail
@@ -601,7 +702,18 @@ VCvtRpiI32F32Vop1::VCvtRpiI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtRpiI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_rpi_i32_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_rpi_i32_f32_dpp"
+          : "v_cvt_rpi_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtRpiI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -662,7 +774,18 @@ VCvtFlrI32F32Vop1::VCvtFlrI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtFlrI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_flr_i32_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_flr_i32_f32_dpp"
+          : "v_cvt_flr_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFlrI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -723,7 +846,18 @@ VCvtOffF32I4Vop1::VCvtOffF32I4Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_off_f32_i4_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_off_f32_i4_dpp"
+          : "v_cvt_off_f32_i4_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop1>(opcode);
 }
 } // namespace detail
@@ -745,15 +879,23 @@ VCvtF32F64Vop1::VCvtF32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F32_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f64_dpp"
+          : "v_cvt_f32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F32_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F32_F64 does not support SDWA";
   return std::make_unique<VCvtF32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -774,15 +916,23 @@ VCvtF64F32Vop1::VCvtF64F32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F64_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_f32_dpp"
+          : "v_cvt_f64_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support SDWA";
   return std::make_unique<VCvtF64F32Vop1>(opcode);
 }
 } // namespace detail
@@ -843,7 +993,18 @@ VCvtF32Ubyte0Vop1::VCvtF32Ubyte0Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte0_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte0_dpp"
+          : "v_cvt_f32_ubyte0_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop1>(opcode);
 }
 } // namespace detail
@@ -904,7 +1065,18 @@ VCvtF32Ubyte1Vop1::VCvtF32Ubyte1Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte1_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte1_dpp"
+          : "v_cvt_f32_ubyte1_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop1>(opcode);
 }
 } // namespace detail
@@ -965,7 +1137,18 @@ VCvtF32Ubyte2Vop1::VCvtF32Ubyte2Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte2_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte2_dpp"
+          : "v_cvt_f32_ubyte2_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop1>(opcode);
 }
 } // namespace detail
@@ -1026,7 +1209,18 @@ VCvtF32Ubyte3Vop1::VCvtF32Ubyte3Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte3_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte3_dpp"
+          : "v_cvt_f32_ubyte3_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop1>(opcode);
 }
 } // namespace detail
@@ -1048,15 +1242,23 @@ VCvtU32F64Vop1::VCvtU32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_U32_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_U32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f64_dpp"
+          : "v_cvt_u32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_U32_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_U32_F64 does not support SDWA";
   return std::make_unique<VCvtU32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -1077,15 +1279,23 @@ VCvtF64U32Vop1::VCvtF64U32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_U32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F64_U32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_u32_dpp"
+          : "v_cvt_f64_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_U32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_U32 does not support SDWA";
   return std::make_unique<VCvtF64U32Vop1>(opcode);
 }
 } // namespace detail
@@ -1107,15 +1317,23 @@ VTruncF64Vop1::VTruncF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_TRUNC_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_TRUNC_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f64_dpp"
+          : "v_trunc_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_TRUNC_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_TRUNC_F64 does not support SDWA";
   return std::make_unique<VTruncF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1137,15 +1355,23 @@ VCeilF64Vop1::VCeilF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CEIL_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CEIL_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f64_dpp"
+          : "v_ceil_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CEIL_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CEIL_F64 does not support SDWA";
   return std::make_unique<VCeilF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1167,15 +1393,23 @@ VRndneF64Vop1::VRndneF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RNDNE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_RNDNE_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f64_dpp"
+          : "v_rndne_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support SDWA";
   return std::make_unique<VRndneF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1197,15 +1431,23 @@ VFloorF64Vop1::VFloorF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FLOOR_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FLOOR_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_floor_f64_dpp"
+          : "v_floor_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FLOOR_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FLOOR_F64 does not support SDWA";
   return std::make_unique<VFloorF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1221,7 +1463,15 @@ VPipeflushVop1::VPipeflushVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPipeflushVop1(const MachineInst *opcode) {
+DecodeResult decodeVPipeflushVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_pipeflush_dpp"
+          : "v_pipeflush_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPipeflushVop1>(opcode);
 }
 } // namespace detail
@@ -1281,7 +1531,17 @@ VFractF32Vop1::VFractF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_fract_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_fract_f32_dpp"
+          : "v_fract_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1341,7 +1601,17 @@ VTruncF32Vop1::VTruncF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_trunc_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f32_dpp"
+          : "v_trunc_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1401,7 +1671,16 @@ VCeilF32Vop1::VCeilF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ceil_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f32_dpp"
+          : "v_ceil_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1461,7 +1740,17 @@ VRndneF32Vop1::VRndneF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_rndne_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f32_dpp"
+          : "v_rndne_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1521,7 +1810,17 @@ VFloorF32Vop1::VFloorF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_floor_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_floor_f32_dpp"
+          : "v_floor_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1581,7 +1880,16 @@ VExpF32Vop1::VExpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_exp_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_exp_f32_dpp"
+          : "v_exp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1641,7 +1949,16 @@ VLogF32Vop1::VLogF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_log_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_log_f32_dpp"
+          : "v_log_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1701,7 +2018,16 @@ VRcpF32Vop1::VRcpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rcp_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f32_dpp"
+          : "v_rcp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1762,7 +2088,18 @@ VRcpIflagF32Vop1::VRcpIflagF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_rcp_iflag_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_iflag_f32_dpp"
+          : "v_rcp_iflag_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1822,7 +2159,16 @@ VRsqF32Vop1::VRsqF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rsq_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f32_dpp"
+          : "v_rsq_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1844,15 +2190,23 @@ VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RCP_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_RCP_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f64_dpp"
+          : "v_rcp_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support SDWA";
   return std::make_unique<VRcpF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1874,15 +2228,23 @@ VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RSQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_RSQ_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f64_dpp"
+          : "v_rsq_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support SDWA";
   return std::make_unique<VRsqF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1942,7 +2304,16 @@ VSqrtF32Vop1::VSqrtF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sqrt_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f32_dpp"
+          : "v_sqrt_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1964,15 +2335,23 @@ VSqrtF64Vop1::VSqrtF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SQRT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_SQRT_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f64_dpp"
+          : "v_sqrt_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support SDWA";
   return std::make_unique<VSqrtF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2032,7 +2411,16 @@ VSinF32Vop1::VSinF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sin_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sin_f32_dpp"
+          : "v_sin_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop1>(opcode);
 }
 } // namespace detail
@@ -2092,7 +2480,16 @@ VCosF32Vop1::VCosF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_cos_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cos_f32_dpp"
+          : "v_cos_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop1>(opcode);
 }
 } // namespace detail
@@ -2152,7 +2549,16 @@ VNotB32Vop1::VNotB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_not_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_not_b32_dpp"
+          : "v_not_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2212,7 +2618,17 @@ VBfrevB32Vop1::VBfrevB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_bfrev_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_bfrev_b32_dpp"
+          : "v_bfrev_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2272,7 +2688,16 @@ VFfbhU32Vop1::VFfbhU32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhU32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFfbhU32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ffbh_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ffbh_u32_dpp"
+          : "v_ffbh_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhU32Vop1>(opcode);
 }
 } // namespace detail
@@ -2332,7 +2757,16 @@ VFfblB32Vop1::VFfblB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfblB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFfblB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ffbl_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ffbl_b32_dpp"
+          : "v_ffbl_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfblB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2392,7 +2826,16 @@ VFfbhI32Vop1::VFfbhI32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhI32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFfbhI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ffbh_i32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ffbh_i32_dpp"
+          : "v_ffbh_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhI32Vop1>(opcode);
 }
 } // namespace detail
@@ -2414,15 +2857,24 @@ VFrexpExpI32F64Vop1::VFrexpExpI32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_EXP_I32_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FREXP_EXP_I32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f64_dpp"
+          : "v_frexp_exp_i32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_EXP_I32_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_EXP_I32_F64 does not support SDWA";
   return std::make_unique<VFrexpExpI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -2444,15 +2896,24 @@ VFrexpMantF64Vop1::VFrexpMantF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_MANT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FREXP_MANT_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f64_dpp"
+          : "v_frexp_mant_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_MANT_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_MANT_F64 does not support SDWA";
   return std::make_unique<VFrexpMantF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2474,15 +2935,23 @@ VFractF64Vop1::VFractF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FRACT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FRACT_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_fract_f64_dpp"
+          : "v_fract_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FRACT_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FRACT_F64 does not support SDWA";
   return std::make_unique<VFractF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2543,7 +3012,18 @@ VFrexpExpI32F32Vop1::VFrexpExpI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_exp_i32_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f32_dpp"
+          : "v_frexp_exp_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -2604,7 +3084,18 @@ VFrexpMantF32Vop1::VFrexpMantF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_mant_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f32_dpp"
+          : "v_frexp_mant_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop1>(opcode);
 }
 } // namespace detail
@@ -2620,7 +3111,15 @@ VClrexcpVop1::VClrexcpVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClrexcpVop1(const MachineInst *opcode) {
+DecodeResult decodeVClrexcpVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_clrexcp_dpp"
+          : "v_clrexcp_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClrexcpVop1>(opcode);
 }
 } // namespace detail
@@ -2684,7 +3183,18 @@ VMovreldB32Vop1::VMovreldB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovreldB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovreldB32Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_movreld_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movreld_b32_dpp"
+          : "v_movreld_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovreldB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2744,7 +3254,18 @@ VMovrelsB32Vop1::VMovrelsB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsB32Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_movrels_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movrels_b32_dpp"
+          : "v_movrels_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2804,7 +3325,18 @@ VMovrelsdB32Vop1::VMovrelsdB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsdB32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_movrelsd_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_b32_dpp"
+          : "v_movrelsd_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsdB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2864,7 +3396,18 @@ VMovrelsd2B32Vop1::VMovrelsd2B32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsd2B32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_movrelsd_2_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_2_b32_dpp"
+          : "v_movrelsd_2_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsd2B32Vop1>(opcode);
 }
 } // namespace detail
@@ -2926,7 +3469,17 @@ VCvtF16U16Vop1::VCvtF16U16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f16_u16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_u16_dpp"
+          : "v_cvt_f16_u16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop1>(opcode);
 }
 } // namespace detail
@@ -2994,7 +3547,17 @@ VCvtF16I16Vop1::VCvtF16I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f16_i16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_i16_dpp"
+          : "v_cvt_f16_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop1>(opcode);
 }
 } // namespace detail
@@ -3062,7 +3625,17 @@ VCvtU16F16Vop1::VCvtU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_u16_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u16_f16_dpp"
+          : "v_cvt_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3130,7 +3703,17 @@ VCvtI16F16Vop1::VCvtI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_i16_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i16_f16_dpp"
+          : "v_cvt_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3197,7 +3780,16 @@ VRcpF16Vop1::VRcpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rcp_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f16_dpp"
+          : "v_rcp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3264,7 +3856,16 @@ VSqrtF16Vop1::VSqrtF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sqrt_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f16_dpp"
+          : "v_sqrt_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3331,7 +3932,16 @@ VRsqF16Vop1::VRsqF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rsq_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f16_dpp"
+          : "v_rsq_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3398,7 +4008,16 @@ VLogF16Vop1::VLogF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_log_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_log_f16_dpp"
+          : "v_log_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3465,7 +4084,16 @@ VExpF16Vop1::VExpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_exp_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_exp_f16_dpp"
+          : "v_exp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3533,7 +4161,18 @@ VFrexpMantF16Vop1::VFrexpMantF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_mant_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f16_dpp"
+          : "v_frexp_mant_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3601,7 +4240,18 @@ VFrexpExpI16F16Vop1::VFrexpExpI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_exp_i16_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i16_f16_dpp"
+          : "v_frexp_exp_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3668,7 +4318,17 @@ VFloorF16Vop1::VFloorF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_floor_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_floor_f16_dpp"
+          : "v_floor_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3735,7 +4395,16 @@ VCeilF16Vop1::VCeilF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ceil_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f16_dpp"
+          : "v_ceil_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3802,7 +4471,17 @@ VTruncF16Vop1::VTruncF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_trunc_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f16_dpp"
+          : "v_trunc_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3869,7 +4548,17 @@ VRndneF16Vop1::VRndneF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_rndne_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f16_dpp"
+          : "v_rndne_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3936,7 +4625,17 @@ VFractF16Vop1::VFractF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_fract_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_fract_f16_dpp"
+          : "v_fract_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop1>(opcode);
 }
 } // namespace detail
@@ -4003,7 +4702,16 @@ VSinF16Vop1::VSinF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sin_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sin_f16_dpp"
+          : "v_sin_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop1>(opcode);
 }
 } // namespace detail
@@ -4070,7 +4778,16 @@ VCosF16Vop1::VCosF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_cos_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cos_f16_dpp"
+          : "v_cos_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop1>(opcode);
 }
 } // namespace detail
@@ -4137,7 +4854,18 @@ VSatPkU8I16Vop1::VSatPkU8I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_sat_pk_u8_i16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sat_pk_u8_i16_dpp"
+          : "v_sat_pk_u8_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop1>(opcode);
 }
 } // namespace detail
@@ -4199,7 +4927,18 @@ VCvtNormI16F16Vop1::VCvtNormI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_norm_i16_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_i16_f16_dpp"
+          : "v_cvt_norm_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -4267,7 +5006,18 @@ VCvtNormU16F16Vop1::VCvtNormU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_norm_u16_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_u16_f16_dpp"
+          : "v_cvt_norm_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -4292,15 +5042,23 @@ VSwapB32Vop1::VSwapB32Vop1(const MachineInst *inst)
   dst_operands_[1] = &src0;
   num_src_ = 2;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWAP_B32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_SWAP_B32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swap_b32_dpp"
+          : "v_swap_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B32 does not support SDWA";
   return std::make_unique<VSwapB32Vop1>(opcode);
 }
 } // namespace detail
@@ -4321,16 +5079,25 @@ VSwaprelB32Vop1::VSwaprelB32Vop1(const MachineInst *inst)
   src_operands_[2] = &m0;
   num_src_ = 3;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWAPREL_B32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_SWAPREL_B32 does not support SDWA", "");
   m0.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwaprelB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwaprelB32Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swaprel_b32_dpp"
+          : "v_swaprel_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SWAPREL_B32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_SWAPREL_B32 does not support SDWA";
   return std::make_unique<VSwaprelB32Vop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/vop2.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/vop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -78,7 +77,18 @@ VCndmaskB32Vop2::VCndmaskB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cndmask_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_cndmask_b32_dpp"
+          : "v_cndmask_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop2>(opcode);
 }
 } // namespace detail
@@ -119,12 +129,21 @@ VDot2cF32F16Vop2::VDot2cF32F16Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT2C_F32_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot2cF32F16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_dot2c_f32_f16_dpp"
+          : "v_dot2c_f32_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT2C_F32_F16 does not support SDWA";
   return std::make_unique<VDot2cF32F16Vop2>(opcode);
 }
 } // namespace detail
@@ -190,7 +209,16 @@ VAddF32Vop2::VAddF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_f32_dpp"
+          : "v_add_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop2>(opcode);
 }
 } // namespace detail
@@ -256,7 +284,16 @@ VSubF32Vop2::VSubF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_f32_dpp"
+          : "v_sub_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop2>(opcode);
 }
 } // namespace detail
@@ -323,7 +360,17 @@ VSubrevF32Vop2::VSubrevF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f32_dpp"
+          : "v_subrev_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop2>(opcode);
 }
 } // namespace detail
@@ -347,15 +394,24 @@ VMacLegacyF32Vop2::VMacLegacyF32Vop2(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAC_LEGACY_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MAC_LEGACY_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMacLegacyF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMacLegacyF32Vop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mac_legacy_f32_dpp"
+          : "v_mac_legacy_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MAC_LEGACY_F32 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MAC_LEGACY_F32 does not support SDWA";
   return std::make_unique<VMacLegacyF32Vop2>(opcode);
 }
 } // namespace detail
@@ -422,7 +478,18 @@ VMulLegacyF32Vop2::VMulLegacyF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLegacyF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulLegacyF32Vop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_legacy_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_legacy_f32_dpp"
+          : "v_mul_legacy_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLegacyF32Vop2>(opcode);
 }
 } // namespace detail
@@ -488,7 +555,16 @@ VMulF32Vop2::VMulF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mul_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_f32_dpp"
+          : "v_mul_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop2>(opcode);
 }
 } // namespace detail
@@ -555,7 +631,17 @@ VMulI32I24Vop2::VMulI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_i32_i24_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_i32_i24_dpp"
+          : "v_mul_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -622,7 +708,18 @@ VMulHiI32I24Vop2::VMulHiI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_hi_i32_i24_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_i32_i24_dpp"
+          : "v_mul_hi_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -689,7 +786,17 @@ VMulU32U24Vop2::VMulU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_u32_u24_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_u32_u24_dpp"
+          : "v_mul_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -756,7 +863,18 @@ VMulHiU32U24Vop2::VMulHiU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_hi_u32_u24_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_u32_u24_dpp"
+          : "v_mul_hi_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -797,12 +915,21 @@ VDot4cI32I8Vop2::VDot4cI32I8Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT4C_I32_I8 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot4cI32I8Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_dot4c_i32_i8_dpp"
+          : "v_dot4c_i32_i8_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT4C_I32_I8 does not support SDWA";
   return std::make_unique<VDot4cI32I8Vop2>(opcode);
 }
 } // namespace detail
@@ -868,7 +995,16 @@ VMinF32Vop2::VMinF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_f32_dpp"
+          : "v_min_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF32Vop2>(opcode);
 }
 } // namespace detail
@@ -934,7 +1070,16 @@ VMaxF32Vop2::VMaxF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_f32_dpp"
+          : "v_max_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1000,7 +1145,16 @@ VMinI32Vop2::VMinI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_i32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_i32_dpp"
+          : "v_min_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop2>(opcode);
 }
 } // namespace detail
@@ -1066,7 +1220,16 @@ VMaxI32Vop2::VMaxI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_i32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_i32_dpp"
+          : "v_max_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop2>(opcode);
 }
 } // namespace detail
@@ -1132,7 +1295,16 @@ VMinU32Vop2::VMinU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_u32_dpp"
+          : "v_min_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1198,7 +1370,16 @@ VMaxU32Vop2::VMaxU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_u32_dpp"
+          : "v_max_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1265,7 +1446,18 @@ VLshrrevB32Vop2::VLshrrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshrrev_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_lshrrev_b32_dpp"
+          : "v_lshrrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1332,7 +1524,18 @@ VAshrrevI32Vop2::VAshrrevI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_ashrrev_i32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_ashrrev_i32_dpp"
+          : "v_ashrrev_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop2>(opcode);
 }
 } // namespace detail
@@ -1399,7 +1602,18 @@ VLshlrevB32Vop2::VLshlrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshlrev_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b32_dpp"
+          : "v_lshlrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1465,7 +1679,16 @@ VAndB32Vop2::VAndB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_and_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_and_b32_dpp"
+          : "v_and_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1531,7 +1754,16 @@ VOrB32Vop2::VOrB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_or_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_or_b32_dpp"
+          : "v_or_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1597,7 +1829,16 @@ VXorB32Vop2::VXorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_xor_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_xor_b32_dpp"
+          : "v_xor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1663,7 +1904,16 @@ VXnorB32Vop2::VXnorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_xnor_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_xnor_b32_dpp"
+          : "v_xnor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1704,12 +1954,20 @@ VMacF32Vop2::VMacF32Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MAC_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMacF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mac_f32_dpp"
+          : "v_mac_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MAC_F32 does not support SDWA";
   return std::make_unique<VMacF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1737,16 +1995,24 @@ VMadmkF32Vop2::VMadmkF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MADMK_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MADMK_F32 does not support SDWA", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadmkF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMadmkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_madmk_f32_dpp"
+          : "v_madmk_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MADMK_F32 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MADMK_F32 does not support SDWA";
   return std::make_unique<VMadmkF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1774,16 +2040,24 @@ VMadakF32Vop2::VMadakF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MADAK_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_MADAK_F32 does not support SDWA", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadakF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMadakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_madak_f32_dpp"
+          : "v_madak_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MADAK_F32 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_MADAK_F32 does not support SDWA";
   return std::make_unique<VMadakF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1850,7 +2124,17 @@ VAddNcU32Vop2::VAddNcU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_add_nc_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_u32_dpp"
+          : "v_add_nc_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1917,7 +2201,17 @@ VSubNcU32Vop2::VSubNcU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_sub_nc_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_u32_dpp"
+          : "v_sub_nc_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1984,7 +2278,18 @@ VSubrevNcU32Vop2::VSubrevNcU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevNcU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_nc_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_nc_u32_dpp"
+          : "v_subrev_nc_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevNcU32Vop2>(opcode);
 }
 } // namespace detail
@@ -2057,7 +2362,18 @@ VAddCoCiU32Vop2::VAddCoCiU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddCoCiU32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_add_co_ci_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_co_ci_u32_dpp"
+          : "v_add_co_ci_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoCiU32Vop2>(opcode);
 }
 } // namespace detail
@@ -2130,7 +2446,18 @@ VSubCoCiU32Vop2::VSubCoCiU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubCoCiU32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_sub_co_ci_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_co_ci_u32_dpp"
+          : "v_sub_co_ci_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoCiU32Vop2>(opcode);
 }
 } // namespace detail
@@ -2203,7 +2530,18 @@ VSubrevCoCiU32Vop2::VSubrevCoCiU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoCiU32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_co_ci_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_co_ci_u32_dpp"
+          : "v_subrev_co_ci_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoCiU32Vop2>(opcode);
 }
 } // namespace detail
@@ -2244,12 +2582,20 @@ VFmacF32Vop2::VFmacF32Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAC_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f32_dpp"
+          : "v_fmac_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_F32 does not support SDWA";
   return std::make_unique<VFmacF32Vop2>(opcode);
 }
 } // namespace detail
@@ -2277,16 +2623,24 @@ VFmamkF32Vop2::VFmamkF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAMK_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAMK_F32 does not support SDWA", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmamkF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmamkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmamk_f32_dpp"
+          : "v_fmamk_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F32 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F32 does not support SDWA";
   return std::make_unique<VFmamkF32Vop2>(opcode);
 }
 } // namespace detail
@@ -2314,16 +2668,24 @@ VFmaakF32Vop2::VFmaakF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAAK_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAAK_F32 does not support SDWA", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaakF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmaakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmaak_f32_dpp"
+          : "v_fmaak_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F32 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F32 does not support SDWA";
   return std::make_unique<VFmaakF32Vop2>(opcode);
 }
 } // namespace detail
@@ -2390,7 +2752,18 @@ VCvtPkrtzF16F32Vop2::VCvtPkrtzF16F32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkrtzF16F32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkrtzF16F32Vop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_pkrtz_f16_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pkrtz_f16_f32_dpp"
+          : "v_cvt_pkrtz_f16_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkrtzF16F32Vop2>(opcode);
 }
 } // namespace detail
@@ -2457,7 +2830,16 @@ VAddF16Vop2::VAddF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_f16_dpp"
+          : "v_add_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2530,7 +2912,16 @@ VSubF16Vop2::VSubF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_f16_dpp"
+          : "v_sub_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2604,7 +2995,17 @@ VSubrevF16Vop2::VSubrevF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f16_dpp"
+          : "v_subrev_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2677,7 +3078,16 @@ VMulF16Vop2::VMulF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mul_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_f16_dpp"
+          : "v_mul_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2725,12 +3135,20 @@ VFmacF16Vop2::VFmacF16Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAC_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f16_dpp"
+          : "v_fmac_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_F16 does not support SDWA";
   return std::make_unique<VFmacF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2766,16 +3184,24 @@ VFmamkF16Vop2::VFmamkF16Vop2(const MachineInst *inst)
       Operand(16, OperandType::OPR_SIMM32,
               static_cast<int>(
                   (reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAMK_F16 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAMK_F16 does not support SDWA", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmamkF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmamkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmamk_f16_dpp"
+          : "v_fmamk_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F16 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F16 does not support SDWA";
   return std::make_unique<VFmamkF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2811,16 +3237,24 @@ VFmaakF16Vop2::VFmaakF16Vop2(const MachineInst *inst)
       Operand(16, OperandType::OPR_SIMM32,
               static_cast<int>(
                   (reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAAK_F16 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAAK_F16 does not support SDWA", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaakF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmaakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmaak_f16_dpp"
+          : "v_fmaak_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F16 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F16 does not support SDWA";
   return std::make_unique<VFmaakF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2893,7 +3327,16 @@ VMaxF16Vop2::VMaxF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_f16_dpp"
+          : "v_max_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2966,7 +3409,16 @@ VMinF16Vop2::VMinF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_f16_dpp"
+          : "v_min_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF16Vop2>(opcode);
 }
 } // namespace detail
@@ -3039,7 +3491,17 @@ VLdexpF16Vop2::VLdexpF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_ldexp_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_ldexp_f16_dpp"
+          : "v_ldexp_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop2>(opcode);
 }
 } // namespace detail
@@ -3086,12 +3548,20 @@ VPkFmacF16Vop2::VPkFmacF16Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_PK_FMAC_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_pk_fmac_f16_dpp"
+          : "v_pk_fmac_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_PK_FMAC_F16 does not support SDWA";
   return std::make_unique<VPkFmacF16Vop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/vop3.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/vop3.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -30,7 +29,12 @@ VInterpP1F32Vop3::VInterpP1F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP1F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpP1F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_p1_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP1F32Vop3>(opcode);
 }
 } // namespace detail
@@ -53,7 +57,12 @@ VInterpP2F32Vop3::VInterpP2F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_p2_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2F32Vop3>(opcode);
 }
 } // namespace detail
@@ -75,7 +84,12 @@ VInterpMovF32Vop3::VInterpMovF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpMovF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpMovF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_mov_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpMovF32Vop3>(opcode);
 }
 } // namespace detail
@@ -88,7 +102,11 @@ VNopVop3::VNopVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode) {
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_nop", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop3>(opcode);
 }
 } // namespace detail
@@ -109,7 +127,11 @@ VMovB32Vop3::VMovB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mov_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop3>(opcode);
 }
 } // namespace detail
@@ -126,7 +148,12 @@ VReadfirstlaneB32Vop3::VReadfirstlaneB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_readfirstlane_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VReadfirstlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -148,7 +175,11 @@ VCvtI32F64Vop3::VCvtI32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_i32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -169,7 +200,11 @@ VCvtF64I32Vop3::VCvtF64I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f64_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF64I32Vop3>(opcode);
 }
 } // namespace detail
@@ -190,7 +225,11 @@ VCvtF32I32Vop3::VCvtF32I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop3>(opcode);
 }
 } // namespace detail
@@ -211,7 +250,11 @@ VCvtF32U32Vop3::VCvtF32U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop3>(opcode);
 }
 } // namespace detail
@@ -232,7 +275,11 @@ VCvtU32F32Vop3::VCvtU32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_u32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -253,7 +300,11 @@ VCvtI32F32Vop3::VCvtI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -274,7 +325,11 @@ VCvtF16F32Vop3::VCvtF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -302,7 +357,11 @@ VCvtF32F16Vop3::VCvtF32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -323,7 +382,12 @@ VCvtRpiI32F32Vop3::VCvtRpiI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtRpiI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_rpi_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtRpiI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -344,7 +408,12 @@ VCvtFlrI32F32Vop3::VCvtFlrI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtFlrI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_flr_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFlrI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -365,7 +434,12 @@ VCvtOffF32I4Vop3::VCvtOffF32I4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_off_f32_i4", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop3>(opcode);
 }
 } // namespace detail
@@ -387,7 +461,11 @@ VCvtF32F64Vop3::VCvtF32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -408,7 +486,11 @@ VCvtF64F32Vop3::VCvtF64F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f64_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF64F32Vop3>(opcode);
 }
 } // namespace detail
@@ -429,7 +511,12 @@ VCvtF32Ubyte0Vop3::VCvtF32Ubyte0Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte0", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop3>(opcode);
 }
 } // namespace detail
@@ -450,7 +537,12 @@ VCvtF32Ubyte1Vop3::VCvtF32Ubyte1Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte1", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop3>(opcode);
 }
 } // namespace detail
@@ -471,7 +563,12 @@ VCvtF32Ubyte2Vop3::VCvtF32Ubyte2Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte2", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop3>(opcode);
 }
 } // namespace detail
@@ -492,7 +589,12 @@ VCvtF32Ubyte3Vop3::VCvtF32Ubyte3Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte3", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop3>(opcode);
 }
 } // namespace detail
@@ -514,7 +616,11 @@ VCvtU32F64Vop3::VCvtU32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_u32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -535,7 +641,11 @@ VCvtF64U32Vop3::VCvtF64U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f64_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF64U32Vop3>(opcode);
 }
 } // namespace detail
@@ -557,7 +667,11 @@ VTruncF64Vop3::VTruncF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trunc_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF64Vop3>(opcode);
 }
 } // namespace detail
@@ -579,7 +693,11 @@ VCeilF64Vop3::VCeilF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ceil_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF64Vop3>(opcode);
 }
 } // namespace detail
@@ -601,7 +719,11 @@ VRndneF64Vop3::VRndneF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rndne_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF64Vop3>(opcode);
 }
 } // namespace detail
@@ -623,7 +745,11 @@ VFloorF64Vop3::VFloorF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_floor_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF64Vop3>(opcode);
 }
 } // namespace detail
@@ -636,7 +762,11 @@ VPipeflushVop3::VPipeflushVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPipeflushVop3(const MachineInst *opcode) {
+DecodeResult decodeVPipeflushVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_pipeflush", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPipeflushVop3>(opcode);
 }
 } // namespace detail
@@ -657,7 +787,11 @@ VFractF32Vop3::VFractF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fract_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop3>(opcode);
 }
 } // namespace detail
@@ -678,7 +812,11 @@ VTruncF32Vop3::VTruncF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trunc_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop3>(opcode);
 }
 } // namespace detail
@@ -699,7 +837,11 @@ VCeilF32Vop3::VCeilF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ceil_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop3>(opcode);
 }
 } // namespace detail
@@ -720,7 +862,11 @@ VRndneF32Vop3::VRndneF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rndne_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop3>(opcode);
 }
 } // namespace detail
@@ -741,7 +887,11 @@ VFloorF32Vop3::VFloorF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_floor_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop3>(opcode);
 }
 } // namespace detail
@@ -762,7 +912,11 @@ VExpF32Vop3::VExpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_exp_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -783,7 +937,11 @@ VLogF32Vop3::VLogF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_log_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop3>(opcode);
 }
 } // namespace detail
@@ -804,7 +962,11 @@ VRcpF32Vop3::VRcpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -825,7 +987,12 @@ VRcpIflagF32Vop3::VRcpIflagF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_iflag_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop3>(opcode);
 }
 } // namespace detail
@@ -846,7 +1013,11 @@ VRsqF32Vop3::VRsqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rsq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -868,7 +1039,11 @@ VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -890,7 +1065,11 @@ VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rsq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -911,7 +1090,11 @@ VSqrtF32Vop3::VSqrtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sqrt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -933,7 +1116,11 @@ VSqrtF64Vop3::VSqrtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sqrt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -954,7 +1141,11 @@ VSinF32Vop3::VSinF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sin_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop3>(opcode);
 }
 } // namespace detail
@@ -975,7 +1166,11 @@ VCosF32Vop3::VCosF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cos_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop3>(opcode);
 }
 } // namespace detail
@@ -996,7 +1191,11 @@ VNotB32Vop3::VNotB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_not_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1017,7 +1216,11 @@ VBfrevB32Vop3::VBfrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfrev_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1038,7 +1241,11 @@ VFfbhU32Vop3::VFfbhU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFfbhU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ffbh_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhU32Vop3>(opcode);
 }
 } // namespace detail
@@ -1059,7 +1266,11 @@ VFfblB32Vop3::VFfblB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfblB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFfblB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ffbl_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfblB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1080,7 +1291,11 @@ VFfbhI32Vop3::VFfbhI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFfbhI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ffbh_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhI32Vop3>(opcode);
 }
 } // namespace detail
@@ -1102,7 +1317,12 @@ VFrexpExpI32F64Vop3::VFrexpExpI32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_exp_i32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -1124,7 +1344,12 @@ VFrexpMantF64Vop3::VFrexpMantF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_mant_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1146,7 +1371,11 @@ VFractF64Vop3::VFractF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fract_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1167,7 +1396,12 @@ VFrexpExpI32F32Vop3::VFrexpExpI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_exp_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -1188,7 +1422,12 @@ VFrexpMantF32Vop3::VFrexpMantF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_mant_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1201,7 +1440,11 @@ VClrexcpVop3::VClrexcpVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClrexcpVop3(const MachineInst *opcode) {
+DecodeResult decodeVClrexcpVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_clrexcp", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClrexcpVop3>(opcode);
 }
 } // namespace detail
@@ -1225,7 +1468,12 @@ VMovreldB32Vop3::VMovreldB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovreldB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovreldB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_movreld_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovreldB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1245,7 +1493,12 @@ VMovrelsB32Vop3::VMovrelsB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_movrels_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1265,7 +1518,12 @@ VMovrelsdB32Vop3::VMovrelsdB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsdB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_movrelsd_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsdB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1285,7 +1543,12 @@ VMovrelsd2B32Vop3::VMovrelsd2B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsd2B32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_movrelsd_2_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsd2B32Vop3>(opcode);
 }
 } // namespace detail
@@ -1307,7 +1570,11 @@ VCvtF16U16Vop3::VCvtF16U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f16_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop3>(opcode);
 }
 } // namespace detail
@@ -1335,7 +1602,11 @@ VCvtF16I16Vop3::VCvtF16I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f16_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop3>(opcode);
 }
 } // namespace detail
@@ -1363,7 +1634,11 @@ VCvtU16F16Vop3::VCvtU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_u16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1391,7 +1666,11 @@ VCvtI16F16Vop3::VCvtI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1419,7 +1698,11 @@ VRcpF16Vop3::VRcpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1447,7 +1730,11 @@ VSqrtF16Vop3::VSqrtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sqrt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1475,7 +1762,11 @@ VRsqF16Vop3::VRsqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rsq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1503,7 +1794,11 @@ VLogF16Vop3::VLogF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_log_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1531,7 +1826,11 @@ VExpF16Vop3::VExpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_exp_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1559,7 +1858,12 @@ VFrexpMantF16Vop3::VFrexpMantF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_mant_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1587,7 +1891,12 @@ VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_exp_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1615,7 +1924,11 @@ VFloorF16Vop3::VFloorF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_floor_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1643,7 +1956,11 @@ VCeilF16Vop3::VCeilF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ceil_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1671,7 +1988,11 @@ VTruncF16Vop3::VTruncF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trunc_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1699,7 +2020,11 @@ VRndneF16Vop3::VRndneF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rndne_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1727,7 +2052,11 @@ VFractF16Vop3::VFractF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fract_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1755,7 +2084,11 @@ VSinF16Vop3::VSinF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sin_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1783,7 +2116,11 @@ VCosF16Vop3::VCosF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cos_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1810,7 +2147,12 @@ VSatPkU8I16Vop3::VSatPkU8I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sat_pk_u8_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop3>(opcode);
 }
 } // namespace detail
@@ -1832,7 +2174,12 @@ VCvtNormI16F16Vop3::VCvtNormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_norm_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1860,7 +2207,12 @@ VCvtNormU16F16Vop3::VCvtNormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_norm_u16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1895,7 +2247,12 @@ VCndmaskB32Vop3::VCndmaskB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cndmask_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1923,7 +2280,12 @@ VDot2cF32F16Vop3::VDot2cF32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot2cF32F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot2c_f32_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2cF32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1950,7 +2312,11 @@ VAddF32Vop3::VAddF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1977,7 +2343,11 @@ VSubF32Vop3::VSubF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2004,7 +2374,11 @@ VSubrevF32Vop3::VSubrevF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2032,7 +2406,12 @@ VMacLegacyF32Vop3::VMacLegacyF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMacLegacyF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMacLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mac_legacy_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMacLegacyF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2059,7 +2438,12 @@ VMulLegacyF32Vop3::VMulLegacyF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLegacyF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_legacy_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLegacyF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2086,7 +2470,11 @@ VMulF32Vop3::VMulF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2113,7 +2501,11 @@ VMulI32I24Vop3::VMulI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_i32_i24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -2140,7 +2532,12 @@ VMulHiI32I24Vop3::VMulHiI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_i32_i24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -2167,7 +2564,11 @@ VMulU32U24Vop3::VMulU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_u32_u24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -2194,7 +2595,12 @@ VMulHiU32U24Vop3::VMulHiU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_u32_u24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -2222,7 +2628,12 @@ VDot4cI32I8Vop3::VDot4cI32I8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot4cI32I8Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_dot4c_i32_i8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot4cI32I8Vop3>(opcode);
 }
 } // namespace detail
@@ -2249,7 +2660,11 @@ VMinF32Vop3::VMinF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2276,7 +2691,11 @@ VMaxF32Vop3::VMaxF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2303,7 +2722,11 @@ VMinI32Vop3::VMinI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop3>(opcode);
 }
 } // namespace detail
@@ -2330,7 +2753,11 @@ VMaxI32Vop3::VMaxI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop3>(opcode);
 }
 } // namespace detail
@@ -2357,7 +2784,11 @@ VMinU32Vop3::VMinU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2384,7 +2815,11 @@ VMaxU32Vop3::VMaxU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2411,7 +2846,12 @@ VLshrrevB32Vop3::VLshrrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshrrev_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2438,7 +2878,12 @@ VAshrrevI32Vop3::VAshrrevI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashrrev_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop3>(opcode);
 }
 } // namespace detail
@@ -2465,7 +2910,12 @@ VLshlrevB32Vop3::VLshlrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshlrev_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2492,7 +2942,11 @@ VAndB32Vop3::VAndB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_and_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2519,7 +2973,11 @@ VOrB32Vop3::VOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_or_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2546,7 +3004,11 @@ VXorB32Vop3::VXorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xor_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2573,7 +3035,11 @@ VXnorB32Vop3::VXnorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xnor_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2601,7 +3067,11 @@ VMacF32Vop3::VMacF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMacF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mac_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMacF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2628,7 +3098,11 @@ VAddNcU32Vop3::VAddNcU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_nc_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2655,7 +3129,11 @@ VSubNcU32Vop3::VSubNcU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_nc_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2682,7 +3160,12 @@ VSubrevNcU32Vop3::VSubrevNcU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevNcU32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_nc_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevNcU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2710,7 +3193,11 @@ VFmacF32Vop3::VFmacF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fmac_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2737,7 +3224,12 @@ VCvtPkrtzF16F32Vop3::VCvtPkrtzF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pkrtz_f16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkrtzF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -2766,7 +3258,11 @@ VAddF16Vop3::VAddF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2801,7 +3297,11 @@ VSubF16Vop3::VSubF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2836,7 +3336,11 @@ VSubrevF16Vop3::VSubrevF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2871,7 +3375,11 @@ VMulF16Vop3::VMulF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2907,7 +3415,11 @@ VFmacF16Vop3::VFmacF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fmac_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2942,7 +3454,11 @@ VMaxF16Vop3::VMaxF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2977,7 +3493,11 @@ VMinF16Vop3::VMinF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3012,7 +3532,11 @@ VLdexpF16Vop3::VLdexpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ldexp_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3051,7 +3575,12 @@ VMadLegacyF32Vop3::VMadLegacyF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadLegacyF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_legacy_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadLegacyF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3084,7 +3613,11 @@ VMadF32Vop3::VMadF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3117,7 +3650,11 @@ VMadI32I24Vop3::VMadI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_i32_i24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -3150,7 +3687,11 @@ VMadU32U24Vop3::VMadU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_u32_u24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -3183,7 +3724,11 @@ VCubeidF32Vop3::VCubeidF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubeid_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubeidF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3216,7 +3761,11 @@ VCubescF32Vop3::VCubescF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubesc_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubescF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3249,7 +3798,11 @@ VCubetcF32Vop3::VCubetcF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubetc_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubetcF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3282,7 +3835,11 @@ VCubemaF32Vop3::VCubemaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubema_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubemaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3315,7 +3872,11 @@ VBfeU32Vop3::VBfeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfe_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3348,7 +3909,11 @@ VBfeI32Vop3::VBfeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfe_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -3381,7 +3946,11 @@ VBfiB32Vop3::VBfiB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfi_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfiB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3414,7 +3983,11 @@ VFmaF32Vop3::VFmaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3450,7 +4023,11 @@ VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF64Vop3>(opcode);
 }
 } // namespace detail
@@ -3483,7 +4060,11 @@ VLerpU8Vop3::VLerpU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lerp_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLerpU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3516,7 +4097,12 @@ VAlignbitB32Vop3::VAlignbitB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_alignbit_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbitB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3549,7 +4135,12 @@ VAlignbyteB32Vop3::VAlignbyteB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_alignbyte_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbyteB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3582,7 +4173,11 @@ VMullitF32Vop3::VMullitF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMullitF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMullitF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mullit_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMullitF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3615,7 +4210,11 @@ VMin3F32Vop3::VMin3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3648,7 +4247,11 @@ VMin3I32Vop3::VMin3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -3681,7 +4284,11 @@ VMin3U32Vop3::VMin3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3714,7 +4321,11 @@ VMax3F32Vop3::VMax3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3747,7 +4358,11 @@ VMax3I32Vop3::VMax3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -3780,7 +4395,11 @@ VMax3U32Vop3::VMax3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3813,7 +4432,11 @@ VMed3F32Vop3::VMed3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3846,7 +4469,11 @@ VMed3I32Vop3::VMed3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -3879,7 +4506,11 @@ VMed3U32Vop3::VMed3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3912,7 +4543,11 @@ VSadU8Vop3::VSadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3945,7 +4580,11 @@ VSadHiU8Vop3::VSadHiU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_hi_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadHiU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3978,7 +4617,11 @@ VSadU16Vop3::VSadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -4011,7 +4654,11 @@ VSadU32Vop3::VSadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4044,7 +4691,12 @@ VCvtPkU8F32Vop3::VCvtPkU8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_u8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4077,7 +4729,12 @@ VDivFixupF32Vop3::VDivFixupF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4113,7 +4770,12 @@ VDivFixupF64Vop3::VDivFixupF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4142,7 +4804,11 @@ VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4171,7 +4837,11 @@ VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4200,7 +4870,11 @@ VMinF64Vop3::VMinF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4229,7 +4903,11 @@ VMaxF64Vop3::VMaxF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4257,7 +4935,11 @@ VLdexpF64Vop3::VLdexpF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ldexp_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4284,7 +4966,11 @@ VMulLoU32Vop3::VMulLoU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_lo_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4311,7 +4997,11 @@ VMulHiU32Vop3::VMulHiU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4338,7 +5028,11 @@ VMulHiI32Vop3::VMulHiI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4374,7 +5068,12 @@ VDivFmasF32Vop3::VDivFmasF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fmas_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFmasF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4413,7 +5112,12 @@ VDivFmasF64Vop3::VDivFmasF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fmas_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFmasF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4446,7 +5150,11 @@ VMsadU8Vop3::VMsadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_msad_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMsadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -4481,7 +5189,12 @@ VQsadPkU16U8Vop3::VQsadPkU16U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_qsad_pk_u16_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VQsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -4516,7 +5229,12 @@ VMqsadPkU16U8Vop3::VMqsadPkU16U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mqsad_pk_u16_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMqsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -4544,7 +5262,12 @@ VTrigPreopF64Vop3::VTrigPreopF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trig_preop_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTrigPreopF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4574,7 +5297,12 @@ VMqsadU32U8Vop3::VMqsadU32U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mqsad_u32_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMqsadU32U8Vop3>(opcode);
 }
 } // namespace detail
@@ -4607,7 +5335,11 @@ VXor3B32Vop3::VXor3B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXor3B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXor3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xor3_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXor3B32Vop3>(opcode);
 }
 } // namespace detail
@@ -4635,7 +5367,12 @@ VLshlrevB64Vop3::VLshlrevB64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshlrev_b64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -4663,7 +5400,12 @@ VLshrrevB64Vop3::VLshrrevB64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshrrev_b64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -4691,7 +5433,12 @@ VAshrrevI64Vop3::VAshrrevI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashrrev_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI64Vop3>(opcode);
 }
 } // namespace detail
@@ -4720,7 +5467,11 @@ VAddNcU16Vop3::VAddNcU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_nc_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcU16Vop3>(opcode);
 }
 } // namespace detail
@@ -4755,7 +5506,11 @@ VSubNcU16Vop3::VSubNcU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_nc_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcU16Vop3>(opcode);
 }
 } // namespace detail
@@ -4790,7 +5545,11 @@ VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_lo_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU16Vop3>(opcode);
 }
 } // namespace detail
@@ -4825,7 +5584,12 @@ VLshrrevB16Vop3::VLshrrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshrrev_b16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -4860,7 +5624,12 @@ VAshrrevI16Vop3::VAshrrevI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashrrev_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI16Vop3>(opcode);
 }
 } // namespace detail
@@ -4895,7 +5664,11 @@ VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU16Vop3>(opcode);
 }
 } // namespace detail
@@ -4930,7 +5703,11 @@ VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI16Vop3>(opcode);
 }
 } // namespace detail
@@ -4965,7 +5742,11 @@ VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU16Vop3>(opcode);
 }
 } // namespace detail
@@ -5000,7 +5781,11 @@ VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI16Vop3>(opcode);
 }
 } // namespace detail
@@ -5035,7 +5820,11 @@ VAddNcI16Vop3::VAddNcI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_nc_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcI16Vop3>(opcode);
 }
 } // namespace detail
@@ -5070,7 +5859,11 @@ VSubNcI16Vop3::VSubNcI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_nc_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcI16Vop3>(opcode);
 }
 } // namespace detail
@@ -5105,7 +5898,12 @@ VPackB32F16Vop3::VPackB32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_pack_b32_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPackB32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -5134,7 +5932,12 @@ VCvtPknormI16F16Vop3::VCvtPknormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -5163,7 +5966,12 @@ VCvtPknormU16F16Vop3::VCvtPknormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_u16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -5192,7 +6000,12 @@ VLshlrevB16Vop3::VLshlrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshlrev_b16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -5234,7 +6047,11 @@ VMadU16Vop3::VMadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -5259,7 +6076,12 @@ VInterpP1llF16Vop3::VInterpP1llF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP1llF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpP1llF16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_p1ll_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP1llF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5280,7 +6102,12 @@ VInterpP1lvF16Vop3::VInterpP1lvF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP1lvF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpP1lvF16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_p1lv_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP1lvF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5313,7 +6140,11 @@ VPermB32Vop3::VPermB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_perm_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPermB32Vop3>(opcode);
 }
 } // namespace detail
@@ -5346,7 +6177,11 @@ VXadU32Vop3::VXadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xad_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -5379,7 +6214,12 @@ VLshlAddU32Vop3::VLshlAddU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshl_add_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlAddU32Vop3>(opcode);
 }
 } // namespace detail
@@ -5412,7 +6252,12 @@ VAddLshlU32Vop3::VAddLshlU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_lshl_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddLshlU32Vop3>(opcode);
 }
 } // namespace detail
@@ -5448,7 +6293,11 @@ VFmaF16Vop3::VFmaF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5490,7 +6339,11 @@ VMin3F16Vop3::VMin3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -5532,7 +6385,11 @@ VMin3I16Vop3::VMin3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -5574,7 +6431,11 @@ VMin3U16Vop3::VMin3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -5616,7 +6477,11 @@ VMax3F16Vop3::VMax3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -5658,7 +6523,11 @@ VMax3I16Vop3::VMax3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -5700,7 +6569,11 @@ VMax3U16Vop3::VMax3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -5742,7 +6615,11 @@ VMed3F16Vop3::VMed3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -5784,7 +6661,11 @@ VMed3I16Vop3::VMed3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -5826,7 +6707,11 @@ VMed3U16Vop3::VMed3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -5853,7 +6738,12 @@ VInterpP2F16Vop3::VInterpP2F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_p2_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2F16Vop3>(opcode);
 }
 } // namespace detail
@@ -5895,7 +6785,11 @@ VMadI16Vop3::VMadI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI16Vop3>(opcode);
 }
 } // namespace detail
@@ -5937,7 +6831,12 @@ VDivFixupF16Vop3::VDivFixupF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5962,7 +6861,12 @@ VReadlaneB32Vop3::VReadlaneB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_readlane_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VReadlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -5986,7 +6890,12 @@ VWritelaneB32Vop3::VWritelaneB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_writelane_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VWritelaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -6013,7 +6922,11 @@ VLdexpF32Vop3::VLdexpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ldexp_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6040,7 +6953,11 @@ VBfmB32Vop3::VBfmB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfm_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfmB32Vop3>(opcode);
 }
 } // namespace detail
@@ -6067,7 +6984,12 @@ VBcntU32B32Vop3::VBcntU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bcnt_u32_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBcntU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -6094,7 +7016,12 @@ VMbcntLoU32B32Vop3::VMbcntLoU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mbcnt_lo_u32_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntLoU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -6121,7 +7048,12 @@ VMbcntHiU32B32Vop3::VMbcntHiU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mbcnt_hi_u32_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntHiU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -6148,7 +7080,12 @@ VCvtPknormI16F32Vop3::VCvtPknormI16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormI16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_i16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormI16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6175,7 +7112,12 @@ VCvtPknormU16F32Vop3::VCvtPknormU16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormU16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_u16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormU16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6202,7 +7144,12 @@ VCvtPkU16U32Vop3::VCvtPkU16U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_u16_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU16U32Vop3>(opcode);
 }
 } // namespace detail
@@ -6229,7 +7176,12 @@ VCvtPkI16I32Vop3::VCvtPkI16I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_i16_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkI16I32Vop3>(opcode);
 }
 } // namespace detail
@@ -6262,7 +7214,11 @@ VAdd3U32Vop3::VAdd3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAdd3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -6295,7 +7251,11 @@ VLshlOrB32Vop3::VLshlOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshl_or_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -6328,7 +7288,11 @@ VAndOrB32Vop3::VAndOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_and_or_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -6361,7 +7325,11 @@ VOr3B32Vop3::VOr3B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_or3_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOr3B32Vop3>(opcode);
 }
 } // namespace detail
@@ -6396,7 +7364,11 @@ VMadU32U16Vop3::VMadU32U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_u32_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U16Vop3>(opcode);
 }
 } // namespace detail
@@ -6431,7 +7403,11 @@ VMadI32I16Vop3::VMadI32I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_i32_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I16Vop3>(opcode);
 }
 } // namespace detail
@@ -6458,7 +7434,11 @@ VSubNcI32Vop3::VSubNcI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_nc_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcI32Vop3>(opcode);
 }
 } // namespace detail
@@ -6487,7 +7467,12 @@ VPermlane16B32Vop3::VPermlane16B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlane16B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlane16B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_permlane16_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPermlane16B32Vop3>(opcode);
 }
 } // namespace detail
@@ -6516,7 +7501,12 @@ VPermlanex16B32Vop3::VPermlanex16B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlanex16B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlanex16B32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_permlanex16_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPermlanex16B32Vop3>(opcode);
 }
 } // namespace detail
@@ -6543,7 +7533,11 @@ VAddNcI32Vop3::VAddNcI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_nc_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcI32Vop3>(opcode);
 }
 } // namespace detail
@@ -6570,7 +7564,11 @@ VCmpFF32Vop3::VCmpFF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6597,7 +7595,11 @@ VCmpLtF32Vop3::VCmpLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6624,7 +7626,11 @@ VCmpEqF32Vop3::VCmpEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6651,7 +7657,11 @@ VCmpLeF32Vop3::VCmpLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6678,7 +7688,11 @@ VCmpGtF32Vop3::VCmpGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6705,7 +7719,11 @@ VCmpLgF32Vop3::VCmpLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6732,7 +7750,11 @@ VCmpGeF32Vop3::VCmpGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6759,7 +7781,11 @@ VCmpOF32Vop3::VCmpOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_o_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6786,7 +7812,11 @@ VCmpUF32Vop3::VCmpUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_u_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6813,7 +7843,11 @@ VCmpNgeF32Vop3::VCmpNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6840,7 +7874,11 @@ VCmpNlgF32Vop3::VCmpNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6867,7 +7905,11 @@ VCmpNgtF32Vop3::VCmpNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ngt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6894,7 +7936,11 @@ VCmpNleF32Vop3::VCmpNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nle_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6921,7 +7967,11 @@ VCmpNeqF32Vop3::VCmpNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_neq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6948,7 +7998,11 @@ VCmpNltF32Vop3::VCmpNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6975,7 +8029,11 @@ VCmpTruF32Vop3::VCmpTruF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_tru_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTruF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7006,7 +8064,11 @@ VCmpxFF32Vop3::VCmpxFF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7037,7 +8099,11 @@ VCmpxLtF32Vop3::VCmpxLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7068,7 +8134,11 @@ VCmpxEqF32Vop3::VCmpxEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7099,7 +8169,11 @@ VCmpxLeF32Vop3::VCmpxLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7130,7 +8204,11 @@ VCmpxGtF32Vop3::VCmpxGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7161,7 +8239,11 @@ VCmpxLgF32Vop3::VCmpxLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7192,7 +8274,11 @@ VCmpxGeF32Vop3::VCmpxGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7223,7 +8309,11 @@ VCmpxOF32Vop3::VCmpxOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_o_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7254,7 +8344,11 @@ VCmpxUF32Vop3::VCmpxUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_u_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7285,7 +8379,12 @@ VCmpxNgeF32Vop3::VCmpxNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7316,7 +8415,12 @@ VCmpxNlgF32Vop3::VCmpxNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7347,7 +8451,12 @@ VCmpxNgtF32Vop3::VCmpxNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ngt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7378,7 +8487,12 @@ VCmpxNleF32Vop3::VCmpxNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nle_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7409,7 +8523,12 @@ VCmpxNeqF32Vop3::VCmpxNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_neq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7440,7 +8559,12 @@ VCmpxNltF32Vop3::VCmpxNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7471,7 +8595,12 @@ VCmpxTruF32Vop3::VCmpxTruF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_tru_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTruF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7500,7 +8629,11 @@ VCmpFF64Vop3::VCmpFF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7529,7 +8662,11 @@ VCmpLtF64Vop3::VCmpLtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7558,7 +8695,11 @@ VCmpEqF64Vop3::VCmpEqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7587,7 +8728,11 @@ VCmpLeF64Vop3::VCmpLeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7616,7 +8761,11 @@ VCmpGtF64Vop3::VCmpGtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7645,7 +8794,11 @@ VCmpLgF64Vop3::VCmpLgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7674,7 +8827,11 @@ VCmpGeF64Vop3::VCmpGeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7703,7 +8860,11 @@ VCmpOF64Vop3::VCmpOF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_o_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7732,7 +8893,11 @@ VCmpUF64Vop3::VCmpUF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_u_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7761,7 +8926,11 @@ VCmpNgeF64Vop3::VCmpNgeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7790,7 +8959,11 @@ VCmpNlgF64Vop3::VCmpNlgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7819,7 +8992,11 @@ VCmpNgtF64Vop3::VCmpNgtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ngt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7848,7 +9025,11 @@ VCmpNleF64Vop3::VCmpNleF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nle_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7877,7 +9058,11 @@ VCmpNeqF64Vop3::VCmpNeqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_neq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7906,7 +9091,11 @@ VCmpNltF64Vop3::VCmpNltF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7935,7 +9124,11 @@ VCmpTruF64Vop3::VCmpTruF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_tru_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTruF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7968,7 +9161,11 @@ VCmpxFF64Vop3::VCmpxFF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8001,7 +9198,11 @@ VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8034,7 +9235,11 @@ VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8067,7 +9272,11 @@ VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8100,7 +9309,11 @@ VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8133,7 +9346,11 @@ VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8166,7 +9383,11 @@ VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8199,7 +9420,11 @@ VCmpxOF64Vop3::VCmpxOF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_o_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8232,7 +9457,11 @@ VCmpxUF64Vop3::VCmpxUF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_u_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8265,7 +9494,12 @@ VCmpxNgeF64Vop3::VCmpxNgeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8298,7 +9532,12 @@ VCmpxNlgF64Vop3::VCmpxNlgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8331,7 +9570,12 @@ VCmpxNgtF64Vop3::VCmpxNgtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ngt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8364,7 +9608,12 @@ VCmpxNleF64Vop3::VCmpxNleF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nle_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8397,7 +9646,12 @@ VCmpxNeqF64Vop3::VCmpxNeqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_neq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8430,7 +9684,12 @@ VCmpxNltF64Vop3::VCmpxNltF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8463,7 +9722,12 @@ VCmpxTruF64Vop3::VCmpxTruF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_tru_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTruF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8490,7 +9754,11 @@ VCmpFI32Vop3::VCmpFI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8517,7 +9785,11 @@ VCmpLtI32Vop3::VCmpLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8544,7 +9816,11 @@ VCmpEqI32Vop3::VCmpEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8571,7 +9847,11 @@ VCmpLeI32Vop3::VCmpLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8598,7 +9878,11 @@ VCmpGtI32Vop3::VCmpGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8625,7 +9909,11 @@ VCmpNeI32Vop3::VCmpNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8652,7 +9940,11 @@ VCmpGeI32Vop3::VCmpGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8679,7 +9971,11 @@ VCmpTI32Vop3::VCmpTI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8706,7 +10002,12 @@ VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_class_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -8735,7 +10036,11 @@ VCmpLtI16Vop3::VCmpLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8764,7 +10069,11 @@ VCmpEqI16Vop3::VCmpEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8793,7 +10102,11 @@ VCmpLeI16Vop3::VCmpLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8822,7 +10135,11 @@ VCmpGtI16Vop3::VCmpGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8851,7 +10168,11 @@ VCmpNeI16Vop3::VCmpNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8880,7 +10201,11 @@ VCmpGeI16Vop3::VCmpGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8909,7 +10234,12 @@ VCmpClassF16Vop3::VCmpClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_class_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -8940,7 +10270,11 @@ VCmpxFI32Vop3::VCmpxFI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8971,7 +10305,11 @@ VCmpxLtI32Vop3::VCmpxLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9002,7 +10340,11 @@ VCmpxEqI32Vop3::VCmpxEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9033,7 +10375,11 @@ VCmpxLeI32Vop3::VCmpxLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9064,7 +10410,11 @@ VCmpxGtI32Vop3::VCmpxGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9095,7 +10445,11 @@ VCmpxNeI32Vop3::VCmpxNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9126,7 +10480,11 @@ VCmpxGeI32Vop3::VCmpxGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9157,7 +10515,11 @@ VCmpxTI32Vop3::VCmpxTI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9188,7 +10550,12 @@ VCmpxClassF32Vop3::VCmpxClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_class_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -9221,7 +10588,11 @@ VCmpxLtI16Vop3::VCmpxLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -9254,7 +10625,11 @@ VCmpxEqI16Vop3::VCmpxEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -9287,7 +10662,11 @@ VCmpxLeI16Vop3::VCmpxLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -9320,7 +10699,11 @@ VCmpxGtI16Vop3::VCmpxGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -9353,7 +10736,11 @@ VCmpxNeI16Vop3::VCmpxNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -9386,7 +10773,11 @@ VCmpxGeI16Vop3::VCmpxGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -9419,7 +10810,12 @@ VCmpxClassF16Vop3::VCmpxClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_class_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -9448,7 +10844,11 @@ VCmpFI64Vop3::VCmpFI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9477,7 +10877,11 @@ VCmpLtI64Vop3::VCmpLtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9506,7 +10910,11 @@ VCmpEqI64Vop3::VCmpEqI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9535,7 +10943,11 @@ VCmpLeI64Vop3::VCmpLeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9564,7 +10976,11 @@ VCmpGtI64Vop3::VCmpGtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9593,7 +11009,11 @@ VCmpNeI64Vop3::VCmpNeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9622,7 +11042,11 @@ VCmpGeI64Vop3::VCmpGeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9651,7 +11075,11 @@ VCmpTI64Vop3::VCmpTI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9679,7 +11107,12 @@ VCmpClassF64Vop3::VCmpClassF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_class_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -9708,7 +11141,11 @@ VCmpLtU16Vop3::VCmpLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9737,7 +11174,11 @@ VCmpEqU16Vop3::VCmpEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9766,7 +11207,11 @@ VCmpLeU16Vop3::VCmpLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9795,7 +11240,11 @@ VCmpGtU16Vop3::VCmpGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9824,7 +11273,11 @@ VCmpNeU16Vop3::VCmpNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9853,7 +11306,11 @@ VCmpGeU16Vop3::VCmpGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9886,7 +11343,11 @@ VCmpxFI64Vop3::VCmpxFI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9919,7 +11380,11 @@ VCmpxLtI64Vop3::VCmpxLtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9952,7 +11417,11 @@ VCmpxEqI64Vop3::VCmpxEqI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9985,7 +11454,11 @@ VCmpxLeI64Vop3::VCmpxLeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -10018,7 +11491,11 @@ VCmpxGtI64Vop3::VCmpxGtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -10051,7 +11528,11 @@ VCmpxNeI64Vop3::VCmpxNeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -10084,7 +11565,11 @@ VCmpxGeI64Vop3::VCmpxGeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -10117,7 +11602,11 @@ VCmpxTI64Vop3::VCmpxTI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI64Vop3>(opcode);
 }
 } // namespace detail
@@ -10149,7 +11638,12 @@ VCmpxClassF64Vop3::VCmpxClassF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_class_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -10182,7 +11676,11 @@ VCmpxLtU16Vop3::VCmpxLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -10215,7 +11713,11 @@ VCmpxEqU16Vop3::VCmpxEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -10248,7 +11750,11 @@ VCmpxLeU16Vop3::VCmpxLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -10281,7 +11787,11 @@ VCmpxGtU16Vop3::VCmpxGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -10314,7 +11824,11 @@ VCmpxNeU16Vop3::VCmpxNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -10347,7 +11861,11 @@ VCmpxGeU16Vop3::VCmpxGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -10374,7 +11892,11 @@ VCmpFU32Vop3::VCmpFU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10401,7 +11923,11 @@ VCmpLtU32Vop3::VCmpLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10428,7 +11954,11 @@ VCmpEqU32Vop3::VCmpEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10455,7 +11985,11 @@ VCmpLeU32Vop3::VCmpLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10482,7 +12016,11 @@ VCmpGtU32Vop3::VCmpGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10509,7 +12047,11 @@ VCmpNeU32Vop3::VCmpNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10536,7 +12078,11 @@ VCmpGeU32Vop3::VCmpGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10563,7 +12109,11 @@ VCmpTU32Vop3::VCmpTU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10592,7 +12142,11 @@ VCmpFF16Vop3::VCmpFF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10621,7 +12175,11 @@ VCmpLtF16Vop3::VCmpLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10650,7 +12208,11 @@ VCmpEqF16Vop3::VCmpEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10679,7 +12241,11 @@ VCmpLeF16Vop3::VCmpLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10708,7 +12274,11 @@ VCmpGtF16Vop3::VCmpGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10737,7 +12307,11 @@ VCmpLgF16Vop3::VCmpLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10766,7 +12340,11 @@ VCmpGeF16Vop3::VCmpGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10795,7 +12373,11 @@ VCmpOF16Vop3::VCmpOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_o_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10826,7 +12408,11 @@ VCmpxFU32Vop3::VCmpxFU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10857,7 +12443,11 @@ VCmpxLtU32Vop3::VCmpxLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10888,7 +12478,11 @@ VCmpxEqU32Vop3::VCmpxEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10919,7 +12513,11 @@ VCmpxLeU32Vop3::VCmpxLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10950,7 +12548,11 @@ VCmpxGtU32Vop3::VCmpxGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10981,7 +12583,11 @@ VCmpxNeU32Vop3::VCmpxNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -11012,7 +12618,11 @@ VCmpxGeU32Vop3::VCmpxGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -11043,7 +12653,11 @@ VCmpxTU32Vop3::VCmpxTU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU32Vop3>(opcode);
 }
 } // namespace detail
@@ -11076,7 +12690,11 @@ VCmpxFF16Vop3::VCmpxFF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11109,7 +12727,11 @@ VCmpxLtF16Vop3::VCmpxLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11142,7 +12764,11 @@ VCmpxEqF16Vop3::VCmpxEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11175,7 +12801,11 @@ VCmpxLeF16Vop3::VCmpxLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11208,7 +12838,11 @@ VCmpxGtF16Vop3::VCmpxGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11241,7 +12875,11 @@ VCmpxLgF16Vop3::VCmpxLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11274,7 +12912,11 @@ VCmpxGeF16Vop3::VCmpxGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11307,7 +12949,11 @@ VCmpxOF16Vop3::VCmpxOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_o_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11336,7 +12982,11 @@ VCmpFU64Vop3::VCmpFU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11365,7 +13015,11 @@ VCmpLtU64Vop3::VCmpLtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11394,7 +13048,11 @@ VCmpEqU64Vop3::VCmpEqU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11423,7 +13081,11 @@ VCmpLeU64Vop3::VCmpLeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11452,7 +13114,11 @@ VCmpGtU64Vop3::VCmpGtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11481,7 +13147,11 @@ VCmpNeU64Vop3::VCmpNeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11510,7 +13180,11 @@ VCmpGeU64Vop3::VCmpGeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11539,7 +13213,11 @@ VCmpTU64Vop3::VCmpTU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11568,7 +13246,11 @@ VCmpUF16Vop3::VCmpUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_u_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11597,7 +13279,11 @@ VCmpNgeF16Vop3::VCmpNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11626,7 +13312,11 @@ VCmpNlgF16Vop3::VCmpNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11655,7 +13345,11 @@ VCmpNgtF16Vop3::VCmpNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ngt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11684,7 +13378,11 @@ VCmpNleF16Vop3::VCmpNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nle_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11713,7 +13411,11 @@ VCmpNeqF16Vop3::VCmpNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_neq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11742,7 +13444,11 @@ VCmpNltF16Vop3::VCmpNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11771,7 +13477,11 @@ VCmpTruF16Vop3::VCmpTruF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_tru_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTruF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11804,7 +13514,11 @@ VCmpxFU64Vop3::VCmpxFU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11837,7 +13551,11 @@ VCmpxLtU64Vop3::VCmpxLtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11870,7 +13588,11 @@ VCmpxEqU64Vop3::VCmpxEqU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11903,7 +13625,11 @@ VCmpxLeU64Vop3::VCmpxLeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11936,7 +13662,11 @@ VCmpxGtU64Vop3::VCmpxGtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11969,7 +13699,11 @@ VCmpxNeU64Vop3::VCmpxNeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -12002,7 +13736,11 @@ VCmpxGeU64Vop3::VCmpxGeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -12035,7 +13773,11 @@ VCmpxTU64Vop3::VCmpxTU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU64Vop3>(opcode);
 }
 } // namespace detail
@@ -12068,7 +13810,11 @@ VCmpxUF16Vop3::VCmpxUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_u_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12101,7 +13847,12 @@ VCmpxNgeF16Vop3::VCmpxNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12134,7 +13885,12 @@ VCmpxNlgF16Vop3::VCmpxNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12167,7 +13923,12 @@ VCmpxNgtF16Vop3::VCmpxNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ngt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12200,7 +13961,12 @@ VCmpxNleF16Vop3::VCmpxNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nle_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12233,7 +13999,12 @@ VCmpxNeqF16Vop3::VCmpxNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_neq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12266,7 +14037,12 @@ VCmpxNltF16Vop3::VCmpxNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12299,7 +14075,12 @@ VCmpxTruF16Vop3::VCmpxTruF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_tru_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTruF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12330,7 +14111,12 @@ VAddCoCiU32Vop3SdstEnc::VAddCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_add_co_ci_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoCiU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -12361,7 +14147,12 @@ VSubCoCiU32Vop3SdstEnc::VSubCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_sub_co_ci_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoCiU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -12392,7 +14183,12 @@ VSubrevCoCiU32Vop3SdstEnc::VSubrevCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_subrev_co_ci_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoCiU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -12427,7 +14223,12 @@ VDivScaleF32Vop3SdstEnc::VDivScaleF32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_div_scale_f32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivScaleF32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -12468,7 +14269,12 @@ VDivScaleF64Vop3SdstEnc::VDivScaleF64Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_div_scale_f64", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivScaleF64Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -12505,7 +14311,12 @@ VMadU64U32Vop3SdstEnc::VMadU64U32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_mad_u64_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU64U32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -12542,7 +14353,12 @@ VMadI64I32Vop3SdstEnc::VMadI64I32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_mad_i64_i32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI64I32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -12571,7 +14387,12 @@ VAddCoU32Vop3SdstEnc::VAddCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_add_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -12600,7 +14421,12 @@ VSubCoU32Vop3SdstEnc::VSubCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_sub_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -12629,7 +14455,12 @@ VSubrevCoU32Vop3SdstEnc::VSubrevCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_subrev_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/vop3p.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -41,7 +40,11 @@ VPkMadI16Vop3p::VPkMadI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mad_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMadI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -68,7 +71,12 @@ VPkMulLoU16Vop3p::VPkMulLoU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mul_lo_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMulLoU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -95,7 +103,11 @@ VPkAddI16Vop3p::VPkAddI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -122,7 +134,11 @@ VPkSubI16Vop3p::VPkSubI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_sub_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkSubI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -149,7 +165,12 @@ VPkLshlrevB16Vop3p::VPkLshlrevB16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_lshlrev_b16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkLshlrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -176,7 +197,12 @@ VPkLshrrevB16Vop3p::VPkLshrrevB16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_lshrrev_b16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkLshrrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -203,7 +229,12 @@ VPkAshrrevI16Vop3p::VPkAshrrevI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_ashrrev_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAshrrevI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -230,7 +261,11 @@ VPkMaxI16Vop3p::VPkMaxI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_max_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaxI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -257,7 +292,11 @@ VPkMinI16Vop3p::VPkMinI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_min_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -290,7 +329,11 @@ VPkMadU16Vop3p::VPkMadU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mad_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMadU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -317,7 +360,11 @@ VPkAddU16Vop3p::VPkAddU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -344,7 +391,11 @@ VPkSubU16Vop3p::VPkSubU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_sub_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkSubU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -371,7 +422,11 @@ VPkMaxU16Vop3p::VPkMaxU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_max_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaxU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -398,7 +453,11 @@ VPkMinU16Vop3p::VPkMinU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_min_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -431,7 +490,11 @@ VPkFmaF16Vop3p::VPkFmaF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_fma_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkFmaF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -458,7 +521,11 @@ VPkAddF16Vop3p::VPkAddF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -485,7 +552,11 @@ VPkMulF16Vop3p::VPkMulF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mul_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMulF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -512,7 +583,11 @@ VPkMinF16Vop3p::VPkMinF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_min_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -539,7 +614,11 @@ VPkMaxF16Vop3p::VPkMaxF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_max_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaxF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -572,7 +651,12 @@ VDot2F32F16Vop3p::VDot2F32F16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2F32F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2F32F16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_f32_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2F32F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -605,7 +689,12 @@ VDot2I32I16Vop3p::VDot2I32I16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2I32I16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2I32I16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_i32_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2I32I16Vop3p>(opcode);
 }
 } // namespace detail
@@ -638,7 +727,12 @@ VDot2U32U16Vop3p::VDot2U32U16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2U32U16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2U32U16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_u32_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2U32U16Vop3p>(opcode);
 }
 } // namespace detail
@@ -671,7 +765,12 @@ VDot4I32I8Vop3p::VDot4I32I8Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4I32I8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4I32I8Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot4_i32_i8", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot4I32I8Vop3p>(opcode);
 }
 } // namespace detail
@@ -704,7 +803,12 @@ VDot4U32U8Vop3p::VDot4U32U8Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot4_u32_u8", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot4U32U8Vop3p>(opcode);
 }
 } // namespace detail
@@ -737,7 +841,12 @@ VDot8I32I4Vop3p::VDot8I32I4Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8I32I4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8I32I4Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot8_i32_i4", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot8I32I4Vop3p>(opcode);
 }
 } // namespace detail
@@ -770,7 +879,12 @@ VDot8U32U4Vop3p::VDot8U32U4Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot8_u32_u4", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot8U32U4Vop3p>(opcode);
 }
 } // namespace detail
@@ -803,7 +917,12 @@ VFmaMixF32Vop3p::VFmaMixF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixF32Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_fma_mix_f32", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -837,7 +956,12 @@ VFmaMixloF16Vop3p::VFmaMixloF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixloF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_fma_mixlo_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixloF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -877,7 +1001,12 @@ VFmaMixhiF16Vop3p::VFmaMixhiF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixhiF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_fma_mixhi_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixhiF16Vop3p>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/vopc.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/vopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -30,9 +29,6 @@ VCmpFF32Vopc::VCmpFF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -60,7 +56,18 @@ VCmpFF32Vopc::VCmpFF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_f32_sdwa"
+          : "v_cmp_f_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F32 does not support DPP";
   return std::make_unique<VCmpFF32Vopc>(opcode);
 }
 } // namespace detail
@@ -83,9 +90,6 @@ VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -113,7 +117,18 @@ VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_f32_sdwa"
+          : "v_cmp_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F32 does not support DPP";
   return std::make_unique<VCmpLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -136,9 +151,6 @@ VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -166,7 +178,18 @@ VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_f32_sdwa"
+          : "v_cmp_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F32 does not support DPP";
   return std::make_unique<VCmpEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -189,9 +212,6 @@ VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -219,7 +239,18 @@ VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_f32_sdwa"
+          : "v_cmp_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F32 does not support DPP";
   return std::make_unique<VCmpLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -242,9 +273,6 @@ VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -272,7 +300,18 @@ VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_f32_sdwa"
+          : "v_cmp_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F32 does not support DPP";
   return std::make_unique<VCmpGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -295,9 +334,6 @@ VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -325,7 +361,18 @@ VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lg_f32_sdwa"
+          : "v_cmp_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F32 does not support DPP";
   return std::make_unique<VCmpLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -348,9 +395,6 @@ VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -378,7 +422,18 @@ VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_f32_sdwa"
+          : "v_cmp_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F32 does not support DPP";
   return std::make_unique<VCmpGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -400,9 +455,6 @@ VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_O_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -430,7 +482,18 @@ VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_o_f32_sdwa"
+          : "v_cmp_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F32 does not support DPP";
   return std::make_unique<VCmpOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -452,9 +515,6 @@ VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_U_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -482,7 +542,18 @@ VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_u_f32_sdwa"
+          : "v_cmp_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F32 does not support DPP";
   return std::make_unique<VCmpUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -505,9 +576,6 @@ VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -535,7 +603,18 @@ VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nge_f32_sdwa"
+          : "v_cmp_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F32 does not support DPP";
   return std::make_unique<VCmpNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -558,9 +637,6 @@ VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -588,7 +664,18 @@ VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlg_f32_sdwa"
+          : "v_cmp_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F32 does not support DPP";
   return std::make_unique<VCmpNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -611,9 +698,6 @@ VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -641,7 +725,18 @@ VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ngt_f32_sdwa"
+          : "v_cmp_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F32 does not support DPP";
   return std::make_unique<VCmpNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -664,9 +759,6 @@ VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -694,7 +786,18 @@ VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nle_f32_sdwa"
+          : "v_cmp_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F32 does not support DPP";
   return std::make_unique<VCmpNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -717,9 +820,6 @@ VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NEQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -747,7 +847,18 @@ VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_neq_f32_sdwa"
+          : "v_cmp_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F32 does not support DPP";
   return std::make_unique<VCmpNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -770,9 +881,6 @@ VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -800,7 +908,18 @@ VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlt_f32_sdwa"
+          : "v_cmp_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F32 does not support DPP";
   return std::make_unique<VCmpNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -823,9 +942,6 @@ VCmpTruF32Vopc::VCmpTruF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_TRU_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -853,7 +969,18 @@ VCmpTruF32Vopc::VCmpTruF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_tru_f32_sdwa"
+          : "v_cmp_tru_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F32 does not support DPP";
   return std::make_unique<VCmpTruF32Vopc>(opcode);
 }
 } // namespace detail
@@ -878,9 +1005,6 @@ VCmpxFF32Vopc::VCmpxFF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -910,7 +1034,18 @@ VCmpxFF32Vopc::VCmpxFF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_f32_sdwa"
+          : "v_cmpx_f_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F32 does not support DPP";
   return std::make_unique<VCmpxFF32Vopc>(opcode);
 }
 } // namespace detail
@@ -935,9 +1070,6 @@ VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -967,7 +1099,18 @@ VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_f32_sdwa"
+          : "v_cmpx_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F32 does not support DPP";
   return std::make_unique<VCmpxLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -992,9 +1135,6 @@ VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1024,7 +1164,18 @@ VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_f32_sdwa"
+          : "v_cmpx_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F32 does not support DPP";
   return std::make_unique<VCmpxEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1049,9 +1200,6 @@ VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1081,7 +1229,18 @@ VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_f32_sdwa"
+          : "v_cmpx_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F32 does not support DPP";
   return std::make_unique<VCmpxLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1106,9 +1265,6 @@ VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1138,7 +1294,18 @@ VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_f32_sdwa"
+          : "v_cmpx_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F32 does not support DPP";
   return std::make_unique<VCmpxGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1163,9 +1330,6 @@ VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1195,7 +1359,18 @@ VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lg_f32_sdwa"
+          : "v_cmpx_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F32 does not support DPP";
   return std::make_unique<VCmpxLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1220,9 +1395,6 @@ VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1252,7 +1424,18 @@ VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_f32_sdwa"
+          : "v_cmpx_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F32 does not support DPP";
   return std::make_unique<VCmpxGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1277,9 +1460,6 @@ VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_O_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1309,7 +1489,18 @@ VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_o_f32_sdwa"
+          : "v_cmpx_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F32 does not support DPP";
   return std::make_unique<VCmpxOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1334,9 +1525,6 @@ VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_U_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1366,7 +1554,18 @@ VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_u_f32_sdwa"
+          : "v_cmpx_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F32 does not support DPP";
   return std::make_unique<VCmpxUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1391,9 +1590,6 @@ VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1423,7 +1619,19 @@ VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nge_f32_sdwa"
+          : "v_cmpx_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F32 does not support DPP";
   return std::make_unique<VCmpxNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1448,9 +1656,6 @@ VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1480,7 +1685,19 @@ VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlg_f32_sdwa"
+          : "v_cmpx_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F32 does not support DPP";
   return std::make_unique<VCmpxNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1505,9 +1722,6 @@ VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1537,7 +1751,19 @@ VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ngt_f32_sdwa"
+          : "v_cmpx_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F32 does not support DPP";
   return std::make_unique<VCmpxNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1562,9 +1788,6 @@ VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1594,7 +1817,19 @@ VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nle_f32_sdwa"
+          : "v_cmpx_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F32 does not support DPP";
   return std::make_unique<VCmpxNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1619,9 +1854,6 @@ VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NEQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1651,7 +1883,19 @@ VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_neq_f32_sdwa"
+          : "v_cmpx_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F32 does not support DPP";
   return std::make_unique<VCmpxNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1676,9 +1920,6 @@ VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1708,7 +1949,19 @@ VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlt_f32_sdwa"
+          : "v_cmpx_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F32 does not support DPP";
   return std::make_unique<VCmpxNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1733,9 +1986,6 @@ VCmpxTruF32Vopc::VCmpxTruF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_TRU_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1765,7 +2015,19 @@ VCmpxTruF32Vopc::VCmpxTruF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_tru_f32_sdwa"
+          : "v_cmpx_tru_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F32 does not support DPP";
   return std::make_unique<VCmpxTruF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1786,16 +2048,21 @@ VCmpFF64Vopc::VCmpFF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_F_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_f_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F64 does not support SDWA";
   return std::make_unique<VCmpFF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1816,16 +2083,21 @@ VCmpLtF64Vopc::VCmpLtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support SDWA";
   return std::make_unique<VCmpLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1846,16 +2118,21 @@ VCmpEqF64Vopc::VCmpEqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_eq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support SDWA";
   return std::make_unique<VCmpEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1876,16 +2153,21 @@ VCmpLeF64Vopc::VCmpLeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_le_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support SDWA";
   return std::make_unique<VCmpLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1906,16 +2188,21 @@ VCmpGtF64Vopc::VCmpGtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_gt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support SDWA";
   return std::make_unique<VCmpGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1936,16 +2223,21 @@ VCmpLgF64Vopc::VCmpLgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support SDWA";
   return std::make_unique<VCmpLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1966,16 +2258,21 @@ VCmpGeF64Vopc::VCmpGeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support SDWA";
   return std::make_unique<VCmpGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1996,16 +2293,21 @@ VCmpOF64Vopc::VCmpOF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_O_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_O_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_o_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support SDWA";
   return std::make_unique<VCmpOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2026,16 +2328,21 @@ VCmpUF64Vopc::VCmpUF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_U_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_U_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_u_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support SDWA";
   return std::make_unique<VCmpUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2056,16 +2363,21 @@ VCmpNgeF64Vopc::VCmpNgeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support SDWA";
   return std::make_unique<VCmpNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2086,16 +2398,21 @@ VCmpNlgF64Vopc::VCmpNlgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nlg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support SDWA";
   return std::make_unique<VCmpNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2116,16 +2433,21 @@ VCmpNgtF64Vopc::VCmpNgtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ngt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support SDWA";
   return std::make_unique<VCmpNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2146,16 +2468,21 @@ VCmpNleF64Vopc::VCmpNleF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nle_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support SDWA";
   return std::make_unique<VCmpNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2176,16 +2503,21 @@ VCmpNeqF64Vopc::VCmpNeqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_neq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support SDWA";
   return std::make_unique<VCmpNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2206,16 +2538,21 @@ VCmpNltF64Vopc::VCmpNltF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nlt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support SDWA";
   return std::make_unique<VCmpNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2236,16 +2573,21 @@ VCmpTruF64Vopc::VCmpTruF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_TRU_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_TRU_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_tru_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F64 does not support SDWA";
   return std::make_unique<VCmpTruF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2268,18 +2610,23 @@ VCmpxFF64Vopc::VCmpxFF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_F_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_f_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F64 does not support SDWA";
   return std::make_unique<VCmpxFF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2302,18 +2649,23 @@ VCmpxLtF64Vopc::VCmpxLtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support SDWA";
   return std::make_unique<VCmpxLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2336,18 +2688,23 @@ VCmpxEqF64Vopc::VCmpxEqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_eq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support SDWA";
   return std::make_unique<VCmpxEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2370,18 +2727,23 @@ VCmpxLeF64Vopc::VCmpxLeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_le_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support SDWA";
   return std::make_unique<VCmpxLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2404,18 +2766,23 @@ VCmpxGtF64Vopc::VCmpxGtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_gt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support SDWA";
   return std::make_unique<VCmpxGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2438,18 +2805,23 @@ VCmpxLgF64Vopc::VCmpxLgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support SDWA";
   return std::make_unique<VCmpxLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2472,18 +2844,23 @@ VCmpxGeF64Vopc::VCmpxGeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support SDWA";
   return std::make_unique<VCmpxGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2506,18 +2883,23 @@ VCmpxOF64Vopc::VCmpxOF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_O_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_O_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_o_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support SDWA";
   return std::make_unique<VCmpxOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2540,18 +2922,23 @@ VCmpxUF64Vopc::VCmpxUF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_U_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_U_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_u_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support SDWA";
   return std::make_unique<VCmpxUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2574,18 +2961,24 @@ VCmpxNgeF64Vopc::VCmpxNgeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support SDWA";
   return std::make_unique<VCmpxNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2608,18 +3001,24 @@ VCmpxNlgF64Vopc::VCmpxNlgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nlg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support SDWA";
   return std::make_unique<VCmpxNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2642,18 +3041,24 @@ VCmpxNgtF64Vopc::VCmpxNgtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ngt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support SDWA";
   return std::make_unique<VCmpxNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2676,18 +3081,24 @@ VCmpxNleF64Vopc::VCmpxNleF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nle_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support SDWA";
   return std::make_unique<VCmpxNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2710,18 +3121,24 @@ VCmpxNeqF64Vopc::VCmpxNeqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_neq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support SDWA";
   return std::make_unique<VCmpxNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2744,18 +3161,24 @@ VCmpxNltF64Vopc::VCmpxNltF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nlt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support SDWA";
   return std::make_unique<VCmpxNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2778,18 +3201,24 @@ VCmpxTruF64Vopc::VCmpxTruF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_TRU_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_TRU_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_tru_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F64 does not support SDWA";
   return std::make_unique<VCmpxTruF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2811,9 +3240,6 @@ VCmpFI32Vopc::VCmpFI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2841,7 +3267,18 @@ VCmpFI32Vopc::VCmpFI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_i32_sdwa"
+          : "v_cmp_f_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I32 does not support DPP";
   return std::make_unique<VCmpFI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2864,9 +3301,6 @@ VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2894,7 +3328,18 @@ VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_i32_sdwa"
+          : "v_cmp_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I32 does not support DPP";
   return std::make_unique<VCmpLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2917,9 +3362,6 @@ VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2947,7 +3389,18 @@ VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_i32_sdwa"
+          : "v_cmp_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I32 does not support DPP";
   return std::make_unique<VCmpEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2970,9 +3423,6 @@ VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3000,7 +3450,18 @@ VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_i32_sdwa"
+          : "v_cmp_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I32 does not support DPP";
   return std::make_unique<VCmpLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3023,9 +3484,6 @@ VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3053,7 +3511,18 @@ VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_i32_sdwa"
+          : "v_cmp_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I32 does not support DPP";
   return std::make_unique<VCmpGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3076,9 +3545,6 @@ VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3106,7 +3572,18 @@ VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_i32_sdwa"
+          : "v_cmp_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I32 does not support DPP";
   return std::make_unique<VCmpNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3129,9 +3606,6 @@ VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3159,7 +3633,18 @@ VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_i32_sdwa"
+          : "v_cmp_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I32 does not support DPP";
   return std::make_unique<VCmpGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3181,9 +3666,6 @@ VCmpTI32Vopc::VCmpTI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3211,7 +3693,18 @@ VCmpTI32Vopc::VCmpTI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_i32_sdwa"
+          : "v_cmp_t_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I32 does not support DPP";
   return std::make_unique<VCmpTI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3234,9 +3727,6 @@ VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_CLASS_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3264,7 +3754,19 @@ VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_class_f32_sdwa"
+          : "v_cmp_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F32 does not support DPP";
   return std::make_unique<VCmpClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3288,9 +3790,6 @@ VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3318,7 +3817,18 @@ VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_i16_sdwa"
+          : "v_cmp_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I16 does not support DPP";
   return std::make_unique<VCmpLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -3342,9 +3852,6 @@ VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3372,7 +3879,18 @@ VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_i16_sdwa"
+          : "v_cmp_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I16 does not support DPP";
   return std::make_unique<VCmpEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -3396,9 +3914,6 @@ VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3426,7 +3941,18 @@ VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_i16_sdwa"
+          : "v_cmp_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I16 does not support DPP";
   return std::make_unique<VCmpLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -3450,9 +3976,6 @@ VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3480,7 +4003,18 @@ VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_i16_sdwa"
+          : "v_cmp_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I16 does not support DPP";
   return std::make_unique<VCmpGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -3504,9 +4038,6 @@ VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3534,7 +4065,18 @@ VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_i16_sdwa"
+          : "v_cmp_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I16 does not support DPP";
   return std::make_unique<VCmpNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -3558,9 +4100,6 @@ VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3588,7 +4127,18 @@ VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_i16_sdwa"
+          : "v_cmp_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I16 does not support DPP";
   return std::make_unique<VCmpGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -3612,9 +4162,6 @@ VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_CLASS_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3642,7 +4189,19 @@ VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_class_f16_sdwa"
+          : "v_cmp_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F16 does not support DPP";
   return std::make_unique<VCmpClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3667,9 +4226,6 @@ VCmpxFI32Vopc::VCmpxFI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3699,7 +4255,18 @@ VCmpxFI32Vopc::VCmpxFI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_i32_sdwa"
+          : "v_cmpx_f_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I32 does not support DPP";
   return std::make_unique<VCmpxFI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3724,9 +4291,6 @@ VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3756,7 +4320,18 @@ VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_i32_sdwa"
+          : "v_cmpx_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I32 does not support DPP";
   return std::make_unique<VCmpxLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3781,9 +4356,6 @@ VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3813,7 +4385,18 @@ VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_i32_sdwa"
+          : "v_cmpx_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I32 does not support DPP";
   return std::make_unique<VCmpxEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3838,9 +4421,6 @@ VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3870,7 +4450,18 @@ VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_i32_sdwa"
+          : "v_cmpx_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I32 does not support DPP";
   return std::make_unique<VCmpxLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3895,9 +4486,6 @@ VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3927,7 +4515,18 @@ VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_i32_sdwa"
+          : "v_cmpx_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I32 does not support DPP";
   return std::make_unique<VCmpxGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3952,9 +4551,6 @@ VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3984,7 +4580,18 @@ VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_i32_sdwa"
+          : "v_cmpx_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I32 does not support DPP";
   return std::make_unique<VCmpxNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -4009,9 +4616,6 @@ VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4041,7 +4645,18 @@ VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_i32_sdwa"
+          : "v_cmpx_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I32 does not support DPP";
   return std::make_unique<VCmpxGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -4066,9 +4681,6 @@ VCmpxTI32Vopc::VCmpxTI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4098,7 +4710,18 @@ VCmpxTI32Vopc::VCmpxTI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_i32_sdwa"
+          : "v_cmpx_t_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I32 does not support DPP";
   return std::make_unique<VCmpxTI32Vopc>(opcode);
 }
 } // namespace detail
@@ -4123,9 +4746,6 @@ VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_CLASS_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4155,7 +4775,19 @@ VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_class_f32_sdwa"
+          : "v_cmpx_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F32 does not support DPP";
   return std::make_unique<VCmpxClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4181,9 +4813,6 @@ VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4213,7 +4842,18 @@ VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_i16_sdwa"
+          : "v_cmpx_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I16 does not support DPP";
   return std::make_unique<VCmpxLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4239,9 +4879,6 @@ VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4271,7 +4908,18 @@ VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_i16_sdwa"
+          : "v_cmpx_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I16 does not support DPP";
   return std::make_unique<VCmpxEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4297,9 +4945,6 @@ VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4329,7 +4974,18 @@ VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_i16_sdwa"
+          : "v_cmpx_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I16 does not support DPP";
   return std::make_unique<VCmpxLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4355,9 +5011,6 @@ VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4387,7 +5040,18 @@ VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_i16_sdwa"
+          : "v_cmpx_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I16 does not support DPP";
   return std::make_unique<VCmpxGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4413,9 +5077,6 @@ VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4445,7 +5106,18 @@ VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_i16_sdwa"
+          : "v_cmpx_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I16 does not support DPP";
   return std::make_unique<VCmpxNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4471,9 +5143,6 @@ VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4503,7 +5172,18 @@ VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_i16_sdwa"
+          : "v_cmpx_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I16 does not support DPP";
   return std::make_unique<VCmpxGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4529,9 +5209,6 @@ VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_CLASS_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4561,7 +5238,19 @@ VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_class_f16_sdwa"
+          : "v_cmpx_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F16 does not support DPP";
   return std::make_unique<VCmpxClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4582,16 +5271,21 @@ VCmpFI64Vopc::VCmpFI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_F_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_f_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I64 does not support SDWA";
   return std::make_unique<VCmpFI64Vopc>(opcode);
 }
 } // namespace detail
@@ -4612,16 +5306,21 @@ VCmpLtI64Vopc::VCmpLtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support SDWA";
   return std::make_unique<VCmpLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -4642,16 +5341,21 @@ VCmpEqI64Vopc::VCmpEqI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_eq_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support SDWA";
   return std::make_unique<VCmpEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -4672,16 +5376,21 @@ VCmpLeI64Vopc::VCmpLeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_le_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support SDWA";
   return std::make_unique<VCmpLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -4702,16 +5411,21 @@ VCmpGtI64Vopc::VCmpGtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_gt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support SDWA";
   return std::make_unique<VCmpGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -4732,16 +5446,21 @@ VCmpNeI64Vopc::VCmpNeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ne_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support SDWA";
   return std::make_unique<VCmpNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -4762,16 +5481,21 @@ VCmpGeI64Vopc::VCmpGeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ge_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support SDWA";
   return std::make_unique<VCmpGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -4792,16 +5516,21 @@ VCmpTI64Vopc::VCmpTI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_T_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_t_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I64 does not support SDWA";
   return std::make_unique<VCmpTI64Vopc>(opcode);
 }
 } // namespace detail
@@ -4822,16 +5551,22 @@ VCmpClassF64Vopc::VCmpClassF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_class_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support SDWA";
   return std::make_unique<VCmpClassF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4855,9 +5590,6 @@ VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4885,7 +5617,18 @@ VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_u16_sdwa"
+          : "v_cmp_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U16 does not support DPP";
   return std::make_unique<VCmpLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -4909,9 +5652,6 @@ VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4939,7 +5679,18 @@ VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_u16_sdwa"
+          : "v_cmp_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U16 does not support DPP";
   return std::make_unique<VCmpEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -4963,9 +5714,6 @@ VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4993,7 +5741,18 @@ VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_u16_sdwa"
+          : "v_cmp_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U16 does not support DPP";
   return std::make_unique<VCmpLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5017,9 +5776,6 @@ VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5047,7 +5803,18 @@ VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_u16_sdwa"
+          : "v_cmp_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U16 does not support DPP";
   return std::make_unique<VCmpGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5071,9 +5838,6 @@ VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5101,7 +5865,18 @@ VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_u16_sdwa"
+          : "v_cmp_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U16 does not support DPP";
   return std::make_unique<VCmpNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5125,9 +5900,6 @@ VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5155,7 +5927,18 @@ VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_u16_sdwa"
+          : "v_cmp_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U16 does not support DPP";
   return std::make_unique<VCmpGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5178,18 +5961,23 @@ VCmpxFI64Vopc::VCmpxFI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_F_I64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_f_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I64 does not support SDWA";
   return std::make_unique<VCmpxFI64Vopc>(opcode);
 }
 } // namespace detail
@@ -5212,18 +6000,23 @@ VCmpxLtI64Vopc::VCmpxLtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support SDWA";
   return std::make_unique<VCmpxLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -5246,18 +6039,23 @@ VCmpxEqI64Vopc::VCmpxEqI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_eq_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support SDWA";
   return std::make_unique<VCmpxEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -5280,18 +6078,23 @@ VCmpxLeI64Vopc::VCmpxLeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_le_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support SDWA";
   return std::make_unique<VCmpxLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -5314,18 +6117,23 @@ VCmpxGtI64Vopc::VCmpxGtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_gt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support SDWA";
   return std::make_unique<VCmpxGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -5348,18 +6156,23 @@ VCmpxNeI64Vopc::VCmpxNeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ne_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support SDWA";
   return std::make_unique<VCmpxNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -5382,18 +6195,23 @@ VCmpxGeI64Vopc::VCmpxGeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ge_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support SDWA";
   return std::make_unique<VCmpxGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -5416,18 +6234,23 @@ VCmpxTI64Vopc::VCmpxTI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_T_I64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_t_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I64 does not support SDWA";
   return std::make_unique<VCmpxTI64Vopc>(opcode);
 }
 } // namespace detail
@@ -5450,18 +6273,24 @@ VCmpxClassF64Vopc::VCmpxClassF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_class_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support SDWA";
   return std::make_unique<VCmpxClassF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5487,9 +6316,6 @@ VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5519,7 +6345,18 @@ VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_u16_sdwa"
+          : "v_cmpx_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U16 does not support DPP";
   return std::make_unique<VCmpxLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5545,9 +6382,6 @@ VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5577,7 +6411,18 @@ VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_u16_sdwa"
+          : "v_cmpx_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U16 does not support DPP";
   return std::make_unique<VCmpxEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5603,9 +6448,6 @@ VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5635,7 +6477,18 @@ VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_u16_sdwa"
+          : "v_cmpx_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U16 does not support DPP";
   return std::make_unique<VCmpxLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5661,9 +6514,6 @@ VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5693,7 +6543,18 @@ VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_u16_sdwa"
+          : "v_cmpx_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U16 does not support DPP";
   return std::make_unique<VCmpxGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5719,9 +6580,6 @@ VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5751,7 +6609,18 @@ VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_u16_sdwa"
+          : "v_cmpx_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U16 does not support DPP";
   return std::make_unique<VCmpxNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5777,9 +6646,6 @@ VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5809,7 +6675,18 @@ VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_u16_sdwa"
+          : "v_cmpx_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U16 does not support DPP";
   return std::make_unique<VCmpxGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5831,9 +6708,6 @@ VCmpFU32Vopc::VCmpFU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5861,7 +6735,18 @@ VCmpFU32Vopc::VCmpFU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_u32_sdwa"
+          : "v_cmp_f_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U32 does not support DPP";
   return std::make_unique<VCmpFU32Vopc>(opcode);
 }
 } // namespace detail
@@ -5884,9 +6769,6 @@ VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5914,7 +6796,18 @@ VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_u32_sdwa"
+          : "v_cmp_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U32 does not support DPP";
   return std::make_unique<VCmpLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -5937,9 +6830,6 @@ VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5967,7 +6857,18 @@ VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_u32_sdwa"
+          : "v_cmp_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U32 does not support DPP";
   return std::make_unique<VCmpEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -5990,9 +6891,6 @@ VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6020,7 +6918,18 @@ VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_u32_sdwa"
+          : "v_cmp_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U32 does not support DPP";
   return std::make_unique<VCmpLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6043,9 +6952,6 @@ VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6073,7 +6979,18 @@ VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_u32_sdwa"
+          : "v_cmp_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U32 does not support DPP";
   return std::make_unique<VCmpGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6096,9 +7013,6 @@ VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6126,7 +7040,18 @@ VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_u32_sdwa"
+          : "v_cmp_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U32 does not support DPP";
   return std::make_unique<VCmpNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6149,9 +7074,6 @@ VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6179,7 +7101,18 @@ VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_u32_sdwa"
+          : "v_cmp_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U32 does not support DPP";
   return std::make_unique<VCmpGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6201,9 +7134,6 @@ VCmpTU32Vopc::VCmpTU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6231,7 +7161,18 @@ VCmpTU32Vopc::VCmpTU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_u32_sdwa"
+          : "v_cmp_t_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U32 does not support DPP";
   return std::make_unique<VCmpTU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6254,9 +7195,6 @@ VCmpFF16Vopc::VCmpFF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6284,7 +7222,18 @@ VCmpFF16Vopc::VCmpFF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_f16_sdwa"
+          : "v_cmp_f_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F16 does not support DPP";
   return std::make_unique<VCmpFF16Vopc>(opcode);
 }
 } // namespace detail
@@ -6308,9 +7257,6 @@ VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6338,7 +7284,18 @@ VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_f16_sdwa"
+          : "v_cmp_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F16 does not support DPP";
   return std::make_unique<VCmpLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -6362,9 +7319,6 @@ VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6392,7 +7346,18 @@ VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_f16_sdwa"
+          : "v_cmp_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F16 does not support DPP";
   return std::make_unique<VCmpEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -6416,9 +7381,6 @@ VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6446,7 +7408,18 @@ VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_f16_sdwa"
+          : "v_cmp_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F16 does not support DPP";
   return std::make_unique<VCmpLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -6470,9 +7443,6 @@ VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6500,7 +7470,18 @@ VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_f16_sdwa"
+          : "v_cmp_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F16 does not support DPP";
   return std::make_unique<VCmpGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -6524,9 +7505,6 @@ VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6554,7 +7532,18 @@ VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lg_f16_sdwa"
+          : "v_cmp_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F16 does not support DPP";
   return std::make_unique<VCmpLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -6578,9 +7567,6 @@ VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6608,7 +7594,18 @@ VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_f16_sdwa"
+          : "v_cmp_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F16 does not support DPP";
   return std::make_unique<VCmpGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -6631,9 +7628,6 @@ VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_O_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6661,7 +7655,18 @@ VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_o_f16_sdwa"
+          : "v_cmp_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F16 does not support DPP";
   return std::make_unique<VCmpOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -6686,9 +7691,6 @@ VCmpxFU32Vopc::VCmpxFU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6718,7 +7720,18 @@ VCmpxFU32Vopc::VCmpxFU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_u32_sdwa"
+          : "v_cmpx_f_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U32 does not support DPP";
   return std::make_unique<VCmpxFU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6743,9 +7756,6 @@ VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6775,7 +7785,18 @@ VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_u32_sdwa"
+          : "v_cmpx_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U32 does not support DPP";
   return std::make_unique<VCmpxLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6800,9 +7821,6 @@ VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6832,7 +7850,18 @@ VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_u32_sdwa"
+          : "v_cmpx_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U32 does not support DPP";
   return std::make_unique<VCmpxEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6857,9 +7886,6 @@ VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6889,7 +7915,18 @@ VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_u32_sdwa"
+          : "v_cmpx_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U32 does not support DPP";
   return std::make_unique<VCmpxLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6914,9 +7951,6 @@ VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6946,7 +7980,18 @@ VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_u32_sdwa"
+          : "v_cmpx_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U32 does not support DPP";
   return std::make_unique<VCmpxGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6971,9 +8016,6 @@ VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7003,7 +8045,18 @@ VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_u32_sdwa"
+          : "v_cmpx_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U32 does not support DPP";
   return std::make_unique<VCmpxNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7028,9 +8081,6 @@ VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7060,7 +8110,18 @@ VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_u32_sdwa"
+          : "v_cmpx_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U32 does not support DPP";
   return std::make_unique<VCmpxGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7085,9 +8146,6 @@ VCmpxTU32Vopc::VCmpxTU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7117,7 +8175,18 @@ VCmpxTU32Vopc::VCmpxTU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_u32_sdwa"
+          : "v_cmpx_t_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U32 does not support DPP";
   return std::make_unique<VCmpxTU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7143,9 +8212,6 @@ VCmpxFF16Vopc::VCmpxFF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7175,7 +8241,18 @@ VCmpxFF16Vopc::VCmpxFF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_f16_sdwa"
+          : "v_cmpx_f_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F16 does not support DPP";
   return std::make_unique<VCmpxFF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7201,9 +8278,6 @@ VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7233,7 +8307,18 @@ VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_f16_sdwa"
+          : "v_cmpx_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F16 does not support DPP";
   return std::make_unique<VCmpxLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7259,9 +8344,6 @@ VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7291,7 +8373,18 @@ VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_f16_sdwa"
+          : "v_cmpx_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F16 does not support DPP";
   return std::make_unique<VCmpxEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7317,9 +8410,6 @@ VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7349,7 +8439,18 @@ VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_f16_sdwa"
+          : "v_cmpx_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F16 does not support DPP";
   return std::make_unique<VCmpxLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7375,9 +8476,6 @@ VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7407,7 +8505,18 @@ VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_f16_sdwa"
+          : "v_cmpx_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F16 does not support DPP";
   return std::make_unique<VCmpxGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7433,9 +8542,6 @@ VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7465,7 +8571,18 @@ VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lg_f16_sdwa"
+          : "v_cmpx_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F16 does not support DPP";
   return std::make_unique<VCmpxLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7491,9 +8608,6 @@ VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7523,7 +8637,18 @@ VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_f16_sdwa"
+          : "v_cmpx_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F16 does not support DPP";
   return std::make_unique<VCmpxGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7549,9 +8674,6 @@ VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_O_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7581,7 +8703,18 @@ VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_o_f16_sdwa"
+          : "v_cmpx_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F16 does not support DPP";
   return std::make_unique<VCmpxOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7602,16 +8735,21 @@ VCmpFU64Vopc::VCmpFU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_F_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_f_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U64 does not support SDWA";
   return std::make_unique<VCmpFU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7632,16 +8770,21 @@ VCmpLtU64Vopc::VCmpLtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support SDWA";
   return std::make_unique<VCmpLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7662,16 +8805,21 @@ VCmpEqU64Vopc::VCmpEqU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_eq_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support SDWA";
   return std::make_unique<VCmpEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7692,16 +8840,21 @@ VCmpLeU64Vopc::VCmpLeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_le_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support SDWA";
   return std::make_unique<VCmpLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7722,16 +8875,21 @@ VCmpGtU64Vopc::VCmpGtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_gt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support SDWA";
   return std::make_unique<VCmpGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7752,16 +8910,21 @@ VCmpNeU64Vopc::VCmpNeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ne_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support SDWA";
   return std::make_unique<VCmpNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7782,16 +8945,21 @@ VCmpGeU64Vopc::VCmpGeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ge_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support SDWA";
   return std::make_unique<VCmpGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7812,16 +8980,21 @@ VCmpTU64Vopc::VCmpTU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_T_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_t_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U64 does not support SDWA";
   return std::make_unique<VCmpTU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7844,9 +9017,6 @@ VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_U_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7874,7 +9044,18 @@ VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_u_f16_sdwa"
+          : "v_cmp_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F16 does not support DPP";
   return std::make_unique<VCmpUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7898,9 +9079,6 @@ VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7928,7 +9106,18 @@ VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nge_f16_sdwa"
+          : "v_cmp_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F16 does not support DPP";
   return std::make_unique<VCmpNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7952,9 +9141,6 @@ VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7982,7 +9168,18 @@ VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlg_f16_sdwa"
+          : "v_cmp_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F16 does not support DPP";
   return std::make_unique<VCmpNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8006,9 +9203,6 @@ VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8036,7 +9230,18 @@ VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ngt_f16_sdwa"
+          : "v_cmp_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F16 does not support DPP";
   return std::make_unique<VCmpNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8060,9 +9265,6 @@ VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8090,7 +9292,18 @@ VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nle_f16_sdwa"
+          : "v_cmp_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F16 does not support DPP";
   return std::make_unique<VCmpNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8114,9 +9327,6 @@ VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NEQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8144,7 +9354,18 @@ VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_neq_f16_sdwa"
+          : "v_cmp_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F16 does not support DPP";
   return std::make_unique<VCmpNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8168,9 +9389,6 @@ VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8198,7 +9416,18 @@ VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlt_f16_sdwa"
+          : "v_cmp_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F16 does not support DPP";
   return std::make_unique<VCmpNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8222,9 +9451,6 @@ VCmpTruF16Vopc::VCmpTruF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_TRU_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8252,7 +9478,18 @@ VCmpTruF16Vopc::VCmpTruF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_tru_f16_sdwa"
+          : "v_cmp_tru_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F16 does not support DPP";
   return std::make_unique<VCmpTruF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8275,18 +9512,23 @@ VCmpxFU64Vopc::VCmpxFU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_F_U64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_f_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U64 does not support SDWA";
   return std::make_unique<VCmpxFU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8309,18 +9551,23 @@ VCmpxLtU64Vopc::VCmpxLtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support SDWA";
   return std::make_unique<VCmpxLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8343,18 +9590,23 @@ VCmpxEqU64Vopc::VCmpxEqU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_eq_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support SDWA";
   return std::make_unique<VCmpxEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8377,18 +9629,23 @@ VCmpxLeU64Vopc::VCmpxLeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_le_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support SDWA";
   return std::make_unique<VCmpxLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8411,18 +9668,23 @@ VCmpxGtU64Vopc::VCmpxGtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_gt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support SDWA";
   return std::make_unique<VCmpxGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8445,18 +9707,23 @@ VCmpxNeU64Vopc::VCmpxNeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ne_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support SDWA";
   return std::make_unique<VCmpxNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8479,18 +9746,23 @@ VCmpxGeU64Vopc::VCmpxGeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ge_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support SDWA";
   return std::make_unique<VCmpxGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8513,18 +9785,23 @@ VCmpxTU64Vopc::VCmpxTU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_T_U64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_t_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U64 does not support SDWA";
   return std::make_unique<VCmpxTU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8550,9 +9827,6 @@ VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_U_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8582,7 +9856,18 @@ VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_u_f16_sdwa"
+          : "v_cmpx_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F16 does not support DPP";
   return std::make_unique<VCmpxUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8608,9 +9893,6 @@ VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8640,7 +9922,19 @@ VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nge_f16_sdwa"
+          : "v_cmpx_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F16 does not support DPP";
   return std::make_unique<VCmpxNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8666,9 +9960,6 @@ VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8698,7 +9989,19 @@ VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlg_f16_sdwa"
+          : "v_cmpx_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F16 does not support DPP";
   return std::make_unique<VCmpxNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8724,9 +10027,6 @@ VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8756,7 +10056,19 @@ VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ngt_f16_sdwa"
+          : "v_cmpx_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F16 does not support DPP";
   return std::make_unique<VCmpxNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8782,9 +10094,6 @@ VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8814,7 +10123,19 @@ VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nle_f16_sdwa"
+          : "v_cmpx_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F16 does not support DPP";
   return std::make_unique<VCmpxNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8840,9 +10161,6 @@ VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NEQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8872,7 +10190,19 @@ VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_neq_f16_sdwa"
+          : "v_cmpx_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F16 does not support DPP";
   return std::make_unique<VCmpxNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8898,9 +10228,6 @@ VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8930,7 +10257,19 @@ VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlt_f16_sdwa"
+          : "v_cmpx_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F16 does not support DPP";
   return std::make_unique<VCmpxNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8956,9 +10295,6 @@ VCmpxTruF16Vopc::VCmpxTruF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_TRU_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8988,7 +10324,19 @@ VCmpxTruF16Vopc::VCmpxTruF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_tru_f16_sdwa"
+          : "v_cmpx_tru_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F16 does not support DPP";
   return std::make_unique<VCmpxTruF16Vopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/decoder.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/decoder.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/vop3p.h"
-#include "util/except.h"
 #include <array>
 #include <bit>
 #include <format>
@@ -15,1415 +14,1908 @@ namespace rocjitsu {
 namespace rdna2 {
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCsubMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicFcmpswapMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicFcmpswapX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicFmaxMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicFmaxX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicFminMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicFminX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSminMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUminMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferGl0InvMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferGl1InvMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSbyteMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadShortD16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadSshortMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUbyteMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadUshortMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreByteMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreShortMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAppendDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsBpermuteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsConsumeDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsBarrierDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsInitDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaBrDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaPDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaVDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsNopDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrderedCountDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPermuteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2st64B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRead2st64B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadAddtidB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB128Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadB96Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI8D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadI8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU16D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU16D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU8D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsReadU8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSwizzleB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrapRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2st64B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrite2st64B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteAddtidB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB128Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB16D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWriteB96Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeExpExp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicFcmpswapFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicFcmpswapX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicFmaxFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicFmaxX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicFminFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicFminX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSminFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSminX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUminFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicUminX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorX2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordx2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordx3Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadDwordx4Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSbyteFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadShortD16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadShortD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadSshortFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUbyteFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadUshortFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreByteD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreByteFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordx2Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordx3Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreDwordx4Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreShortD16HiFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreShortFlat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicAddMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicAndMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicCmpswapMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicDecMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicFcmpswapMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicFmaxMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicFminMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicIncMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicOrMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSmaxMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSminMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSubMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSwapMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicUmaxMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicUminMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicXorMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageBvh64IntersectRayMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageBvhIntersectRayMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4BClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4BClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4BMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4BOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CBClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CBClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CBMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CBOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4COMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4ClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4ClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4OMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4hMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4hPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather8hPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGetLodMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGetResinfoMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadBy2Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadBy4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipBy2Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipBy4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipPck2Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipPck4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipPckSgnMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadPck2Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadPck4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadPckSgnMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageMsaaLoadMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdClG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdClOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCCdOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdClG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdClOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCdOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreBy2Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreBy4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipBy2Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipBy4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipPck2Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipPck4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStorePck2Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStorePck4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStorePckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddcU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn1SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn1WrexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn1WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2WrexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndn2WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBarrierSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCallB64Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbguserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClauseSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkEqI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkEqU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGeI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGeU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGtI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGtU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLeI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLeU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLgI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLgU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLtI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLtU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCodeEndSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDenormModeSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf0I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf0I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf1I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFf1I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32I64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFlbitI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetpcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGl1InvSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSInstPrefetchSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx2Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx4Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadDwordx8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMemrealtimeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMemtimeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsd2B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn1SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRfeB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRoundModeSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetkillSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetpcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubbU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubvectorLoopBeginSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubvectorLoopEndSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSwappcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTtracedataImmSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSVersionSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntDepctrSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntExpcntSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntLgkmcntSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntVmcntSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntVscntSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClrexcpVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClrexcpVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTruF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormI16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPknormU16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkrtzF16F32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2F32F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2I32I16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2U32U16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4I32I8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8I32I4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhI32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhU32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfbhU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfblB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFfblB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaLegacyF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixhiF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixloF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaakF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaakF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacLegacyF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacLegacyF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmamkF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmamkF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpMovF32Vintrp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpMovF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP1F32Vintrp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP1F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP1llF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP1lvF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2F32Vintrp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovreldB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovreldB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLegacyF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLegacyF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMullitF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlane16B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlanex16B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPipeflushVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPipeflushVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwaprelB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXor3B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode);
+DecodeResult decodeBufferAtomicAddMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCsubMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicFcmpswapMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicFcmpswapX2Mubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicFmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicFmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicFminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicFminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrMubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferGl0InvMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferGl1InvMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXMubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadShortD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadSshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadUshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreByteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreShortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAppendDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsBpermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsConsumeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsBarrierDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsInitDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaBrDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaPDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaVDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsNopDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrderedCountDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2st64B32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRead2st64B64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadAddtidB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI8D16HiDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadI8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU16D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU16D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU8D16HiDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsReadU8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSwizzleB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrapRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2st64B32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrite2st64B64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteAddtidB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB16D16HiDs(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB8D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWriteB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchgRtnB32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrxchgRtnB64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeExpExp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapFlat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicFcmpswapFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicFcmpswapX2Flat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicFmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicFmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicFminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicFminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrX2Flat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicUminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordx2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordx3Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadDwordx4Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadShortD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadShortD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadSshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadUshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreByteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreByteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordx2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordx3Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreDwordx4Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreShortD16HiFlat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreShortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicAddMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicAndMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicCmpswapMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicDecMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicFcmpswapMimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicFmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicFminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicIncMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicOrMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSubMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSwapMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicUmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicUminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicXorMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageBvh64IntersectRayMimg(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageBvhIntersectRayMimg(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4BClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4BClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4BMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4BOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CBClMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CBClOMimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CBMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CBOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLzMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLzOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4COMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4ClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4ClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4Mimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4OMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4hMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4hPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather8hPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGetLodMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGetResinfoMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadBy2Mimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadBy4Mimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipBy2Mimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipBy4Mimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipPck2Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipPck4Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipPckMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipPckSgnMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadPck2Mimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadPck4Mimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadPckMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadPckSgnMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageMsaaLoadMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdClG16Mimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdClMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdClOG16Mimg(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdClOMimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdOG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCCdOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClOG16Mimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDOG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdClG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdClOG16Mimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdOG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCdOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleClMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleClOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClOG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDG16Mimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDOG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLzMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLzOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleOMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreBy2Mimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreBy4Mimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipBy2Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipBy4Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipPck2Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipPck4Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStorePck2Mimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStorePck4Mimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStorePckMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddcU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn1SaveexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn1WrexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn1WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2SaveexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2WrexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndn2WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBarrierSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx16Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx4Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadDwordx8Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCallB64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysSopp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbguserSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClauseSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkEqI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkEqU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLgI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLgU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCodeEndSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDenormModeSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf0I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf0I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf1I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFf1I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32I64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFlbitI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGl1InvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSInstPrefetchSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx16Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx4Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadDwordx8Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMemrealtimeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMemtimeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsd2B32Sop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrSaveexecB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn1SaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2SaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRfeB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRoundModeSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetkillSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubbU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubvectorLoopBeginSopk(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubvectorLoopEndSopk(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSwappcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTtracedataImmSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSVersionSopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntDepctrSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntExpcntSopk(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntLgkmcntSopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntVmcntSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntVscntSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoCiU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClrexcpVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClrexcpVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTruF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTruF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFlrI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFlrI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPknormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkrtzF16F32Vop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtRpiI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtRpiI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2F32F16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2I32I16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2U32U16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2cF32F16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4I32I8Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4cI32I8Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8I32I4Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhU32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfbhU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfblB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFfblB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacLegacyF32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacLegacyF32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmamkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmamkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpMovF32Vintrp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpMovF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP1F32Vintrp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP1F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP1llF16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP1lvF16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2F32Vintrp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovreldB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovreldB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsd2B32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsd2B32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsdB32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsdB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLegacyF32Vop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMullitF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlane16B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlanex16B32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPipeflushVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPipeflushVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoCiU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoCiU32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevNcU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevNcU32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwaprelB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXor3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 } // namespace detail
 
 struct DecoderImpl {
 public:
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 
 private:
-  using DecodeFunc = std::unique_ptr<Instruction> (*)(const MachineInst *);
-  static std::unique_ptr<Instruction> decodeInvalid(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopp(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVintrp(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3p(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeDs(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeFlat(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMubuf(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMtbuf(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMimg(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSmem(const MachineInst *opcode);
+  using DecodeFunc = DecodeResult (*)(const MachineInst *, const DecodeErrorEmitter &);
+  static DecodeResult decodeInvalid(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVintrp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMtbuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
   static const std::array<DecodeFunc, 512> primary_decode_table;
   static const std::array<DecodeFunc, 256> sub_decode_vopc;
   static const std::array<DecodeFunc, 256> sub_decode_vop1;
@@ -1441,88 +1933,102 @@ private:
   static const std::array<DecodeFunc, 256> sub_decode_smem;
 };
 
-std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
-  return DecoderImpl::decode(opcode);
+DecodeResult Decoder::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  return DecoderImpl::decode(opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decode(const MachineInst *opcode) {
+DecodeResult DecoderImpl::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
   Sop1MachineInst op = std::bit_cast<decltype(op)>(*opcode);
-  return primary_decode_table[op.encoding](opcode);
+  return primary_decode_table[op.encoding](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decodeInvalid(const MachineInst *opcode) {
-  throw util::InvalidInst(std::format("{:X}", *opcode));
-  return nullptr;
+DecodeResult DecoderImpl::decodeInvalid(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  return emit_error.emit() << "Invalid instruction opcode: " << std::format("{:X}", *opcode);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vopc[op.op](opcode);
+  return sub_decode_vopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop1[op.op](opcode);
+  return sub_decode_vop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sop1[op.op](opcode);
+  return sub_decode_sop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopc[op.op](opcode);
+  return sub_decode_sopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopp(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopp::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopp[op.op](opcode);
+  return sub_decode_sopp[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVintrp(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVintrp(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
   Vintrp::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vintrp[op.op](opcode);
+  return sub_decode_vintrp[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3p(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3p(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Vop3p::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3p[op.op](opcode);
+  return sub_decode_vop3p[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop3::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3[op.op](opcode);
+  return sub_decode_vop3[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeDs(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeDs(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
   Ds::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_ds[op.op](opcode);
+  return sub_decode_ds[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeFlat(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeFlat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Flat::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_flat[op.op](opcode);
+  return sub_decode_flat[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMubuf(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Mubuf::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mubuf[op.op](opcode);
+  return sub_decode_mubuf[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMtbuf(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMtbuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Mtbuf::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mtbuf[op.op](opcode);
+  return sub_decode_mtbuf[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMimg(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Mimg::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mimg[op.op](opcode);
+  return sub_decode_mimg[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSmem(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Smem::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_smem[op.op](opcode);
+  return sub_decode_smem[op.op](opcode, emit_error);
 }
 
 const std::array<DecoderImpl::DecodeFunc, 512> DecoderImpl::primary_decode_table = {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/decoder.h
@@ -8,6 +8,7 @@
 #define ROCJITSU_ISA_ARCH_AMDGPU_RDNA2_DECODER_H_
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/machine_insts.h"
+#include "rocjitsu/isa/decode_result.h"
 #include <array>
 #include <cstddef>
 #include <memory>
@@ -21,7 +22,7 @@ namespace rdna2 {
 class Decoder {
 public:
   static constexpr std::size_t kMaxInstructionWords = 3;
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 };
 
 } // namespace rdna2

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/ds.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/ds.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/ds.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -31,7 +30,11 @@ DsAddU32Ds::DsAddU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU32Ds>(opcode);
 }
 } // namespace detail
@@ -54,7 +57,11 @@ DsSubU32Ds::DsSubU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU32Ds>(opcode);
 }
 } // namespace detail
@@ -77,7 +84,11 @@ DsRsubU32Ds::DsRsubU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU32Ds>(opcode);
 }
 } // namespace detail
@@ -100,7 +111,11 @@ DsIncU32Ds::DsIncU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU32Ds>(opcode);
 }
 } // namespace detail
@@ -123,7 +138,11 @@ DsDecU32Ds::DsDecU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU32Ds>(opcode);
 }
 } // namespace detail
@@ -146,7 +165,11 @@ DsMinI32Ds::DsMinI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI32Ds>(opcode);
 }
 } // namespace detail
@@ -169,7 +192,11 @@ DsMaxI32Ds::DsMaxI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI32Ds>(opcode);
 }
 } // namespace detail
@@ -192,7 +219,11 @@ DsMinU32Ds::DsMinU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU32Ds>(opcode);
 }
 } // namespace detail
@@ -215,7 +246,11 @@ DsMaxU32Ds::DsMaxU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU32Ds>(opcode);
 }
 } // namespace detail
@@ -238,7 +273,11 @@ DsAndB32Ds::DsAndB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB32Ds>(opcode);
 }
 } // namespace detail
@@ -261,7 +300,11 @@ DsOrB32Ds::DsOrB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB32Ds>(opcode);
 }
 } // namespace detail
@@ -284,7 +327,11 @@ DsXorB32Ds::DsXorB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB32Ds>(opcode);
 }
 } // namespace detail
@@ -309,7 +356,11 @@ DsMskorB32Ds::DsMskorB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB32Ds>(opcode);
 }
 } // namespace detail
@@ -330,7 +381,11 @@ DsWriteB32Ds::DsWriteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB32Ds>(opcode);
 }
 } // namespace detail
@@ -353,7 +408,11 @@ DsWrite2B32Ds::DsWrite2B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2B32Ds>(opcode);
 }
 } // namespace detail
@@ -376,7 +435,12 @@ DsWrite2st64B32Ds::DsWrite2st64B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2st64B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2st64B32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2st64_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2st64B32Ds>(opcode);
 }
 } // namespace detail
@@ -401,7 +465,11 @@ DsCmpstB32Ds::DsCmpstB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstB32Ds>(opcode);
 }
 } // namespace detail
@@ -426,7 +494,11 @@ DsCmpstF32Ds::DsCmpstF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstF32Ds>(opcode);
 }
 } // namespace detail
@@ -449,7 +521,11 @@ DsMinF32Ds::DsMinF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinF32Ds>(opcode);
 }
 } // namespace detail
@@ -472,7 +548,11 @@ DsMaxF32Ds::DsMaxF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxF32Ds>(opcode);
 }
 } // namespace detail
@@ -485,7 +565,11 @@ DsNopDs::DsNopDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsNopDs(const MachineInst *opcode) {
+DecodeResult decodeDsNopDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Ds::validate_encoding("ds_nop", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsNopDs>(opcode);
 }
 } // namespace detail
@@ -508,7 +592,11 @@ DsAddF32Ds::DsAddF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddF32Ds>(opcode);
 }
 } // namespace detail
@@ -521,7 +609,12 @@ DsGwsSemaReleaseAllDs::DsGwsSemaReleaseAllDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_release_all", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaReleaseAllDs>(opcode);
 }
 } // namespace detail
@@ -536,7 +629,11 @@ DsGwsInitDs::DsGwsInitDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsInitDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsInitDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_init", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsInitDs>(opcode);
 }
 } // namespace detail
@@ -549,7 +646,11 @@ DsGwsSemaVDs::DsGwsSemaVDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaVDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaVDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_v", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaVDs>(opcode);
 }
 } // namespace detail
@@ -564,7 +665,11 @@ DsGwsSemaBrDs::DsGwsSemaBrDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaBrDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaBrDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_br", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaBrDs>(opcode);
 }
 } // namespace detail
@@ -577,7 +682,11 @@ DsGwsSemaPDs::DsGwsSemaPDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaPDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaPDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_p", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaPDs>(opcode);
 }
 } // namespace detail
@@ -592,7 +701,11 @@ DsGwsBarrierDs::DsGwsBarrierDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsBarrierDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsBarrierDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_barrier", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsBarrierDs>(opcode);
 }
 } // namespace detail
@@ -613,7 +726,11 @@ DsWriteB8Ds::DsWriteB8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB8Ds>(opcode);
 }
 } // namespace detail
@@ -634,7 +751,11 @@ DsWriteB16Ds::DsWriteB16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB16Ds>(opcode);
 }
 } // namespace detail
@@ -659,7 +780,11 @@ DsAddRtnU32Ds::DsAddRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -684,7 +809,11 @@ DsSubRtnU32Ds::DsSubRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -709,7 +838,11 @@ DsRsubRtnU32Ds::DsRsubRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -734,7 +867,11 @@ DsIncRtnU32Ds::DsIncRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -759,7 +896,11 @@ DsDecRtnU32Ds::DsDecRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -784,7 +925,11 @@ DsMinRtnI32Ds::DsMinRtnI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI32Ds>(opcode);
 }
 } // namespace detail
@@ -809,7 +954,11 @@ DsMaxRtnI32Ds::DsMaxRtnI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI32Ds>(opcode);
 }
 } // namespace detail
@@ -834,7 +983,11 @@ DsMinRtnU32Ds::DsMinRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -859,7 +1012,11 @@ DsMaxRtnU32Ds::DsMaxRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -884,7 +1041,11 @@ DsAndRtnB32Ds::DsAndRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -909,7 +1070,11 @@ DsOrRtnB32Ds::DsOrRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -934,7 +1099,11 @@ DsXorRtnB32Ds::DsXorRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -961,7 +1130,12 @@ DsMskorRtnB32Ds::DsMskorRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -986,7 +1160,12 @@ DsWrxchgRtnB32Ds::DsWrxchgRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchgRtnB32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchgRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1013,7 +1192,12 @@ DsWrxchg2RtnB32Ds::DsWrxchg2RtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2RtnB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2RtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1040,7 +1224,12 @@ DsWrxchg2st64RtnB32Ds::DsWrxchg2st64RtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2st64RtnB32Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2st64_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2st64RtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1067,7 +1256,12 @@ DsCmpstRtnB32Ds::DsCmpstRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1094,7 +1288,12 @@ DsCmpstRtnF32Ds::DsCmpstRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnF32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1119,7 +1318,11 @@ DsMinRtnF32Ds::DsMinRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1144,7 +1347,11 @@ DsMaxRtnF32Ds::DsMaxRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1170,7 +1377,11 @@ DsWrapRtnB32Ds::DsWrapRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrapRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrapRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrap_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrapRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1187,7 +1398,11 @@ DsSwizzleB32Ds::DsSwizzleB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSwizzleB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSwizzleB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_swizzle_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSwizzleB32Ds>(opcode);
 }
 } // namespace detail
@@ -1208,7 +1423,11 @@ DsReadB32Ds::DsReadB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB32Ds>(opcode);
 }
 } // namespace detail
@@ -1229,7 +1448,11 @@ DsRead2B32Ds::DsRead2B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2B32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2B32Ds>(opcode);
 }
 } // namespace detail
@@ -1250,7 +1473,12 @@ DsRead2st64B32Ds::DsRead2st64B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2st64B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2st64B32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2st64_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2st64B32Ds>(opcode);
 }
 } // namespace detail
@@ -1271,7 +1499,11 @@ DsReadI8Ds::DsReadI8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadI8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI8Ds>(opcode);
 }
 } // namespace detail
@@ -1298,7 +1530,11 @@ DsReadU8Ds::DsReadU8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU8Ds>(opcode);
 }
 } // namespace detail
@@ -1325,7 +1561,11 @@ DsReadI16Ds::DsReadI16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadI16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI16Ds>(opcode);
 }
 } // namespace detail
@@ -1352,7 +1592,11 @@ DsReadU16Ds::DsReadU16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU16Ds>(opcode);
 }
 } // namespace detail
@@ -1379,7 +1623,11 @@ DsConsumeDs::DsConsumeDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsConsumeDs(const MachineInst *opcode) {
+DecodeResult decodeDsConsumeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_consume", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsConsumeDs>(opcode);
 }
 } // namespace detail
@@ -1400,7 +1648,11 @@ DsAppendDs::DsAppendDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAppendDs(const MachineInst *opcode) {
+DecodeResult decodeDsAppendDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_append", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAppendDs>(opcode);
 }
 } // namespace detail
@@ -1420,7 +1672,12 @@ DsOrderedCountDs::DsOrderedCountDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrderedCountDs(const MachineInst *opcode) {
+DecodeResult decodeDsOrderedCountDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_ordered_count", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrderedCountDs>(opcode);
 }
 } // namespace detail
@@ -1443,7 +1700,11 @@ DsAddU64Ds::DsAddU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU64Ds>(opcode);
 }
 } // namespace detail
@@ -1466,7 +1727,11 @@ DsSubU64Ds::DsSubU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU64Ds>(opcode);
 }
 } // namespace detail
@@ -1489,7 +1754,11 @@ DsRsubU64Ds::DsRsubU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU64Ds>(opcode);
 }
 } // namespace detail
@@ -1512,7 +1781,11 @@ DsIncU64Ds::DsIncU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU64Ds>(opcode);
 }
 } // namespace detail
@@ -1535,7 +1808,11 @@ DsDecU64Ds::DsDecU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU64Ds>(opcode);
 }
 } // namespace detail
@@ -1558,7 +1835,11 @@ DsMinI64Ds::DsMinI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI64Ds>(opcode);
 }
 } // namespace detail
@@ -1581,7 +1862,11 @@ DsMaxI64Ds::DsMaxI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI64Ds>(opcode);
 }
 } // namespace detail
@@ -1604,7 +1889,11 @@ DsMinU64Ds::DsMinU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU64Ds>(opcode);
 }
 } // namespace detail
@@ -1627,7 +1916,11 @@ DsMaxU64Ds::DsMaxU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU64Ds>(opcode);
 }
 } // namespace detail
@@ -1650,7 +1943,11 @@ DsAndB64Ds::DsAndB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB64Ds>(opcode);
 }
 } // namespace detail
@@ -1673,7 +1970,11 @@ DsOrB64Ds::DsOrB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB64Ds>(opcode);
 }
 } // namespace detail
@@ -1696,7 +1997,11 @@ DsXorB64Ds::DsXorB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB64Ds>(opcode);
 }
 } // namespace detail
@@ -1721,7 +2026,11 @@ DsMskorB64Ds::DsMskorB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB64Ds>(opcode);
 }
 } // namespace detail
@@ -1742,7 +2051,11 @@ DsWriteB64Ds::DsWriteB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB64Ds>(opcode);
 }
 } // namespace detail
@@ -1765,7 +2078,11 @@ DsWrite2B64Ds::DsWrite2B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2B64Ds>(opcode);
 }
 } // namespace detail
@@ -1788,7 +2105,12 @@ DsWrite2st64B64Ds::DsWrite2st64B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrite2st64B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrite2st64B64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write2st64_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrite2st64B64Ds>(opcode);
 }
 } // namespace detail
@@ -1813,7 +2135,11 @@ DsCmpstB64Ds::DsCmpstB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstB64Ds>(opcode);
 }
 } // namespace detail
@@ -1838,7 +2164,11 @@ DsCmpstF64Ds::DsCmpstF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstF64Ds>(opcode);
 }
 } // namespace detail
@@ -1861,7 +2191,11 @@ DsMinF64Ds::DsMinF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinF64Ds>(opcode);
 }
 } // namespace detail
@@ -1884,7 +2218,11 @@ DsMaxF64Ds::DsMaxF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxF64Ds>(opcode);
 }
 } // namespace detail
@@ -1909,7 +2247,11 @@ DsAddRtnF32Ds::DsAddRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1934,7 +2276,11 @@ DsAddRtnU64Ds::DsAddRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -1959,7 +2305,11 @@ DsSubRtnU64Ds::DsSubRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -1984,7 +2334,11 @@ DsRsubRtnU64Ds::DsRsubRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2009,7 +2363,11 @@ DsIncRtnU64Ds::DsIncRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2034,7 +2392,11 @@ DsDecRtnU64Ds::DsDecRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2059,7 +2421,11 @@ DsMinRtnI64Ds::DsMinRtnI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI64Ds>(opcode);
 }
 } // namespace detail
@@ -2084,7 +2450,11 @@ DsMaxRtnI64Ds::DsMaxRtnI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI64Ds>(opcode);
 }
 } // namespace detail
@@ -2109,7 +2479,11 @@ DsMinRtnU64Ds::DsMinRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2134,7 +2508,11 @@ DsMaxRtnU64Ds::DsMaxRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2159,7 +2537,11 @@ DsAndRtnB64Ds::DsAndRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2184,7 +2566,11 @@ DsOrRtnB64Ds::DsOrRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2209,7 +2595,11 @@ DsXorRtnB64Ds::DsXorRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2236,7 +2626,12 @@ DsMskorRtnB64Ds::DsMskorRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2261,7 +2656,12 @@ DsWrxchgRtnB64Ds::DsWrxchgRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchgRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchgRtnB64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchgRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2288,7 +2688,12 @@ DsWrxchg2RtnB64Ds::DsWrxchg2RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2RtnB64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2315,7 +2720,12 @@ DsWrxchg2st64RtnB64Ds::DsWrxchg2st64RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrxchg2st64RtnB64Ds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrxchg2st64_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrxchg2st64RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2342,7 +2752,12 @@ DsCmpstRtnB64Ds::DsCmpstRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnB64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2369,7 +2784,12 @@ DsCmpstRtnF64Ds::DsCmpstRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstRtnF64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpst_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -2394,7 +2814,11 @@ DsMinRtnF64Ds::DsMinRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -2419,7 +2843,11 @@ DsMaxRtnF64Ds::DsMaxRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -2440,7 +2868,11 @@ DsReadB64Ds::DsReadB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB64Ds>(opcode);
 }
 } // namespace detail
@@ -2461,7 +2893,11 @@ DsRead2B64Ds::DsRead2B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2B64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2B64Ds>(opcode);
 }
 } // namespace detail
@@ -2482,7 +2918,12 @@ DsRead2st64B64Ds::DsRead2st64B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRead2st64B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRead2st64B64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read2st64_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRead2st64B64Ds>(opcode);
 }
 } // namespace detail
@@ -2507,7 +2948,12 @@ DsCondxchg32RtnB64Ds::DsCondxchg32RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_condxchg32_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCondxchg32RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2528,7 +2974,12 @@ DsWriteB8D16HiDs::DsWriteB8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB8D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2549,7 +3000,12 @@ DsWriteB16D16HiDs::DsWriteB16D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB16D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB16D16HiDs(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b16_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB16D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2570,7 +3026,11 @@ DsReadU8D16Ds::DsReadU8D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU8D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u8_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU8D16Ds>(opcode);
 }
 } // namespace detail
@@ -2597,7 +3057,12 @@ DsReadU8D16HiDs::DsReadU8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsReadU8D16HiDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2624,7 +3089,11 @@ DsReadI8D16Ds::DsReadI8D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI8D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i8_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI8D16Ds>(opcode);
 }
 } // namespace detail
@@ -2651,7 +3120,12 @@ DsReadI8D16HiDs::DsReadI8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadI8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsReadI8D16HiDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_i8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadI8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2678,7 +3152,11 @@ DsReadU16D16Ds::DsReadU16D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU16D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadU16D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u16_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU16D16Ds>(opcode);
 }
 } // namespace detail
@@ -2705,7 +3183,12 @@ DsReadU16D16HiDs::DsReadU16D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadU16D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsReadU16D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_u16_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadU16D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2732,7 +3215,12 @@ DsWriteAddtidB32Ds::DsWriteAddtidB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteAddtidB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteAddtidB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_addtid_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteAddtidB32Ds>(opcode);
 }
 } // namespace detail
@@ -2753,7 +3241,12 @@ DsReadAddtidB32Ds::DsReadAddtidB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadAddtidB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadAddtidB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_addtid_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadAddtidB32Ds>(opcode);
 }
 } // namespace detail
@@ -2772,7 +3265,11 @@ DsPermuteB32Ds::DsPermuteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPermuteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsPermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_permute_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPermuteB32Ds>(opcode);
 }
 } // namespace detail
@@ -2791,7 +3288,12 @@ DsBpermuteB32Ds::DsBpermuteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsBpermuteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsBpermuteB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_bpermute_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsBpermuteB32Ds>(opcode);
 }
 } // namespace detail
@@ -2812,7 +3314,11 @@ DsWriteB96Ds::DsWriteB96Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB96Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b96", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB96Ds>(opcode);
 }
 } // namespace detail
@@ -2833,7 +3339,11 @@ DsWriteB128Ds::DsWriteB128Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWriteB128Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWriteB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_write_b128", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWriteB128Ds>(opcode);
 }
 } // namespace detail
@@ -2854,7 +3364,11 @@ DsReadB96Ds::DsReadB96Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB96Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b96", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB96Ds>(opcode);
 }
 } // namespace detail
@@ -2875,7 +3389,11 @@ DsReadB128Ds::DsReadB128Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsReadB128Ds(const MachineInst *opcode) {
+DecodeResult decodeDsReadB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_read_b128", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsReadB128Ds>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/encodings.h
@@ -10,6 +10,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna2/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
+#include "rocjitsu/isa/decode_result.h"
 #include "rocjitsu/isa/instruction.h"
 #include <array>
 #include <cstdint>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/exp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/exp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/exp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -33,7 +32,11 @@ ExpExp::ExpExp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeExpExp(const MachineInst *opcode) {
+DecodeResult decodeExpExp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Exp::validate_encoding("exp", reinterpret_cast<const Exp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ExpExp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/flat.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/flat.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/flat.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -40,7 +39,12 @@ FlatLoadUbyteFlat::FlatLoadUbyteFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUbyteFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ubyte", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUbyteFlat>(opcode);
 }
 } // namespace detail
@@ -72,7 +76,12 @@ FlatLoadSbyteFlat::FlatLoadSbyteFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSbyteFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSbyteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sbyte", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSbyteFlat>(opcode);
 }
 } // namespace detail
@@ -104,7 +113,12 @@ FlatLoadUshortFlat::FlatLoadUshortFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUshortFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ushort", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUshortFlat>(opcode);
 }
 } // namespace detail
@@ -136,7 +150,12 @@ FlatLoadSshortFlat::FlatLoadSshortFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSshortFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSshortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sshort", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSshortFlat>(opcode);
 }
 } // namespace detail
@@ -168,7 +187,12 @@ FlatLoadDwordFlat::FlatLoadDwordFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dword", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordFlat>(opcode);
 }
 } // namespace detail
@@ -200,7 +224,12 @@ FlatLoadDwordx2Flat::FlatLoadDwordx2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordx2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordx2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dwordx2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordx2Flat>(opcode);
 }
 } // namespace detail
@@ -232,7 +261,12 @@ FlatLoadDwordx4Flat::FlatLoadDwordx4Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordx4Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordx4Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dwordx4", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordx4Flat>(opcode);
 }
 } // namespace detail
@@ -264,7 +298,12 @@ FlatLoadDwordx3Flat::FlatLoadDwordx3Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadDwordx3Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadDwordx3Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_dwordx3", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadDwordx3Flat>(opcode);
 }
 } // namespace detail
@@ -296,7 +335,12 @@ FlatStoreByteFlat::FlatStoreByteFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreByteFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreByteFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_byte", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreByteFlat>(opcode);
 }
 } // namespace detail
@@ -328,7 +372,12 @@ FlatStoreByteD16HiFlat::FlatStoreByteD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreByteD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreByteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_byte_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreByteD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -360,7 +409,12 @@ FlatStoreShortFlat::FlatStoreShortFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreShortFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreShortFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_short", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreShortFlat>(opcode);
 }
 } // namespace detail
@@ -392,7 +446,12 @@ FlatStoreShortD16HiFlat::FlatStoreShortD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreShortD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreShortD16HiFlat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_short_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreShortD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -424,7 +483,12 @@ FlatStoreDwordFlat::FlatStoreDwordFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dword", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordFlat>(opcode);
 }
 } // namespace detail
@@ -456,7 +520,12 @@ FlatStoreDwordx2Flat::FlatStoreDwordx2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordx2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordx2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dwordx2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordx2Flat>(opcode);
 }
 } // namespace detail
@@ -488,7 +557,12 @@ FlatStoreDwordx4Flat::FlatStoreDwordx4Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordx4Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordx4Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dwordx4", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordx4Flat>(opcode);
 }
 } // namespace detail
@@ -520,7 +594,12 @@ FlatStoreDwordx3Flat::FlatStoreDwordx3Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreDwordx3Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreDwordx3Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_dwordx3", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreDwordx3Flat>(opcode);
 }
 } // namespace detail
@@ -552,7 +631,12 @@ FlatLoadUbyteD16Flat::FlatLoadUbyteD16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ubyte_d16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUbyteD16Flat>(opcode);
 }
 } // namespace detail
@@ -591,7 +675,12 @@ FlatLoadUbyteD16HiFlat::FlatLoadUbyteD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_ubyte_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadUbyteD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -630,7 +719,12 @@ FlatLoadSbyteD16Flat::FlatLoadSbyteD16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSbyteD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sbyte_d16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSbyteD16Flat>(opcode);
 }
 } // namespace detail
@@ -669,7 +763,12 @@ FlatLoadSbyteD16HiFlat::FlatLoadSbyteD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_sbyte_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadSbyteD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -708,7 +807,12 @@ FlatLoadShortD16Flat::FlatLoadShortD16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadShortD16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadShortD16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_short_d16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadShortD16Flat>(opcode);
 }
 } // namespace detail
@@ -747,7 +851,12 @@ FlatLoadShortD16HiFlat::FlatLoadShortD16HiFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadShortD16HiFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadShortD16HiFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_short_d16_hi", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadShortD16HiFlat>(opcode);
 }
 } // namespace detail
@@ -789,7 +898,12 @@ FlatAtomicSwapFlat::FlatAtomicSwapFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_swap", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapFlat>(opcode);
 }
 } // namespace detail
@@ -824,7 +938,12 @@ FlatAtomicCmpswapFlat::FlatAtomicCmpswapFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapFlat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_cmpswap", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapFlat>(opcode);
 }
 } // namespace detail
@@ -859,7 +978,12 @@ FlatAtomicAddFlat::FlatAtomicAddFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddFlat>(opcode);
 }
 } // namespace detail
@@ -894,7 +1018,12 @@ FlatAtomicSubFlat::FlatAtomicSubFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_sub", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubFlat>(opcode);
 }
 } // namespace detail
@@ -929,7 +1058,12 @@ FlatAtomicSminFlat::FlatAtomicSminFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSminFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smin", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSminFlat>(opcode);
 }
 } // namespace detail
@@ -964,7 +1098,12 @@ FlatAtomicUminFlat::FlatAtomicUminFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUminFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umin", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUminFlat>(opcode);
 }
 } // namespace detail
@@ -999,7 +1138,12 @@ FlatAtomicSmaxFlat::FlatAtomicSmaxFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smax", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSmaxFlat>(opcode);
 }
 } // namespace detail
@@ -1034,7 +1178,12 @@ FlatAtomicUmaxFlat::FlatAtomicUmaxFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umax", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUmaxFlat>(opcode);
 }
 } // namespace detail
@@ -1069,7 +1218,12 @@ FlatAtomicAndFlat::FlatAtomicAndFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_and", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndFlat>(opcode);
 }
 } // namespace detail
@@ -1104,7 +1258,12 @@ FlatAtomicOrFlat::FlatAtomicOrFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_or", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrFlat>(opcode);
 }
 } // namespace detail
@@ -1139,7 +1298,12 @@ FlatAtomicXorFlat::FlatAtomicXorFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_xor", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorFlat>(opcode);
 }
 } // namespace detail
@@ -1174,7 +1338,12 @@ FlatAtomicIncFlat::FlatAtomicIncFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_inc", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncFlat>(opcode);
 }
 } // namespace detail
@@ -1209,7 +1378,12 @@ FlatAtomicDecFlat::FlatAtomicDecFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecFlat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_dec", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecFlat>(opcode);
 }
 } // namespace detail
@@ -1244,7 +1418,12 @@ FlatAtomicFcmpswapFlat::FlatAtomicFcmpswapFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicFcmpswapFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicFcmpswapFlat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_fcmpswap", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicFcmpswapFlat>(opcode);
 }
 } // namespace detail
@@ -1279,7 +1458,12 @@ FlatAtomicFminFlat::FlatAtomicFminFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicFminFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicFminFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_fmin", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicFminFlat>(opcode);
 }
 } // namespace detail
@@ -1314,7 +1498,12 @@ FlatAtomicFmaxFlat::FlatAtomicFmaxFlat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicFmaxFlat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicFmaxFlat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_fmax", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicFmaxFlat>(opcode);
 }
 } // namespace detail
@@ -1349,7 +1538,12 @@ FlatAtomicSwapX2Flat::FlatAtomicSwapX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_swap_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapX2Flat>(opcode);
 }
 } // namespace detail
@@ -1384,7 +1578,12 @@ FlatAtomicCmpswapX2Flat::FlatAtomicCmpswapX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapX2Flat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_cmpswap_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapX2Flat>(opcode);
 }
 } // namespace detail
@@ -1419,7 +1618,12 @@ FlatAtomicAddX2Flat::FlatAtomicAddX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddX2Flat>(opcode);
 }
 } // namespace detail
@@ -1454,7 +1658,12 @@ FlatAtomicSubX2Flat::FlatAtomicSubX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_sub_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubX2Flat>(opcode);
 }
 } // namespace detail
@@ -1489,7 +1698,12 @@ FlatAtomicSminX2Flat::FlatAtomicSminX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSminX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smin_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSminX2Flat>(opcode);
 }
 } // namespace detail
@@ -1524,7 +1738,12 @@ FlatAtomicUminX2Flat::FlatAtomicUminX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUminX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umin_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUminX2Flat>(opcode);
 }
 } // namespace detail
@@ -1559,7 +1778,12 @@ FlatAtomicSmaxX2Flat::FlatAtomicSmaxX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_smax_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSmaxX2Flat>(opcode);
 }
 } // namespace detail
@@ -1594,7 +1818,12 @@ FlatAtomicUmaxX2Flat::FlatAtomicUmaxX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicUmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_umax_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicUmaxX2Flat>(opcode);
 }
 } // namespace detail
@@ -1629,7 +1858,12 @@ FlatAtomicAndX2Flat::FlatAtomicAndX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_and_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndX2Flat>(opcode);
 }
 } // namespace detail
@@ -1664,7 +1898,12 @@ FlatAtomicOrX2Flat::FlatAtomicOrX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrX2Flat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_or_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrX2Flat>(opcode);
 }
 } // namespace detail
@@ -1699,7 +1938,12 @@ FlatAtomicXorX2Flat::FlatAtomicXorX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_xor_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorX2Flat>(opcode);
 }
 } // namespace detail
@@ -1734,7 +1978,12 @@ FlatAtomicIncX2Flat::FlatAtomicIncX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_inc_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncX2Flat>(opcode);
 }
 } // namespace detail
@@ -1769,7 +2018,12 @@ FlatAtomicDecX2Flat::FlatAtomicDecX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecX2Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_dec_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecX2Flat>(opcode);
 }
 } // namespace detail
@@ -1804,7 +2058,12 @@ FlatAtomicFcmpswapX2Flat::FlatAtomicFcmpswapX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicFcmpswapX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicFcmpswapX2Flat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_fcmpswap_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicFcmpswapX2Flat>(opcode);
 }
 } // namespace detail
@@ -1839,7 +2098,12 @@ FlatAtomicFminX2Flat::FlatAtomicFminX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicFminX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicFminX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_fmin_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicFminX2Flat>(opcode);
 }
 } // namespace detail
@@ -1874,7 +2138,12 @@ FlatAtomicFmaxX2Flat::FlatAtomicFmaxX2Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicFmaxX2Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicFmaxX2Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_fmax_x2", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicFmaxX2Flat>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/mimg.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/mimg.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/mimg.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -26,7 +25,11 @@ ImageLoadMimg::ImageLoadMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMimg>(opcode);
 }
 } // namespace detail
@@ -45,7 +48,12 @@ ImageLoadMipMimg::ImageLoadMipMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipMimg>(opcode);
 }
 } // namespace detail
@@ -64,7 +72,12 @@ ImageLoadPckMimg::ImageLoadPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadPckMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadPckMimg>(opcode);
 }
 } // namespace detail
@@ -83,7 +96,12 @@ ImageLoadPckSgnMimg::ImageLoadPckSgnMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadPckSgnMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadPckSgnMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_pck_sgn", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadPckSgnMimg>(opcode);
 }
 } // namespace detail
@@ -102,7 +120,12 @@ ImageLoadMipPckMimg::ImageLoadMipPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipPckMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipPckMimg>(opcode);
 }
 } // namespace detail
@@ -121,7 +144,12 @@ ImageLoadMipPckSgnMimg::ImageLoadMipPckSgnMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipPckSgnMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipPckSgnMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_pck_sgn", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipPckSgnMimg>(opcode);
 }
 } // namespace detail
@@ -140,7 +168,11 @@ ImageStoreMimg::ImageStoreMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMimg>(opcode);
 }
 } // namespace detail
@@ -159,7 +191,12 @@ ImageStoreMipMimg::ImageStoreMipMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipMimg>(opcode);
 }
 } // namespace detail
@@ -178,7 +215,12 @@ ImageStorePckMimg::ImageStorePckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStorePckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStorePckMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStorePckMimg>(opcode);
 }
 } // namespace detail
@@ -197,7 +239,12 @@ ImageStoreMipPckMimg::ImageStoreMipPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipPckMimg>(opcode);
 }
 } // namespace detail
@@ -216,7 +263,12 @@ ImageGetResinfoMimg::ImageGetResinfoMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGetResinfoMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGetResinfoMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_get_resinfo", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGetResinfoMimg>(opcode);
 }
 } // namespace detail
@@ -236,7 +288,12 @@ ImageAtomicSwapMimg::ImageAtomicSwapMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSwapMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSwapMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_swap", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSwapMimg>(opcode);
 }
 } // namespace detail
@@ -256,7 +313,12 @@ ImageAtomicCmpswapMimg::ImageAtomicCmpswapMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicCmpswapMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicCmpswapMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_cmpswap", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicCmpswapMimg>(opcode);
 }
 } // namespace detail
@@ -276,7 +338,12 @@ ImageAtomicAddMimg::ImageAtomicAddMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicAddMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicAddMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_add", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicAddMimg>(opcode);
 }
 } // namespace detail
@@ -296,7 +363,12 @@ ImageAtomicSubMimg::ImageAtomicSubMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSubMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSubMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_sub", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSubMimg>(opcode);
 }
 } // namespace detail
@@ -316,7 +388,12 @@ ImageAtomicSminMimg::ImageAtomicSminMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSminMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_smin", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSminMimg>(opcode);
 }
 } // namespace detail
@@ -336,7 +413,12 @@ ImageAtomicUminMimg::ImageAtomicUminMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicUminMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicUminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_umin", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicUminMimg>(opcode);
 }
 } // namespace detail
@@ -356,7 +438,12 @@ ImageAtomicSmaxMimg::ImageAtomicSmaxMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSmaxMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_smax", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSmaxMimg>(opcode);
 }
 } // namespace detail
@@ -376,7 +463,12 @@ ImageAtomicUmaxMimg::ImageAtomicUmaxMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicUmaxMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicUmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_umax", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicUmaxMimg>(opcode);
 }
 } // namespace detail
@@ -396,7 +488,12 @@ ImageAtomicAndMimg::ImageAtomicAndMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicAndMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicAndMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_and", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicAndMimg>(opcode);
 }
 } // namespace detail
@@ -416,7 +513,12 @@ ImageAtomicOrMimg::ImageAtomicOrMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicOrMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicOrMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_or", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicOrMimg>(opcode);
 }
 } // namespace detail
@@ -436,7 +538,12 @@ ImageAtomicXorMimg::ImageAtomicXorMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicXorMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicXorMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_xor", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicXorMimg>(opcode);
 }
 } // namespace detail
@@ -456,7 +563,12 @@ ImageAtomicIncMimg::ImageAtomicIncMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicIncMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicIncMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_inc", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicIncMimg>(opcode);
 }
 } // namespace detail
@@ -476,7 +588,12 @@ ImageAtomicDecMimg::ImageAtomicDecMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicDecMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicDecMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_dec", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicDecMimg>(opcode);
 }
 } // namespace detail
@@ -496,7 +613,12 @@ ImageAtomicFcmpswapMimg::ImageAtomicFcmpswapMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicFcmpswapMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicFcmpswapMimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_fcmpswap", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicFcmpswapMimg>(opcode);
 }
 } // namespace detail
@@ -516,7 +638,12 @@ ImageAtomicFminMimg::ImageAtomicFminMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicFminMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicFminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_fmin", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicFminMimg>(opcode);
 }
 } // namespace detail
@@ -536,7 +663,12 @@ ImageAtomicFmaxMimg::ImageAtomicFmaxMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicFmaxMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicFmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_fmax", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicFmaxMimg>(opcode);
 }
 } // namespace detail
@@ -557,7 +689,12 @@ ImageSampleMimg::ImageSampleMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleMimg(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleMimg>(opcode);
 }
 } // namespace detail
@@ -578,7 +715,12 @@ ImageSampleClMimg::ImageSampleClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleClMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleClMimg>(opcode);
 }
 } // namespace detail
@@ -599,7 +741,12 @@ ImageSampleDMimg::ImageSampleDMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDMimg>(opcode);
 }
 } // namespace detail
@@ -620,7 +767,12 @@ ImageSampleDClMimg::ImageSampleDClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClMimg>(opcode);
 }
 } // namespace detail
@@ -641,7 +793,12 @@ ImageSampleLMimg::ImageSampleLMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLMimg>(opcode);
 }
 } // namespace detail
@@ -662,7 +819,12 @@ ImageSampleBMimg::ImageSampleBMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBMimg>(opcode);
 }
 } // namespace detail
@@ -683,7 +845,12 @@ ImageSampleBClMimg::ImageSampleBClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBClMimg>(opcode);
 }
 } // namespace detail
@@ -704,7 +871,12 @@ ImageSampleLzMimg::ImageSampleLzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLzMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLzMimg>(opcode);
 }
 } // namespace detail
@@ -725,7 +897,12 @@ ImageSampleCMimg::ImageSampleCMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCMimg>(opcode);
 }
 } // namespace detail
@@ -746,7 +923,12 @@ ImageSampleCClMimg::ImageSampleCClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCClMimg>(opcode);
 }
 } // namespace detail
@@ -767,7 +949,12 @@ ImageSampleCDMimg::ImageSampleCDMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDMimg>(opcode);
 }
 } // namespace detail
@@ -788,7 +975,12 @@ ImageSampleCDClMimg::ImageSampleCDClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClMimg>(opcode);
 }
 } // namespace detail
@@ -809,7 +1001,12 @@ ImageSampleCLMimg::ImageSampleCLMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLMimg>(opcode);
 }
 } // namespace detail
@@ -830,7 +1027,12 @@ ImageSampleCBMimg::ImageSampleCBMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBMimg>(opcode);
 }
 } // namespace detail
@@ -851,7 +1053,12 @@ ImageSampleCBClMimg::ImageSampleCBClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBClMimg>(opcode);
 }
 } // namespace detail
@@ -872,7 +1079,12 @@ ImageSampleCLzMimg::ImageSampleCLzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLzMimg>(opcode);
 }
 } // namespace detail
@@ -893,7 +1105,12 @@ ImageSampleOMimg::ImageSampleOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleOMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleOMimg>(opcode);
 }
 } // namespace detail
@@ -914,7 +1131,12 @@ ImageSampleClOMimg::ImageSampleClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleClOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleClOMimg>(opcode);
 }
 } // namespace detail
@@ -935,7 +1157,12 @@ ImageSampleDOMimg::ImageSampleDOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDOMimg>(opcode);
 }
 } // namespace detail
@@ -956,7 +1183,12 @@ ImageSampleDClOMimg::ImageSampleDClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClOMimg>(opcode);
 }
 } // namespace detail
@@ -977,7 +1209,12 @@ ImageSampleLOMimg::ImageSampleLOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_l_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLOMimg>(opcode);
 }
 } // namespace detail
@@ -998,7 +1235,12 @@ ImageSampleBOMimg::ImageSampleBOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBOMimg>(opcode);
 }
 } // namespace detail
@@ -1019,7 +1261,12 @@ ImageSampleBClOMimg::ImageSampleBClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBClOMimg>(opcode);
 }
 } // namespace detail
@@ -1040,7 +1287,12 @@ ImageSampleLzOMimg::ImageSampleLzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLzOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLzOMimg>(opcode);
 }
 } // namespace detail
@@ -1061,7 +1313,12 @@ ImageSampleCOMimg::ImageSampleCOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCOMimg>(opcode);
 }
 } // namespace detail
@@ -1082,7 +1339,12 @@ ImageSampleCClOMimg::ImageSampleCClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCClOMimg>(opcode);
 }
 } // namespace detail
@@ -1103,7 +1365,12 @@ ImageSampleCDOMimg::ImageSampleCDOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDOMimg>(opcode);
 }
 } // namespace detail
@@ -1124,7 +1391,12 @@ ImageSampleCDClOMimg::ImageSampleCDClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClOMimg>(opcode);
 }
 } // namespace detail
@@ -1145,7 +1417,12 @@ ImageSampleCLOMimg::ImageSampleCLOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_l_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLOMimg>(opcode);
 }
 } // namespace detail
@@ -1166,7 +1443,12 @@ ImageSampleCBOMimg::ImageSampleCBOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBOMimg>(opcode);
 }
 } // namespace detail
@@ -1187,7 +1469,12 @@ ImageSampleCBClOMimg::ImageSampleCBClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBClOMimg>(opcode);
 }
 } // namespace detail
@@ -1208,7 +1495,12 @@ ImageSampleCLzOMimg::ImageSampleCLzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLzOMimg>(opcode);
 }
 } // namespace detail
@@ -1229,7 +1521,12 @@ ImageGather4Mimg::ImageGather4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4Mimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4Mimg>(opcode);
 }
 } // namespace detail
@@ -1250,7 +1547,12 @@ ImageGather4ClMimg::ImageGather4ClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4ClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4ClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4ClMimg>(opcode);
 }
 } // namespace detail
@@ -1269,7 +1571,12 @@ ImageLoadBy2Mimg::ImageLoadBy2Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadBy2Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadBy2Mimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_by2", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadBy2Mimg>(opcode);
 }
 } // namespace detail
@@ -1288,7 +1595,12 @@ ImageLoadBy4Mimg::ImageLoadBy4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadBy4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadBy4Mimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_by4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadBy4Mimg>(opcode);
 }
 } // namespace detail
@@ -1309,7 +1621,12 @@ ImageGather4LMimg::ImageGather4LMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LMimg>(opcode);
 }
 } // namespace detail
@@ -1330,7 +1647,12 @@ ImageGather4BMimg::ImageGather4BMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4BMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4BMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4BMimg>(opcode);
 }
 } // namespace detail
@@ -1351,7 +1673,12 @@ ImageGather4BClMimg::ImageGather4BClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4BClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4BClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4BClMimg>(opcode);
 }
 } // namespace detail
@@ -1372,7 +1699,12 @@ ImageGather4LzMimg::ImageGather4LzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LzMimg>(opcode);
 }
 } // namespace detail
@@ -1393,7 +1725,12 @@ ImageGather4CMimg::ImageGather4CMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CMimg>(opcode);
 }
 } // namespace detail
@@ -1414,7 +1751,12 @@ ImageGather4CClMimg::ImageGather4CClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CClMimg>(opcode);
 }
 } // namespace detail
@@ -1433,7 +1775,12 @@ ImageLoadMipBy2Mimg::ImageLoadMipBy2Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipBy2Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipBy2Mimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_by2", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipBy2Mimg>(opcode);
 }
 } // namespace detail
@@ -1452,7 +1799,12 @@ ImageLoadMipBy4Mimg::ImageLoadMipBy4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipBy4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipBy4Mimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_by4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipBy4Mimg>(opcode);
 }
 } // namespace detail
@@ -1473,7 +1825,12 @@ ImageGather4CLMimg::ImageGather4CLMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLMimg>(opcode);
 }
 } // namespace detail
@@ -1494,7 +1851,12 @@ ImageGather4CBMimg::ImageGather4CBMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CBMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CBMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CBMimg>(opcode);
 }
 } // namespace detail
@@ -1515,7 +1877,12 @@ ImageGather4CBClMimg::ImageGather4CBClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CBClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CBClMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CBClMimg>(opcode);
 }
 } // namespace detail
@@ -1536,7 +1903,12 @@ ImageGather4CLzMimg::ImageGather4CLzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLzMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLzMimg>(opcode);
 }
 } // namespace detail
@@ -1557,7 +1929,12 @@ ImageGather4OMimg::ImageGather4OMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4OMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4OMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4OMimg>(opcode);
 }
 } // namespace detail
@@ -1578,7 +1955,12 @@ ImageGather4ClOMimg::ImageGather4ClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4ClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4ClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4ClOMimg>(opcode);
 }
 } // namespace detail
@@ -1597,7 +1979,12 @@ ImageStoreBy2Mimg::ImageStoreBy2Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreBy2Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreBy2Mimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_by2", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreBy2Mimg>(opcode);
 }
 } // namespace detail
@@ -1616,7 +2003,12 @@ ImageStoreBy4Mimg::ImageStoreBy4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreBy4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreBy4Mimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_by4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreBy4Mimg>(opcode);
 }
 } // namespace detail
@@ -1637,7 +2029,12 @@ ImageGather4LOMimg::ImageGather4LOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_l_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LOMimg>(opcode);
 }
 } // namespace detail
@@ -1658,7 +2055,12 @@ ImageGather4BOMimg::ImageGather4BOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4BOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4BOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_b_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4BOMimg>(opcode);
 }
 } // namespace detail
@@ -1679,7 +2081,12 @@ ImageGather4BClOMimg::ImageGather4BClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4BClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4BClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_b_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4BClOMimg>(opcode);
 }
 } // namespace detail
@@ -1700,7 +2107,12 @@ ImageGather4LzOMimg::ImageGather4LzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LzOMimg>(opcode);
 }
 } // namespace detail
@@ -1721,7 +2133,12 @@ ImageGather4COMimg::ImageGather4COMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4COMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4COMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4COMimg>(opcode);
 }
 } // namespace detail
@@ -1742,7 +2159,12 @@ ImageGather4CClOMimg::ImageGather4CClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CClOMimg>(opcode);
 }
 } // namespace detail
@@ -1761,7 +2183,12 @@ ImageStoreMipBy2Mimg::ImageStoreMipBy2Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipBy2Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipBy2Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip_by2", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipBy2Mimg>(opcode);
 }
 } // namespace detail
@@ -1780,7 +2207,12 @@ ImageStoreMipBy4Mimg::ImageStoreMipBy4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipBy4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipBy4Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip_by4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipBy4Mimg>(opcode);
 }
 } // namespace detail
@@ -1801,7 +2233,12 @@ ImageGather4CLOMimg::ImageGather4CLOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_l_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLOMimg>(opcode);
 }
 } // namespace detail
@@ -1822,7 +2259,12 @@ ImageGather4CBOMimg::ImageGather4CBOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CBOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CBOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_b_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CBOMimg>(opcode);
 }
 } // namespace detail
@@ -1843,7 +2285,12 @@ ImageGather4CBClOMimg::ImageGather4CBClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CBClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CBClOMimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_b_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CBClOMimg>(opcode);
 }
 } // namespace detail
@@ -1864,7 +2311,12 @@ ImageGather4CLzOMimg::ImageGather4CLzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLzOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLzOMimg>(opcode);
 }
 } // namespace detail
@@ -1885,7 +2337,12 @@ ImageGetLodMimg::ImageGetLodMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGetLodMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGetLodMimg(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_get_lod", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGetLodMimg>(opcode);
 }
 } // namespace detail
@@ -1906,7 +2363,12 @@ ImageGather4hMimg::ImageGather4hMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4hMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4hMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4h", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4hMimg>(opcode);
 }
 } // namespace detail
@@ -1927,7 +2389,12 @@ ImageGather4hPckMimg::ImageGather4hPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4hPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4hPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4h_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4hPckMimg>(opcode);
 }
 } // namespace detail
@@ -1948,7 +2415,12 @@ ImageGather8hPckMimg::ImageGather8hPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather8hPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather8hPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather8h_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather8hPckMimg>(opcode);
 }
 } // namespace detail
@@ -1969,7 +2441,12 @@ ImageSampleCdMimg::ImageSampleCdMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdMimg>(opcode);
 }
 } // namespace detail
@@ -1990,7 +2467,12 @@ ImageSampleCdClMimg::ImageSampleCdClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdClMimg>(opcode);
 }
 } // namespace detail
@@ -2011,7 +2493,12 @@ ImageSampleCCdMimg::ImageSampleCCdMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdMimg>(opcode);
 }
 } // namespace detail
@@ -2032,7 +2519,12 @@ ImageSampleCCdClMimg::ImageSampleCCdClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdClMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdClMimg>(opcode);
 }
 } // namespace detail
@@ -2053,7 +2545,12 @@ ImageSampleCdOMimg::ImageSampleCdOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdOMimg>(opcode);
 }
 } // namespace detail
@@ -2074,7 +2571,12 @@ ImageSampleCdClOMimg::ImageSampleCdClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdClOMimg>(opcode);
 }
 } // namespace detail
@@ -2095,7 +2597,12 @@ ImageSampleCCdOMimg::ImageSampleCCdOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdOMimg>(opcode);
 }
 } // namespace detail
@@ -2116,7 +2623,12 @@ ImageSampleCCdClOMimg::ImageSampleCCdClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdClOMimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdClOMimg>(opcode);
 }
 } // namespace detail
@@ -2135,7 +2647,12 @@ ImageLoadPck2Mimg::ImageLoadPck2Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadPck2Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadPck2Mimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_pck2", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadPck2Mimg>(opcode);
 }
 } // namespace detail
@@ -2154,7 +2671,12 @@ ImageLoadPck4Mimg::ImageLoadPck4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadPck4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadPck4Mimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_pck4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadPck4Mimg>(opcode);
 }
 } // namespace detail
@@ -2173,7 +2695,12 @@ ImageLoadMipPck2Mimg::ImageLoadMipPck2Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipPck2Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipPck2Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_pck2", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipPck2Mimg>(opcode);
 }
 } // namespace detail
@@ -2192,7 +2719,12 @@ ImageLoadMipPck4Mimg::ImageLoadMipPck4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipPck4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipPck4Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_pck4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipPck4Mimg>(opcode);
 }
 } // namespace detail
@@ -2211,7 +2743,12 @@ ImageStorePck2Mimg::ImageStorePck2Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStorePck2Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageStorePck2Mimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_pck2", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStorePck2Mimg>(opcode);
 }
 } // namespace detail
@@ -2230,7 +2767,12 @@ ImageStorePck4Mimg::ImageStorePck4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStorePck4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageStorePck4Mimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_pck4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStorePck4Mimg>(opcode);
 }
 } // namespace detail
@@ -2249,7 +2791,12 @@ ImageStoreMipPck2Mimg::ImageStoreMipPck2Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipPck2Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipPck2Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip_pck2", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipPck2Mimg>(opcode);
 }
 } // namespace detail
@@ -2268,7 +2815,12 @@ ImageStoreMipPck4Mimg::ImageStoreMipPck4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipPck4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipPck4Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip_pck4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipPck4Mimg>(opcode);
 }
 } // namespace detail
@@ -2287,7 +2839,12 @@ ImageMsaaLoadMimg::ImageMsaaLoadMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageMsaaLoadMimg(const MachineInst *opcode) {
+DecodeResult decodeImageMsaaLoadMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_msaa_load", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageMsaaLoadMimg>(opcode);
 }
 } // namespace detail
@@ -2308,7 +2865,12 @@ ImageSampleDG16Mimg::ImageSampleDG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDG16Mimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2329,7 +2891,12 @@ ImageSampleDClG16Mimg::ImageSampleDClG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_cl_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2350,7 +2917,12 @@ ImageSampleCDG16Mimg::ImageSampleCDG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2371,7 +2943,12 @@ ImageSampleCDClG16Mimg::ImageSampleCDClG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_cl_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2392,7 +2969,12 @@ ImageSampleDOG16Mimg::ImageSampleDOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDOG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2413,7 +2995,12 @@ ImageSampleDClOG16Mimg::ImageSampleDClOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClOG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_cl_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2434,7 +3021,12 @@ ImageSampleCDOG16Mimg::ImageSampleCDOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDOG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2455,7 +3047,12 @@ ImageSampleCDClOG16Mimg::ImageSampleCDClOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClOG16Mimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_cl_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2474,7 +3071,12 @@ ImageBvhIntersectRayMimg::ImageBvhIntersectRayMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageBvhIntersectRayMimg(const MachineInst *opcode) {
+DecodeResult decodeImageBvhIntersectRayMimg(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_bvh_intersect_ray", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageBvhIntersectRayMimg>(opcode);
 }
 } // namespace detail
@@ -2493,7 +3095,12 @@ ImageBvh64IntersectRayMimg::ImageBvh64IntersectRayMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageBvh64IntersectRayMimg(const MachineInst *opcode) {
+DecodeResult decodeImageBvh64IntersectRayMimg(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_bvh64_intersect_ray", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageBvh64IntersectRayMimg>(opcode);
 }
 } // namespace detail
@@ -2514,7 +3121,12 @@ ImageSampleCdG16Mimg::ImageSampleCdG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2535,7 +3147,12 @@ ImageSampleCdClG16Mimg::ImageSampleCdClG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdClG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdClG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd_cl_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdClG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2556,7 +3173,12 @@ ImageSampleCCdG16Mimg::ImageSampleCCdG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2577,7 +3199,12 @@ ImageSampleCCdClG16Mimg::ImageSampleCCdClG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdClG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdClG16Mimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd_cl_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdClG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2598,7 +3225,12 @@ ImageSampleCdOG16Mimg::ImageSampleCdOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdOG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2619,7 +3251,12 @@ ImageSampleCdClOG16Mimg::ImageSampleCdClOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCdClOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCdClOG16Mimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cd_cl_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCdClOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2640,7 +3277,12 @@ ImageSampleCCdOG16Mimg::ImageSampleCCdOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdOG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -2661,7 +3303,12 @@ ImageSampleCCdClOG16Mimg::ImageSampleCCdClOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCCdClOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCCdClOG16Mimg(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cd_cl_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCCdClOG16Mimg>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/mtbuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/mtbuf.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/mtbuf.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -43,7 +42,12 @@ TbufferLoadFormatXMtbuf::TbufferLoadFormatXMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -68,7 +72,12 @@ TbufferLoadFormatXyMtbuf::TbufferLoadFormatXyMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xy", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -93,7 +102,12 @@ TbufferLoadFormatXyzMtbuf::TbufferLoadFormatXyzMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xyz", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -118,7 +132,12 @@ TbufferLoadFormatXyzwMtbuf::TbufferLoadFormatXyzwMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xyzw", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -143,7 +162,12 @@ TbufferStoreFormatXMtbuf::TbufferStoreFormatXMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -168,7 +192,12 @@ TbufferStoreFormatXyMtbuf::TbufferStoreFormatXyMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xy", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -193,7 +222,12 @@ TbufferStoreFormatXyzMtbuf::TbufferStoreFormatXyzMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xyz", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -218,7 +252,12 @@ TbufferStoreFormatXyzwMtbuf::TbufferStoreFormatXyzwMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xyzw", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -243,7 +282,12 @@ TbufferLoadFormatD16XMtbuf::TbufferLoadFormatD16XMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_d16_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XMtbuf>(opcode);
 }
 } // namespace detail
@@ -274,7 +318,13 @@ TbufferLoadFormatD16XyMtbuf::TbufferLoadFormatD16XyMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XyMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_format_d16_xy",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XyMtbuf>(opcode);
 }
 } // namespace detail
@@ -299,7 +349,13 @@ TbufferLoadFormatD16XyzMtbuf::TbufferLoadFormatD16XyzMtbuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_format_d16_xyz",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -330,7 +386,13 @@ TbufferLoadFormatD16XyzwMtbuf::TbufferLoadFormatD16XyzwMtbuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_format_d16_xyzw",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatD16XyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -355,7 +417,13 @@ TbufferStoreFormatD16XMtbuf::TbufferStoreFormatD16XMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_x",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XMtbuf>(opcode);
 }
 } // namespace detail
@@ -380,7 +448,13 @@ TbufferStoreFormatD16XyMtbuf::TbufferStoreFormatD16XyMtbuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XyMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_xy",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XyMtbuf>(opcode);
 }
 } // namespace detail
@@ -405,7 +479,13 @@ TbufferStoreFormatD16XyzMtbuf::TbufferStoreFormatD16XyzMtbuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XyzMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_xyz",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -430,7 +510,13 @@ TbufferStoreFormatD16XyzwMtbuf::TbufferStoreFormatD16XyzwMtbuf(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatD16XyzwMtbuf(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_format_d16_xyzw",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatD16XyzwMtbuf>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/mubuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/mubuf.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/mubuf.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -43,7 +42,12 @@ BufferLoadFormatXMubuf::BufferLoadFormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXMubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -68,7 +72,12 @@ BufferLoadFormatXyMubuf::BufferLoadFormatXyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -93,7 +102,12 @@ BufferLoadFormatXyzMubuf::BufferLoadFormatXyzMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xyz", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -118,7 +132,12 @@ BufferLoadFormatXyzwMubuf::BufferLoadFormatXyzwMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xyzw", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -143,7 +162,12 @@ BufferStoreFormatXMubuf::BufferStoreFormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -168,7 +192,12 @@ BufferStoreFormatXyMubuf::BufferStoreFormatXyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -193,7 +222,12 @@ BufferStoreFormatXyzMubuf::BufferStoreFormatXyzMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xyz", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -218,7 +252,12 @@ BufferStoreFormatXyzwMubuf::BufferStoreFormatXyzwMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xyzw", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -243,7 +282,12 @@ BufferLoadUbyteMubuf::BufferLoadUbyteMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUbyteMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ubyte", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUbyteMubuf>(opcode);
 }
 } // namespace detail
@@ -268,7 +312,12 @@ BufferLoadSbyteMubuf::BufferLoadSbyteMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSbyteMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSbyteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sbyte", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSbyteMubuf>(opcode);
 }
 } // namespace detail
@@ -293,7 +342,12 @@ BufferLoadUshortMubuf::BufferLoadUshortMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUshortMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ushort", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUshortMubuf>(opcode);
 }
 } // namespace detail
@@ -318,7 +372,12 @@ BufferLoadSshortMubuf::BufferLoadSshortMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSshortMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSshortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sshort", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSshortMubuf>(opcode);
 }
 } // namespace detail
@@ -343,7 +402,12 @@ BufferLoadDwordMubuf::BufferLoadDwordMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dword", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordMubuf>(opcode);
 }
 } // namespace detail
@@ -368,7 +432,12 @@ BufferLoadDwordx2Mubuf::BufferLoadDwordx2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordx2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dwordx2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordx2Mubuf>(opcode);
 }
 } // namespace detail
@@ -393,7 +462,12 @@ BufferLoadDwordx4Mubuf::BufferLoadDwordx4Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordx4Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dwordx4", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordx4Mubuf>(opcode);
 }
 } // namespace detail
@@ -418,7 +492,12 @@ BufferLoadDwordx3Mubuf::BufferLoadDwordx3Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadDwordx3Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_dwordx3", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadDwordx3Mubuf>(opcode);
 }
 } // namespace detail
@@ -443,7 +522,12 @@ BufferStoreByteMubuf::BufferStoreByteMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreByteMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreByteMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_byte", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreByteMubuf>(opcode);
 }
 } // namespace detail
@@ -468,7 +552,12 @@ BufferStoreByteD16HiMubuf::BufferStoreByteD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreByteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_byte_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreByteD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -493,7 +582,12 @@ BufferStoreShortMubuf::BufferStoreShortMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreShortMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreShortMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_short", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreShortMubuf>(opcode);
 }
 } // namespace detail
@@ -518,7 +612,12 @@ BufferStoreShortD16HiMubuf::BufferStoreShortD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreShortD16HiMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_short_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreShortD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -543,7 +642,12 @@ BufferStoreDwordMubuf::BufferStoreDwordMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dword", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordMubuf>(opcode);
 }
 } // namespace detail
@@ -568,7 +672,12 @@ BufferStoreDwordx2Mubuf::BufferStoreDwordx2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordx2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dwordx2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordx2Mubuf>(opcode);
 }
 } // namespace detail
@@ -593,7 +702,12 @@ BufferStoreDwordx4Mubuf::BufferStoreDwordx4Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordx4Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dwordx4", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordx4Mubuf>(opcode);
 }
 } // namespace detail
@@ -618,7 +732,12 @@ BufferStoreDwordx3Mubuf::BufferStoreDwordx3Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreDwordx3Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_dwordx3", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreDwordx3Mubuf>(opcode);
 }
 } // namespace detail
@@ -643,7 +762,12 @@ BufferLoadUbyteD16Mubuf::BufferLoadUbyteD16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ubyte_d16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUbyteD16Mubuf>(opcode);
 }
 } // namespace detail
@@ -675,7 +799,12 @@ BufferLoadUbyteD16HiMubuf::BufferLoadUbyteD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_ubyte_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadUbyteD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -707,7 +836,12 @@ BufferLoadSbyteD16Mubuf::BufferLoadSbyteD16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sbyte_d16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSbyteD16Mubuf>(opcode);
 }
 } // namespace detail
@@ -739,7 +873,12 @@ BufferLoadSbyteD16HiMubuf::BufferLoadSbyteD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_sbyte_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadSbyteD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -771,7 +910,12 @@ BufferLoadShortD16Mubuf::BufferLoadShortD16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadShortD16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadShortD16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_short_d16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadShortD16Mubuf>(opcode);
 }
 } // namespace detail
@@ -803,7 +947,12 @@ BufferLoadShortD16HiMubuf::BufferLoadShortD16HiMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_short_d16_hi", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadShortD16HiMubuf>(opcode);
 }
 } // namespace detail
@@ -835,7 +984,13 @@ BufferLoadFormatD16HiXMubuf::BufferLoadFormatD16HiXMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_format_d16_hi_x",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16HiXMubuf>(opcode);
 }
 } // namespace detail
@@ -867,7 +1022,13 @@ BufferStoreFormatD16HiXMubuf::BufferStoreFormatD16HiXMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16HiXMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_hi_x",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16HiXMubuf>(opcode);
 }
 } // namespace detail
@@ -894,7 +1055,12 @@ BufferAtomicSwapMubuf::BufferAtomicSwapMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_swap", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapMubuf>(opcode);
 }
 } // namespace detail
@@ -922,7 +1088,12 @@ BufferAtomicCmpswapMubuf::BufferAtomicCmpswapMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_cmpswap", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapMubuf>(opcode);
 }
 } // namespace detail
@@ -949,7 +1120,12 @@ BufferAtomicAddMubuf::BufferAtomicAddMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddMubuf>(opcode);
 }
 } // namespace detail
@@ -976,7 +1152,12 @@ BufferAtomicSubMubuf::BufferAtomicSubMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_sub", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubMubuf>(opcode);
 }
 } // namespace detail
@@ -1003,7 +1184,12 @@ BufferAtomicCsubMubuf::BufferAtomicCsubMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCsubMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCsubMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_csub", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCsubMubuf>(opcode);
 }
 } // namespace detail
@@ -1030,7 +1216,12 @@ BufferAtomicSminMubuf::BufferAtomicSminMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSminMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smin", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSminMubuf>(opcode);
 }
 } // namespace detail
@@ -1057,7 +1248,12 @@ BufferAtomicUminMubuf::BufferAtomicUminMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUminMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umin", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUminMubuf>(opcode);
 }
 } // namespace detail
@@ -1084,7 +1280,12 @@ BufferAtomicSmaxMubuf::BufferAtomicSmaxMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smax", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSmaxMubuf>(opcode);
 }
 } // namespace detail
@@ -1111,7 +1312,12 @@ BufferAtomicUmaxMubuf::BufferAtomicUmaxMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umax", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUmaxMubuf>(opcode);
 }
 } // namespace detail
@@ -1138,7 +1344,12 @@ BufferAtomicAndMubuf::BufferAtomicAndMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_and", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndMubuf>(opcode);
 }
 } // namespace detail
@@ -1165,7 +1376,12 @@ BufferAtomicOrMubuf::BufferAtomicOrMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrMubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_or", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrMubuf>(opcode);
 }
 } // namespace detail
@@ -1192,7 +1408,12 @@ BufferAtomicXorMubuf::BufferAtomicXorMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_xor", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorMubuf>(opcode);
 }
 } // namespace detail
@@ -1219,7 +1440,12 @@ BufferAtomicIncMubuf::BufferAtomicIncMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_inc", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncMubuf>(opcode);
 }
 } // namespace detail
@@ -1246,7 +1472,12 @@ BufferAtomicDecMubuf::BufferAtomicDecMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecMubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_dec", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecMubuf>(opcode);
 }
 } // namespace detail
@@ -1274,7 +1505,12 @@ BufferAtomicFcmpswapMubuf::BufferAtomicFcmpswapMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicFcmpswapMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicFcmpswapMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_fcmpswap", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicFcmpswapMubuf>(opcode);
 }
 } // namespace detail
@@ -1301,7 +1537,12 @@ BufferAtomicFminMubuf::BufferAtomicFminMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicFminMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicFminMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_fmin", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicFminMubuf>(opcode);
 }
 } // namespace detail
@@ -1328,7 +1569,12 @@ BufferAtomicFmaxMubuf::BufferAtomicFmaxMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicFmaxMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicFmaxMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_fmax", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicFmaxMubuf>(opcode);
 }
 } // namespace detail
@@ -1355,7 +1601,12 @@ BufferAtomicSwapX2Mubuf::BufferAtomicSwapX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_swap_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1383,7 +1634,12 @@ BufferAtomicCmpswapX2Mubuf::BufferAtomicCmpswapX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapX2Mubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_cmpswap_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1410,7 +1666,12 @@ BufferAtomicAddX2Mubuf::BufferAtomicAddX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1437,7 +1698,12 @@ BufferAtomicSubX2Mubuf::BufferAtomicSubX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_sub_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1464,7 +1730,12 @@ BufferAtomicSminX2Mubuf::BufferAtomicSminX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smin_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSminX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1491,7 +1762,12 @@ BufferAtomicUminX2Mubuf::BufferAtomicUminX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umin_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUminX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1518,7 +1794,12 @@ BufferAtomicSmaxX2Mubuf::BufferAtomicSmaxX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_smax_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSmaxX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1545,7 +1826,12 @@ BufferAtomicUmaxX2Mubuf::BufferAtomicUmaxX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicUmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_umax_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicUmaxX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1572,7 +1858,12 @@ BufferAtomicAndX2Mubuf::BufferAtomicAndX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_and_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1599,7 +1890,12 @@ BufferAtomicOrX2Mubuf::BufferAtomicOrX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrX2Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_or_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1626,7 +1922,12 @@ BufferAtomicXorX2Mubuf::BufferAtomicXorX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_xor_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1653,7 +1954,12 @@ BufferAtomicIncX2Mubuf::BufferAtomicIncX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_inc_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1680,7 +1986,12 @@ BufferAtomicDecX2Mubuf::BufferAtomicDecX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecX2Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_dec_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1708,7 +2019,12 @@ BufferAtomicFcmpswapX2Mubuf::BufferAtomicFcmpswapX2Mubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicFcmpswapX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicFcmpswapX2Mubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_fcmpswap_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicFcmpswapX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1735,7 +2051,12 @@ BufferAtomicFminX2Mubuf::BufferAtomicFminX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicFminX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicFminX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_fmin_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicFminX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1762,7 +2083,12 @@ BufferAtomicFmaxX2Mubuf::BufferAtomicFmaxX2Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicFmaxX2Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicFmaxX2Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_fmax_x2", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicFmaxX2Mubuf>(opcode);
 }
 } // namespace detail
@@ -1775,7 +2101,12 @@ BufferGl0InvMubuf::BufferGl0InvMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferGl0InvMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferGl0InvMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_gl0_inv", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferGl0InvMubuf>(opcode);
 }
 } // namespace detail
@@ -1788,7 +2119,12 @@ BufferGl1InvMubuf::BufferGl1InvMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferGl1InvMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferGl1InvMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_gl1_inv", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferGl1InvMubuf>(opcode);
 }
 } // namespace detail
@@ -1813,7 +2149,12 @@ BufferLoadFormatD16XMubuf::BufferLoadFormatD16XMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_d16_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XMubuf>(opcode);
 }
 } // namespace detail
@@ -1845,7 +2186,12 @@ BufferLoadFormatD16XyMubuf::BufferLoadFormatD16XyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XyMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_d16_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XyMubuf>(opcode);
 }
 } // namespace detail
@@ -1870,7 +2216,13 @@ BufferLoadFormatD16XyzMubuf::BufferLoadFormatD16XyzMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_format_d16_xyz",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XyzMubuf>(opcode);
 }
 } // namespace detail
@@ -1902,7 +2254,13 @@ BufferLoadFormatD16XyzwMubuf::BufferLoadFormatD16XyzwMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_format_d16_xyzw",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatD16XyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -1927,7 +2285,12 @@ BufferStoreFormatD16XMubuf::BufferStoreFormatD16XMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_d16_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XMubuf>(opcode);
 }
 } // namespace detail
@@ -1952,7 +2315,13 @@ BufferStoreFormatD16XyMubuf::BufferStoreFormatD16XyMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XyMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_xy",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XyMubuf>(opcode);
 }
 } // namespace detail
@@ -1977,7 +2346,13 @@ BufferStoreFormatD16XyzMubuf::BufferStoreFormatD16XyzMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XyzMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_xyz",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XyzMubuf>(opcode);
 }
 } // namespace detail
@@ -2002,7 +2377,13 @@ BufferStoreFormatD16XyzwMubuf::BufferStoreFormatD16XyzwMubuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatD16XyzwMubuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_format_d16_xyzw",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatD16XyzwMubuf>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/operand.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/operand.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/scalar_static_resolve.h"
-#include "util/except.h"
 #include <format>
 #include <optional>
 #include <stdexcept>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/smem.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/smem.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/smem.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -35,7 +34,11 @@ SLoadDwordSmem::SLoadDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordSmem>(opcode);
 }
 } // namespace detail
@@ -56,7 +59,12 @@ SLoadDwordx2Smem::SLoadDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx2Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -77,7 +85,12 @@ SLoadDwordx4Smem::SLoadDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx4Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -98,7 +111,12 @@ SLoadDwordx8Smem::SLoadDwordx8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx8Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx8Smem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx8Smem>(opcode);
 }
 } // namespace detail
@@ -119,7 +137,12 @@ SLoadDwordx16Smem::SLoadDwordx16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadDwordx16Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadDwordx16Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_dwordx16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadDwordx16Smem>(opcode);
 }
 } // namespace detail
@@ -140,7 +163,12 @@ SBufferLoadDwordSmem::SBufferLoadDwordSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dword", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordSmem>(opcode);
 }
 } // namespace detail
@@ -161,7 +189,12 @@ SBufferLoadDwordx2Smem::SBufferLoadDwordx2Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx2Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx2Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx2", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx2Smem>(opcode);
 }
 } // namespace detail
@@ -182,7 +215,12 @@ SBufferLoadDwordx4Smem::SBufferLoadDwordx4Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx4Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx4Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx4", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx4Smem>(opcode);
 }
 } // namespace detail
@@ -203,7 +241,12 @@ SBufferLoadDwordx8Smem::SBufferLoadDwordx8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx8Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx8Smem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx8Smem>(opcode);
 }
 } // namespace detail
@@ -224,7 +267,12 @@ SBufferLoadDwordx16Smem::SBufferLoadDwordx16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadDwordx16Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadDwordx16Smem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_dwordx16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadDwordx16Smem>(opcode);
 }
 } // namespace detail
@@ -237,7 +285,11 @@ SGl1InvSmem::SGl1InvSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGl1InvSmem(const MachineInst *opcode) {
+DecodeResult decodeSGl1InvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_gl1_inv", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGl1InvSmem>(opcode);
 }
 } // namespace detail
@@ -250,7 +302,11 @@ SDcacheInvSmem::SDcacheInvSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_inv", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheInvSmem>(opcode);
 }
 } // namespace detail
@@ -265,7 +321,11 @@ SMemtimeSmem::SMemtimeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMemtimeSmem(const MachineInst *opcode) {
+DecodeResult decodeSMemtimeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_memtime", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMemtimeSmem>(opcode);
 }
 } // namespace detail
@@ -280,7 +340,12 @@ SMemrealtimeSmem::SMemrealtimeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMemrealtimeSmem(const MachineInst *opcode) {
+DecodeResult decodeSMemrealtimeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_memrealtime", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMemrealtimeSmem>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/sop1.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/sop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -29,7 +28,11 @@ SMovB32Sop1::SMovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -52,7 +55,11 @@ SMovB64Sop1::SMovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -78,7 +85,11 @@ SCmovB32Sop1::SCmovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -105,7 +116,11 @@ SCmovB64Sop1::SCmovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -129,7 +144,11 @@ SNotB32Sop1::SNotB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB32Sop1>(opcode);
 }
 } // namespace detail
@@ -154,7 +173,11 @@ SNotB64Sop1::SNotB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB64Sop1>(opcode);
 }
 } // namespace detail
@@ -178,7 +201,11 @@ SWqmB32Sop1::SWqmB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB32Sop1>(opcode);
 }
 } // namespace detail
@@ -203,7 +230,11 @@ SWqmB64Sop1::SWqmB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB64Sop1>(opcode);
 }
 } // namespace detail
@@ -224,7 +255,11 @@ SBrevB32Sop1::SBrevB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB32Sop1>(opcode);
 }
 } // namespace detail
@@ -246,7 +281,11 @@ SBrevB64Sop1::SBrevB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB64Sop1>(opcode);
 }
 } // namespace detail
@@ -270,7 +309,12 @@ SBcnt0I32B32Sop1::SBcnt0I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -295,7 +339,12 @@ SBcnt0I32B64Sop1::SBcnt0I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -319,7 +368,12 @@ SBcnt1I32B32Sop1::SBcnt1I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -344,7 +398,12 @@ SBcnt1I32B64Sop1::SBcnt1I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -365,7 +424,11 @@ SFf0I32B32Sop1::SFf0I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf0I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf0I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff0_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf0I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -387,7 +450,11 @@ SFf0I32B64Sop1::SFf0I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf0I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf0I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff0_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf0I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -408,7 +475,11 @@ SFf1I32B32Sop1::SFf1I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf1I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf1I32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff1_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf1I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -430,7 +501,11 @@ SFf1I32B64Sop1::SFf1I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFf1I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFf1I32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ff1_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFf1I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -451,7 +526,12 @@ SFlbitI32B32Sop1::SFlbitI32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -473,7 +553,12 @@ SFlbitI32B64Sop1::SFlbitI32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -494,7 +579,11 @@ SFlbitI32Sop1::SFlbitI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32Sop1>(opcode);
 }
 } // namespace detail
@@ -516,7 +605,12 @@ SFlbitI32I64Sop1::SFlbitI32I64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFlbitI32I64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFlbitI32I64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_flbit_i32_i64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFlbitI32I64Sop1>(opcode);
 }
 } // namespace detail
@@ -538,7 +632,11 @@ SSextI32I8Sop1::SSextI32I8Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i8", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I8Sop1>(opcode);
 }
 } // namespace detail
@@ -560,7 +658,12 @@ SSextI32I16Sop1::SSextI32I16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I16Sop1>(opcode);
 }
 } // namespace detail
@@ -582,7 +685,12 @@ SBitset0B32Sop1::SBitset0B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B32Sop1>(opcode);
 }
 } // namespace detail
@@ -604,7 +712,12 @@ SBitset0B64Sop1::SBitset0B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B64Sop1>(opcode);
 }
 } // namespace detail
@@ -626,7 +739,12 @@ SBitset1B32Sop1::SBitset1B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B32Sop1>(opcode);
 }
 } // namespace detail
@@ -648,7 +766,12 @@ SBitset1B64Sop1::SBitset1B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B64Sop1>(opcode);
 }
 } // namespace detail
@@ -666,7 +789,11 @@ SGetpcB64Sop1::SGetpcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetpcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSGetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_getpc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetpcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -685,7 +812,11 @@ SSetpcB64Sop1::SSetpcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetpcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_setpc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetpcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -708,7 +839,11 @@ SSwappcB64Sop1::SSwappcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSwappcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSwappcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_swappc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSwappcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -726,7 +861,11 @@ SRfeB64Sop1::SRfeB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRfeB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSRfeB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_rfe_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRfeB64Sop1>(opcode);
 }
 } // namespace detail
@@ -758,7 +897,12 @@ SAndSaveexecB64Sop1::SAndSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -791,7 +935,12 @@ SOrSaveexecB64Sop1::SOrSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -823,7 +972,12 @@ SXorSaveexecB64Sop1::SXorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -855,7 +1009,12 @@ SAndn2SaveexecB64Sop1::SAndn2SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn2SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn2_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -887,7 +1046,12 @@ SOrn2SaveexecB64Sop1::SOrn2SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrn2SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_orn2_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -919,7 +1083,12 @@ SNandSaveexecB64Sop1::SNandSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nand_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -951,7 +1120,12 @@ SNorSaveexecB64Sop1::SNorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -983,7 +1157,12 @@ SXnorSaveexecB64Sop1::SXnorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xnor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1007,7 +1186,12 @@ SQuadmaskB32Sop1::SQuadmaskB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1032,7 +1216,12 @@ SQuadmaskB64Sop1::SQuadmaskB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1052,7 +1241,12 @@ SMovrelsB32Sop1::SMovrelsB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrels_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1072,7 +1266,12 @@ SMovrelsB64Sop1::SMovrelsB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrels_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1096,7 +1295,12 @@ SMovreldB32Sop1::SMovreldB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1121,7 +1325,12 @@ SMovreldB64Sop1::SMovreldB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1145,7 +1354,11 @@ SAbsI32Sop1::SAbsI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_abs_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsI32Sop1>(opcode);
 }
 } // namespace detail
@@ -1177,7 +1390,12 @@ SAndn1SaveexecB64Sop1::SAndn1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn1SaveexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1209,7 +1427,12 @@ SOrn1SaveexecB64Sop1::SOrn1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrn1SaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_orn1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1241,7 +1464,12 @@ SAndn1WrexecB64Sop1::SAndn1WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn1WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn1WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn1_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn1WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1273,7 +1501,12 @@ SAndn2WrexecB64Sop1::SAndn2WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn2WrexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn2_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1294,7 +1527,12 @@ SBitreplicateB64B32Sop1::SBitreplicateB64B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitreplicate_b64_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitreplicateB64B32Sop1>(opcode);
 }
 } // namespace detail
@@ -1325,7 +1563,12 @@ SAndSaveexecB32Sop1::SAndSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1357,7 +1600,12 @@ SOrSaveexecB32Sop1::SOrSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrSaveexecB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1388,7 +1636,12 @@ SXorSaveexecB32Sop1::SXorSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xor_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1419,7 +1672,12 @@ SAndn2SaveexecB32Sop1::SAndn2SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn2SaveexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn2_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1450,7 +1708,12 @@ SOrn2SaveexecB32Sop1::SOrn2SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrn2SaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_orn2_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1481,7 +1744,12 @@ SNandSaveexecB32Sop1::SNandSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNandSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nand_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1512,7 +1780,12 @@ SNorSaveexecB32Sop1::SNorSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nor_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1543,7 +1816,12 @@ SXnorSaveexecB32Sop1::SXnorSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXnorSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xnor_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1574,7 +1852,12 @@ SAndn1SaveexecB32Sop1::SAndn1SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn1SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn1SaveexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn1_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn1SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1605,7 +1888,12 @@ SOrn1SaveexecB32Sop1::SOrn1SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn1SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrn1SaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_orn1_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn1SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1636,7 +1924,12 @@ SAndn1WrexecB32Sop1::SAndn1WrexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn1WrexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn1WrexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn1_wrexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn1WrexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1667,7 +1960,12 @@ SAndn2WrexecB32Sop1::SAndn2WrexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2WrexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndn2WrexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_andn2_wrexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2WrexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1687,7 +1985,12 @@ SMovrelsd2B32Sop1::SMovrelsd2B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsd2B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsd2B32Sop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrelsd_2_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsd2B32Sop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/sop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/sop2.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/sop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -37,7 +36,11 @@ SAddU32Sop2::SAddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -67,7 +70,11 @@ SSubU32Sop2::SSubU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubU32Sop2>(opcode);
 }
 } // namespace detail
@@ -97,7 +104,11 @@ SAddI32Sop2::SAddI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddI32Sop2>(opcode);
 }
 } // namespace detail
@@ -127,7 +138,11 @@ SSubI32Sop2::SSubI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubI32Sop2>(opcode);
 }
 } // namespace detail
@@ -160,7 +175,11 @@ SAddcU32Sop2::SAddcU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddcU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddcU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_addc_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddcU32Sop2>(opcode);
 }
 } // namespace detail
@@ -193,7 +212,11 @@ SSubbU32Sop2::SSubbU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubbU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubbU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_subb_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubbU32Sop2>(opcode);
 }
 } // namespace detail
@@ -223,7 +246,11 @@ SMinI32Sop2::SMinI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinI32Sop2>(opcode);
 }
 } // namespace detail
@@ -253,7 +280,11 @@ SMinU32Sop2::SMinU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinU32Sop2>(opcode);
 }
 } // namespace detail
@@ -283,7 +314,11 @@ SMaxI32Sop2::SMaxI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxI32Sop2>(opcode);
 }
 } // namespace detail
@@ -313,7 +348,11 @@ SMaxU32Sop2::SMaxU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxU32Sop2>(opcode);
 }
 } // namespace detail
@@ -343,7 +382,12 @@ SCselectB32Sop2::SCselectB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCselectB32Sop2>(opcode);
 }
 } // namespace detail
@@ -375,7 +419,12 @@ SCselectB64Sop2::SCselectB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCselectB64Sop2>(opcode);
 }
 } // namespace detail
@@ -405,7 +454,11 @@ SAndB32Sop2::SAndB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndB32Sop2>(opcode);
 }
 } // namespace detail
@@ -437,7 +490,11 @@ SAndB64Sop2::SAndB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndB64Sop2>(opcode);
 }
 } // namespace detail
@@ -468,7 +525,11 @@ SOrB32Sop2::SOrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -501,7 +562,11 @@ SOrB64Sop2::SOrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -531,7 +596,11 @@ SXorB32Sop2::SXorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -563,7 +632,11 @@ SXorB64Sop2::SXorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -593,7 +666,11 @@ SAndn2B32Sop2::SAndn2B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_andn2_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2B32Sop2>(opcode);
 }
 } // namespace detail
@@ -625,7 +702,11 @@ SAndn2B64Sop2::SAndn2B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndn2B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_andn2_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndn2B64Sop2>(opcode);
 }
 } // namespace detail
@@ -655,7 +736,11 @@ SOrn2B32Sop2::SOrn2B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrn2B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_orn2_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2B32Sop2>(opcode);
 }
 } // namespace detail
@@ -687,7 +772,11 @@ SOrn2B64Sop2::SOrn2B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrn2B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrn2B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_orn2_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrn2B64Sop2>(opcode);
 }
 } // namespace detail
@@ -717,7 +806,11 @@ SNandB32Sop2::SNandB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandB32Sop2>(opcode);
 }
 } // namespace detail
@@ -749,7 +842,11 @@ SNandB64Sop2::SNandB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandB64Sop2>(opcode);
 }
 } // namespace detail
@@ -779,7 +876,11 @@ SNorB32Sop2::SNorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -811,7 +912,11 @@ SNorB64Sop2::SNorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -841,7 +946,11 @@ SXnorB32Sop2::SXnorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -873,7 +982,11 @@ SXnorB64Sop2::SXnorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -903,7 +1016,11 @@ SLshlB32Sop2::SLshlB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshlB32Sop2>(opcode);
 }
 } // namespace detail
@@ -934,7 +1051,11 @@ SLshlB64Sop2::SLshlB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshlB64Sop2>(opcode);
 }
 } // namespace detail
@@ -964,7 +1085,11 @@ SLshrB32Sop2::SLshrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -995,7 +1120,11 @@ SLshrB64Sop2::SLshrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1025,7 +1154,11 @@ SAshrI32Sop2::SAshrI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAshrI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1056,7 +1189,11 @@ SAshrI64Sop2::SAshrI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAshrI64Sop2>(opcode);
 }
 } // namespace detail
@@ -1083,7 +1220,11 @@ SBfmB32Sop2::SBfmB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfmB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1110,7 +1251,11 @@ SBfmB64Sop2::SBfmB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfmB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1137,7 +1282,11 @@ SMulI32Sop2::SMulI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1167,7 +1316,11 @@ SBfeU32Sop2::SBfeU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1197,7 +1350,11 @@ SBfeI32Sop2::SBfeI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1228,7 +1385,11 @@ SBfeU64Sop2::SBfeU64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeU64Sop2>(opcode);
 }
 } // namespace detail
@@ -1259,7 +1420,11 @@ SBfeI64Sop2::SBfeI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeI64Sop2>(opcode);
 }
 } // namespace detail
@@ -1289,7 +1454,12 @@ SAbsdiffI32Sop2::SAbsdiffI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_absdiff_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsdiffI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1319,7 +1489,12 @@ SLshl1AddU32Sop2::SLshl1AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl1_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl1AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1349,7 +1524,12 @@ SLshl2AddU32Sop2::SLshl2AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl2_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl2AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1379,7 +1559,12 @@ SLshl3AddU32Sop2::SLshl3AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl3_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl3AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1409,7 +1594,12 @@ SLshl4AddU32Sop2::SLshl4AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl4_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl4AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1438,7 +1628,12 @@ SPackLlB32B16Sop2::SPackLlB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_ll_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackLlB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1466,7 +1661,12 @@ SPackLhB32B16Sop2::SPackLhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_lh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackLhB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1493,7 +1693,12 @@ SPackHhB32B16Sop2::SPackHhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_hh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackHhB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1520,7 +1725,11 @@ SMulHiU32Sop2::SMulHiU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulHiU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1547,7 +1756,11 @@ SMulHiI32Sop2::SMulHiI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulHiI32Sop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/sopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/sopc.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/sopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -35,7 +34,11 @@ SCmpEqI32Sopc::SCmpEqI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqI32Sopc>(opcode);
 }
 } // namespace detail
@@ -63,7 +66,11 @@ SCmpLgI32Sopc::SCmpLgI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgI32Sopc>(opcode);
 }
 } // namespace detail
@@ -91,7 +98,11 @@ SCmpGtI32Sopc::SCmpGtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -119,7 +130,11 @@ SCmpGeI32Sopc::SCmpGeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -147,7 +162,11 @@ SCmpLtI32Sopc::SCmpLtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -175,7 +194,11 @@ SCmpLeI32Sopc::SCmpLeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -203,7 +226,11 @@ SCmpEqU32Sopc::SCmpEqU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqU32Sopc>(opcode);
 }
 } // namespace detail
@@ -231,7 +258,11 @@ SCmpLgU32Sopc::SCmpLgU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgU32Sopc>(opcode);
 }
 } // namespace detail
@@ -259,7 +290,11 @@ SCmpGtU32Sopc::SCmpGtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -287,7 +322,11 @@ SCmpGeU32Sopc::SCmpGeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -315,7 +354,11 @@ SCmpLtU32Sopc::SCmpLtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -343,7 +386,11 @@ SCmpLeU32Sopc::SCmpLeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -371,7 +418,12 @@ SBitcmp0B32Sopc::SBitcmp0B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp0B32Sopc>(opcode);
 }
 } // namespace detail
@@ -399,7 +451,12 @@ SBitcmp1B32Sopc::SBitcmp1B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp1B32Sopc>(opcode);
 }
 } // namespace detail
@@ -428,7 +485,12 @@ SBitcmp0B64Sopc::SBitcmp0B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp0B64Sopc>(opcode);
 }
 } // namespace detail
@@ -457,7 +519,12 @@ SBitcmp1B64Sopc::SBitcmp1B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp1B64Sopc>(opcode);
 }
 } // namespace detail
@@ -487,7 +554,11 @@ SCmpEqU64Sopc::SCmpEqU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqU64Sopc>(opcode);
 }
 } // namespace detail
@@ -517,7 +588,11 @@ SCmpLgU64Sopc::SCmpLgU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgU64Sopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/sopk.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -24,7 +23,11 @@ SMovkI32Sopk::SMovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_movk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -39,7 +42,11 @@ SVersionSopk::SVersionSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSVersionSopk(const MachineInst *opcode) {
+DecodeResult decodeSVersionSopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_version", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SVersionSopk>(opcode);
 }
 } // namespace detail
@@ -61,7 +68,11 @@ SCmovkI32Sopk::SCmovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmovk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -81,7 +92,11 @@ SCmpkEqI32Sopk::SCmpkEqI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkEqI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkEqI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_eq_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkEqI32Sopk>(opcode);
 }
 } // namespace detail
@@ -101,7 +116,11 @@ SCmpkLgI32Sopk::SCmpkLgI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLgI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLgI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lg_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLgI32Sopk>(opcode);
 }
 } // namespace detail
@@ -121,7 +140,11 @@ SCmpkGtI32Sopk::SCmpkGtI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGtI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_gt_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGtI32Sopk>(opcode);
 }
 } // namespace detail
@@ -141,7 +164,11 @@ SCmpkGeI32Sopk::SCmpkGeI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGeI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_ge_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGeI32Sopk>(opcode);
 }
 } // namespace detail
@@ -161,7 +188,11 @@ SCmpkLtI32Sopk::SCmpkLtI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLtI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lt_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLtI32Sopk>(opcode);
 }
 } // namespace detail
@@ -181,7 +212,11 @@ SCmpkLeI32Sopk::SCmpkLeI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLeI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_le_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLeI32Sopk>(opcode);
 }
 } // namespace detail
@@ -201,7 +236,11 @@ SCmpkEqU32Sopk::SCmpkEqU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkEqU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkEqU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_eq_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkEqU32Sopk>(opcode);
 }
 } // namespace detail
@@ -221,7 +260,11 @@ SCmpkLgU32Sopk::SCmpkLgU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLgU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLgU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lg_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLgU32Sopk>(opcode);
 }
 } // namespace detail
@@ -241,7 +284,11 @@ SCmpkGtU32Sopk::SCmpkGtU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGtU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_gt_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGtU32Sopk>(opcode);
 }
 } // namespace detail
@@ -261,7 +308,11 @@ SCmpkGeU32Sopk::SCmpkGeU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGeU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_ge_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGeU32Sopk>(opcode);
 }
 } // namespace detail
@@ -281,7 +332,11 @@ SCmpkLtU32Sopk::SCmpkLtU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLtU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lt_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLtU32Sopk>(opcode);
 }
 } // namespace detail
@@ -301,7 +356,11 @@ SCmpkLeU32Sopk::SCmpkLeU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLeU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_le_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLeU32Sopk>(opcode);
 }
 } // namespace detail
@@ -322,7 +381,11 @@ SAddkI32Sopk::SAddkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSAddkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_addk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -340,7 +403,11 @@ SMulkI32Sopk::SMulkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_mulk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -357,7 +424,11 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_getreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -374,7 +445,11 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -399,7 +474,12 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_imm32_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregImm32B32Sopk>(opcode);
 }
 } // namespace detail
@@ -428,7 +508,11 @@ SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCallB64Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCallB64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_call_b64", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCallB64Sopk>(opcode);
 }
 } // namespace detail
@@ -451,7 +535,12 @@ SWaitcntVscntSopk::SWaitcntVscntSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntVscntSopk(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntVscntSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_waitcnt_vscnt", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntVscntSopk>(opcode);
 }
 } // namespace detail
@@ -469,7 +558,12 @@ SWaitcntVmcntSopk::SWaitcntVmcntSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntVmcntSopk(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntVmcntSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_waitcnt_vmcnt", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntVmcntSopk>(opcode);
 }
 } // namespace detail
@@ -487,7 +581,12 @@ SWaitcntExpcntSopk::SWaitcntExpcntSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntExpcntSopk(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntExpcntSopk(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_waitcnt_expcnt", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntExpcntSopk>(opcode);
 }
 } // namespace detail
@@ -505,7 +604,12 @@ SWaitcntLgkmcntSopk::SWaitcntLgkmcntSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntLgkmcntSopk(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntLgkmcntSopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_waitcnt_lgkmcnt", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntLgkmcntSopk>(opcode);
 }
 } // namespace detail
@@ -529,7 +633,12 @@ SSubvectorLoopBeginSopk::SSubvectorLoopBeginSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubvectorLoopBeginSopk(const MachineInst *opcode) {
+DecodeResult decodeSSubvectorLoopBeginSopk(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_subvector_loop_begin", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubvectorLoopBeginSopk>(opcode);
 }
 } // namespace detail
@@ -553,7 +662,12 @@ SSubvectorLoopEndSopk::SSubvectorLoopEndSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubvectorLoopEndSopk(const MachineInst *opcode) {
+DecodeResult decodeSSubvectorLoopEndSopk(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_subvector_loop_end", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubvectorLoopEndSopk>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/sopp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/sopp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/sopp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -22,7 +21,11 @@ SNopSopp::SNopSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode) {
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_nop", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNopSopp>(opcode);
 }
 } // namespace detail
@@ -36,7 +39,11 @@ SEndpgmSopp::SEndpgmSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSopp>(opcode);
 }
 } // namespace detail
@@ -53,7 +60,11 @@ SBranchSopp::SBranchSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode) {
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_branch", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBranchSopp>(opcode);
 }
 } // namespace detail
@@ -71,7 +82,11 @@ SWakeupSopp::SWakeupSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode) {
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wakeup", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWakeupSopp>(opcode);
 }
 } // namespace detail
@@ -91,7 +106,12 @@ SCbranchScc0Sopp::SCbranchScc0Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc0", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc0Sopp>(opcode);
 }
 } // namespace detail
@@ -116,7 +136,12 @@ SCbranchScc1Sopp::SCbranchScc1Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc1", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc1Sopp>(opcode);
 }
 } // namespace detail
@@ -141,7 +166,12 @@ SCbranchVcczSopp::SCbranchVcczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVcczSopp>(opcode);
 }
 } // namespace detail
@@ -166,7 +196,12 @@ SCbranchVccnzSopp::SCbranchVccnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVccnzSopp>(opcode);
 }
 } // namespace detail
@@ -191,7 +226,12 @@ SCbranchExeczSopp::SCbranchExeczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExeczSopp>(opcode);
 }
 } // namespace detail
@@ -216,7 +256,12 @@ SCbranchExecnzSopp::SCbranchExecnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExecnzSopp>(opcode);
 }
 } // namespace detail
@@ -235,7 +280,11 @@ SBarrierSopp::SBarrierSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBarrierSopp(const MachineInst *opcode) {
+DecodeResult decodeSBarrierSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_barrier", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBarrierSopp>(opcode);
 }
 } // namespace detail
@@ -250,7 +299,11 @@ SSetkillSopp::SSetkillSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetkillSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetkillSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setkill", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetkillSopp>(opcode);
 }
 } // namespace detail
@@ -266,7 +319,11 @@ SWaitcntSopp::SWaitcntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_waitcnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntSopp>(opcode);
 }
 } // namespace detail
@@ -281,7 +338,11 @@ SSethaltSopp::SSethaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sethalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSethaltSopp>(opcode);
 }
 } // namespace detail
@@ -296,7 +357,11 @@ SSleepSopp::SSleepSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode) {
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sleep", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSleepSopp>(opcode);
 }
 } // namespace detail
@@ -311,7 +376,11 @@ SSetprioSopp::SSetprioSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setprio", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetprioSopp>(opcode);
 }
 } // namespace detail
@@ -329,7 +398,11 @@ SSendmsgSopp::SSendmsgSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsg", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsgSopp>(opcode);
 }
 } // namespace detail
@@ -347,7 +420,12 @@ SSendmsghaltSopp::SSendmsghaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsghalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsghaltSopp>(opcode);
 }
 } // namespace detail
@@ -362,7 +440,11 @@ STrapSopp::STrapSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode) {
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_trap", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STrapSopp>(opcode);
 }
 } // namespace detail
@@ -375,7 +457,11 @@ SIcacheInvSopp::SIcacheInvSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode) {
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_icache_inv", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIcacheInvSopp>(opcode);
 }
 } // namespace detail
@@ -390,7 +476,12 @@ SIncperflevelSopp::SIncperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_incperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIncperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -405,7 +496,12 @@ SDecperflevelSopp::SDecperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_decperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDecperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -421,7 +517,12 @@ STtracedataSopp::STtracedataSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode) {
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_ttracedata", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STtracedataSopp>(opcode);
 }
 } // namespace detail
@@ -436,7 +537,12 @@ SCbranchCdbgsysSopp::SCbranchCdbgsysSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysSopp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysSopp>(opcode);
 }
 } // namespace detail
@@ -451,7 +557,12 @@ SCbranchCdbguserSopp::SCbranchCdbguserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbguserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbguserSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbguser", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbguserSopp>(opcode);
 }
 } // namespace detail
@@ -466,7 +577,12 @@ SCbranchCdbgsysOrUserSopp::SCbranchCdbgsysOrUserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys_or_user", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysOrUserSopp>(opcode);
 }
 } // namespace detail
@@ -481,7 +597,12 @@ SCbranchCdbgsysAndUserSopp::SCbranchCdbgsysAndUserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys_and_user", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysAndUserSopp>(opcode);
 }
 } // namespace detail
@@ -495,7 +616,12 @@ SEndpgmSavedSopp::SEndpgmSavedSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm_saved", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSavedSopp>(opcode);
 }
 } // namespace detail
@@ -509,7 +635,12 @@ SEndpgmOrderedPsDoneSopp::SEndpgmOrderedPsDoneSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm_ordered_ps_done", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmOrderedPsDoneSopp>(opcode);
 }
 } // namespace detail
@@ -522,7 +653,11 @@ SCodeEndSopp::SCodeEndSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCodeEndSopp(const MachineInst *opcode) {
+DecodeResult decodeSCodeEndSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_code_end", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCodeEndSopp>(opcode);
 }
 } // namespace detail
@@ -537,7 +672,12 @@ SInstPrefetchSopp::SInstPrefetchSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSInstPrefetchSopp(const MachineInst *opcode) {
+DecodeResult decodeSInstPrefetchSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_inst_prefetch", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SInstPrefetchSopp>(opcode);
 }
 } // namespace detail
@@ -552,7 +692,11 @@ SClauseSopp::SClauseSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClauseSopp(const MachineInst *opcode) {
+DecodeResult decodeSClauseSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_clause", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClauseSopp>(opcode);
 }
 } // namespace detail
@@ -569,7 +713,12 @@ SWaitcntDepctrSopp::SWaitcntDepctrSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntDepctrSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntDepctrSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_waitcnt_depctr", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntDepctrSopp>(opcode);
 }
 } // namespace detail
@@ -584,7 +733,11 @@ SRoundModeSopp::SRoundModeSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRoundModeSopp(const MachineInst *opcode) {
+DecodeResult decodeSRoundModeSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_round_mode", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRoundModeSopp>(opcode);
 }
 } // namespace detail
@@ -599,7 +752,12 @@ SDenormModeSopp::SDenormModeSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDenormModeSopp(const MachineInst *opcode) {
+DecodeResult decodeSDenormModeSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_denorm_mode", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDenormModeSopp>(opcode);
 }
 } // namespace detail
@@ -617,7 +775,12 @@ STtracedataImmSopp::STtracedataImmSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTtracedataImmSopp(const MachineInst *opcode) {
+DecodeResult decodeSTtracedataImmSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_ttracedata_imm", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STtracedataImmSopp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/vintrp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/vintrp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/vintrp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -29,7 +28,12 @@ VInterpP1F32Vintrp::VInterpP1F32Vintrp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP1F32Vintrp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP1F32Vintrp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vintrp::validate_encoding(
+      "v_interp_p1_f32", reinterpret_cast<const Vintrp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP1F32Vintrp>(opcode);
 }
 } // namespace detail
@@ -52,7 +56,12 @@ VInterpP2F32Vintrp::VInterpP2F32Vintrp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2F32Vintrp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2F32Vintrp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vintrp::validate_encoding(
+      "v_interp_p2_f32", reinterpret_cast<const Vintrp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2F32Vintrp>(opcode);
 }
 } // namespace detail
@@ -74,7 +83,12 @@ VInterpMovF32Vintrp::VInterpMovF32Vintrp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpMovF32Vintrp(const MachineInst *opcode) {
+DecodeResult decodeVInterpMovF32Vintrp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vintrp::validate_encoding(
+      "v_interp_mov_f32", reinterpret_cast<const Vintrp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpMovF32Vintrp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/vop1.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/vop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -23,7 +22,15 @@ VNopVop1::VNopVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode) {
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_nop_dpp"
+          : "v_nop_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop1>(opcode);
 }
 } // namespace detail
@@ -83,7 +90,16 @@ VMovB32Vop1::VMovB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mov_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_mov_b32_dpp"
+          : "v_mov_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop1>(opcode);
 }
 } // namespace detail
@@ -100,15 +116,24 @@ VReadfirstlaneB32Vop1::VReadfirstlaneB32Vop1(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_readfirstlane_b32_dpp"
+          : "v_readfirstlane_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support SDWA";
   return std::make_unique<VReadfirstlaneB32Vop1>(opcode);
 }
 } // namespace detail
@@ -130,15 +155,23 @@ VCvtI32F64Vop1::VCvtI32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_I32_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_I32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f64_dpp"
+          : "v_cvt_i32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_I32_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_I32_F64 does not support SDWA";
   return std::make_unique<VCvtI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -159,15 +192,23 @@ VCvtF64I32Vop1::VCvtF64I32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_I32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F64_I32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_i32_dpp"
+          : "v_cvt_f64_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_I32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_I32 does not support SDWA";
   return std::make_unique<VCvtF64I32Vop1>(opcode);
 }
 } // namespace detail
@@ -228,7 +269,17 @@ VCvtF32I32Vop1::VCvtF32I32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_i32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_i32_dpp"
+          : "v_cvt_f32_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop1>(opcode);
 }
 } // namespace detail
@@ -289,7 +340,17 @@ VCvtF32U32Vop1::VCvtF32U32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_u32_dpp"
+          : "v_cvt_f32_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop1>(opcode);
 }
 } // namespace detail
@@ -350,7 +411,17 @@ VCvtU32F32Vop1::VCvtU32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_u32_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f32_dpp"
+          : "v_cvt_u32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -411,7 +482,17 @@ VCvtI32F32Vop1::VCvtI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_i32_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f32_dpp"
+          : "v_cvt_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -472,7 +553,17 @@ VCvtF16F32Vop1::VCvtF16F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f16_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_f32_dpp"
+          : "v_cvt_f16_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop1>(opcode);
 }
 } // namespace detail
@@ -540,7 +631,17 @@ VCvtF32F16Vop1::VCvtF32F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f16_dpp"
+          : "v_cvt_f32_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop1>(opcode);
 }
 } // namespace detail
@@ -601,7 +702,18 @@ VCvtRpiI32F32Vop1::VCvtRpiI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtRpiI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_rpi_i32_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_rpi_i32_f32_dpp"
+          : "v_cvt_rpi_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtRpiI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -662,7 +774,18 @@ VCvtFlrI32F32Vop1::VCvtFlrI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtFlrI32F32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_flr_i32_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_flr_i32_f32_dpp"
+          : "v_cvt_flr_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFlrI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -723,7 +846,18 @@ VCvtOffF32I4Vop1::VCvtOffF32I4Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_off_f32_i4_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_off_f32_i4_dpp"
+          : "v_cvt_off_f32_i4_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop1>(opcode);
 }
 } // namespace detail
@@ -745,15 +879,23 @@ VCvtF32F64Vop1::VCvtF32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F32_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f64_dpp"
+          : "v_cvt_f32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F32_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F32_F64 does not support SDWA";
   return std::make_unique<VCvtF32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -774,15 +916,23 @@ VCvtF64F32Vop1::VCvtF64F32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F64_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_f32_dpp"
+          : "v_cvt_f64_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support SDWA";
   return std::make_unique<VCvtF64F32Vop1>(opcode);
 }
 } // namespace detail
@@ -843,7 +993,18 @@ VCvtF32Ubyte0Vop1::VCvtF32Ubyte0Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte0_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte0_dpp"
+          : "v_cvt_f32_ubyte0_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop1>(opcode);
 }
 } // namespace detail
@@ -904,7 +1065,18 @@ VCvtF32Ubyte1Vop1::VCvtF32Ubyte1Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte1_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte1_dpp"
+          : "v_cvt_f32_ubyte1_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop1>(opcode);
 }
 } // namespace detail
@@ -965,7 +1137,18 @@ VCvtF32Ubyte2Vop1::VCvtF32Ubyte2Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte2_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte2_dpp"
+          : "v_cvt_f32_ubyte2_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop1>(opcode);
 }
 } // namespace detail
@@ -1026,7 +1209,18 @@ VCvtF32Ubyte3Vop1::VCvtF32Ubyte3Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f32_ubyte3_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte3_dpp"
+          : "v_cvt_f32_ubyte3_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop1>(opcode);
 }
 } // namespace detail
@@ -1048,15 +1242,23 @@ VCvtU32F64Vop1::VCvtU32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_U32_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_U32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f64_dpp"
+          : "v_cvt_u32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_U32_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_U32_F64 does not support SDWA";
   return std::make_unique<VCvtU32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -1077,15 +1279,23 @@ VCvtF64U32Vop1::VCvtF64U32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_U32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CVT_F64_U32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_u32_dpp"
+          : "v_cvt_f64_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_U32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_U32 does not support SDWA";
   return std::make_unique<VCvtF64U32Vop1>(opcode);
 }
 } // namespace detail
@@ -1107,15 +1317,23 @@ VTruncF64Vop1::VTruncF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_TRUNC_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_TRUNC_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f64_dpp"
+          : "v_trunc_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_TRUNC_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_TRUNC_F64 does not support SDWA";
   return std::make_unique<VTruncF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1137,15 +1355,23 @@ VCeilF64Vop1::VCeilF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CEIL_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CEIL_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f64_dpp"
+          : "v_ceil_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CEIL_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CEIL_F64 does not support SDWA";
   return std::make_unique<VCeilF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1167,15 +1393,23 @@ VRndneF64Vop1::VRndneF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RNDNE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_RNDNE_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f64_dpp"
+          : "v_rndne_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support SDWA";
   return std::make_unique<VRndneF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1197,15 +1431,23 @@ VFloorF64Vop1::VFloorF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FLOOR_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FLOOR_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_floor_f64_dpp"
+          : "v_floor_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FLOOR_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FLOOR_F64 does not support SDWA";
   return std::make_unique<VFloorF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1221,7 +1463,15 @@ VPipeflushVop1::VPipeflushVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPipeflushVop1(const MachineInst *opcode) {
+DecodeResult decodeVPipeflushVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_pipeflush_dpp"
+          : "v_pipeflush_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPipeflushVop1>(opcode);
 }
 } // namespace detail
@@ -1281,7 +1531,17 @@ VFractF32Vop1::VFractF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_fract_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_fract_f32_dpp"
+          : "v_fract_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1341,7 +1601,17 @@ VTruncF32Vop1::VTruncF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_trunc_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f32_dpp"
+          : "v_trunc_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1401,7 +1671,16 @@ VCeilF32Vop1::VCeilF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ceil_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f32_dpp"
+          : "v_ceil_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1461,7 +1740,17 @@ VRndneF32Vop1::VRndneF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_rndne_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f32_dpp"
+          : "v_rndne_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1521,7 +1810,17 @@ VFloorF32Vop1::VFloorF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_floor_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_floor_f32_dpp"
+          : "v_floor_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1581,7 +1880,16 @@ VExpF32Vop1::VExpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_exp_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_exp_f32_dpp"
+          : "v_exp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1641,7 +1949,16 @@ VLogF32Vop1::VLogF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_log_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_log_f32_dpp"
+          : "v_log_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1701,7 +2018,16 @@ VRcpF32Vop1::VRcpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rcp_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f32_dpp"
+          : "v_rcp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1762,7 +2088,18 @@ VRcpIflagF32Vop1::VRcpIflagF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_rcp_iflag_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_iflag_f32_dpp"
+          : "v_rcp_iflag_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1822,7 +2159,16 @@ VRsqF32Vop1::VRsqF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rsq_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f32_dpp"
+          : "v_rsq_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1844,15 +2190,23 @@ VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RCP_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_RCP_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f64_dpp"
+          : "v_rcp_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support SDWA";
   return std::make_unique<VRcpF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1874,15 +2228,23 @@ VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RSQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_RSQ_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f64_dpp"
+          : "v_rsq_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support SDWA";
   return std::make_unique<VRsqF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1942,7 +2304,16 @@ VSqrtF32Vop1::VSqrtF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sqrt_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f32_dpp"
+          : "v_sqrt_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1964,15 +2335,23 @@ VSqrtF64Vop1::VSqrtF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SQRT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_SQRT_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f64_dpp"
+          : "v_sqrt_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support SDWA";
   return std::make_unique<VSqrtF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2032,7 +2411,16 @@ VSinF32Vop1::VSinF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sin_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sin_f32_dpp"
+          : "v_sin_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop1>(opcode);
 }
 } // namespace detail
@@ -2092,7 +2480,16 @@ VCosF32Vop1::VCosF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_cos_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cos_f32_dpp"
+          : "v_cos_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop1>(opcode);
 }
 } // namespace detail
@@ -2152,7 +2549,16 @@ VNotB32Vop1::VNotB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_not_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_not_b32_dpp"
+          : "v_not_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2212,7 +2618,17 @@ VBfrevB32Vop1::VBfrevB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_bfrev_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_bfrev_b32_dpp"
+          : "v_bfrev_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2272,7 +2688,16 @@ VFfbhU32Vop1::VFfbhU32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhU32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFfbhU32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ffbh_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ffbh_u32_dpp"
+          : "v_ffbh_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhU32Vop1>(opcode);
 }
 } // namespace detail
@@ -2332,7 +2757,16 @@ VFfblB32Vop1::VFfblB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfblB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFfblB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ffbl_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ffbl_b32_dpp"
+          : "v_ffbl_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfblB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2392,7 +2826,16 @@ VFfbhI32Vop1::VFfbhI32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhI32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFfbhI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ffbh_i32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ffbh_i32_dpp"
+          : "v_ffbh_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhI32Vop1>(opcode);
 }
 } // namespace detail
@@ -2414,15 +2857,24 @@ VFrexpExpI32F64Vop1::VFrexpExpI32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_EXP_I32_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FREXP_EXP_I32_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f64_dpp"
+          : "v_frexp_exp_i32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_EXP_I32_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_EXP_I32_F64 does not support SDWA";
   return std::make_unique<VFrexpExpI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -2444,15 +2896,24 @@ VFrexpMantF64Vop1::VFrexpMantF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_MANT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FREXP_MANT_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f64_dpp"
+          : "v_frexp_mant_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_MANT_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_MANT_F64 does not support SDWA";
   return std::make_unique<VFrexpMantF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2474,15 +2935,23 @@ VFractF64Vop1::VFractF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FRACT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FRACT_F64 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_fract_f64_dpp"
+          : "v_fract_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FRACT_F64 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FRACT_F64 does not support SDWA";
   return std::make_unique<VFractF64Vop1>(opcode);
 }
 } // namespace detail
@@ -2543,7 +3012,18 @@ VFrexpExpI32F32Vop1::VFrexpExpI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_exp_i32_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f32_dpp"
+          : "v_frexp_exp_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -2604,7 +3084,18 @@ VFrexpMantF32Vop1::VFrexpMantF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_mant_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f32_dpp"
+          : "v_frexp_mant_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop1>(opcode);
 }
 } // namespace detail
@@ -2620,7 +3111,15 @@ VClrexcpVop1::VClrexcpVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClrexcpVop1(const MachineInst *opcode) {
+DecodeResult decodeVClrexcpVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_clrexcp_dpp"
+          : "v_clrexcp_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClrexcpVop1>(opcode);
 }
 } // namespace detail
@@ -2684,7 +3183,18 @@ VMovreldB32Vop1::VMovreldB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovreldB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovreldB32Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_movreld_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movreld_b32_dpp"
+          : "v_movreld_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovreldB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2744,7 +3254,18 @@ VMovrelsB32Vop1::VMovrelsB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsB32Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_movrels_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movrels_b32_dpp"
+          : "v_movrels_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2804,7 +3325,18 @@ VMovrelsdB32Vop1::VMovrelsdB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsdB32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_movrelsd_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_b32_dpp"
+          : "v_movrelsd_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsdB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2864,7 +3396,18 @@ VMovrelsd2B32Vop1::VMovrelsd2B32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsd2B32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_movrelsd_2_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_2_b32_dpp"
+          : "v_movrelsd_2_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsd2B32Vop1>(opcode);
 }
 } // namespace detail
@@ -2926,7 +3469,17 @@ VCvtF16U16Vop1::VCvtF16U16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f16_u16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_u16_dpp"
+          : "v_cvt_f16_u16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop1>(opcode);
 }
 } // namespace detail
@@ -2994,7 +3547,17 @@ VCvtF16I16Vop1::VCvtF16I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_f16_i16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_i16_dpp"
+          : "v_cvt_f16_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop1>(opcode);
 }
 } // namespace detail
@@ -3062,7 +3625,17 @@ VCvtU16F16Vop1::VCvtU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_u16_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u16_f16_dpp"
+          : "v_cvt_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3130,7 +3703,17 @@ VCvtI16F16Vop1::VCvtI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_i16_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i16_f16_dpp"
+          : "v_cvt_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3197,7 +3780,16 @@ VRcpF16Vop1::VRcpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rcp_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f16_dpp"
+          : "v_rcp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3264,7 +3856,16 @@ VSqrtF16Vop1::VSqrtF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sqrt_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f16_dpp"
+          : "v_sqrt_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3331,7 +3932,16 @@ VRsqF16Vop1::VRsqF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_rsq_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f16_dpp"
+          : "v_rsq_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3398,7 +4008,16 @@ VLogF16Vop1::VLogF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_log_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_log_f16_dpp"
+          : "v_log_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3465,7 +4084,16 @@ VExpF16Vop1::VExpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_exp_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_exp_f16_dpp"
+          : "v_exp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3533,7 +4161,18 @@ VFrexpMantF16Vop1::VFrexpMantF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_mant_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f16_dpp"
+          : "v_frexp_mant_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3601,7 +4240,18 @@ VFrexpExpI16F16Vop1::VFrexpExpI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_frexp_exp_i16_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i16_f16_dpp"
+          : "v_frexp_exp_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3668,7 +4318,17 @@ VFloorF16Vop1::VFloorF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_floor_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_floor_f16_dpp"
+          : "v_floor_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3735,7 +4395,16 @@ VCeilF16Vop1::VCeilF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_ceil_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f16_dpp"
+          : "v_ceil_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3802,7 +4471,17 @@ VTruncF16Vop1::VTruncF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_trunc_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f16_dpp"
+          : "v_trunc_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3869,7 +4548,17 @@ VRndneF16Vop1::VRndneF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_rndne_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f16_dpp"
+          : "v_rndne_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3936,7 +4625,17 @@ VFractF16Vop1::VFractF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_fract_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_fract_f16_dpp"
+          : "v_fract_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop1>(opcode);
 }
 } // namespace detail
@@ -4003,7 +4702,16 @@ VSinF16Vop1::VSinF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sin_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sin_f16_dpp"
+          : "v_sin_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop1>(opcode);
 }
 } // namespace detail
@@ -4070,7 +4778,16 @@ VCosF16Vop1::VCosF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_cos_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cos_f16_dpp"
+          : "v_cos_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop1>(opcode);
 }
 } // namespace detail
@@ -4137,7 +4854,18 @@ VSatPkU8I16Vop1::VSatPkU8I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_sat_pk_u8_i16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sat_pk_u8_i16_dpp"
+          : "v_sat_pk_u8_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop1>(opcode);
 }
 } // namespace detail
@@ -4199,7 +4927,18 @@ VCvtNormI16F16Vop1::VCvtNormI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_norm_i16_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_i16_f16_dpp"
+          : "v_cvt_norm_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -4267,7 +5006,18 @@ VCvtNormU16F16Vop1::VCvtNormU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_norm_u16_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_u16_f16_dpp"
+          : "v_cvt_norm_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -4292,15 +5042,23 @@ VSwapB32Vop1::VSwapB32Vop1(const MachineInst *inst)
   dst_operands_[1] = &src0;
   num_src_ = 2;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWAP_B32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_SWAP_B32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swap_b32_dpp"
+          : "v_swap_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B32 does not support SDWA";
   return std::make_unique<VSwapB32Vop1>(opcode);
 }
 } // namespace detail
@@ -4321,16 +5079,25 @@ VSwaprelB32Vop1::VSwaprelB32Vop1(const MachineInst *inst)
   src_operands_[2] = &m0;
   num_src_ = 3;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWAPREL_B32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_SWAPREL_B32 does not support SDWA", "");
   m0.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwaprelB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwaprelB32Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swaprel_b32_dpp"
+          : "v_swaprel_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SWAPREL_B32 does not support DPP";
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_SWAPREL_B32 does not support SDWA";
   return std::make_unique<VSwaprelB32Vop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/vop2.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/vop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -78,7 +77,18 @@ VCndmaskB32Vop2::VCndmaskB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cndmask_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_cndmask_b32_dpp"
+          : "v_cndmask_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop2>(opcode);
 }
 } // namespace detail
@@ -119,12 +129,21 @@ VDot2cF32F16Vop2::VDot2cF32F16Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT2C_F32_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2cF32F16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot2cF32F16Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_dot2c_f32_f16_dpp"
+          : "v_dot2c_f32_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT2C_F32_F16 does not support SDWA";
   return std::make_unique<VDot2cF32F16Vop2>(opcode);
 }
 } // namespace detail
@@ -190,7 +209,16 @@ VAddF32Vop2::VAddF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_f32_dpp"
+          : "v_add_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop2>(opcode);
 }
 } // namespace detail
@@ -256,7 +284,16 @@ VSubF32Vop2::VSubF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_f32_dpp"
+          : "v_sub_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop2>(opcode);
 }
 } // namespace detail
@@ -323,7 +360,17 @@ VSubrevF32Vop2::VSubrevF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f32_dpp"
+          : "v_subrev_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop2>(opcode);
 }
 } // namespace detail
@@ -347,15 +394,24 @@ VFmacLegacyF32Vop2::VFmacLegacyF32Vop2(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAC_LEGACY_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAC_LEGACY_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacLegacyF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacLegacyF32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmac_legacy_f32_dpp"
+          : "v_fmac_legacy_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_LEGACY_F32 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_LEGACY_F32 does not support SDWA";
   return std::make_unique<VFmacLegacyF32Vop2>(opcode);
 }
 } // namespace detail
@@ -422,7 +478,18 @@ VMulLegacyF32Vop2::VMulLegacyF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLegacyF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulLegacyF32Vop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_legacy_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_legacy_f32_dpp"
+          : "v_mul_legacy_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLegacyF32Vop2>(opcode);
 }
 } // namespace detail
@@ -488,7 +555,16 @@ VMulF32Vop2::VMulF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mul_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_f32_dpp"
+          : "v_mul_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop2>(opcode);
 }
 } // namespace detail
@@ -555,7 +631,17 @@ VMulI32I24Vop2::VMulI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_i32_i24_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_i32_i24_dpp"
+          : "v_mul_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -622,7 +708,18 @@ VMulHiI32I24Vop2::VMulHiI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_hi_i32_i24_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_i32_i24_dpp"
+          : "v_mul_hi_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -689,7 +786,17 @@ VMulU32U24Vop2::VMulU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_u32_u24_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_u32_u24_dpp"
+          : "v_mul_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -756,7 +863,18 @@ VMulHiU32U24Vop2::VMulHiU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_mul_hi_u32_u24_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_u32_u24_dpp"
+          : "v_mul_hi_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -797,12 +915,21 @@ VDot4cI32I8Vop2::VDot4cI32I8Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_DOT4C_I32_I8 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4cI32I8Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot4cI32I8Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_dot4c_i32_i8_dpp"
+          : "v_dot4c_i32_i8_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_DOT4C_I32_I8 does not support SDWA";
   return std::make_unique<VDot4cI32I8Vop2>(opcode);
 }
 } // namespace detail
@@ -868,7 +995,16 @@ VMinF32Vop2::VMinF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_f32_dpp"
+          : "v_min_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF32Vop2>(opcode);
 }
 } // namespace detail
@@ -934,7 +1070,16 @@ VMaxF32Vop2::VMaxF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_f32_dpp"
+          : "v_max_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1000,7 +1145,16 @@ VMinI32Vop2::VMinI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_i32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_i32_dpp"
+          : "v_min_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop2>(opcode);
 }
 } // namespace detail
@@ -1066,7 +1220,16 @@ VMaxI32Vop2::VMaxI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_i32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_i32_dpp"
+          : "v_max_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop2>(opcode);
 }
 } // namespace detail
@@ -1132,7 +1295,16 @@ VMinU32Vop2::VMinU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_u32_dpp"
+          : "v_min_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1198,7 +1370,16 @@ VMaxU32Vop2::VMaxU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_u32_dpp"
+          : "v_max_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1265,7 +1446,18 @@ VLshrrevB32Vop2::VLshrrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshrrev_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_lshrrev_b32_dpp"
+          : "v_lshrrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1332,7 +1524,18 @@ VAshrrevI32Vop2::VAshrrevI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_ashrrev_i32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_ashrrev_i32_dpp"
+          : "v_ashrrev_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop2>(opcode);
 }
 } // namespace detail
@@ -1399,7 +1602,18 @@ VLshlrevB32Vop2::VLshlrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_lshlrev_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b32_dpp"
+          : "v_lshlrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1465,7 +1679,16 @@ VAndB32Vop2::VAndB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_and_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_and_b32_dpp"
+          : "v_and_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1531,7 +1754,16 @@ VOrB32Vop2::VOrB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_or_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_or_b32_dpp"
+          : "v_or_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1597,7 +1829,16 @@ VXorB32Vop2::VXorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_xor_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_xor_b32_dpp"
+          : "v_xor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1663,7 +1904,16 @@ VXnorB32Vop2::VXnorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_xnor_b32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_xnor_b32_dpp"
+          : "v_xnor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1730,7 +1980,17 @@ VAddNcU32Vop2::VAddNcU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_add_nc_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_u32_dpp"
+          : "v_add_nc_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1797,7 +2057,17 @@ VSubNcU32Vop2::VSubNcU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_sub_nc_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_u32_dpp"
+          : "v_sub_nc_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1864,7 +2134,18 @@ VSubrevNcU32Vop2::VSubrevNcU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevNcU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_nc_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_nc_u32_dpp"
+          : "v_subrev_nc_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevNcU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1937,7 +2218,18 @@ VAddCoCiU32Vop2::VAddCoCiU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddCoCiU32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_add_co_ci_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_co_ci_u32_dpp"
+          : "v_add_co_ci_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoCiU32Vop2>(opcode);
 }
 } // namespace detail
@@ -2010,7 +2302,18 @@ VSubCoCiU32Vop2::VSubCoCiU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubCoCiU32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_sub_co_ci_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_co_ci_u32_dpp"
+          : "v_sub_co_ci_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoCiU32Vop2>(opcode);
 }
 } // namespace detail
@@ -2083,7 +2386,18 @@ VSubrevCoCiU32Vop2::VSubrevCoCiU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoCiU32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_co_ci_u32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_co_ci_u32_dpp"
+          : "v_subrev_co_ci_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoCiU32Vop2>(opcode);
 }
 } // namespace detail
@@ -2124,12 +2438,20 @@ VFmacF32Vop2::VFmacF32Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAC_F32 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f32_dpp"
+          : "v_fmac_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_F32 does not support SDWA";
   return std::make_unique<VFmacF32Vop2>(opcode);
 }
 } // namespace detail
@@ -2157,16 +2479,24 @@ VFmamkF32Vop2::VFmamkF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAMK_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAMK_F32 does not support SDWA", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmamkF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmamkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmamk_f32_dpp"
+          : "v_fmamk_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F32 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F32 does not support SDWA";
   return std::make_unique<VFmamkF32Vop2>(opcode);
 }
 } // namespace detail
@@ -2194,16 +2524,24 @@ VFmaakF32Vop2::VFmaakF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAAK_F32 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAAK_F32 does not support SDWA", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaakF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmaakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmaak_f32_dpp"
+          : "v_fmaak_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F32 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F32 does not support SDWA";
   return std::make_unique<VFmaakF32Vop2>(opcode);
 }
 } // namespace detail
@@ -2270,7 +2608,18 @@ VCvtPkrtzF16F32Vop2::VCvtPkrtzF16F32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkrtzF16F32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkrtzF16F32Vop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cvt_pkrtz_f16_f32_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pkrtz_f16_f32_dpp"
+          : "v_cvt_pkrtz_f16_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkrtzF16F32Vop2>(opcode);
 }
 } // namespace detail
@@ -2337,7 +2686,16 @@ VAddF16Vop2::VAddF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_add_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_f16_dpp"
+          : "v_add_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2410,7 +2768,16 @@ VSubF16Vop2::VSubF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_sub_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_f16_dpp"
+          : "v_sub_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2484,7 +2851,17 @@ VSubrevF16Vop2::VSubrevF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_subrev_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f16_dpp"
+          : "v_subrev_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2557,7 +2934,16 @@ VMulF16Vop2::VMulF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_mul_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_f16_dpp"
+          : "v_mul_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2605,12 +2991,20 @@ VFmacF16Vop2::VFmacF16Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAC_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f16_dpp"
+          : "v_fmac_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_F16 does not support SDWA";
   return std::make_unique<VFmacF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2646,16 +3040,24 @@ VFmamkF16Vop2::VFmamkF16Vop2(const MachineInst *inst)
       Operand(16, OperandType::OPR_SIMM32,
               static_cast<int>(
                   (reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAMK_F16 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAMK_F16 does not support SDWA", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmamkF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmamkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmamk_f16_dpp"
+          : "v_fmamk_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F16 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F16 does not support SDWA";
   return std::make_unique<VFmamkF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2691,16 +3093,24 @@ VFmaakF16Vop2::VFmaakF16Vop2(const MachineInst *inst)
       Operand(16, OperandType::OPR_SIMM32,
               static_cast<int>(
                   (reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAAK_F16 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_FMAAK_F16 does not support SDWA", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaakF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmaakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmaak_f16_dpp"
+          : "v_fmaak_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F16 does not support DPP";
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F16 does not support SDWA";
   return std::make_unique<VFmaakF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2773,7 +3183,16 @@ VMaxF16Vop2::VMaxF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_max_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_f16_dpp"
+          : "v_max_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2846,7 +3265,16 @@ VMinF16Vop2::VMinF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA ? "v_min_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_f16_dpp"
+          : "v_min_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2919,7 +3347,17 @@ VLdexpF16Vop2::VLdexpF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_ldexp_f16_sdwa"
+      : amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_ldexp_f16_dpp"
+          : "v_ldexp_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2966,12 +3404,20 @@ VPkFmacF16Vop2::VPkFmacF16Vop2(const MachineInst *inst)
     dpp_bound_ctrl_ = dp->bound_ctrl;
     dpp_fi_ = dp->fi;
   }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_PK_FMAC_F16 does not support SDWA", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_pk_fmac_f16_dpp"
+          : "v_pk_fmac_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_PK_FMAC_F16 does not support SDWA";
   return std::make_unique<VPkFmacF16Vop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/vop3.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/vop3.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -30,7 +29,12 @@ VInterpP1F32Vop3::VInterpP1F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP1F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpP1F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_p1_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP1F32Vop3>(opcode);
 }
 } // namespace detail
@@ -53,7 +57,12 @@ VInterpP2F32Vop3::VInterpP2F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_p2_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2F32Vop3>(opcode);
 }
 } // namespace detail
@@ -75,7 +84,12 @@ VInterpMovF32Vop3::VInterpMovF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpMovF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpMovF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_mov_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpMovF32Vop3>(opcode);
 }
 } // namespace detail
@@ -88,7 +102,11 @@ VNopVop3::VNopVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode) {
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_nop", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop3>(opcode);
 }
 } // namespace detail
@@ -109,7 +127,11 @@ VMovB32Vop3::VMovB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mov_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop3>(opcode);
 }
 } // namespace detail
@@ -126,7 +148,12 @@ VReadfirstlaneB32Vop3::VReadfirstlaneB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_readfirstlane_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VReadfirstlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -148,7 +175,11 @@ VCvtI32F64Vop3::VCvtI32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_i32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -169,7 +200,11 @@ VCvtF64I32Vop3::VCvtF64I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f64_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF64I32Vop3>(opcode);
 }
 } // namespace detail
@@ -190,7 +225,11 @@ VCvtF32I32Vop3::VCvtF32I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop3>(opcode);
 }
 } // namespace detail
@@ -211,7 +250,11 @@ VCvtF32U32Vop3::VCvtF32U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop3>(opcode);
 }
 } // namespace detail
@@ -232,7 +275,11 @@ VCvtU32F32Vop3::VCvtU32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_u32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -253,7 +300,11 @@ VCvtI32F32Vop3::VCvtI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -274,7 +325,11 @@ VCvtF16F32Vop3::VCvtF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -302,7 +357,11 @@ VCvtF32F16Vop3::VCvtF32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -323,7 +382,12 @@ VCvtRpiI32F32Vop3::VCvtRpiI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtRpiI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtRpiI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_rpi_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtRpiI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -344,7 +408,12 @@ VCvtFlrI32F32Vop3::VCvtFlrI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFlrI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtFlrI32F32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_flr_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFlrI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -365,7 +434,12 @@ VCvtOffF32I4Vop3::VCvtOffF32I4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_off_f32_i4", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop3>(opcode);
 }
 } // namespace detail
@@ -387,7 +461,11 @@ VCvtF32F64Vop3::VCvtF32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -408,7 +486,11 @@ VCvtF64F32Vop3::VCvtF64F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f64_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF64F32Vop3>(opcode);
 }
 } // namespace detail
@@ -429,7 +511,12 @@ VCvtF32Ubyte0Vop3::VCvtF32Ubyte0Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte0", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop3>(opcode);
 }
 } // namespace detail
@@ -450,7 +537,12 @@ VCvtF32Ubyte1Vop3::VCvtF32Ubyte1Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte1", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop3>(opcode);
 }
 } // namespace detail
@@ -471,7 +563,12 @@ VCvtF32Ubyte2Vop3::VCvtF32Ubyte2Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte2", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop3>(opcode);
 }
 } // namespace detail
@@ -492,7 +589,12 @@ VCvtF32Ubyte3Vop3::VCvtF32Ubyte3Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f32_ubyte3", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop3>(opcode);
 }
 } // namespace detail
@@ -514,7 +616,11 @@ VCvtU32F64Vop3::VCvtU32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_u32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -535,7 +641,11 @@ VCvtF64U32Vop3::VCvtF64U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f64_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF64U32Vop3>(opcode);
 }
 } // namespace detail
@@ -557,7 +667,11 @@ VTruncF64Vop3::VTruncF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trunc_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF64Vop3>(opcode);
 }
 } // namespace detail
@@ -579,7 +693,11 @@ VCeilF64Vop3::VCeilF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ceil_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF64Vop3>(opcode);
 }
 } // namespace detail
@@ -601,7 +719,11 @@ VRndneF64Vop3::VRndneF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rndne_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF64Vop3>(opcode);
 }
 } // namespace detail
@@ -623,7 +745,11 @@ VFloorF64Vop3::VFloorF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_floor_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF64Vop3>(opcode);
 }
 } // namespace detail
@@ -636,7 +762,11 @@ VPipeflushVop3::VPipeflushVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPipeflushVop3(const MachineInst *opcode) {
+DecodeResult decodeVPipeflushVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_pipeflush", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPipeflushVop3>(opcode);
 }
 } // namespace detail
@@ -657,7 +787,11 @@ VFractF32Vop3::VFractF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fract_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop3>(opcode);
 }
 } // namespace detail
@@ -678,7 +812,11 @@ VTruncF32Vop3::VTruncF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trunc_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop3>(opcode);
 }
 } // namespace detail
@@ -699,7 +837,11 @@ VCeilF32Vop3::VCeilF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ceil_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop3>(opcode);
 }
 } // namespace detail
@@ -720,7 +862,11 @@ VRndneF32Vop3::VRndneF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rndne_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop3>(opcode);
 }
 } // namespace detail
@@ -741,7 +887,11 @@ VFloorF32Vop3::VFloorF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_floor_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop3>(opcode);
 }
 } // namespace detail
@@ -762,7 +912,11 @@ VExpF32Vop3::VExpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_exp_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -783,7 +937,11 @@ VLogF32Vop3::VLogF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_log_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop3>(opcode);
 }
 } // namespace detail
@@ -804,7 +962,11 @@ VRcpF32Vop3::VRcpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -825,7 +987,12 @@ VRcpIflagF32Vop3::VRcpIflagF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_iflag_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop3>(opcode);
 }
 } // namespace detail
@@ -846,7 +1013,11 @@ VRsqF32Vop3::VRsqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rsq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -868,7 +1039,11 @@ VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -890,7 +1065,11 @@ VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rsq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -911,7 +1090,11 @@ VSqrtF32Vop3::VSqrtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sqrt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -933,7 +1116,11 @@ VSqrtF64Vop3::VSqrtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sqrt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -954,7 +1141,11 @@ VSinF32Vop3::VSinF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sin_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop3>(opcode);
 }
 } // namespace detail
@@ -975,7 +1166,11 @@ VCosF32Vop3::VCosF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cos_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop3>(opcode);
 }
 } // namespace detail
@@ -996,7 +1191,11 @@ VNotB32Vop3::VNotB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_not_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1017,7 +1216,11 @@ VBfrevB32Vop3::VBfrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfrev_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1038,7 +1241,11 @@ VFfbhU32Vop3::VFfbhU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFfbhU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ffbh_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhU32Vop3>(opcode);
 }
 } // namespace detail
@@ -1059,7 +1266,11 @@ VFfblB32Vop3::VFfblB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfblB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFfblB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ffbl_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfblB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1080,7 +1291,11 @@ VFfbhI32Vop3::VFfbhI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFfbhI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFfbhI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ffbh_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFfbhI32Vop3>(opcode);
 }
 } // namespace detail
@@ -1102,7 +1317,12 @@ VFrexpExpI32F64Vop3::VFrexpExpI32F64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_exp_i32_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -1124,7 +1344,12 @@ VFrexpMantF64Vop3::VFrexpMantF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_mant_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1146,7 +1371,11 @@ VFractF64Vop3::VFractF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fract_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1167,7 +1396,12 @@ VFrexpExpI32F32Vop3::VFrexpExpI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_exp_i32_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -1188,7 +1422,12 @@ VFrexpMantF32Vop3::VFrexpMantF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_mant_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1201,7 +1440,11 @@ VClrexcpVop3::VClrexcpVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClrexcpVop3(const MachineInst *opcode) {
+DecodeResult decodeVClrexcpVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_clrexcp", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClrexcpVop3>(opcode);
 }
 } // namespace detail
@@ -1225,7 +1468,12 @@ VMovreldB32Vop3::VMovreldB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovreldB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovreldB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_movreld_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovreldB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1245,7 +1493,12 @@ VMovrelsB32Vop3::VMovrelsB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_movrels_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1265,7 +1518,12 @@ VMovrelsdB32Vop3::VMovrelsdB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsdB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_movrelsd_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsdB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1285,7 +1543,12 @@ VMovrelsd2B32Vop3::VMovrelsd2B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsd2B32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_movrelsd_2_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsd2B32Vop3>(opcode);
 }
 } // namespace detail
@@ -1307,7 +1570,11 @@ VCvtF16U16Vop3::VCvtF16U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f16_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop3>(opcode);
 }
 } // namespace detail
@@ -1335,7 +1602,11 @@ VCvtF16I16Vop3::VCvtF16I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_f16_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop3>(opcode);
 }
 } // namespace detail
@@ -1363,7 +1634,11 @@ VCvtU16F16Vop3::VCvtU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_u16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1391,7 +1666,11 @@ VCvtI16F16Vop3::VCvtI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1419,7 +1698,11 @@ VRcpF16Vop3::VRcpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rcp_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1447,7 +1730,11 @@ VSqrtF16Vop3::VSqrtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sqrt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1475,7 +1762,11 @@ VRsqF16Vop3::VRsqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rsq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1503,7 +1794,11 @@ VLogF16Vop3::VLogF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_log_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1531,7 +1826,11 @@ VExpF16Vop3::VExpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_exp_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1559,7 +1858,12 @@ VFrexpMantF16Vop3::VFrexpMantF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_mant_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1587,7 +1891,12 @@ VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_frexp_exp_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1615,7 +1924,11 @@ VFloorF16Vop3::VFloorF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_floor_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1643,7 +1956,11 @@ VCeilF16Vop3::VCeilF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ceil_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1671,7 +1988,11 @@ VTruncF16Vop3::VTruncF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trunc_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1699,7 +2020,11 @@ VRndneF16Vop3::VRndneF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_rndne_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1727,7 +2052,11 @@ VFractF16Vop3::VFractF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fract_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1755,7 +2084,11 @@ VSinF16Vop3::VSinF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sin_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1783,7 +2116,11 @@ VCosF16Vop3::VCosF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cos_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop3>(opcode);
 }
 } // namespace detail
@@ -1810,7 +2147,12 @@ VSatPkU8I16Vop3::VSatPkU8I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sat_pk_u8_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop3>(opcode);
 }
 } // namespace detail
@@ -1832,7 +2174,12 @@ VCvtNormI16F16Vop3::VCvtNormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_norm_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1860,7 +2207,12 @@ VCvtNormU16F16Vop3::VCvtNormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_norm_u16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -1895,7 +2247,12 @@ VCndmaskB32Vop3::VCndmaskB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cndmask_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1922,7 +2279,11 @@ VAddF32Vop3::VAddF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1949,7 +2310,11 @@ VSubF32Vop3::VSubF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1976,7 +2341,11 @@ VSubrevF32Vop3::VSubrevF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2004,7 +2373,12 @@ VFmacLegacyF32Vop3::VFmacLegacyF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacLegacyF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacLegacyF32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fmac_legacy_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacLegacyF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2031,7 +2405,12 @@ VMulLegacyF32Vop3::VMulLegacyF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLegacyF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_legacy_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLegacyF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2058,7 +2437,11 @@ VMulF32Vop3::VMulF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2085,7 +2468,11 @@ VMulI32I24Vop3::VMulI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_i32_i24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -2112,7 +2499,12 @@ VMulHiI32I24Vop3::VMulHiI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_i32_i24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -2139,7 +2531,11 @@ VMulU32U24Vop3::VMulU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_u32_u24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -2166,7 +2562,12 @@ VMulHiU32U24Vop3::VMulHiU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_u32_u24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -2193,7 +2594,11 @@ VMinF32Vop3::VMinF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2220,7 +2625,11 @@ VMaxF32Vop3::VMaxF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2247,7 +2656,11 @@ VMinI32Vop3::VMinI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop3>(opcode);
 }
 } // namespace detail
@@ -2274,7 +2687,11 @@ VMaxI32Vop3::VMaxI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop3>(opcode);
 }
 } // namespace detail
@@ -2301,7 +2718,11 @@ VMinU32Vop3::VMinU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2328,7 +2749,11 @@ VMaxU32Vop3::VMaxU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2355,7 +2780,12 @@ VLshrrevB32Vop3::VLshrrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshrrev_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2382,7 +2812,12 @@ VAshrrevI32Vop3::VAshrrevI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashrrev_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop3>(opcode);
 }
 } // namespace detail
@@ -2409,7 +2844,12 @@ VLshlrevB32Vop3::VLshlrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshlrev_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2436,7 +2876,11 @@ VAndB32Vop3::VAndB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_and_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2463,7 +2907,11 @@ VOrB32Vop3::VOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_or_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2490,7 +2938,11 @@ VXorB32Vop3::VXorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xor_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2517,7 +2969,11 @@ VXnorB32Vop3::VXnorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xnor_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2544,7 +3000,11 @@ VAddNcU32Vop3::VAddNcU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_nc_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2571,7 +3031,11 @@ VSubNcU32Vop3::VSubNcU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_nc_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2598,7 +3062,12 @@ VSubrevNcU32Vop3::VSubrevNcU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevNcU32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_nc_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevNcU32Vop3>(opcode);
 }
 } // namespace detail
@@ -2626,7 +3095,11 @@ VFmacF32Vop3::VFmacF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fmac_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2653,7 +3126,12 @@ VCvtPkrtzF16F32Vop3::VCvtPkrtzF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkrtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pkrtz_f16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkrtzF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -2682,7 +3160,11 @@ VAddF16Vop3::VAddF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2717,7 +3199,11 @@ VSubF16Vop3::VSubF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2752,7 +3238,11 @@ VSubrevF16Vop3::VSubrevF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_subrev_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2787,7 +3277,11 @@ VMulF16Vop3::VMulF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2823,7 +3317,11 @@ VFmacF16Vop3::VFmacF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fmac_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2858,7 +3356,11 @@ VMaxF16Vop3::VMaxF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2893,7 +3395,11 @@ VMinF16Vop3::VMinF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2928,7 +3434,11 @@ VLdexpF16Vop3::VLdexpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ldexp_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2967,7 +3477,12 @@ VFmaLegacyF32Vop3::VFmaLegacyF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaLegacyF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaLegacyF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_legacy_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaLegacyF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3000,7 +3515,11 @@ VMadI32I24Vop3::VMadI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_i32_i24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -3033,7 +3552,11 @@ VMadU32U24Vop3::VMadU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_u32_u24", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -3066,7 +3589,11 @@ VCubeidF32Vop3::VCubeidF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubeid_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubeidF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3099,7 +3626,11 @@ VCubescF32Vop3::VCubescF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubesc_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubescF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3132,7 +3663,11 @@ VCubetcF32Vop3::VCubetcF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubetc_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubetcF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3165,7 +3700,11 @@ VCubemaF32Vop3::VCubemaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cubema_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubemaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3198,7 +3737,11 @@ VBfeU32Vop3::VBfeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfe_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3231,7 +3774,11 @@ VBfeI32Vop3::VBfeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfe_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -3264,7 +3811,11 @@ VBfiB32Vop3::VBfiB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfi_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfiB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3297,7 +3848,11 @@ VFmaF32Vop3::VFmaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3333,7 +3888,11 @@ VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF64Vop3>(opcode);
 }
 } // namespace detail
@@ -3366,7 +3925,11 @@ VLerpU8Vop3::VLerpU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lerp_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLerpU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3399,7 +3962,12 @@ VAlignbitB32Vop3::VAlignbitB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_alignbit_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbitB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3432,7 +4000,12 @@ VAlignbyteB32Vop3::VAlignbyteB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_alignbyte_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbyteB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3465,7 +4038,11 @@ VMullitF32Vop3::VMullitF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMullitF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMullitF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mullit_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMullitF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3498,7 +4075,11 @@ VMin3F32Vop3::VMin3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3531,7 +4112,11 @@ VMin3I32Vop3::VMin3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -3564,7 +4149,11 @@ VMin3U32Vop3::VMin3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3597,7 +4186,11 @@ VMax3F32Vop3::VMax3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3630,7 +4223,11 @@ VMax3I32Vop3::VMax3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -3663,7 +4260,11 @@ VMax3U32Vop3::VMax3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3696,7 +4297,11 @@ VMed3F32Vop3::VMed3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3729,7 +4334,11 @@ VMed3I32Vop3::VMed3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -3762,7 +4371,11 @@ VMed3U32Vop3::VMed3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -3795,7 +4408,11 @@ VSadU8Vop3::VSadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3828,7 +4445,11 @@ VSadHiU8Vop3::VSadHiU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_hi_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadHiU8Vop3>(opcode);
 }
 } // namespace detail
@@ -3861,7 +4482,11 @@ VSadU16Vop3::VSadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -3894,7 +4519,11 @@ VSadU32Vop3::VSadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sad_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -3927,7 +4556,12 @@ VCvtPkU8F32Vop3::VCvtPkU8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_u8_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -3960,7 +4594,12 @@ VDivFixupF32Vop3::VDivFixupF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3996,7 +4635,12 @@ VDivFixupF64Vop3::VDivFixupF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4025,7 +4669,11 @@ VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4054,7 +4702,11 @@ VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4083,7 +4735,11 @@ VMinF64Vop3::VMinF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4112,7 +4768,11 @@ VMaxF64Vop3::VMaxF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4140,7 +4800,11 @@ VLdexpF64Vop3::VLdexpF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ldexp_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4167,7 +4831,11 @@ VMulLoU32Vop3::VMulLoU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_lo_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4194,7 +4862,11 @@ VMulHiU32Vop3::VMulHiU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4221,7 +4893,11 @@ VMulHiI32Vop3::VMulHiI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_hi_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4257,7 +4933,12 @@ VDivFmasF32Vop3::VDivFmasF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fmas_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFmasF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4296,7 +4977,12 @@ VDivFmasF64Vop3::VDivFmasF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fmas_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFmasF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4329,7 +5015,11 @@ VMsadU8Vop3::VMsadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_msad_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMsadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -4364,7 +5054,12 @@ VQsadPkU16U8Vop3::VQsadPkU16U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_qsad_pk_u16_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VQsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -4399,7 +5094,12 @@ VMqsadPkU16U8Vop3::VMqsadPkU16U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mqsad_pk_u16_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMqsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -4427,7 +5127,12 @@ VTrigPreopF64Vop3::VTrigPreopF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_trig_preop_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTrigPreopF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4457,7 +5162,12 @@ VMqsadU32U8Vop3::VMqsadU32U8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mqsad_u32_u8", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMqsadU32U8Vop3>(opcode);
 }
 } // namespace detail
@@ -4490,7 +5200,11 @@ VXor3B32Vop3::VXor3B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXor3B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXor3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xor3_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXor3B32Vop3>(opcode);
 }
 } // namespace detail
@@ -4518,7 +5232,12 @@ VLshlrevB64Vop3::VLshlrevB64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshlrev_b64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -4546,7 +5265,12 @@ VLshrrevB64Vop3::VLshrrevB64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshrrev_b64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -4574,7 +5298,12 @@ VAshrrevI64Vop3::VAshrrevI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashrrev_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI64Vop3>(opcode);
 }
 } // namespace detail
@@ -4603,7 +5332,11 @@ VAddNcU16Vop3::VAddNcU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_nc_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcU16Vop3>(opcode);
 }
 } // namespace detail
@@ -4638,7 +5371,11 @@ VSubNcU16Vop3::VSubNcU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_nc_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcU16Vop3>(opcode);
 }
 } // namespace detail
@@ -4673,7 +5410,11 @@ VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mul_lo_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU16Vop3>(opcode);
 }
 } // namespace detail
@@ -4708,7 +5449,12 @@ VLshrrevB16Vop3::VLshrrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshrrev_b16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -4743,7 +5489,12 @@ VAshrrevI16Vop3::VAshrrevI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ashrrev_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI16Vop3>(opcode);
 }
 } // namespace detail
@@ -4778,7 +5529,11 @@ VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU16Vop3>(opcode);
 }
 } // namespace detail
@@ -4813,7 +5568,11 @@ VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI16Vop3>(opcode);
 }
 } // namespace detail
@@ -4848,7 +5607,11 @@ VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU16Vop3>(opcode);
 }
 } // namespace detail
@@ -4883,7 +5646,11 @@ VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI16Vop3>(opcode);
 }
 } // namespace detail
@@ -4918,7 +5685,11 @@ VAddNcI16Vop3::VAddNcI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_nc_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcI16Vop3>(opcode);
 }
 } // namespace detail
@@ -4953,7 +5724,11 @@ VSubNcI16Vop3::VSubNcI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_nc_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcI16Vop3>(opcode);
 }
 } // namespace detail
@@ -4988,7 +5763,12 @@ VPackB32F16Vop3::VPackB32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_pack_b32_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPackB32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -5017,7 +5797,12 @@ VCvtPknormI16F16Vop3::VCvtPknormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_i16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -5046,7 +5831,12 @@ VCvtPknormU16F16Vop3::VCvtPknormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_u16_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -5075,7 +5865,12 @@ VLshlrevB16Vop3::VLshlrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshlrev_b16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -5117,7 +5912,11 @@ VMadU16Vop3::VMadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -5142,7 +5941,12 @@ VInterpP1llF16Vop3::VInterpP1llF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP1llF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpP1llF16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_p1ll_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP1llF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5163,7 +5967,12 @@ VInterpP1lvF16Vop3::VInterpP1lvF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP1lvF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpP1lvF16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_p1lv_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP1lvF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5196,7 +6005,11 @@ VPermB32Vop3::VPermB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_perm_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPermB32Vop3>(opcode);
 }
 } // namespace detail
@@ -5229,7 +6042,11 @@ VXadU32Vop3::VXadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_xad_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -5262,7 +6079,12 @@ VLshlAddU32Vop3::VLshlAddU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshl_add_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlAddU32Vop3>(opcode);
 }
 } // namespace detail
@@ -5295,7 +6117,12 @@ VAddLshlU32Vop3::VAddLshlU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_lshl_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddLshlU32Vop3>(opcode);
 }
 } // namespace detail
@@ -5331,7 +6158,11 @@ VFmaF16Vop3::VFmaF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_fma_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5373,7 +6204,11 @@ VMin3F16Vop3::VMin3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -5415,7 +6250,11 @@ VMin3I16Vop3::VMin3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -5457,7 +6296,11 @@ VMin3U16Vop3::VMin3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_min3_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -5499,7 +6342,11 @@ VMax3F16Vop3::VMax3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -5541,7 +6388,11 @@ VMax3I16Vop3::VMax3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -5583,7 +6434,11 @@ VMax3U16Vop3::VMax3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_max3_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -5625,7 +6480,11 @@ VMed3F16Vop3::VMed3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -5667,7 +6526,11 @@ VMed3I16Vop3::VMed3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -5709,7 +6572,11 @@ VMed3U16Vop3::VMed3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_med3_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -5736,7 +6603,12 @@ VInterpP2F16Vop3::VInterpP2F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_interp_p2_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2F16Vop3>(opcode);
 }
 } // namespace detail
@@ -5778,7 +6650,11 @@ VMadI16Vop3::VMadI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI16Vop3>(opcode);
 }
 } // namespace detail
@@ -5820,7 +6696,12 @@ VDivFixupF16Vop3::VDivFixupF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_div_fixup_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5845,7 +6726,12 @@ VReadlaneB32Vop3::VReadlaneB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_readlane_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VReadlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -5869,7 +6755,12 @@ VWritelaneB32Vop3::VWritelaneB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_writelane_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VWritelaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -5896,7 +6787,11 @@ VLdexpF32Vop3::VLdexpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_ldexp_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5923,7 +6818,11 @@ VBfmB32Vop3::VBfmB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bfm_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfmB32Vop3>(opcode);
 }
 } // namespace detail
@@ -5950,7 +6849,12 @@ VBcntU32B32Vop3::VBcntU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_bcnt_u32_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBcntU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -5977,7 +6881,12 @@ VMbcntLoU32B32Vop3::VMbcntLoU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mbcnt_lo_u32_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntLoU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -6004,7 +6913,12 @@ VMbcntHiU32B32Vop3::VMbcntHiU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mbcnt_hi_u32_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntHiU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -6031,7 +6945,12 @@ VCvtPknormI16F32Vop3::VCvtPknormI16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormI16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_i16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormI16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6058,7 +6977,12 @@ VCvtPknormU16F32Vop3::VCvtPknormU16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPknormU16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPknormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pknorm_u16_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPknormU16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6085,7 +7009,12 @@ VCvtPkU16U32Vop3::VCvtPkU16U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_u16_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU16U32Vop3>(opcode);
 }
 } // namespace detail
@@ -6112,7 +7041,12 @@ VCvtPkI16I32Vop3::VCvtPkI16I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cvt_pk_i16_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkI16I32Vop3>(opcode);
 }
 } // namespace detail
@@ -6145,7 +7079,11 @@ VAdd3U32Vop3::VAdd3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add3_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAdd3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -6178,7 +7116,11 @@ VLshlOrB32Vop3::VLshlOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_lshl_or_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -6211,7 +7153,11 @@ VAndOrB32Vop3::VAndOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_and_or_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -6244,7 +7190,11 @@ VOr3B32Vop3::VOr3B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_or3_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOr3B32Vop3>(opcode);
 }
 } // namespace detail
@@ -6279,7 +7229,11 @@ VMadU32U16Vop3::VMadU32U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_u32_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U16Vop3>(opcode);
 }
 } // namespace detail
@@ -6314,7 +7268,11 @@ VMadI32I16Vop3::VMadI32I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_mad_i32_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I16Vop3>(opcode);
 }
 } // namespace detail
@@ -6341,7 +7299,11 @@ VSubNcI32Vop3::VSubNcI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_sub_nc_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcI32Vop3>(opcode);
 }
 } // namespace detail
@@ -6370,7 +7332,12 @@ VPermlane16B32Vop3::VPermlane16B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlane16B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlane16B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_permlane16_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPermlane16B32Vop3>(opcode);
 }
 } // namespace detail
@@ -6399,7 +7366,12 @@ VPermlanex16B32Vop3::VPermlanex16B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlanex16B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlanex16B32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_permlanex16_b32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPermlanex16B32Vop3>(opcode);
 }
 } // namespace detail
@@ -6426,7 +7398,11 @@ VAddNcI32Vop3::VAddNcI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_add_nc_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcI32Vop3>(opcode);
 }
 } // namespace detail
@@ -6453,7 +7429,11 @@ VCmpFF32Vop3::VCmpFF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6480,7 +7460,11 @@ VCmpLtF32Vop3::VCmpLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6507,7 +7491,11 @@ VCmpEqF32Vop3::VCmpEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6534,7 +7522,11 @@ VCmpLeF32Vop3::VCmpLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6561,7 +7553,11 @@ VCmpGtF32Vop3::VCmpGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6588,7 +7584,11 @@ VCmpLgF32Vop3::VCmpLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6615,7 +7615,11 @@ VCmpGeF32Vop3::VCmpGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6642,7 +7646,11 @@ VCmpOF32Vop3::VCmpOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_o_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6669,7 +7677,11 @@ VCmpUF32Vop3::VCmpUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_u_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6696,7 +7708,11 @@ VCmpNgeF32Vop3::VCmpNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6723,7 +7739,11 @@ VCmpNlgF32Vop3::VCmpNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6750,7 +7770,11 @@ VCmpNgtF32Vop3::VCmpNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ngt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6777,7 +7801,11 @@ VCmpNleF32Vop3::VCmpNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nle_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6804,7 +7832,11 @@ VCmpNeqF32Vop3::VCmpNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_neq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6831,7 +7863,11 @@ VCmpNltF32Vop3::VCmpNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6858,7 +7894,11 @@ VCmpTruF32Vop3::VCmpTruF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_tru_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTruF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6889,7 +7929,11 @@ VCmpxFF32Vop3::VCmpxFF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6920,7 +7964,11 @@ VCmpxLtF32Vop3::VCmpxLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6951,7 +7999,11 @@ VCmpxEqF32Vop3::VCmpxEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6982,7 +8034,11 @@ VCmpxLeF32Vop3::VCmpxLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7013,7 +8069,11 @@ VCmpxGtF32Vop3::VCmpxGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7044,7 +8104,11 @@ VCmpxLgF32Vop3::VCmpxLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7075,7 +8139,11 @@ VCmpxGeF32Vop3::VCmpxGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7106,7 +8174,11 @@ VCmpxOF32Vop3::VCmpxOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_o_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7137,7 +8209,11 @@ VCmpxUF32Vop3::VCmpxUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_u_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7168,7 +8244,12 @@ VCmpxNgeF32Vop3::VCmpxNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nge_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7199,7 +8280,12 @@ VCmpxNlgF32Vop3::VCmpxNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlg_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7230,7 +8316,12 @@ VCmpxNgtF32Vop3::VCmpxNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ngt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7261,7 +8352,12 @@ VCmpxNleF32Vop3::VCmpxNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nle_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7292,7 +8388,12 @@ VCmpxNeqF32Vop3::VCmpxNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_neq_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7323,7 +8424,12 @@ VCmpxNltF32Vop3::VCmpxNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlt_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7354,7 +8460,12 @@ VCmpxTruF32Vop3::VCmpxTruF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_tru_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTruF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7383,7 +8494,11 @@ VCmpFF64Vop3::VCmpFF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7412,7 +8527,11 @@ VCmpLtF64Vop3::VCmpLtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7441,7 +8560,11 @@ VCmpEqF64Vop3::VCmpEqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7470,7 +8593,11 @@ VCmpLeF64Vop3::VCmpLeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7499,7 +8626,11 @@ VCmpGtF64Vop3::VCmpGtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7528,7 +8659,11 @@ VCmpLgF64Vop3::VCmpLgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7557,7 +8692,11 @@ VCmpGeF64Vop3::VCmpGeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7586,7 +8725,11 @@ VCmpOF64Vop3::VCmpOF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_o_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7615,7 +8758,11 @@ VCmpUF64Vop3::VCmpUF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_u_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7644,7 +8791,11 @@ VCmpNgeF64Vop3::VCmpNgeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7673,7 +8824,11 @@ VCmpNlgF64Vop3::VCmpNlgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7702,7 +8857,11 @@ VCmpNgtF64Vop3::VCmpNgtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ngt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7731,7 +8890,11 @@ VCmpNleF64Vop3::VCmpNleF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nle_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7760,7 +8923,11 @@ VCmpNeqF64Vop3::VCmpNeqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_neq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7789,7 +8956,11 @@ VCmpNltF64Vop3::VCmpNltF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7818,7 +8989,11 @@ VCmpTruF64Vop3::VCmpTruF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_tru_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTruF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7851,7 +9026,11 @@ VCmpxFF64Vop3::VCmpxFF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7884,7 +9063,11 @@ VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7917,7 +9100,11 @@ VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7950,7 +9137,11 @@ VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7983,7 +9174,11 @@ VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8016,7 +9211,11 @@ VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8049,7 +9248,11 @@ VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8082,7 +9285,11 @@ VCmpxOF64Vop3::VCmpxOF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_o_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8115,7 +9322,11 @@ VCmpxUF64Vop3::VCmpxUF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_u_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8148,7 +9359,12 @@ VCmpxNgeF64Vop3::VCmpxNgeF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nge_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8181,7 +9397,12 @@ VCmpxNlgF64Vop3::VCmpxNlgF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlg_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8214,7 +9435,12 @@ VCmpxNgtF64Vop3::VCmpxNgtF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ngt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8247,7 +9473,12 @@ VCmpxNleF64Vop3::VCmpxNleF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nle_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8280,7 +9511,12 @@ VCmpxNeqF64Vop3::VCmpxNeqF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_neq_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8313,7 +9549,12 @@ VCmpxNltF64Vop3::VCmpxNltF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlt_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8346,7 +9587,12 @@ VCmpxTruF64Vop3::VCmpxTruF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_tru_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTruF64Vop3>(opcode);
 }
 } // namespace detail
@@ -8373,7 +9619,11 @@ VCmpFI32Vop3::VCmpFI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8400,7 +9650,11 @@ VCmpLtI32Vop3::VCmpLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8427,7 +9681,11 @@ VCmpEqI32Vop3::VCmpEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8454,7 +9712,11 @@ VCmpLeI32Vop3::VCmpLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8481,7 +9743,11 @@ VCmpGtI32Vop3::VCmpGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8508,7 +9774,11 @@ VCmpNeI32Vop3::VCmpNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8535,7 +9805,11 @@ VCmpGeI32Vop3::VCmpGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8562,7 +9836,11 @@ VCmpTI32Vop3::VCmpTI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8589,7 +9867,12 @@ VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_class_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -8618,7 +9901,11 @@ VCmpLtI16Vop3::VCmpLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8647,7 +9934,11 @@ VCmpEqI16Vop3::VCmpEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8676,7 +9967,11 @@ VCmpLeI16Vop3::VCmpLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8705,7 +10000,11 @@ VCmpGtI16Vop3::VCmpGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8734,7 +10033,11 @@ VCmpNeI16Vop3::VCmpNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8763,7 +10066,11 @@ VCmpGeI16Vop3::VCmpGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8792,7 +10099,12 @@ VCmpClassF16Vop3::VCmpClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_class_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -8823,7 +10135,11 @@ VCmpxFI32Vop3::VCmpxFI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8854,7 +10170,11 @@ VCmpxLtI32Vop3::VCmpxLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8885,7 +10205,11 @@ VCmpxEqI32Vop3::VCmpxEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8916,7 +10240,11 @@ VCmpxLeI32Vop3::VCmpxLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8947,7 +10275,11 @@ VCmpxGtI32Vop3::VCmpxGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -8978,7 +10310,11 @@ VCmpxNeI32Vop3::VCmpxNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9009,7 +10345,11 @@ VCmpxGeI32Vop3::VCmpxGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9040,7 +10380,11 @@ VCmpxTI32Vop3::VCmpxTI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_i32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9071,7 +10415,12 @@ VCmpxClassF32Vop3::VCmpxClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_class_f32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -9104,7 +10453,11 @@ VCmpxLtI16Vop3::VCmpxLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -9137,7 +10490,11 @@ VCmpxEqI16Vop3::VCmpxEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -9170,7 +10527,11 @@ VCmpxLeI16Vop3::VCmpxLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -9203,7 +10564,11 @@ VCmpxGtI16Vop3::VCmpxGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -9236,7 +10601,11 @@ VCmpxNeI16Vop3::VCmpxNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -9269,7 +10638,11 @@ VCmpxGeI16Vop3::VCmpxGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_i16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -9302,7 +10675,12 @@ VCmpxClassF16Vop3::VCmpxClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_class_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -9331,7 +10709,11 @@ VCmpFI64Vop3::VCmpFI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9360,7 +10742,11 @@ VCmpLtI64Vop3::VCmpLtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9389,7 +10775,11 @@ VCmpEqI64Vop3::VCmpEqI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9418,7 +10808,11 @@ VCmpLeI64Vop3::VCmpLeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9447,7 +10841,11 @@ VCmpGtI64Vop3::VCmpGtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9476,7 +10874,11 @@ VCmpNeI64Vop3::VCmpNeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9505,7 +10907,11 @@ VCmpGeI64Vop3::VCmpGeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9534,7 +10940,11 @@ VCmpTI64Vop3::VCmpTI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9562,7 +10972,12 @@ VCmpClassF64Vop3::VCmpClassF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_class_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -9591,7 +11006,11 @@ VCmpLtU16Vop3::VCmpLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9620,7 +11039,11 @@ VCmpEqU16Vop3::VCmpEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9649,7 +11072,11 @@ VCmpLeU16Vop3::VCmpLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9678,7 +11105,11 @@ VCmpGtU16Vop3::VCmpGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9707,7 +11138,11 @@ VCmpNeU16Vop3::VCmpNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9736,7 +11171,11 @@ VCmpGeU16Vop3::VCmpGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9769,7 +11208,11 @@ VCmpxFI64Vop3::VCmpxFI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9802,7 +11245,11 @@ VCmpxLtI64Vop3::VCmpxLtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9835,7 +11282,11 @@ VCmpxEqI64Vop3::VCmpxEqI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9868,7 +11319,11 @@ VCmpxLeI64Vop3::VCmpxLeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9901,7 +11356,11 @@ VCmpxGtI64Vop3::VCmpxGtI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9934,7 +11393,11 @@ VCmpxNeI64Vop3::VCmpxNeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -9967,7 +11430,11 @@ VCmpxGeI64Vop3::VCmpxGeI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -10000,7 +11467,11 @@ VCmpxTI64Vop3::VCmpxTI64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_i64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI64Vop3>(opcode);
 }
 } // namespace detail
@@ -10032,7 +11503,12 @@ VCmpxClassF64Vop3::VCmpxClassF64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_class_f64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -10065,7 +11541,11 @@ VCmpxLtU16Vop3::VCmpxLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -10098,7 +11578,11 @@ VCmpxEqU16Vop3::VCmpxEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -10131,7 +11615,11 @@ VCmpxLeU16Vop3::VCmpxLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -10164,7 +11652,11 @@ VCmpxGtU16Vop3::VCmpxGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -10197,7 +11689,11 @@ VCmpxNeU16Vop3::VCmpxNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -10230,7 +11726,11 @@ VCmpxGeU16Vop3::VCmpxGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_u16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -10257,7 +11757,11 @@ VCmpFU32Vop3::VCmpFU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10284,7 +11788,11 @@ VCmpLtU32Vop3::VCmpLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10311,7 +11819,11 @@ VCmpEqU32Vop3::VCmpEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10338,7 +11850,11 @@ VCmpLeU32Vop3::VCmpLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10365,7 +11881,11 @@ VCmpGtU32Vop3::VCmpGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10392,7 +11912,11 @@ VCmpNeU32Vop3::VCmpNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10419,7 +11943,11 @@ VCmpGeU32Vop3::VCmpGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10446,7 +11974,11 @@ VCmpTU32Vop3::VCmpTU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10475,7 +12007,11 @@ VCmpFF16Vop3::VCmpFF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10504,7 +12040,11 @@ VCmpLtF16Vop3::VCmpLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10533,7 +12073,11 @@ VCmpEqF16Vop3::VCmpEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10562,7 +12106,11 @@ VCmpLeF16Vop3::VCmpLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10591,7 +12139,11 @@ VCmpGtF16Vop3::VCmpGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10620,7 +12172,11 @@ VCmpLgF16Vop3::VCmpLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10649,7 +12205,11 @@ VCmpGeF16Vop3::VCmpGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10678,7 +12238,11 @@ VCmpOF16Vop3::VCmpOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_o_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10709,7 +12273,11 @@ VCmpxFU32Vop3::VCmpxFU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10740,7 +12308,11 @@ VCmpxLtU32Vop3::VCmpxLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10771,7 +12343,11 @@ VCmpxEqU32Vop3::VCmpxEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10802,7 +12378,11 @@ VCmpxLeU32Vop3::VCmpxLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10833,7 +12413,11 @@ VCmpxGtU32Vop3::VCmpxGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10864,7 +12448,11 @@ VCmpxNeU32Vop3::VCmpxNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10895,7 +12483,11 @@ VCmpxGeU32Vop3::VCmpxGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10926,7 +12518,11 @@ VCmpxTU32Vop3::VCmpxTU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_u32", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10959,7 +12555,11 @@ VCmpxFF16Vop3::VCmpxFF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10992,7 +12592,11 @@ VCmpxLtF16Vop3::VCmpxLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11025,7 +12629,11 @@ VCmpxEqF16Vop3::VCmpxEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11058,7 +12666,11 @@ VCmpxLeF16Vop3::VCmpxLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11091,7 +12703,11 @@ VCmpxGtF16Vop3::VCmpxGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11124,7 +12740,11 @@ VCmpxLgF16Vop3::VCmpxLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11157,7 +12777,11 @@ VCmpxGeF16Vop3::VCmpxGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11190,7 +12814,11 @@ VCmpxOF16Vop3::VCmpxOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_o_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11219,7 +12847,11 @@ VCmpFU64Vop3::VCmpFU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_f_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11248,7 +12880,11 @@ VCmpLtU64Vop3::VCmpLtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_lt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11277,7 +12913,11 @@ VCmpEqU64Vop3::VCmpEqU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_eq_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11306,7 +12946,11 @@ VCmpLeU64Vop3::VCmpLeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_le_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11335,7 +12979,11 @@ VCmpGtU64Vop3::VCmpGtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_gt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11364,7 +13012,11 @@ VCmpNeU64Vop3::VCmpNeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ne_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11393,7 +13045,11 @@ VCmpGeU64Vop3::VCmpGeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ge_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11422,7 +13078,11 @@ VCmpTU64Vop3::VCmpTU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_t_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11451,7 +13111,11 @@ VCmpUF16Vop3::VCmpUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_u_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11480,7 +13144,11 @@ VCmpNgeF16Vop3::VCmpNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11509,7 +13177,11 @@ VCmpNlgF16Vop3::VCmpNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11538,7 +13210,11 @@ VCmpNgtF16Vop3::VCmpNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_ngt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11567,7 +13243,11 @@ VCmpNleF16Vop3::VCmpNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nle_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11596,7 +13276,11 @@ VCmpNeqF16Vop3::VCmpNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_neq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11625,7 +13309,11 @@ VCmpNltF16Vop3::VCmpNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_nlt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11654,7 +13342,11 @@ VCmpTruF16Vop3::VCmpTruF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmp_tru_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTruF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11687,7 +13379,11 @@ VCmpxFU64Vop3::VCmpxFU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_f_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11720,7 +13416,11 @@ VCmpxLtU64Vop3::VCmpxLtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_lt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11753,7 +13453,11 @@ VCmpxEqU64Vop3::VCmpxEqU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_eq_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11786,7 +13490,11 @@ VCmpxLeU64Vop3::VCmpxLeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_le_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11819,7 +13527,11 @@ VCmpxGtU64Vop3::VCmpxGtU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_gt_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11852,7 +13564,11 @@ VCmpxNeU64Vop3::VCmpxNeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ne_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11885,7 +13601,11 @@ VCmpxGeU64Vop3::VCmpxGeU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ge_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11918,7 +13638,11 @@ VCmpxTU64Vop3::VCmpxTU64Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_t_u64", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU64Vop3>(opcode);
 }
 } // namespace detail
@@ -11951,7 +13675,11 @@ VCmpxUF16Vop3::VCmpxUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_u_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11984,7 +13712,12 @@ VCmpxNgeF16Vop3::VCmpxNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nge_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12017,7 +13750,12 @@ VCmpxNlgF16Vop3::VCmpxNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlg_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12050,7 +13788,12 @@ VCmpxNgtF16Vop3::VCmpxNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_ngt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12083,7 +13826,12 @@ VCmpxNleF16Vop3::VCmpxNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nle_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12116,7 +13864,12 @@ VCmpxNeqF16Vop3::VCmpxNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_neq_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12149,7 +13902,12 @@ VCmpxNltF16Vop3::VCmpxNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_nlt_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12182,7 +13940,12 @@ VCmpxTruF16Vop3::VCmpxTruF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3::validate_encoding(
+      "v_cmpx_tru_f16", reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTruF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12213,7 +13976,12 @@ VAddCoCiU32Vop3SdstEnc::VAddCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_add_co_ci_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoCiU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -12244,7 +14012,12 @@ VSubCoCiU32Vop3SdstEnc::VSubCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_sub_co_ci_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoCiU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -12275,7 +14048,12 @@ VSubrevCoCiU32Vop3SdstEnc::VSubrevCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_subrev_co_ci_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoCiU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -12310,7 +14088,12 @@ VDivScaleF32Vop3SdstEnc::VDivScaleF32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_div_scale_f32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivScaleF32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -12351,7 +14134,12 @@ VDivScaleF64Vop3SdstEnc::VDivScaleF64Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_div_scale_f64", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivScaleF64Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -12388,7 +14176,12 @@ VMadU64U32Vop3SdstEnc::VMadU64U32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_mad_u64_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU64U32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -12425,7 +14218,12 @@ VMadI64I32Vop3SdstEnc::VMadI64I32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_mad_i64_i32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI64I32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -12454,7 +14252,12 @@ VAddCoU32Vop3SdstEnc::VAddCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_add_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -12483,7 +14286,12 @@ VSubCoU32Vop3SdstEnc::VSubCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_sub_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -12512,7 +14320,12 @@ VSubrevCoU32Vop3SdstEnc::VSubrevCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3SdstEnc::validate_encoding(
+      "v_subrev_co_u32", reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/vop3p.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -41,7 +40,11 @@ VPkMadI16Vop3p::VPkMadI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mad_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMadI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -68,7 +71,12 @@ VPkMulLoU16Vop3p::VPkMulLoU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mul_lo_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMulLoU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -95,7 +103,11 @@ VPkAddI16Vop3p::VPkAddI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -122,7 +134,11 @@ VPkSubI16Vop3p::VPkSubI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_sub_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkSubI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -149,7 +165,12 @@ VPkLshlrevB16Vop3p::VPkLshlrevB16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_lshlrev_b16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkLshlrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -176,7 +197,12 @@ VPkLshrrevB16Vop3p::VPkLshrrevB16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_lshrrev_b16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkLshrrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -203,7 +229,12 @@ VPkAshrrevI16Vop3p::VPkAshrrevI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_ashrrev_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAshrrevI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -230,7 +261,11 @@ VPkMaxI16Vop3p::VPkMaxI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_max_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaxI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -257,7 +292,11 @@ VPkMinI16Vop3p::VPkMinI16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_min_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -290,7 +329,11 @@ VPkMadU16Vop3p::VPkMadU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mad_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMadU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -317,7 +360,11 @@ VPkAddU16Vop3p::VPkAddU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -344,7 +391,11 @@ VPkSubU16Vop3p::VPkSubU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_sub_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkSubU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -371,7 +422,11 @@ VPkMaxU16Vop3p::VPkMaxU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_max_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaxU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -398,7 +453,11 @@ VPkMinU16Vop3p::VPkMinU16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_min_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -431,7 +490,11 @@ VPkFmaF16Vop3p::VPkFmaF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_fma_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkFmaF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -458,7 +521,11 @@ VPkAddF16Vop3p::VPkAddF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_add_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkAddF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -485,7 +552,11 @@ VPkMulF16Vop3p::VPkMulF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_mul_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMulF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -512,7 +583,11 @@ VPkMinF16Vop3p::VPkMinF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_min_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMinF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -539,7 +614,11 @@ VPkMaxF16Vop3p::VPkMaxF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_pk_max_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPkMaxF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -572,7 +651,12 @@ VDot2F32F16Vop3p::VDot2F32F16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2F32F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2F32F16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_f32_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2F32F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -605,7 +689,12 @@ VDot2I32I16Vop3p::VDot2I32I16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2I32I16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2I32I16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_i32_i16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2I32I16Vop3p>(opcode);
 }
 } // namespace detail
@@ -638,7 +727,12 @@ VDot2U32U16Vop3p::VDot2U32U16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2U32U16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2U32U16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot2_u32_u16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2U32U16Vop3p>(opcode);
 }
 } // namespace detail
@@ -671,7 +765,12 @@ VDot4I32I8Vop3p::VDot4I32I8Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4I32I8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4I32I8Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot4_i32_i8", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot4I32I8Vop3p>(opcode);
 }
 } // namespace detail
@@ -704,7 +803,12 @@ VDot4U32U8Vop3p::VDot4U32U8Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot4_u32_u8", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot4U32U8Vop3p>(opcode);
 }
 } // namespace detail
@@ -737,7 +841,12 @@ VDot8I32I4Vop3p::VDot8I32I4Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8I32I4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8I32I4Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot8_i32_i4", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot8I32I4Vop3p>(opcode);
 }
 } // namespace detail
@@ -770,7 +879,12 @@ VDot8U32U4Vop3p::VDot8U32U4Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_dot8_u32_u4", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot8U32U4Vop3p>(opcode);
 }
 } // namespace detail
@@ -803,7 +917,12 @@ VFmaMixF32Vop3p::VFmaMixF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixF32Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_fma_mix_f32", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -837,7 +956,12 @@ VFmaMixloF16Vop3p::VFmaMixloF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixloF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_fma_mixlo_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixloF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -877,7 +1001,12 @@ VFmaMixhiF16Vop3p::VFmaMixhiF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixhiF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vop3p::validate_encoding(
+      "v_fma_mixhi_f16", reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixhiF16Vop3p>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/vopc.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/vopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -30,9 +29,6 @@ VCmpFF32Vopc::VCmpFF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -60,7 +56,18 @@ VCmpFF32Vopc::VCmpFF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_f32_sdwa"
+          : "v_cmp_f_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F32 does not support DPP";
   return std::make_unique<VCmpFF32Vopc>(opcode);
 }
 } // namespace detail
@@ -83,9 +90,6 @@ VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -113,7 +117,18 @@ VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_f32_sdwa"
+          : "v_cmp_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F32 does not support DPP";
   return std::make_unique<VCmpLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -136,9 +151,6 @@ VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -166,7 +178,18 @@ VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_f32_sdwa"
+          : "v_cmp_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F32 does not support DPP";
   return std::make_unique<VCmpEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -189,9 +212,6 @@ VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -219,7 +239,18 @@ VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_f32_sdwa"
+          : "v_cmp_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F32 does not support DPP";
   return std::make_unique<VCmpLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -242,9 +273,6 @@ VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -272,7 +300,18 @@ VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_f32_sdwa"
+          : "v_cmp_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F32 does not support DPP";
   return std::make_unique<VCmpGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -295,9 +334,6 @@ VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -325,7 +361,18 @@ VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lg_f32_sdwa"
+          : "v_cmp_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F32 does not support DPP";
   return std::make_unique<VCmpLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -348,9 +395,6 @@ VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -378,7 +422,18 @@ VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_f32_sdwa"
+          : "v_cmp_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F32 does not support DPP";
   return std::make_unique<VCmpGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -400,9 +455,6 @@ VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_O_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -430,7 +482,18 @@ VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_o_f32_sdwa"
+          : "v_cmp_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F32 does not support DPP";
   return std::make_unique<VCmpOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -452,9 +515,6 @@ VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_U_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -482,7 +542,18 @@ VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_u_f32_sdwa"
+          : "v_cmp_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F32 does not support DPP";
   return std::make_unique<VCmpUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -505,9 +576,6 @@ VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -535,7 +603,18 @@ VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nge_f32_sdwa"
+          : "v_cmp_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F32 does not support DPP";
   return std::make_unique<VCmpNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -558,9 +637,6 @@ VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -588,7 +664,18 @@ VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlg_f32_sdwa"
+          : "v_cmp_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F32 does not support DPP";
   return std::make_unique<VCmpNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -611,9 +698,6 @@ VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -641,7 +725,18 @@ VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ngt_f32_sdwa"
+          : "v_cmp_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F32 does not support DPP";
   return std::make_unique<VCmpNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -664,9 +759,6 @@ VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -694,7 +786,18 @@ VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nle_f32_sdwa"
+          : "v_cmp_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F32 does not support DPP";
   return std::make_unique<VCmpNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -717,9 +820,6 @@ VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NEQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -747,7 +847,18 @@ VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_neq_f32_sdwa"
+          : "v_cmp_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F32 does not support DPP";
   return std::make_unique<VCmpNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -770,9 +881,6 @@ VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -800,7 +908,18 @@ VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlt_f32_sdwa"
+          : "v_cmp_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F32 does not support DPP";
   return std::make_unique<VCmpNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -823,9 +942,6 @@ VCmpTruF32Vopc::VCmpTruF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_TRU_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -853,7 +969,18 @@ VCmpTruF32Vopc::VCmpTruF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_tru_f32_sdwa"
+          : "v_cmp_tru_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F32 does not support DPP";
   return std::make_unique<VCmpTruF32Vopc>(opcode);
 }
 } // namespace detail
@@ -878,9 +1005,6 @@ VCmpxFF32Vopc::VCmpxFF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -910,7 +1034,18 @@ VCmpxFF32Vopc::VCmpxFF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_f32_sdwa"
+          : "v_cmpx_f_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F32 does not support DPP";
   return std::make_unique<VCmpxFF32Vopc>(opcode);
 }
 } // namespace detail
@@ -935,9 +1070,6 @@ VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -967,7 +1099,18 @@ VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_f32_sdwa"
+          : "v_cmpx_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F32 does not support DPP";
   return std::make_unique<VCmpxLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -992,9 +1135,6 @@ VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1024,7 +1164,18 @@ VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_f32_sdwa"
+          : "v_cmpx_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F32 does not support DPP";
   return std::make_unique<VCmpxEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1049,9 +1200,6 @@ VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1081,7 +1229,18 @@ VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_f32_sdwa"
+          : "v_cmpx_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F32 does not support DPP";
   return std::make_unique<VCmpxLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1106,9 +1265,6 @@ VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1138,7 +1294,18 @@ VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_f32_sdwa"
+          : "v_cmpx_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F32 does not support DPP";
   return std::make_unique<VCmpxGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1163,9 +1330,6 @@ VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1195,7 +1359,18 @@ VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lg_f32_sdwa"
+          : "v_cmpx_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F32 does not support DPP";
   return std::make_unique<VCmpxLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1220,9 +1395,6 @@ VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1252,7 +1424,18 @@ VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_f32_sdwa"
+          : "v_cmpx_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F32 does not support DPP";
   return std::make_unique<VCmpxGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1277,9 +1460,6 @@ VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_O_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1309,7 +1489,18 @@ VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_o_f32_sdwa"
+          : "v_cmpx_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F32 does not support DPP";
   return std::make_unique<VCmpxOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1334,9 +1525,6 @@ VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_U_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1366,7 +1554,18 @@ VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_u_f32_sdwa"
+          : "v_cmpx_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F32 does not support DPP";
   return std::make_unique<VCmpxUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1391,9 +1590,6 @@ VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1423,7 +1619,19 @@ VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nge_f32_sdwa"
+          : "v_cmpx_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F32 does not support DPP";
   return std::make_unique<VCmpxNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1448,9 +1656,6 @@ VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLG_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1480,7 +1685,19 @@ VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlg_f32_sdwa"
+          : "v_cmpx_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F32 does not support DPP";
   return std::make_unique<VCmpxNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1505,9 +1722,6 @@ VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1537,7 +1751,19 @@ VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ngt_f32_sdwa"
+          : "v_cmpx_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F32 does not support DPP";
   return std::make_unique<VCmpxNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1562,9 +1788,6 @@ VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLE_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1594,7 +1817,19 @@ VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nle_f32_sdwa"
+          : "v_cmpx_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F32 does not support DPP";
   return std::make_unique<VCmpxNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1619,9 +1854,6 @@ VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NEQ_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1651,7 +1883,19 @@ VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_neq_f32_sdwa"
+          : "v_cmpx_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F32 does not support DPP";
   return std::make_unique<VCmpxNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1676,9 +1920,6 @@ VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLT_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1708,7 +1949,19 @@ VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlt_f32_sdwa"
+          : "v_cmpx_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F32 does not support DPP";
   return std::make_unique<VCmpxNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1733,9 +1986,6 @@ VCmpxTruF32Vopc::VCmpxTruF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_TRU_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -1765,7 +2015,19 @@ VCmpxTruF32Vopc::VCmpxTruF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_tru_f32_sdwa"
+          : "v_cmpx_tru_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F32 does not support DPP";
   return std::make_unique<VCmpxTruF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1786,16 +2048,21 @@ VCmpFF64Vopc::VCmpFF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_F_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_f_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F64 does not support SDWA";
   return std::make_unique<VCmpFF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1816,16 +2083,21 @@ VCmpLtF64Vopc::VCmpLtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support SDWA";
   return std::make_unique<VCmpLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1846,16 +2118,21 @@ VCmpEqF64Vopc::VCmpEqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_eq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support SDWA";
   return std::make_unique<VCmpEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1876,16 +2153,21 @@ VCmpLeF64Vopc::VCmpLeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_le_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support SDWA";
   return std::make_unique<VCmpLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1906,16 +2188,21 @@ VCmpGtF64Vopc::VCmpGtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_gt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support SDWA";
   return std::make_unique<VCmpGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1936,16 +2223,21 @@ VCmpLgF64Vopc::VCmpLgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support SDWA";
   return std::make_unique<VCmpLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1966,16 +2258,21 @@ VCmpGeF64Vopc::VCmpGeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support SDWA";
   return std::make_unique<VCmpGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1996,16 +2293,21 @@ VCmpOF64Vopc::VCmpOF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_O_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_O_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_o_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support SDWA";
   return std::make_unique<VCmpOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2026,16 +2328,21 @@ VCmpUF64Vopc::VCmpUF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_U_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_U_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_u_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support SDWA";
   return std::make_unique<VCmpUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2056,16 +2363,21 @@ VCmpNgeF64Vopc::VCmpNgeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support SDWA";
   return std::make_unique<VCmpNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2086,16 +2398,21 @@ VCmpNlgF64Vopc::VCmpNlgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nlg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support SDWA";
   return std::make_unique<VCmpNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2116,16 +2433,21 @@ VCmpNgtF64Vopc::VCmpNgtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ngt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support SDWA";
   return std::make_unique<VCmpNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2146,16 +2468,21 @@ VCmpNleF64Vopc::VCmpNleF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nle_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support SDWA";
   return std::make_unique<VCmpNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2176,16 +2503,21 @@ VCmpNeqF64Vopc::VCmpNeqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_neq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support SDWA";
   return std::make_unique<VCmpNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2206,16 +2538,21 @@ VCmpNltF64Vopc::VCmpNltF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_nlt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support SDWA";
   return std::make_unique<VCmpNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2236,16 +2573,21 @@ VCmpTruF64Vopc::VCmpTruF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_TRU_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_TRU_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_tru_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F64 does not support SDWA";
   return std::make_unique<VCmpTruF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2268,18 +2610,23 @@ VCmpxFF64Vopc::VCmpxFF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_F_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_f_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F64 does not support SDWA";
   return std::make_unique<VCmpxFF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2302,18 +2649,23 @@ VCmpxLtF64Vopc::VCmpxLtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support SDWA";
   return std::make_unique<VCmpxLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2336,18 +2688,23 @@ VCmpxEqF64Vopc::VCmpxEqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_eq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support SDWA";
   return std::make_unique<VCmpxEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2370,18 +2727,23 @@ VCmpxLeF64Vopc::VCmpxLeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_le_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support SDWA";
   return std::make_unique<VCmpxLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2404,18 +2766,23 @@ VCmpxGtF64Vopc::VCmpxGtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_gt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support SDWA";
   return std::make_unique<VCmpxGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2438,18 +2805,23 @@ VCmpxLgF64Vopc::VCmpxLgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support SDWA";
   return std::make_unique<VCmpxLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2472,18 +2844,23 @@ VCmpxGeF64Vopc::VCmpxGeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support SDWA";
   return std::make_unique<VCmpxGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2506,18 +2883,23 @@ VCmpxOF64Vopc::VCmpxOF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_O_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_O_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_o_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support SDWA";
   return std::make_unique<VCmpxOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2540,18 +2922,23 @@ VCmpxUF64Vopc::VCmpxUF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_U_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_U_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_u_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support SDWA";
   return std::make_unique<VCmpxUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2574,18 +2961,24 @@ VCmpxNgeF64Vopc::VCmpxNgeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nge_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support SDWA";
   return std::make_unique<VCmpxNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2608,18 +3001,24 @@ VCmpxNlgF64Vopc::VCmpxNlgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nlg_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support SDWA";
   return std::make_unique<VCmpxNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2642,18 +3041,24 @@ VCmpxNgtF64Vopc::VCmpxNgtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ngt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support SDWA";
   return std::make_unique<VCmpxNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2676,18 +3081,24 @@ VCmpxNleF64Vopc::VCmpxNleF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nle_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support SDWA";
   return std::make_unique<VCmpxNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2710,18 +3121,24 @@ VCmpxNeqF64Vopc::VCmpxNeqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_neq_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support SDWA";
   return std::make_unique<VCmpxNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2744,18 +3161,24 @@ VCmpxNltF64Vopc::VCmpxNltF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_nlt_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support SDWA";
   return std::make_unique<VCmpxNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2778,18 +3201,24 @@ VCmpxTruF64Vopc::VCmpxTruF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_TRU_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_TRU_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_tru_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F64 does not support SDWA";
   return std::make_unique<VCmpxTruF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2811,9 +3240,6 @@ VCmpFI32Vopc::VCmpFI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2841,7 +3267,18 @@ VCmpFI32Vopc::VCmpFI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_i32_sdwa"
+          : "v_cmp_f_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I32 does not support DPP";
   return std::make_unique<VCmpFI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2864,9 +3301,6 @@ VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2894,7 +3328,18 @@ VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_i32_sdwa"
+          : "v_cmp_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I32 does not support DPP";
   return std::make_unique<VCmpLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2917,9 +3362,6 @@ VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -2947,7 +3389,18 @@ VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_i32_sdwa"
+          : "v_cmp_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I32 does not support DPP";
   return std::make_unique<VCmpEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2970,9 +3423,6 @@ VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3000,7 +3450,18 @@ VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_i32_sdwa"
+          : "v_cmp_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I32 does not support DPP";
   return std::make_unique<VCmpLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3023,9 +3484,6 @@ VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3053,7 +3511,18 @@ VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_i32_sdwa"
+          : "v_cmp_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I32 does not support DPP";
   return std::make_unique<VCmpGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3076,9 +3545,6 @@ VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3106,7 +3572,18 @@ VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_i32_sdwa"
+          : "v_cmp_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I32 does not support DPP";
   return std::make_unique<VCmpNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3129,9 +3606,6 @@ VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3159,7 +3633,18 @@ VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_i32_sdwa"
+          : "v_cmp_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I32 does not support DPP";
   return std::make_unique<VCmpGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3181,9 +3666,6 @@ VCmpTI32Vopc::VCmpTI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3211,7 +3693,18 @@ VCmpTI32Vopc::VCmpTI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_i32_sdwa"
+          : "v_cmp_t_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I32 does not support DPP";
   return std::make_unique<VCmpTI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3234,9 +3727,6 @@ VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_CLASS_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3264,7 +3754,19 @@ VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_class_f32_sdwa"
+          : "v_cmp_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F32 does not support DPP";
   return std::make_unique<VCmpClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3288,9 +3790,6 @@ VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3318,7 +3817,18 @@ VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_i16_sdwa"
+          : "v_cmp_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I16 does not support DPP";
   return std::make_unique<VCmpLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -3342,9 +3852,6 @@ VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3372,7 +3879,18 @@ VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_i16_sdwa"
+          : "v_cmp_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I16 does not support DPP";
   return std::make_unique<VCmpEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -3396,9 +3914,6 @@ VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3426,7 +3941,18 @@ VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_i16_sdwa"
+          : "v_cmp_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I16 does not support DPP";
   return std::make_unique<VCmpLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -3450,9 +3976,6 @@ VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3480,7 +4003,18 @@ VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_i16_sdwa"
+          : "v_cmp_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I16 does not support DPP";
   return std::make_unique<VCmpGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -3504,9 +4038,6 @@ VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3534,7 +4065,18 @@ VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_i16_sdwa"
+          : "v_cmp_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I16 does not support DPP";
   return std::make_unique<VCmpNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -3558,9 +4100,6 @@ VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3588,7 +4127,18 @@ VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_i16_sdwa"
+          : "v_cmp_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I16 does not support DPP";
   return std::make_unique<VCmpGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -3612,9 +4162,6 @@ VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_CLASS_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3642,7 +4189,19 @@ VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_class_f16_sdwa"
+          : "v_cmp_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F16 does not support DPP";
   return std::make_unique<VCmpClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3667,9 +4226,6 @@ VCmpxFI32Vopc::VCmpxFI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3699,7 +4255,18 @@ VCmpxFI32Vopc::VCmpxFI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_i32_sdwa"
+          : "v_cmpx_f_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I32 does not support DPP";
   return std::make_unique<VCmpxFI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3724,9 +4291,6 @@ VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3756,7 +4320,18 @@ VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_i32_sdwa"
+          : "v_cmpx_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I32 does not support DPP";
   return std::make_unique<VCmpxLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3781,9 +4356,6 @@ VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3813,7 +4385,18 @@ VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_i32_sdwa"
+          : "v_cmpx_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I32 does not support DPP";
   return std::make_unique<VCmpxEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3838,9 +4421,6 @@ VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3870,7 +4450,18 @@ VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_i32_sdwa"
+          : "v_cmpx_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I32 does not support DPP";
   return std::make_unique<VCmpxLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3895,9 +4486,6 @@ VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3927,7 +4515,18 @@ VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_i32_sdwa"
+          : "v_cmpx_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I32 does not support DPP";
   return std::make_unique<VCmpxGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -3952,9 +4551,6 @@ VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -3984,7 +4580,18 @@ VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_i32_sdwa"
+          : "v_cmpx_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I32 does not support DPP";
   return std::make_unique<VCmpxNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -4009,9 +4616,6 @@ VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4041,7 +4645,18 @@ VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_i32_sdwa"
+          : "v_cmpx_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I32 does not support DPP";
   return std::make_unique<VCmpxGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -4066,9 +4681,6 @@ VCmpxTI32Vopc::VCmpxTI32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_I32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4098,7 +4710,18 @@ VCmpxTI32Vopc::VCmpxTI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_i32_sdwa"
+          : "v_cmpx_t_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I32 does not support DPP";
   return std::make_unique<VCmpxTI32Vopc>(opcode);
 }
 } // namespace detail
@@ -4123,9 +4746,6 @@ VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_CLASS_F32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4155,7 +4775,19 @@ VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_class_f32_sdwa"
+          : "v_cmpx_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F32 does not support DPP";
   return std::make_unique<VCmpxClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4181,9 +4813,6 @@ VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4213,7 +4842,18 @@ VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_i16_sdwa"
+          : "v_cmpx_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I16 does not support DPP";
   return std::make_unique<VCmpxLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4239,9 +4879,6 @@ VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4271,7 +4908,18 @@ VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_i16_sdwa"
+          : "v_cmpx_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I16 does not support DPP";
   return std::make_unique<VCmpxEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4297,9 +4945,6 @@ VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4329,7 +4974,18 @@ VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_i16_sdwa"
+          : "v_cmpx_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I16 does not support DPP";
   return std::make_unique<VCmpxLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4355,9 +5011,6 @@ VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4387,7 +5040,18 @@ VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_i16_sdwa"
+          : "v_cmpx_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I16 does not support DPP";
   return std::make_unique<VCmpxGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4413,9 +5077,6 @@ VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4445,7 +5106,18 @@ VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_i16_sdwa"
+          : "v_cmpx_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I16 does not support DPP";
   return std::make_unique<VCmpxNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4471,9 +5143,6 @@ VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_I16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4503,7 +5172,18 @@ VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_i16_sdwa"
+          : "v_cmpx_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I16 does not support DPP";
   return std::make_unique<VCmpxGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -4529,9 +5209,6 @@ VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_CLASS_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4561,7 +5238,19 @@ VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_class_f16_sdwa"
+          : "v_cmpx_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F16 does not support DPP";
   return std::make_unique<VCmpxClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4582,16 +5271,21 @@ VCmpFI64Vopc::VCmpFI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_F_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_f_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I64 does not support SDWA";
   return std::make_unique<VCmpFI64Vopc>(opcode);
 }
 } // namespace detail
@@ -4612,16 +5306,21 @@ VCmpLtI64Vopc::VCmpLtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support SDWA";
   return std::make_unique<VCmpLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -4642,16 +5341,21 @@ VCmpEqI64Vopc::VCmpEqI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_eq_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support SDWA";
   return std::make_unique<VCmpEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -4672,16 +5376,21 @@ VCmpLeI64Vopc::VCmpLeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_le_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support SDWA";
   return std::make_unique<VCmpLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -4702,16 +5411,21 @@ VCmpGtI64Vopc::VCmpGtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GT_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_gt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support SDWA";
   return std::make_unique<VCmpGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -4732,16 +5446,21 @@ VCmpNeI64Vopc::VCmpNeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ne_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support SDWA";
   return std::make_unique<VCmpNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -4762,16 +5481,21 @@ VCmpGeI64Vopc::VCmpGeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GE_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ge_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support SDWA";
   return std::make_unique<VCmpGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -4792,16 +5516,21 @@ VCmpTI64Vopc::VCmpTI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_T_I64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_t_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I64 does not support SDWA";
   return std::make_unique<VCmpTI64Vopc>(opcode);
 }
 } // namespace detail
@@ -4822,16 +5551,22 @@ VCmpClassF64Vopc::VCmpClassF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_class_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support SDWA";
   return std::make_unique<VCmpClassF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4855,9 +5590,6 @@ VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4885,7 +5617,18 @@ VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_u16_sdwa"
+          : "v_cmp_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U16 does not support DPP";
   return std::make_unique<VCmpLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -4909,9 +5652,6 @@ VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4939,7 +5679,18 @@ VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_u16_sdwa"
+          : "v_cmp_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U16 does not support DPP";
   return std::make_unique<VCmpEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -4963,9 +5714,6 @@ VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -4993,7 +5741,18 @@ VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_u16_sdwa"
+          : "v_cmp_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U16 does not support DPP";
   return std::make_unique<VCmpLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5017,9 +5776,6 @@ VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5047,7 +5803,18 @@ VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_u16_sdwa"
+          : "v_cmp_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U16 does not support DPP";
   return std::make_unique<VCmpGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5071,9 +5838,6 @@ VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5101,7 +5865,18 @@ VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_u16_sdwa"
+          : "v_cmp_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U16 does not support DPP";
   return std::make_unique<VCmpNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5125,9 +5900,6 @@ VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5155,7 +5927,18 @@ VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_u16_sdwa"
+          : "v_cmp_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U16 does not support DPP";
   return std::make_unique<VCmpGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5178,18 +5961,23 @@ VCmpxFI64Vopc::VCmpxFI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_F_I64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_f_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I64 does not support SDWA";
   return std::make_unique<VCmpxFI64Vopc>(opcode);
 }
 } // namespace detail
@@ -5212,18 +6000,23 @@ VCmpxLtI64Vopc::VCmpxLtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support SDWA";
   return std::make_unique<VCmpxLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -5246,18 +6039,23 @@ VCmpxEqI64Vopc::VCmpxEqI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_eq_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support SDWA";
   return std::make_unique<VCmpxEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -5280,18 +6078,23 @@ VCmpxLeI64Vopc::VCmpxLeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_le_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support SDWA";
   return std::make_unique<VCmpxLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -5314,18 +6117,23 @@ VCmpxGtI64Vopc::VCmpxGtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_gt_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support SDWA";
   return std::make_unique<VCmpxGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -5348,18 +6156,23 @@ VCmpxNeI64Vopc::VCmpxNeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ne_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support SDWA";
   return std::make_unique<VCmpxNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -5382,18 +6195,23 @@ VCmpxGeI64Vopc::VCmpxGeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ge_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support SDWA";
   return std::make_unique<VCmpxGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -5416,18 +6234,23 @@ VCmpxTI64Vopc::VCmpxTI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_I64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_T_I64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_t_i64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I64 does not support SDWA";
   return std::make_unique<VCmpxTI64Vopc>(opcode);
 }
 } // namespace detail
@@ -5450,18 +6273,24 @@ VCmpxClassF64Vopc::VCmpxClassF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_class_f64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support SDWA";
   return std::make_unique<VCmpxClassF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5487,9 +6316,6 @@ VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5519,7 +6345,18 @@ VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_u16_sdwa"
+          : "v_cmpx_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U16 does not support DPP";
   return std::make_unique<VCmpxLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5545,9 +6382,6 @@ VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5577,7 +6411,18 @@ VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_u16_sdwa"
+          : "v_cmpx_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U16 does not support DPP";
   return std::make_unique<VCmpxEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5603,9 +6448,6 @@ VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5635,7 +6477,18 @@ VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_u16_sdwa"
+          : "v_cmpx_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U16 does not support DPP";
   return std::make_unique<VCmpxLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5661,9 +6514,6 @@ VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5693,7 +6543,18 @@ VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_u16_sdwa"
+          : "v_cmpx_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U16 does not support DPP";
   return std::make_unique<VCmpxGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5719,9 +6580,6 @@ VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5751,7 +6609,18 @@ VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_u16_sdwa"
+          : "v_cmpx_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U16 does not support DPP";
   return std::make_unique<VCmpxNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5777,9 +6646,6 @@ VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_U16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5809,7 +6675,18 @@ VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_u16_sdwa"
+          : "v_cmpx_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U16 does not support DPP";
   return std::make_unique<VCmpxGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5831,9 +6708,6 @@ VCmpFU32Vopc::VCmpFU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5861,7 +6735,18 @@ VCmpFU32Vopc::VCmpFU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_u32_sdwa"
+          : "v_cmp_f_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U32 does not support DPP";
   return std::make_unique<VCmpFU32Vopc>(opcode);
 }
 } // namespace detail
@@ -5884,9 +6769,6 @@ VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5914,7 +6796,18 @@ VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_u32_sdwa"
+          : "v_cmp_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U32 does not support DPP";
   return std::make_unique<VCmpLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -5937,9 +6830,6 @@ VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -5967,7 +6857,18 @@ VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_u32_sdwa"
+          : "v_cmp_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U32 does not support DPP";
   return std::make_unique<VCmpEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -5990,9 +6891,6 @@ VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6020,7 +6918,18 @@ VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_u32_sdwa"
+          : "v_cmp_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U32 does not support DPP";
   return std::make_unique<VCmpLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6043,9 +6952,6 @@ VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6073,7 +6979,18 @@ VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_u32_sdwa"
+          : "v_cmp_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U32 does not support DPP";
   return std::make_unique<VCmpGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6096,9 +7013,6 @@ VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6126,7 +7040,18 @@ VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ne_u32_sdwa"
+          : "v_cmp_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U32 does not support DPP";
   return std::make_unique<VCmpNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6149,9 +7074,6 @@ VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6179,7 +7101,18 @@ VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_u32_sdwa"
+          : "v_cmp_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U32 does not support DPP";
   return std::make_unique<VCmpGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6201,9 +7134,6 @@ VCmpTU32Vopc::VCmpTU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6231,7 +7161,18 @@ VCmpTU32Vopc::VCmpTU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_t_u32_sdwa"
+          : "v_cmp_t_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U32 does not support DPP";
   return std::make_unique<VCmpTU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6254,9 +7195,6 @@ VCmpFF16Vopc::VCmpFF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6284,7 +7222,18 @@ VCmpFF16Vopc::VCmpFF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_f_f16_sdwa"
+          : "v_cmp_f_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F16 does not support DPP";
   return std::make_unique<VCmpFF16Vopc>(opcode);
 }
 } // namespace detail
@@ -6308,9 +7257,6 @@ VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6338,7 +7284,18 @@ VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lt_f16_sdwa"
+          : "v_cmp_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F16 does not support DPP";
   return std::make_unique<VCmpLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -6362,9 +7319,6 @@ VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6392,7 +7346,18 @@ VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_eq_f16_sdwa"
+          : "v_cmp_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F16 does not support DPP";
   return std::make_unique<VCmpEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -6416,9 +7381,6 @@ VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6446,7 +7408,18 @@ VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_le_f16_sdwa"
+          : "v_cmp_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F16 does not support DPP";
   return std::make_unique<VCmpLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -6470,9 +7443,6 @@ VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6500,7 +7470,18 @@ VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_gt_f16_sdwa"
+          : "v_cmp_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F16 does not support DPP";
   return std::make_unique<VCmpGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -6524,9 +7505,6 @@ VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6554,7 +7532,18 @@ VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_lg_f16_sdwa"
+          : "v_cmp_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F16 does not support DPP";
   return std::make_unique<VCmpLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -6578,9 +7567,6 @@ VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6608,7 +7594,18 @@ VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ge_f16_sdwa"
+          : "v_cmp_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F16 does not support DPP";
   return std::make_unique<VCmpGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -6631,9 +7628,6 @@ VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_O_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6661,7 +7655,18 @@ VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_o_f16_sdwa"
+          : "v_cmp_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F16 does not support DPP";
   return std::make_unique<VCmpOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -6686,9 +7691,6 @@ VCmpxFU32Vopc::VCmpxFU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6718,7 +7720,18 @@ VCmpxFU32Vopc::VCmpxFU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_u32_sdwa"
+          : "v_cmpx_f_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U32 does not support DPP";
   return std::make_unique<VCmpxFU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6743,9 +7756,6 @@ VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6775,7 +7785,18 @@ VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_u32_sdwa"
+          : "v_cmpx_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U32 does not support DPP";
   return std::make_unique<VCmpxLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6800,9 +7821,6 @@ VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6832,7 +7850,18 @@ VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_u32_sdwa"
+          : "v_cmpx_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U32 does not support DPP";
   return std::make_unique<VCmpxEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6857,9 +7886,6 @@ VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6889,7 +7915,18 @@ VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_u32_sdwa"
+          : "v_cmpx_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U32 does not support DPP";
   return std::make_unique<VCmpxLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6914,9 +7951,6 @@ VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -6946,7 +7980,18 @@ VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_u32_sdwa"
+          : "v_cmpx_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U32 does not support DPP";
   return std::make_unique<VCmpxGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6971,9 +8016,6 @@ VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7003,7 +8045,18 @@ VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ne_u32_sdwa"
+          : "v_cmpx_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U32 does not support DPP";
   return std::make_unique<VCmpxNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7028,9 +8081,6 @@ VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7060,7 +8110,18 @@ VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_u32_sdwa"
+          : "v_cmpx_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U32 does not support DPP";
   return std::make_unique<VCmpxGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7085,9 +8146,6 @@ VCmpxTU32Vopc::VCmpxTU32Vopc(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_U32 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(32, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7117,7 +8175,18 @@ VCmpxTU32Vopc::VCmpxTU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_t_u32_sdwa"
+          : "v_cmpx_t_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U32 does not support DPP";
   return std::make_unique<VCmpxTU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7143,9 +8212,6 @@ VCmpxFF16Vopc::VCmpxFF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7175,7 +8241,18 @@ VCmpxFF16Vopc::VCmpxFF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_f_f16_sdwa"
+          : "v_cmpx_f_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F16 does not support DPP";
   return std::make_unique<VCmpxFF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7201,9 +8278,6 @@ VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7233,7 +8307,18 @@ VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lt_f16_sdwa"
+          : "v_cmpx_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F16 does not support DPP";
   return std::make_unique<VCmpxLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7259,9 +8344,6 @@ VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7291,7 +8373,18 @@ VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_eq_f16_sdwa"
+          : "v_cmpx_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F16 does not support DPP";
   return std::make_unique<VCmpxEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7317,9 +8410,6 @@ VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7349,7 +8439,18 @@ VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_le_f16_sdwa"
+          : "v_cmpx_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F16 does not support DPP";
   return std::make_unique<VCmpxLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7375,9 +8476,6 @@ VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7407,7 +8505,18 @@ VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_gt_f16_sdwa"
+          : "v_cmpx_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F16 does not support DPP";
   return std::make_unique<VCmpxGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7433,9 +8542,6 @@ VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7465,7 +8571,18 @@ VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_lg_f16_sdwa"
+          : "v_cmpx_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F16 does not support DPP";
   return std::make_unique<VCmpxLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7491,9 +8608,6 @@ VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7523,7 +8637,18 @@ VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ge_f16_sdwa"
+          : "v_cmpx_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F16 does not support DPP";
   return std::make_unique<VCmpxGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7549,9 +8674,6 @@ VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_O_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7581,7 +8703,18 @@ VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_o_f16_sdwa"
+          : "v_cmpx_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F16 does not support DPP";
   return std::make_unique<VCmpxOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7602,16 +8735,21 @@ VCmpFU64Vopc::VCmpFU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_F_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_f_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U64 does not support SDWA";
   return std::make_unique<VCmpFU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7632,16 +8770,21 @@ VCmpLtU64Vopc::VCmpLtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_lt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support SDWA";
   return std::make_unique<VCmpLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7662,16 +8805,21 @@ VCmpEqU64Vopc::VCmpEqU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_eq_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support SDWA";
   return std::make_unique<VCmpEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7692,16 +8840,21 @@ VCmpLeU64Vopc::VCmpLeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_LE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_le_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support SDWA";
   return std::make_unique<VCmpLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7722,16 +8875,21 @@ VCmpGtU64Vopc::VCmpGtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GT_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_gt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support SDWA";
   return std::make_unique<VCmpGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7752,16 +8910,21 @@ VCmpNeU64Vopc::VCmpNeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_NE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ne_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support SDWA";
   return std::make_unique<VCmpNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7782,16 +8945,21 @@ VCmpGeU64Vopc::VCmpGeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_GE_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_ge_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support SDWA";
   return std::make_unique<VCmpGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7812,16 +8980,21 @@ VCmpTU64Vopc::VCmpTU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMP_T_U64 does not support SDWA", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmp_t_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U64 does not support SDWA";
   return std::make_unique<VCmpTU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7844,9 +9017,6 @@ VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_U_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7874,7 +9044,18 @@ VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_u_f16_sdwa"
+          : "v_cmp_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F16 does not support DPP";
   return std::make_unique<VCmpUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7898,9 +9079,6 @@ VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7928,7 +9106,18 @@ VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nge_f16_sdwa"
+          : "v_cmp_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F16 does not support DPP";
   return std::make_unique<VCmpNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -7952,9 +9141,6 @@ VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -7982,7 +9168,18 @@ VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlg_f16_sdwa"
+          : "v_cmp_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F16 does not support DPP";
   return std::make_unique<VCmpNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8006,9 +9203,6 @@ VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8036,7 +9230,18 @@ VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_ngt_f16_sdwa"
+          : "v_cmp_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F16 does not support DPP";
   return std::make_unique<VCmpNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8060,9 +9265,6 @@ VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8090,7 +9292,18 @@ VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nle_f16_sdwa"
+          : "v_cmp_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F16 does not support DPP";
   return std::make_unique<VCmpNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8114,9 +9327,6 @@ VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NEQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8144,7 +9354,18 @@ VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_neq_f16_sdwa"
+          : "v_cmp_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F16 does not support DPP";
   return std::make_unique<VCmpNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8168,9 +9389,6 @@ VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8198,7 +9416,18 @@ VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_nlt_f16_sdwa"
+          : "v_cmp_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F16 does not support DPP";
   return std::make_unique<VCmpNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8222,9 +9451,6 @@ VCmpTruF16Vopc::VCmpTruF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_TRU_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8252,7 +9478,18 @@ VCmpTruF16Vopc::VCmpTruF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTruF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTruF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmp_tru_f16_sdwa"
+          : "v_cmp_tru_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_TRU_F16 does not support DPP";
   return std::make_unique<VCmpTruF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8275,18 +9512,23 @@ VCmpxFU64Vopc::VCmpxFU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_F_U64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_f_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U64 does not support SDWA";
   return std::make_unique<VCmpxFU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8309,18 +9551,23 @@ VCmpxLtU64Vopc::VCmpxLtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_lt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support SDWA";
   return std::make_unique<VCmpxLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8343,18 +9590,23 @@ VCmpxEqU64Vopc::VCmpxEqU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_eq_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support SDWA";
   return std::make_unique<VCmpxEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8377,18 +9629,23 @@ VCmpxLeU64Vopc::VCmpxLeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_le_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support SDWA";
   return std::make_unique<VCmpxLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8411,18 +9668,23 @@ VCmpxGtU64Vopc::VCmpxGtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_gt_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support SDWA";
   return std::make_unique<VCmpxGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8445,18 +9707,23 @@ VCmpxNeU64Vopc::VCmpxNeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ne_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support SDWA";
   return std::make_unique<VCmpxNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8479,18 +9746,23 @@ VCmpxGeU64Vopc::VCmpxGeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_ge_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support SDWA";
   return std::make_unique<VCmpxGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8513,18 +9785,23 @@ VCmpxTU64Vopc::VCmpxTU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_U64 does not support DPP", "");
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA)
-    throw util::InvalidInst("V_CMPX_T_U64 does not support SDWA", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      "v_cmpx_t_u64_e32", reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U64 does not support DPP";
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U64 does not support SDWA";
   return std::make_unique<VCmpxTU64Vopc>(opcode);
 }
 } // namespace detail
@@ -8550,9 +9827,6 @@ VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_U_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8582,7 +9856,18 @@ VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_u_f16_sdwa"
+          : "v_cmpx_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F16 does not support DPP";
   return std::make_unique<VCmpxUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8608,9 +9893,6 @@ VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8640,7 +9922,19 @@ VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nge_f16_sdwa"
+          : "v_cmpx_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F16 does not support DPP";
   return std::make_unique<VCmpxNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8666,9 +9960,6 @@ VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLG_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8698,7 +9989,19 @@ VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlg_f16_sdwa"
+          : "v_cmpx_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F16 does not support DPP";
   return std::make_unique<VCmpxNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8724,9 +10027,6 @@ VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8756,7 +10056,19 @@ VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_ngt_f16_sdwa"
+          : "v_cmpx_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F16 does not support DPP";
   return std::make_unique<VCmpxNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8782,9 +10094,6 @@ VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLE_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8814,7 +10123,19 @@ VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nle_f16_sdwa"
+          : "v_cmpx_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F16 does not support DPP";
   return std::make_unique<VCmpxNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8840,9 +10161,6 @@ VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NEQ_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8872,7 +10190,19 @@ VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_neq_f16_sdwa"
+          : "v_cmpx_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F16 does not support DPP";
   return std::make_unique<VCmpxNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8898,9 +10228,6 @@ VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLT_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8930,7 +10257,19 @@ VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_nlt_f16_sdwa"
+          : "v_cmpx_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F16 does not support DPP";
   return std::make_unique<VCmpxNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8956,9 +10295,6 @@ VCmpxTruF16Vopc::VCmpxTruF16Vopc(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_TRU_F16 does not support DPP", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA) {
     auto *sw = reinterpret_cast<const VopcVopSdwaSdstEncMachineInst *>(inst);
     src0 = Operand(16, sw->s0 ? OperandType::OPR_SRC : OperandType::OPR_VGPR, sw->vsrc0);
@@ -8988,7 +10324,19 @@ VCmpxTruF16Vopc::VCmpxTruF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTruF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTruF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_SDWA
+          ? "v_cmpx_tru_f16_sdwa"
+          : "v_cmpx_tru_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_TRU_F16 does not support DPP";
   return std::make_unique<VCmpxTruF16Vopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/decoder.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/decoder.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/vopd.h"
-#include "util/except.h"
 #include <array>
 #include <bit>
 #include <format>
@@ -16,1397 +15,1845 @@ namespace rocjitsu {
 namespace rdna3 {
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddU32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddU64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndB32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndB64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapB32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapB64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapF32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCsubU32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecU32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecU64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncU32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncU64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxF32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxI32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxI64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxU32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxU64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinF32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinI32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinI64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinU32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinU64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrB32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrB64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubU32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubU64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapB32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapB64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorB32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorB64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferGl0InvMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferGl1InvMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadB128Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadB32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadB64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadB96Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16B16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16HiB16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16HiFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16HiI8Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16HiU8Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16I8Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16U8Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadI16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadI8Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadU16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadU8Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB128Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB8Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB96Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16HiB16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16HiB8Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16HiFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddGsRegRtnDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAppendDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsBpermuteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsBvhStackRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsConsumeDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsBarrierDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsInitDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaBrDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaPDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaVDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoad2addrB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoad2addrB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoad2addrStride64B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoad2addrStride64B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadAddtidB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadB128Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadB96Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadI16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadI8D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadI8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadI8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU16D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU16D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU8D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsNopDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrderedCountDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPermuteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStore2addrB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStore2addrB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStore2addrStride64B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStore2addrStride64B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreAddtidB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB128Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB16D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB96Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchg2addrRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchg2addrRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchg2addrStride64RtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchg2addrStride64RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchgRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchgRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubGsRegRtnDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSwizzleB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrapRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeExpExp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddF32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddU32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddU64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndB32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndB64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapB32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapB64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapF32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecU32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecU64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncU32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncU64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxF32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxI32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxI64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxU32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxU64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinF32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinI32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinI64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinU32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinU64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrB32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrB64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubU32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubU64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapB32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapB64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorB32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorB64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadB128Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadB32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadB64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadB96Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16B16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16HiB16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16HiI8Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16HiU8Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16I8Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16U8Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadI16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadI8Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadU16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadU8Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB128Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB8Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB96Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreD16HiB16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreD16HiB8Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicAddMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicAndMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicCmpswapMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicDecMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicIncMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicOrMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSmaxMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSminMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSubMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSwapMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicUmaxMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicUminMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicXorMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageBvh64IntersectRayMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageBvhIntersectRayMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4BClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4BMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CBClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CBMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4ClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4OMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4hMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGetLodMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGetResinfoMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipPckSgnMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadPckSgnMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageMsaaLoadMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStorePckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeLdsDirectLoadLdsdir(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeLdsParamLoadLdsdir(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddcU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot0SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot0SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot0WrexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot0WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1WrexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBarrierSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB128Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB256Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB32Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB512Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB64Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCallB64Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbguserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClauseSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClsI32I64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClsI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClzI32U32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClzI32U64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkEqI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkEqU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGeI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGeU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGtI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGtU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLeI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLeU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLgI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLgU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLtI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLtU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCodeEndSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCtzI32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCtzI32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDelayAluSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDenormModeSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetpcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGl1InvSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB128Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB256Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB32Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB512Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB64Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsd2B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot0SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot0SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot1B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot1B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot1SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackHlB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRfeB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRoundModeSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsgRtnB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsgRtnB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetInstPrefetchDistanceSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetkillSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetpcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubbU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSwappcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTtracedataImmSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSVersionSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitEventSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitIdleSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntDepctrSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntExpcntSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntLgkmcntSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntVmcntSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntVscntSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClsI32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClsI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClzI32U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClzI32U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCtzI32B32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCtzI32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFloorI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFloorI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNearestI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNearestI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkI16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkNormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkNormI16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkNormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkNormU16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkRtzF16F32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkRtzF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32U16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2Bf16Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2F16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2F32Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2F32F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2accF32F16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4I32Iu8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8I32Iu4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaDx9ZeroF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixhiF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixloF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaakF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaakF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacDx9ZeroF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacDx9ZeroF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmamkF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmamkF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP10F16F32Vinterp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP10F32Vinterp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP10RtzF16F32Vinterp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2F16F32Vinterp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2F32Vinterp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2RtzF16F32Vinterp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxminF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxminF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxminI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxminU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinmaxF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinmaxF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinmaxI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinmaxU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovreldB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovreldB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulDx9ZeroF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulDx9ZeroF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMullitF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlane16B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlane64B32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlanex16B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPipeflushVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPipeflushVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwapB16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwaprelB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaBf1616x16x16Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x16F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaI3216x16x16Iu4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaI3216x16x16Iu8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXor3B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode);
+DecodeResult decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndB32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndB64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapB32Mubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapB64Mubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapF32Mubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCsubU32Mubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxI32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxI64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinI32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinI64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrB32Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrB64Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapB32Mubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapB64Mubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorB32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorB64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferGl0InvMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferGl1InvMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadB128Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadB32Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadB64Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadB96Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16B16Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16FormatXMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16FormatXyMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16FormatXyzMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16FormatXyzwMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16HiB16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16HiFormatXMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16HiI8Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16HiU8Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16I8Mubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16U8Mubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXMubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadI16Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadI8Mubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadU16Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadU8Mubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB128Mubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB16Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB32Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB64Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB8Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB96Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16FormatXMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16FormatXyMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16FormatXyzMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16FormatXyzwMubuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16HiB16Mubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16HiB8Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16HiFormatXMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddGsRegRtnDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAppendDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsBpermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsBvhStackRtnB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreRtnB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreRtnB64Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreRtnF32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreRtnF64Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsConsumeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsBarrierDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsInitDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaBrDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaPDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaVDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoad2addrB32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoad2addrB64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoad2addrStride64B32Ds(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoad2addrStride64B64Ds(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadAddtidB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadI16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadI8D16HiDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadI8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU16D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU16D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU8D16HiDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsNopDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrderedCountDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStore2addrB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStore2addrB64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStore2addrStride64B32Ds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStore2addrStride64B64Ds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreAddtidB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB16D16HiDs(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB8D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchg2addrRtnB32Ds(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchg2addrRtnB64Ds(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchg2addrStride64RtnB32Ds(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchg2addrStride64RtnB64Ds(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchgRtnB32Ds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchgRtnB64Ds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubGsRegRtnDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSwizzleB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrapRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeExpExp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddF32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndB32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndB64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapB32Flat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapB64Flat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapF32Flat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxF32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxI32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxI64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinF32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinI32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinI64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrB32Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrB64Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapB32Flat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapB64Flat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorB32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorB64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadB128Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadB32Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadB64Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadB96Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16B16Flat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16HiB16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16HiI8Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16HiU8Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16I8Flat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16U8Flat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadI16Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadI8Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadU16Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadU8Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB128Flat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB16Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB32Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB64Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB8Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB96Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreD16HiB16Flat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreD16HiB8Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicAddMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicAndMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicCmpswapMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicDecMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicIncMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicOrMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSubMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSwapMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicUmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicUminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicXorMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageBvh64IntersectRayMimg(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageBvhIntersectRayMimg(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4BClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4BMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CBClMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CBMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLzMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLzOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4ClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4Mimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4OMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4hMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGetLodMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGetResinfoMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipPckMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipPckSgnMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadPckMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadPckSgnMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageMsaaLoadMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClOG16Mimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDOG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleClMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleClOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClOG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDG16Mimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDOG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLzMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLzOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleOMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStorePckMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeLdsDirectLoadLdsdir(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeLdsParamLoadLdsdir(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddcU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot0SaveexecB32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot0SaveexecB64Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot0WrexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot0WrexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1SaveexecB32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1SaveexecB64Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1WrexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1WrexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBarrierSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB128Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB256Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB32Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB512Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB64Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCallB64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysSopp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbguserSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClauseSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClsI32I64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClzI32U32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClzI32U64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkEqI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkEqU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLgI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLgU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCodeEndSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCtzI32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCtzI32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDelayAluSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDenormModeSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGl1InvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB128Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB256Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB32Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB512Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB64Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsd2B32Sop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot0SaveexecB32Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot0SaveexecB64Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot1B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot1B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot1SaveexecB32Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot1SaveexecB64Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrSaveexecB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackHlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRfeB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRoundModeSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsgRtnB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsgRtnB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetInstPrefetchDistanceSopp(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetkillSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubbU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSwappcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTtracedataImmSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSVersionSopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitEventSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitIdleSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntDepctrSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntExpcntSopk(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntLgkmcntSopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntVmcntSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntVscntSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadD16FormatXMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadD16FormatXyMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadD16FormatXyzMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadD16FormatXyzwMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreD16FormatXMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreD16FormatXyMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreD16FormatXyzMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreD16FormatXyzwMtbuf(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoCiU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClsI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClsI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClzI32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClzI32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCtzI32B32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCtzI32B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFloorI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFloorI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNearestI32F32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNearestI32F32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkI16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkNormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkNormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkNormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkNormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkRtzF16F32Vop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkRtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2Bf16Bf16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2F16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2F32Bf16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2F32F16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2accF32F16Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4I32Iu8Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8I32Iu4Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaDx9ZeroF32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacDx9ZeroF32Vop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacDx9ZeroF32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmamkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmamkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP10F16F32Vinterp(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP10F32Vinterp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP10RtzF16F32Vinterp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2F16F32Vinterp(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2F32Vinterp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2RtzF16F32Vinterp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxminF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxminF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxminI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxminU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinmaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinmaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinmaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinmaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovreldB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovreldB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsd2B32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsd2B32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsdB32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsdB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulDx9ZeroF32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulDx9ZeroF32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMullitF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlane16B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlane64B32Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlanex16B32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPipeflushVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPipeflushVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoCiU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoCiU32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevNcU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevNcU32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwapB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwaprelB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaBf1616x16x16Bf16Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF1616x16x16F16Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x16Bf16Vop3p(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x16F16Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaI3216x16x16Iu4Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaI3216x16x16Iu8Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXor3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 } // namespace detail
 
 struct DecoderImpl {
 public:
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 
 private:
-  using DecodeFunc = std::unique_ptr<Instruction> (*)(const MachineInst *);
-  static std::unique_ptr<Instruction> decodeInvalid(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> decodeVopd(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopp(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3p(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVinterp(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeLdsdir(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeDs(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeFlat(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMubuf(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMtbuf(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMimg(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSmem(const MachineInst *opcode);
+  using DecodeFunc = DecodeResult (*)(const MachineInst *, const DecodeErrorEmitter &);
+  static DecodeResult decodeInvalid(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult decodeVopd(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVinterp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeLdsdir(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMtbuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
   static const std::array<DecodeFunc, 512> primary_decode_table;
   static const std::array<DecodeFunc, 256> sub_decode_vopc;
   static const std::array<DecodeFunc, 256> sub_decode_vop1;
@@ -1425,97 +1872,116 @@ private:
   static const std::array<DecodeFunc, 256> sub_decode_smem;
 };
 
-std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
-  return DecoderImpl::decode(opcode);
+DecodeResult Decoder::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  return DecoderImpl::decode(opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decode(const MachineInst *opcode) {
+DecodeResult DecoderImpl::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
   Sop1MachineInst op = std::bit_cast<decltype(op)>(*opcode);
-  return primary_decode_table[op.encoding](opcode);
+  return primary_decode_table[op.encoding](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decodeInvalid(const MachineInst *opcode) {
-  throw util::InvalidInst(std::format("{:X}", *opcode));
-  return nullptr;
+DecodeResult DecoderImpl::decodeInvalid(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  return emit_error.emit() << "Invalid instruction opcode: " << std::format("{:X}", *opcode);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decodeVopd(const MachineInst *opcode) {
+DecodeResult DecoderImpl::decodeVopd(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vopd::validate_encoding(opcode, emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<Vopd>(opcode);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vopc[op.op](opcode);
+  return sub_decode_vopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop1[op.op](opcode);
+  return sub_decode_vop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sop1[op.op](opcode);
+  return sub_decode_sop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopc[op.op](opcode);
+  return sub_decode_sopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopp(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopp::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopp[op.op](opcode);
+  return sub_decode_sopp[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3p(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3p(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Vop3p::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3p[op.op](opcode);
+  return sub_decode_vop3p[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVinterp(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVinterp(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
   Vinterp::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vinterp[op.op](opcode);
+  return sub_decode_vinterp[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeLdsdir(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeLdsdir(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
   Ldsdir::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_ldsdir[op.op](opcode);
+  return sub_decode_ldsdir[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop3::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3[op.op](opcode);
+  return sub_decode_vop3[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeDs(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeDs(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
   Ds::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_ds[op.op](opcode);
+  return sub_decode_ds[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeFlat(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeFlat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Flat::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_flat[op.op](opcode);
+  return sub_decode_flat[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMubuf(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Mubuf::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mubuf[op.op](opcode);
+  return sub_decode_mubuf[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMtbuf(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMtbuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Mtbuf::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mtbuf[op.op](opcode);
+  return sub_decode_mtbuf[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMimg(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Mimg::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mimg[op.op](opcode);
+  return sub_decode_mimg[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSmem(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Smem::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_smem[op.op](opcode);
+  return sub_decode_smem[op.op](opcode, emit_error);
 }
 
 const std::array<DecoderImpl::DecodeFunc, 512> DecoderImpl::primary_decode_table = {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/decoder.h
@@ -8,6 +8,7 @@
 #define ROCJITSU_ISA_ARCH_AMDGPU_RDNA3_DECODER_H_
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/machine_insts.h"
+#include "rocjitsu/isa/decode_result.h"
 #include <array>
 #include <cstddef>
 #include <memory>
@@ -21,7 +22,7 @@ namespace rdna3 {
 class Decoder {
 public:
   static constexpr std::size_t kMaxInstructionWords = 3;
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 };
 
 } // namespace rdna3

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/ds.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/ds.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/ds.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -31,7 +30,11 @@ DsAddU32Ds::DsAddU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU32Ds>(opcode);
 }
 } // namespace detail
@@ -54,7 +57,11 @@ DsSubU32Ds::DsSubU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU32Ds>(opcode);
 }
 } // namespace detail
@@ -77,7 +84,11 @@ DsRsubU32Ds::DsRsubU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU32Ds>(opcode);
 }
 } // namespace detail
@@ -100,7 +111,11 @@ DsIncU32Ds::DsIncU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU32Ds>(opcode);
 }
 } // namespace detail
@@ -123,7 +138,11 @@ DsDecU32Ds::DsDecU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU32Ds>(opcode);
 }
 } // namespace detail
@@ -146,7 +165,11 @@ DsMinI32Ds::DsMinI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI32Ds>(opcode);
 }
 } // namespace detail
@@ -169,7 +192,11 @@ DsMaxI32Ds::DsMaxI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI32Ds>(opcode);
 }
 } // namespace detail
@@ -192,7 +219,11 @@ DsMinU32Ds::DsMinU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU32Ds>(opcode);
 }
 } // namespace detail
@@ -215,7 +246,11 @@ DsMaxU32Ds::DsMaxU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU32Ds>(opcode);
 }
 } // namespace detail
@@ -238,7 +273,11 @@ DsAndB32Ds::DsAndB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB32Ds>(opcode);
 }
 } // namespace detail
@@ -261,7 +300,11 @@ DsOrB32Ds::DsOrB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB32Ds>(opcode);
 }
 } // namespace detail
@@ -284,7 +327,11 @@ DsXorB32Ds::DsXorB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB32Ds>(opcode);
 }
 } // namespace detail
@@ -309,7 +356,11 @@ DsMskorB32Ds::DsMskorB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB32Ds>(opcode);
 }
 } // namespace detail
@@ -330,7 +381,11 @@ DsStoreB32Ds::DsStoreB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB32Ds>(opcode);
 }
 } // namespace detail
@@ -353,7 +408,12 @@ DsStore2addrB32Ds::DsStore2addrB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStore2addrB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStore2addrB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_2addr_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStore2addrB32Ds>(opcode);
 }
 } // namespace detail
@@ -376,7 +436,12 @@ DsStore2addrStride64B32Ds::DsStore2addrStride64B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStore2addrStride64B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStore2addrStride64B32Ds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_2addr_stride64_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStore2addrStride64B32Ds>(opcode);
 }
 } // namespace detail
@@ -401,7 +466,12 @@ DsCmpstoreB32Ds::DsCmpstoreB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpstore_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreB32Ds>(opcode);
 }
 } // namespace detail
@@ -426,7 +496,12 @@ DsCmpstoreF32Ds::DsCmpstoreF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreF32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpstore_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreF32Ds>(opcode);
 }
 } // namespace detail
@@ -449,7 +524,11 @@ DsMinF32Ds::DsMinF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinF32Ds>(opcode);
 }
 } // namespace detail
@@ -472,7 +551,11 @@ DsMaxF32Ds::DsMaxF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxF32Ds>(opcode);
 }
 } // namespace detail
@@ -485,7 +568,11 @@ DsNopDs::DsNopDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsNopDs(const MachineInst *opcode) {
+DecodeResult decodeDsNopDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Ds::validate_encoding("ds_nop", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsNopDs>(opcode);
 }
 } // namespace detail
@@ -508,7 +595,11 @@ DsAddF32Ds::DsAddF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddF32Ds>(opcode);
 }
 } // namespace detail
@@ -521,7 +612,12 @@ DsGwsSemaReleaseAllDs::DsGwsSemaReleaseAllDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_release_all", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaReleaseAllDs>(opcode);
 }
 } // namespace detail
@@ -536,7 +632,11 @@ DsGwsInitDs::DsGwsInitDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsInitDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsInitDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_init", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsInitDs>(opcode);
 }
 } // namespace detail
@@ -549,7 +649,11 @@ DsGwsSemaVDs::DsGwsSemaVDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaVDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaVDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_v", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaVDs>(opcode);
 }
 } // namespace detail
@@ -564,7 +668,11 @@ DsGwsSemaBrDs::DsGwsSemaBrDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaBrDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaBrDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_br", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaBrDs>(opcode);
 }
 } // namespace detail
@@ -577,7 +685,11 @@ DsGwsSemaPDs::DsGwsSemaPDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaPDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaPDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_p", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaPDs>(opcode);
 }
 } // namespace detail
@@ -592,7 +704,11 @@ DsGwsBarrierDs::DsGwsBarrierDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsBarrierDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsBarrierDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_barrier", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsBarrierDs>(opcode);
 }
 } // namespace detail
@@ -613,7 +729,11 @@ DsStoreB8Ds::DsStoreB8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_b8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB8Ds>(opcode);
 }
 } // namespace detail
@@ -634,7 +754,11 @@ DsStoreB16Ds::DsStoreB16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_b16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB16Ds>(opcode);
 }
 } // namespace detail
@@ -659,7 +783,11 @@ DsAddRtnU32Ds::DsAddRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -684,7 +812,11 @@ DsSubRtnU32Ds::DsSubRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -709,7 +841,11 @@ DsRsubRtnU32Ds::DsRsubRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -734,7 +870,11 @@ DsIncRtnU32Ds::DsIncRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -759,7 +899,11 @@ DsDecRtnU32Ds::DsDecRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -784,7 +928,11 @@ DsMinRtnI32Ds::DsMinRtnI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI32Ds>(opcode);
 }
 } // namespace detail
@@ -809,7 +957,11 @@ DsMaxRtnI32Ds::DsMaxRtnI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI32Ds>(opcode);
 }
 } // namespace detail
@@ -834,7 +986,11 @@ DsMinRtnU32Ds::DsMinRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -859,7 +1015,11 @@ DsMaxRtnU32Ds::DsMaxRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -884,7 +1044,11 @@ DsAndRtnB32Ds::DsAndRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -909,7 +1073,11 @@ DsOrRtnB32Ds::DsOrRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -934,7 +1102,11 @@ DsXorRtnB32Ds::DsXorRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -961,7 +1133,12 @@ DsMskorRtnB32Ds::DsMskorRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -986,7 +1163,12 @@ DsStorexchgRtnB32Ds::DsStorexchgRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchgRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchgRtnB32Ds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_storexchg_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchgRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1013,7 +1195,12 @@ DsStorexchg2addrRtnB32Ds::DsStorexchg2addrRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchg2addrRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchg2addrRtnB32Ds(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_storexchg_2addr_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchg2addrRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1040,7 +1227,13 @@ DsStorexchg2addrStride64RtnB32Ds::DsStorexchg2addrStride64RtnB32Ds(const Machine
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchg2addrStride64RtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchg2addrStride64RtnB32Ds(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Ds::validate_encoding("ds_storexchg_2addr_stride64_rtn_b32",
+                            reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchg2addrStride64RtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1067,7 +1260,12 @@ DsCmpstoreRtnB32Ds::DsCmpstoreRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreRtnB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpstore_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1094,7 +1292,12 @@ DsCmpstoreRtnF32Ds::DsCmpstoreRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreRtnF32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpstore_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1119,7 +1322,11 @@ DsMinRtnF32Ds::DsMinRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1144,7 +1351,11 @@ DsMaxRtnF32Ds::DsMaxRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1170,7 +1381,11 @@ DsWrapRtnB32Ds::DsWrapRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrapRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrapRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrap_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrapRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1187,7 +1402,11 @@ DsSwizzleB32Ds::DsSwizzleB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSwizzleB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSwizzleB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_swizzle_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSwizzleB32Ds>(opcode);
 }
 } // namespace detail
@@ -1208,7 +1427,11 @@ DsLoadB32Ds::DsLoadB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadB32Ds>(opcode);
 }
 } // namespace detail
@@ -1229,7 +1452,12 @@ DsLoad2addrB32Ds::DsLoad2addrB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoad2addrB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoad2addrB32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_2addr_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoad2addrB32Ds>(opcode);
 }
 } // namespace detail
@@ -1250,7 +1478,12 @@ DsLoad2addrStride64B32Ds::DsLoad2addrStride64B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoad2addrStride64B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoad2addrStride64B32Ds(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_2addr_stride64_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoad2addrStride64B32Ds>(opcode);
 }
 } // namespace detail
@@ -1271,7 +1504,11 @@ DsLoadI8Ds::DsLoadI8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadI8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadI8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_i8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadI8Ds>(opcode);
 }
 } // namespace detail
@@ -1292,7 +1529,11 @@ DsLoadU8Ds::DsLoadU8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_u8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU8Ds>(opcode);
 }
 } // namespace detail
@@ -1313,7 +1554,11 @@ DsLoadI16Ds::DsLoadI16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadI16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadI16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_i16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadI16Ds>(opcode);
 }
 } // namespace detail
@@ -1334,7 +1579,11 @@ DsLoadU16Ds::DsLoadU16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_u16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU16Ds>(opcode);
 }
 } // namespace detail
@@ -1355,7 +1604,11 @@ DsConsumeDs::DsConsumeDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsConsumeDs(const MachineInst *opcode) {
+DecodeResult decodeDsConsumeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_consume", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsConsumeDs>(opcode);
 }
 } // namespace detail
@@ -1376,7 +1629,11 @@ DsAppendDs::DsAppendDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAppendDs(const MachineInst *opcode) {
+DecodeResult decodeDsAppendDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_append", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAppendDs>(opcode);
 }
 } // namespace detail
@@ -1401,7 +1658,12 @@ DsOrderedCountDs::DsOrderedCountDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrderedCountDs(const MachineInst *opcode) {
+DecodeResult decodeDsOrderedCountDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_ordered_count", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrderedCountDs>(opcode);
 }
 } // namespace detail
@@ -1424,7 +1686,11 @@ DsAddU64Ds::DsAddU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU64Ds>(opcode);
 }
 } // namespace detail
@@ -1447,7 +1713,11 @@ DsSubU64Ds::DsSubU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU64Ds>(opcode);
 }
 } // namespace detail
@@ -1470,7 +1740,11 @@ DsRsubU64Ds::DsRsubU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU64Ds>(opcode);
 }
 } // namespace detail
@@ -1493,7 +1767,11 @@ DsIncU64Ds::DsIncU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU64Ds>(opcode);
 }
 } // namespace detail
@@ -1516,7 +1794,11 @@ DsDecU64Ds::DsDecU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU64Ds>(opcode);
 }
 } // namespace detail
@@ -1539,7 +1821,11 @@ DsMinI64Ds::DsMinI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI64Ds>(opcode);
 }
 } // namespace detail
@@ -1562,7 +1848,11 @@ DsMaxI64Ds::DsMaxI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI64Ds>(opcode);
 }
 } // namespace detail
@@ -1585,7 +1875,11 @@ DsMinU64Ds::DsMinU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU64Ds>(opcode);
 }
 } // namespace detail
@@ -1608,7 +1902,11 @@ DsMaxU64Ds::DsMaxU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU64Ds>(opcode);
 }
 } // namespace detail
@@ -1631,7 +1929,11 @@ DsAndB64Ds::DsAndB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB64Ds>(opcode);
 }
 } // namespace detail
@@ -1654,7 +1956,11 @@ DsOrB64Ds::DsOrB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB64Ds>(opcode);
 }
 } // namespace detail
@@ -1677,7 +1983,11 @@ DsXorB64Ds::DsXorB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB64Ds>(opcode);
 }
 } // namespace detail
@@ -1702,7 +2012,11 @@ DsMskorB64Ds::DsMskorB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB64Ds>(opcode);
 }
 } // namespace detail
@@ -1723,7 +2037,11 @@ DsStoreB64Ds::DsStoreB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB64Ds>(opcode);
 }
 } // namespace detail
@@ -1746,7 +2064,12 @@ DsStore2addrB64Ds::DsStore2addrB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStore2addrB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStore2addrB64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_2addr_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStore2addrB64Ds>(opcode);
 }
 } // namespace detail
@@ -1769,7 +2092,12 @@ DsStore2addrStride64B64Ds::DsStore2addrStride64B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStore2addrStride64B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStore2addrStride64B64Ds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_2addr_stride64_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStore2addrStride64B64Ds>(opcode);
 }
 } // namespace detail
@@ -1794,7 +2122,12 @@ DsCmpstoreB64Ds::DsCmpstoreB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreB64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpstore_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreB64Ds>(opcode);
 }
 } // namespace detail
@@ -1819,7 +2152,12 @@ DsCmpstoreF64Ds::DsCmpstoreF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreF64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpstore_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreF64Ds>(opcode);
 }
 } // namespace detail
@@ -1842,7 +2180,11 @@ DsMinF64Ds::DsMinF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinF64Ds>(opcode);
 }
 } // namespace detail
@@ -1865,7 +2207,11 @@ DsMaxF64Ds::DsMaxF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxF64Ds>(opcode);
 }
 } // namespace detail
@@ -1890,7 +2236,11 @@ DsAddRtnU64Ds::DsAddRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -1915,7 +2265,11 @@ DsSubRtnU64Ds::DsSubRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -1940,7 +2294,11 @@ DsRsubRtnU64Ds::DsRsubRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -1965,7 +2323,11 @@ DsIncRtnU64Ds::DsIncRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -1990,7 +2352,11 @@ DsDecRtnU64Ds::DsDecRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2015,7 +2381,11 @@ DsMinRtnI64Ds::DsMinRtnI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI64Ds>(opcode);
 }
 } // namespace detail
@@ -2040,7 +2410,11 @@ DsMaxRtnI64Ds::DsMaxRtnI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI64Ds>(opcode);
 }
 } // namespace detail
@@ -2065,7 +2439,11 @@ DsMinRtnU64Ds::DsMinRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2090,7 +2468,11 @@ DsMaxRtnU64Ds::DsMaxRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2115,7 +2497,11 @@ DsAndRtnB64Ds::DsAndRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2140,7 +2526,11 @@ DsOrRtnB64Ds::DsOrRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2165,7 +2555,11 @@ DsXorRtnB64Ds::DsXorRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2192,7 +2586,12 @@ DsMskorRtnB64Ds::DsMskorRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2217,7 +2616,12 @@ DsStorexchgRtnB64Ds::DsStorexchgRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchgRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchgRtnB64Ds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_storexchg_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchgRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2244,7 +2648,12 @@ DsStorexchg2addrRtnB64Ds::DsStorexchg2addrRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchg2addrRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchg2addrRtnB64Ds(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_storexchg_2addr_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchg2addrRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2271,7 +2680,13 @@ DsStorexchg2addrStride64RtnB64Ds::DsStorexchg2addrStride64RtnB64Ds(const Machine
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchg2addrStride64RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchg2addrStride64RtnB64Ds(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Ds::validate_encoding("ds_storexchg_2addr_stride64_rtn_b64",
+                            reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchg2addrStride64RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2298,7 +2713,12 @@ DsCmpstoreRtnB64Ds::DsCmpstoreRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreRtnB64Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpstore_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2325,7 +2745,12 @@ DsCmpstoreRtnF64Ds::DsCmpstoreRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreRtnF64Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpstore_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -2350,7 +2775,11 @@ DsMinRtnF64Ds::DsMinRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -2375,7 +2804,11 @@ DsMaxRtnF64Ds::DsMaxRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -2396,7 +2829,11 @@ DsLoadB64Ds::DsLoadB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadB64Ds>(opcode);
 }
 } // namespace detail
@@ -2417,7 +2854,12 @@ DsLoad2addrB64Ds::DsLoad2addrB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoad2addrB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoad2addrB64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_2addr_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoad2addrB64Ds>(opcode);
 }
 } // namespace detail
@@ -2438,7 +2880,12 @@ DsLoad2addrStride64B64Ds::DsLoad2addrStride64B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoad2addrStride64B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoad2addrStride64B64Ds(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_2addr_stride64_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoad2addrStride64B64Ds>(opcode);
 }
 } // namespace detail
@@ -2463,7 +2910,11 @@ DsAddRtnF32Ds::DsAddRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -2480,7 +2931,12 @@ DsAddGsRegRtnDs::DsAddGsRegRtnDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddGsRegRtnDs(const MachineInst *opcode) {
+DecodeResult decodeDsAddGsRegRtnDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_gs_reg_rtn", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddGsRegRtnDs>(opcode);
 }
 } // namespace detail
@@ -2497,7 +2953,12 @@ DsSubGsRegRtnDs::DsSubGsRegRtnDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubGsRegRtnDs(const MachineInst *opcode) {
+DecodeResult decodeDsSubGsRegRtnDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_gs_reg_rtn", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubGsRegRtnDs>(opcode);
 }
 } // namespace detail
@@ -2522,7 +2983,12 @@ DsCondxchg32RtnB64Ds::DsCondxchg32RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_condxchg32_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCondxchg32RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2543,7 +3009,12 @@ DsStoreB8D16HiDs::DsStoreB8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB8D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_b8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2564,7 +3035,12 @@ DsStoreB16D16HiDs::DsStoreB16D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB16D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB16D16HiDs(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_b16_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB16D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2585,7 +3061,11 @@ DsLoadU8D16Ds::DsLoadU8D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU8D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_u8_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU8D16Ds>(opcode);
 }
 } // namespace detail
@@ -2612,7 +3092,12 @@ DsLoadU8D16HiDs::DsLoadU8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU8D16HiDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_u8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2639,7 +3124,11 @@ DsLoadI8D16Ds::DsLoadI8D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadI8D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_i8_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadI8D16Ds>(opcode);
 }
 } // namespace detail
@@ -2666,7 +3155,12 @@ DsLoadI8D16HiDs::DsLoadI8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadI8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsLoadI8D16HiDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_i8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadI8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2693,7 +3187,11 @@ DsLoadU16D16Ds::DsLoadU16D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU16D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU16D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_u16_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU16D16Ds>(opcode);
 }
 } // namespace detail
@@ -2720,7 +3218,12 @@ DsLoadU16D16HiDs::DsLoadU16D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU16D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU16D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_u16_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU16D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2753,7 +3256,12 @@ DsBvhStackRtnB32Ds::DsBvhStackRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsBvhStackRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsBvhStackRtnB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_bvh_stack_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsBvhStackRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -2774,7 +3282,12 @@ DsStoreAddtidB32Ds::DsStoreAddtidB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreAddtidB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreAddtidB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_addtid_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreAddtidB32Ds>(opcode);
 }
 } // namespace detail
@@ -2795,7 +3308,12 @@ DsLoadAddtidB32Ds::DsLoadAddtidB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadAddtidB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadAddtidB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_addtid_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadAddtidB32Ds>(opcode);
 }
 } // namespace detail
@@ -2814,7 +3332,11 @@ DsPermuteB32Ds::DsPermuteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPermuteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsPermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_permute_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPermuteB32Ds>(opcode);
 }
 } // namespace detail
@@ -2833,7 +3355,12 @@ DsBpermuteB32Ds::DsBpermuteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsBpermuteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsBpermuteB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_bpermute_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsBpermuteB32Ds>(opcode);
 }
 } // namespace detail
@@ -2854,7 +3381,11 @@ DsStoreB96Ds::DsStoreB96Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB96Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_b96", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB96Ds>(opcode);
 }
 } // namespace detail
@@ -2875,7 +3406,11 @@ DsStoreB128Ds::DsStoreB128Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB128Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_b128", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB128Ds>(opcode);
 }
 } // namespace detail
@@ -2896,7 +3431,11 @@ DsLoadB96Ds::DsLoadB96Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadB96Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_b96", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadB96Ds>(opcode);
 }
 } // namespace detail
@@ -2917,7 +3456,11 @@ DsLoadB128Ds::DsLoadB128Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadB128Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_b128", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadB128Ds>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/encodings.cpp
@@ -5,7 +5,6 @@
 // See lib/python/amdisa/README.md for regeneration instructions.
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/encodings.h"
-#include "util/except.h"
 #include <cstring>
 #include <string>
 
@@ -1157,9 +1156,6 @@ Vop3::Vop3(std::string_view mnemonic, const Vop3MachineInst *inst, ExecuteFn exe
   raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
-  if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
-      (has_encoded_literal32()))
-    throw util::InvalidInst("DPP and literal operands cannot be combined", "");
   if (has_encoded_literal32())
     size_ += sizeof(MachineInst);
   if (inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0))
@@ -1257,9 +1253,6 @@ Vop3p::Vop3p(std::string_view mnemonic, const Vop3pMachineInst *inst, ExecuteFn 
   raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
-  if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
-      (has_encoded_literal32()))
-    throw util::InvalidInst("DPP and literal operands cannot be combined", "");
   if (has_encoded_literal32())
     size_ += sizeof(MachineInst);
   if (inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0))
@@ -1466,9 +1459,6 @@ Vop3SdstEnc::Vop3SdstEnc(std::string_view mnemonic, const Vop3SdstEncMachineInst
   raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
-  if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
-      (has_encoded_literal32()))
-    throw util::InvalidInst("DPP and literal operands cannot be combined", "");
   if (has_encoded_literal32())
     size_ += sizeof(MachineInst);
   if (inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/encodings.h
@@ -10,6 +10,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna3/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
+#include "rocjitsu/isa/decode_result.h"
 #include "rocjitsu/isa/instruction.h"
 #include <array>
 #include <cstdint>
@@ -503,6 +504,15 @@ class Vop3 : public IsaInstruction<Isa> {
 public:
   Vop3(std::string_view mnemonic, const Vop3MachineInst *inst, ExecuteFn exec_fn);
   bool has_encoded_literal32() const;
+  static Result validate_encoding([[maybe_unused]] std::string_view mnemonic,
+                                  const Vop3MachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error) {
+    const auto &inst_ = *inst;
+    if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
+        (inst_.src0 == 255 || inst_.src1 == 255 || inst_.src2 == 255)) [[unlikely]]
+      return emit_error.emit() << "DPP and literal operands cannot be combined";
+    return Result::success();
+  }
   void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool has_lit_0();
@@ -529,6 +539,15 @@ class Vop3p : public IsaInstruction<Isa> {
 public:
   Vop3p(std::string_view mnemonic, const Vop3pMachineInst *inst, ExecuteFn exec_fn);
   bool has_encoded_literal32() const;
+  static Result validate_encoding([[maybe_unused]] std::string_view mnemonic,
+                                  const Vop3pMachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error) {
+    const auto &inst_ = *inst;
+    if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
+        (inst_.src0 == 255 || inst_.src1 == 255 || inst_.src2 == 255)) [[unlikely]]
+      return emit_error.emit() << "DPP and literal operands cannot be combined";
+    return Result::success();
+  }
   void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool has_lit_0();
@@ -618,6 +637,15 @@ class Vop3SdstEnc : public IsaInstruction<Isa> {
 public:
   Vop3SdstEnc(std::string_view mnemonic, const Vop3SdstEncMachineInst *inst, ExecuteFn exec_fn);
   bool has_encoded_literal32() const;
+  static Result validate_encoding([[maybe_unused]] std::string_view mnemonic,
+                                  const Vop3SdstEncMachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error) {
+    const auto &inst_ = *inst;
+    if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
+        (inst_.src0 == 255 || inst_.src1 == 255 || inst_.src2 == 255)) [[unlikely]]
+      return emit_error.emit() << "DPP and literal operands cannot be combined";
+    return Result::success();
+  }
   void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool has_lit_0();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/exp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/exp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/exp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -35,7 +34,11 @@ ExpExp::ExpExp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeExpExp(const MachineInst *opcode) {
+DecodeResult decodeExpExp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Exp::validate_encoding("exp", reinterpret_cast<const Exp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ExpExp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/flat.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/flat.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/flat.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -40,7 +39,11 @@ FlatLoadU8Flat::FlatLoadU8Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadU8Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadU8Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_u8", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadU8Flat>(opcode);
 }
 } // namespace detail
@@ -72,7 +75,11 @@ FlatLoadI8Flat::FlatLoadI8Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadI8Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadI8Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_i8", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadI8Flat>(opcode);
 }
 } // namespace detail
@@ -104,7 +111,12 @@ FlatLoadU16Flat::FlatLoadU16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadU16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadU16Flat(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_u16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadU16Flat>(opcode);
 }
 } // namespace detail
@@ -136,7 +148,12 @@ FlatLoadI16Flat::FlatLoadI16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadI16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadI16Flat(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_i16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadI16Flat>(opcode);
 }
 } // namespace detail
@@ -168,7 +185,12 @@ FlatLoadB32Flat::FlatLoadB32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadB32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadB32Flat(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_b32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadB32Flat>(opcode);
 }
 } // namespace detail
@@ -200,7 +222,12 @@ FlatLoadB64Flat::FlatLoadB64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadB64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadB64Flat(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_b64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadB64Flat>(opcode);
 }
 } // namespace detail
@@ -232,7 +259,12 @@ FlatLoadB96Flat::FlatLoadB96Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadB96Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadB96Flat(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_b96", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadB96Flat>(opcode);
 }
 } // namespace detail
@@ -264,7 +296,12 @@ FlatLoadB128Flat::FlatLoadB128Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadB128Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadB128Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_b128", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadB128Flat>(opcode);
 }
 } // namespace detail
@@ -296,7 +333,12 @@ FlatStoreB8Flat::FlatStoreB8Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB8Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB8Flat(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_b8", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB8Flat>(opcode);
 }
 } // namespace detail
@@ -328,7 +370,12 @@ FlatStoreB16Flat::FlatStoreB16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB16Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_b16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB16Flat>(opcode);
 }
 } // namespace detail
@@ -360,7 +407,12 @@ FlatStoreB32Flat::FlatStoreB32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB32Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_b32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB32Flat>(opcode);
 }
 } // namespace detail
@@ -392,7 +444,12 @@ FlatStoreB64Flat::FlatStoreB64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB64Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_b64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB64Flat>(opcode);
 }
 } // namespace detail
@@ -424,7 +481,12 @@ FlatStoreB96Flat::FlatStoreB96Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB96Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB96Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_b96", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB96Flat>(opcode);
 }
 } // namespace detail
@@ -456,7 +518,12 @@ FlatStoreB128Flat::FlatStoreB128Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB128Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB128Flat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_b128", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB128Flat>(opcode);
 }
 } // namespace detail
@@ -488,7 +555,12 @@ FlatLoadD16U8Flat::FlatLoadD16U8Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16U8Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16U8Flat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_d16_u8", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16U8Flat>(opcode);
 }
 } // namespace detail
@@ -526,7 +598,12 @@ FlatLoadD16I8Flat::FlatLoadD16I8Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16I8Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16I8Flat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_d16_i8", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16I8Flat>(opcode);
 }
 } // namespace detail
@@ -564,7 +641,12 @@ FlatLoadD16B16Flat::FlatLoadD16B16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16B16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16B16Flat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_d16_b16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16B16Flat>(opcode);
 }
 } // namespace detail
@@ -602,7 +684,12 @@ FlatLoadD16HiU8Flat::FlatLoadD16HiU8Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16HiU8Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16HiU8Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_d16_hi_u8", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16HiU8Flat>(opcode);
 }
 } // namespace detail
@@ -640,7 +727,12 @@ FlatLoadD16HiI8Flat::FlatLoadD16HiI8Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16HiI8Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16HiI8Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_d16_hi_i8", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16HiI8Flat>(opcode);
 }
 } // namespace detail
@@ -678,7 +770,12 @@ FlatLoadD16HiB16Flat::FlatLoadD16HiB16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16HiB16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16HiB16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_d16_hi_b16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16HiB16Flat>(opcode);
 }
 } // namespace detail
@@ -716,7 +813,12 @@ FlatStoreD16HiB8Flat::FlatStoreD16HiB8Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreD16HiB8Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreD16HiB8Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_d16_hi_b8", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreD16HiB8Flat>(opcode);
 }
 } // namespace detail
@@ -748,7 +850,12 @@ FlatStoreD16HiB16Flat::FlatStoreD16HiB16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreD16HiB16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreD16HiB16Flat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_d16_hi_b16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreD16HiB16Flat>(opcode);
 }
 } // namespace detail
@@ -783,7 +890,12 @@ FlatAtomicSwapB32Flat::FlatAtomicSwapB32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapB32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapB32Flat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_swap_b32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapB32Flat>(opcode);
 }
 } // namespace detail
@@ -818,7 +930,12 @@ FlatAtomicCmpswapB32Flat::FlatAtomicCmpswapB32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapB32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapB32Flat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_cmpswap_b32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapB32Flat>(opcode);
 }
 } // namespace detail
@@ -853,7 +970,12 @@ FlatAtomicAddU32Flat::FlatAtomicAddU32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddU32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add_u32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddU32Flat>(opcode);
 }
 } // namespace detail
@@ -888,7 +1010,12 @@ FlatAtomicSubU32Flat::FlatAtomicSubU32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubU32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_sub_u32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubU32Flat>(opcode);
 }
 } // namespace detail
@@ -923,7 +1050,12 @@ FlatAtomicMinI32Flat::FlatAtomicMinI32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinI32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinI32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_min_i32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinI32Flat>(opcode);
 }
 } // namespace detail
@@ -958,7 +1090,12 @@ FlatAtomicMinU32Flat::FlatAtomicMinU32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinU32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_min_u32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinU32Flat>(opcode);
 }
 } // namespace detail
@@ -993,7 +1130,12 @@ FlatAtomicMaxI32Flat::FlatAtomicMaxI32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxI32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxI32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_max_i32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxI32Flat>(opcode);
 }
 } // namespace detail
@@ -1028,7 +1170,12 @@ FlatAtomicMaxU32Flat::FlatAtomicMaxU32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxU32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_max_u32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxU32Flat>(opcode);
 }
 } // namespace detail
@@ -1063,7 +1210,12 @@ FlatAtomicAndB32Flat::FlatAtomicAndB32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndB32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndB32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_and_b32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndB32Flat>(opcode);
 }
 } // namespace detail
@@ -1098,7 +1250,12 @@ FlatAtomicOrB32Flat::FlatAtomicOrB32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrB32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrB32Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_or_b32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrB32Flat>(opcode);
 }
 } // namespace detail
@@ -1133,7 +1290,12 @@ FlatAtomicXorB32Flat::FlatAtomicXorB32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorB32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorB32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_xor_b32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorB32Flat>(opcode);
 }
 } // namespace detail
@@ -1168,7 +1330,12 @@ FlatAtomicIncU32Flat::FlatAtomicIncU32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncU32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_inc_u32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncU32Flat>(opcode);
 }
 } // namespace detail
@@ -1203,7 +1370,12 @@ FlatAtomicDecU32Flat::FlatAtomicDecU32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecU32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_dec_u32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecU32Flat>(opcode);
 }
 } // namespace detail
@@ -1238,7 +1410,12 @@ FlatAtomicSwapB64Flat::FlatAtomicSwapB64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapB64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapB64Flat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_swap_b64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapB64Flat>(opcode);
 }
 } // namespace detail
@@ -1273,7 +1450,12 @@ FlatAtomicCmpswapB64Flat::FlatAtomicCmpswapB64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapB64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapB64Flat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_cmpswap_b64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapB64Flat>(opcode);
 }
 } // namespace detail
@@ -1308,7 +1490,12 @@ FlatAtomicAddU64Flat::FlatAtomicAddU64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddU64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add_u64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddU64Flat>(opcode);
 }
 } // namespace detail
@@ -1343,7 +1530,12 @@ FlatAtomicSubU64Flat::FlatAtomicSubU64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubU64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_sub_u64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubU64Flat>(opcode);
 }
 } // namespace detail
@@ -1378,7 +1570,12 @@ FlatAtomicMinI64Flat::FlatAtomicMinI64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinI64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinI64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_min_i64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinI64Flat>(opcode);
 }
 } // namespace detail
@@ -1413,7 +1610,12 @@ FlatAtomicMinU64Flat::FlatAtomicMinU64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinU64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_min_u64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinU64Flat>(opcode);
 }
 } // namespace detail
@@ -1448,7 +1650,12 @@ FlatAtomicMaxI64Flat::FlatAtomicMaxI64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxI64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxI64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_max_i64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxI64Flat>(opcode);
 }
 } // namespace detail
@@ -1483,7 +1690,12 @@ FlatAtomicMaxU64Flat::FlatAtomicMaxU64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxU64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_max_u64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxU64Flat>(opcode);
 }
 } // namespace detail
@@ -1518,7 +1730,12 @@ FlatAtomicAndB64Flat::FlatAtomicAndB64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndB64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndB64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_and_b64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndB64Flat>(opcode);
 }
 } // namespace detail
@@ -1553,7 +1770,12 @@ FlatAtomicOrB64Flat::FlatAtomicOrB64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrB64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrB64Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_or_b64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrB64Flat>(opcode);
 }
 } // namespace detail
@@ -1588,7 +1810,12 @@ FlatAtomicXorB64Flat::FlatAtomicXorB64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorB64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorB64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_xor_b64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorB64Flat>(opcode);
 }
 } // namespace detail
@@ -1623,7 +1850,12 @@ FlatAtomicIncU64Flat::FlatAtomicIncU64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncU64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_inc_u64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncU64Flat>(opcode);
 }
 } // namespace detail
@@ -1658,7 +1890,12 @@ FlatAtomicDecU64Flat::FlatAtomicDecU64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecU64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_dec_u64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecU64Flat>(opcode);
 }
 } // namespace detail
@@ -1693,7 +1930,12 @@ FlatAtomicCmpswapF32Flat::FlatAtomicCmpswapF32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapF32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapF32Flat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_cmpswap_f32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapF32Flat>(opcode);
 }
 } // namespace detail
@@ -1728,7 +1970,12 @@ FlatAtomicMinF32Flat::FlatAtomicMinF32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinF32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinF32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_min_f32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinF32Flat>(opcode);
 }
 } // namespace detail
@@ -1763,7 +2010,12 @@ FlatAtomicMaxF32Flat::FlatAtomicMaxF32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxF32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxF32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_max_f32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxF32Flat>(opcode);
 }
 } // namespace detail
@@ -1798,7 +2050,12 @@ FlatAtomicAddF32Flat::FlatAtomicAddF32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddF32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddF32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add_f32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddF32Flat>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/ldsdir.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/ldsdir.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/ldsdir.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -29,7 +28,12 @@ LdsParamLoadLdsdir::LdsParamLoadLdsdir(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeLdsParamLoadLdsdir(const MachineInst *opcode) {
+DecodeResult decodeLdsParamLoadLdsdir(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ldsdir::validate_encoding(
+      "lds_param_load", reinterpret_cast<const Ldsdir::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<LdsParamLoadLdsdir>(opcode);
 }
 } // namespace detail
@@ -49,7 +53,12 @@ LdsDirectLoadLdsdir::LdsDirectLoadLdsdir(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeLdsDirectLoadLdsdir(const MachineInst *opcode) {
+DecodeResult decodeLdsDirectLoadLdsdir(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Ldsdir::validate_encoding(
+      "lds_direct_load", reinterpret_cast<const Ldsdir::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<LdsDirectLoadLdsdir>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/mimg.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/mimg.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/mimg.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -26,7 +25,11 @@ ImageLoadMimg::ImageLoadMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMimg>(opcode);
 }
 } // namespace detail
@@ -45,7 +48,12 @@ ImageLoadMipMimg::ImageLoadMipMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipMimg>(opcode);
 }
 } // namespace detail
@@ -64,7 +72,12 @@ ImageLoadPckMimg::ImageLoadPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadPckMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadPckMimg>(opcode);
 }
 } // namespace detail
@@ -83,7 +96,12 @@ ImageLoadPckSgnMimg::ImageLoadPckSgnMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadPckSgnMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadPckSgnMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_pck_sgn", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadPckSgnMimg>(opcode);
 }
 } // namespace detail
@@ -102,7 +120,12 @@ ImageLoadMipPckMimg::ImageLoadMipPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipPckMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipPckMimg>(opcode);
 }
 } // namespace detail
@@ -121,7 +144,12 @@ ImageLoadMipPckSgnMimg::ImageLoadMipPckSgnMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipPckSgnMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipPckSgnMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_pck_sgn", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipPckSgnMimg>(opcode);
 }
 } // namespace detail
@@ -140,7 +168,11 @@ ImageStoreMimg::ImageStoreMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMimg>(opcode);
 }
 } // namespace detail
@@ -159,7 +191,12 @@ ImageStoreMipMimg::ImageStoreMipMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipMimg>(opcode);
 }
 } // namespace detail
@@ -178,7 +215,12 @@ ImageStorePckMimg::ImageStorePckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStorePckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStorePckMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStorePckMimg>(opcode);
 }
 } // namespace detail
@@ -197,7 +239,12 @@ ImageStoreMipPckMimg::ImageStoreMipPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipPckMimg>(opcode);
 }
 } // namespace detail
@@ -217,7 +264,12 @@ ImageAtomicSwapMimg::ImageAtomicSwapMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSwapMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSwapMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_swap", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSwapMimg>(opcode);
 }
 } // namespace detail
@@ -237,7 +289,12 @@ ImageAtomicCmpswapMimg::ImageAtomicCmpswapMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicCmpswapMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicCmpswapMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_cmpswap", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicCmpswapMimg>(opcode);
 }
 } // namespace detail
@@ -257,7 +314,12 @@ ImageAtomicAddMimg::ImageAtomicAddMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicAddMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicAddMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_add", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicAddMimg>(opcode);
 }
 } // namespace detail
@@ -277,7 +339,12 @@ ImageAtomicSubMimg::ImageAtomicSubMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSubMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSubMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_sub", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSubMimg>(opcode);
 }
 } // namespace detail
@@ -297,7 +364,12 @@ ImageAtomicSminMimg::ImageAtomicSminMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSminMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_smin", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSminMimg>(opcode);
 }
 } // namespace detail
@@ -317,7 +389,12 @@ ImageAtomicUminMimg::ImageAtomicUminMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicUminMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicUminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_umin", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicUminMimg>(opcode);
 }
 } // namespace detail
@@ -337,7 +414,12 @@ ImageAtomicSmaxMimg::ImageAtomicSmaxMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSmaxMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_smax", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSmaxMimg>(opcode);
 }
 } // namespace detail
@@ -357,7 +439,12 @@ ImageAtomicUmaxMimg::ImageAtomicUmaxMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicUmaxMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicUmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_umax", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicUmaxMimg>(opcode);
 }
 } // namespace detail
@@ -377,7 +464,12 @@ ImageAtomicAndMimg::ImageAtomicAndMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicAndMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicAndMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_and", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicAndMimg>(opcode);
 }
 } // namespace detail
@@ -397,7 +489,12 @@ ImageAtomicOrMimg::ImageAtomicOrMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicOrMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicOrMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_or", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicOrMimg>(opcode);
 }
 } // namespace detail
@@ -417,7 +514,12 @@ ImageAtomicXorMimg::ImageAtomicXorMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicXorMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicXorMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_xor", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicXorMimg>(opcode);
 }
 } // namespace detail
@@ -437,7 +539,12 @@ ImageAtomicIncMimg::ImageAtomicIncMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicIncMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicIncMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_inc", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicIncMimg>(opcode);
 }
 } // namespace detail
@@ -457,7 +564,12 @@ ImageAtomicDecMimg::ImageAtomicDecMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicDecMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicDecMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_dec", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicDecMimg>(opcode);
 }
 } // namespace detail
@@ -476,7 +588,12 @@ ImageGetResinfoMimg::ImageGetResinfoMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGetResinfoMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGetResinfoMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_get_resinfo", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGetResinfoMimg>(opcode);
 }
 } // namespace detail
@@ -495,7 +612,12 @@ ImageMsaaLoadMimg::ImageMsaaLoadMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageMsaaLoadMimg(const MachineInst *opcode) {
+DecodeResult decodeImageMsaaLoadMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_msaa_load", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageMsaaLoadMimg>(opcode);
 }
 } // namespace detail
@@ -514,7 +636,12 @@ ImageBvhIntersectRayMimg::ImageBvhIntersectRayMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageBvhIntersectRayMimg(const MachineInst *opcode) {
+DecodeResult decodeImageBvhIntersectRayMimg(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_bvh_intersect_ray", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageBvhIntersectRayMimg>(opcode);
 }
 } // namespace detail
@@ -533,7 +660,12 @@ ImageBvh64IntersectRayMimg::ImageBvh64IntersectRayMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageBvh64IntersectRayMimg(const MachineInst *opcode) {
+DecodeResult decodeImageBvh64IntersectRayMimg(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_bvh64_intersect_ray", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageBvh64IntersectRayMimg>(opcode);
 }
 } // namespace detail
@@ -554,7 +686,12 @@ ImageSampleMimg::ImageSampleMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleMimg(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleMimg>(opcode);
 }
 } // namespace detail
@@ -575,7 +712,12 @@ ImageSampleDMimg::ImageSampleDMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDMimg>(opcode);
 }
 } // namespace detail
@@ -596,7 +738,12 @@ ImageSampleLMimg::ImageSampleLMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLMimg>(opcode);
 }
 } // namespace detail
@@ -617,7 +764,12 @@ ImageSampleBMimg::ImageSampleBMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBMimg>(opcode);
 }
 } // namespace detail
@@ -638,7 +790,12 @@ ImageSampleLzMimg::ImageSampleLzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLzMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLzMimg>(opcode);
 }
 } // namespace detail
@@ -659,7 +816,12 @@ ImageSampleCMimg::ImageSampleCMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCMimg>(opcode);
 }
 } // namespace detail
@@ -680,7 +842,12 @@ ImageSampleCDMimg::ImageSampleCDMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDMimg>(opcode);
 }
 } // namespace detail
@@ -701,7 +868,12 @@ ImageSampleCLMimg::ImageSampleCLMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLMimg>(opcode);
 }
 } // namespace detail
@@ -722,7 +894,12 @@ ImageSampleCBMimg::ImageSampleCBMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBMimg>(opcode);
 }
 } // namespace detail
@@ -743,7 +920,12 @@ ImageSampleCLzMimg::ImageSampleCLzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLzMimg>(opcode);
 }
 } // namespace detail
@@ -764,7 +946,12 @@ ImageSampleOMimg::ImageSampleOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleOMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleOMimg>(opcode);
 }
 } // namespace detail
@@ -785,7 +972,12 @@ ImageSampleDOMimg::ImageSampleDOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDOMimg>(opcode);
 }
 } // namespace detail
@@ -806,7 +998,12 @@ ImageSampleLOMimg::ImageSampleLOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_l_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLOMimg>(opcode);
 }
 } // namespace detail
@@ -827,7 +1024,12 @@ ImageSampleBOMimg::ImageSampleBOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBOMimg>(opcode);
 }
 } // namespace detail
@@ -848,7 +1050,12 @@ ImageSampleLzOMimg::ImageSampleLzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLzOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLzOMimg>(opcode);
 }
 } // namespace detail
@@ -869,7 +1076,12 @@ ImageSampleCOMimg::ImageSampleCOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCOMimg>(opcode);
 }
 } // namespace detail
@@ -890,7 +1102,12 @@ ImageSampleCDOMimg::ImageSampleCDOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDOMimg>(opcode);
 }
 } // namespace detail
@@ -911,7 +1128,12 @@ ImageSampleCLOMimg::ImageSampleCLOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_l_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLOMimg>(opcode);
 }
 } // namespace detail
@@ -932,7 +1154,12 @@ ImageSampleCBOMimg::ImageSampleCBOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBOMimg>(opcode);
 }
 } // namespace detail
@@ -953,7 +1180,12 @@ ImageSampleCLzOMimg::ImageSampleCLzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLzOMimg>(opcode);
 }
 } // namespace detail
@@ -974,7 +1206,12 @@ ImageGather4Mimg::ImageGather4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4Mimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4Mimg>(opcode);
 }
 } // namespace detail
@@ -995,7 +1232,12 @@ ImageGather4LMimg::ImageGather4LMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LMimg>(opcode);
 }
 } // namespace detail
@@ -1016,7 +1258,12 @@ ImageGather4BMimg::ImageGather4BMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4BMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4BMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4BMimg>(opcode);
 }
 } // namespace detail
@@ -1037,7 +1284,12 @@ ImageGather4LzMimg::ImageGather4LzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LzMimg>(opcode);
 }
 } // namespace detail
@@ -1058,7 +1310,12 @@ ImageGather4CMimg::ImageGather4CMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CMimg>(opcode);
 }
 } // namespace detail
@@ -1079,7 +1336,12 @@ ImageGather4CLzMimg::ImageGather4CLzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLzMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLzMimg>(opcode);
 }
 } // namespace detail
@@ -1100,7 +1362,12 @@ ImageGather4OMimg::ImageGather4OMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4OMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4OMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4OMimg>(opcode);
 }
 } // namespace detail
@@ -1121,7 +1388,12 @@ ImageGather4LzOMimg::ImageGather4LzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LzOMimg>(opcode);
 }
 } // namespace detail
@@ -1142,7 +1414,12 @@ ImageGather4CLzOMimg::ImageGather4CLzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLzOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLzOMimg>(opcode);
 }
 } // namespace detail
@@ -1163,7 +1440,12 @@ ImageGetLodMimg::ImageGetLodMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGetLodMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGetLodMimg(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_get_lod", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGetLodMimg>(opcode);
 }
 } // namespace detail
@@ -1184,7 +1466,12 @@ ImageSampleDG16Mimg::ImageSampleDG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDG16Mimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDG16Mimg>(opcode);
 }
 } // namespace detail
@@ -1205,7 +1492,12 @@ ImageSampleCDG16Mimg::ImageSampleCDG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDG16Mimg>(opcode);
 }
 } // namespace detail
@@ -1226,7 +1518,12 @@ ImageSampleDOG16Mimg::ImageSampleDOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDOG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -1247,7 +1544,12 @@ ImageSampleCDOG16Mimg::ImageSampleCDOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDOG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -1268,7 +1570,12 @@ ImageSampleClMimg::ImageSampleClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleClMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleClMimg>(opcode);
 }
 } // namespace detail
@@ -1289,7 +1596,12 @@ ImageSampleDClMimg::ImageSampleDClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClMimg>(opcode);
 }
 } // namespace detail
@@ -1310,7 +1622,12 @@ ImageSampleBClMimg::ImageSampleBClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBClMimg>(opcode);
 }
 } // namespace detail
@@ -1331,7 +1648,12 @@ ImageSampleCClMimg::ImageSampleCClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCClMimg>(opcode);
 }
 } // namespace detail
@@ -1352,7 +1674,12 @@ ImageSampleCDClMimg::ImageSampleCDClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClMimg>(opcode);
 }
 } // namespace detail
@@ -1373,7 +1700,12 @@ ImageSampleCBClMimg::ImageSampleCBClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBClMimg>(opcode);
 }
 } // namespace detail
@@ -1394,7 +1726,12 @@ ImageSampleClOMimg::ImageSampleClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleClOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleClOMimg>(opcode);
 }
 } // namespace detail
@@ -1415,7 +1752,12 @@ ImageSampleDClOMimg::ImageSampleDClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClOMimg>(opcode);
 }
 } // namespace detail
@@ -1436,7 +1778,12 @@ ImageSampleBClOMimg::ImageSampleBClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBClOMimg>(opcode);
 }
 } // namespace detail
@@ -1457,7 +1804,12 @@ ImageSampleCClOMimg::ImageSampleCClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCClOMimg>(opcode);
 }
 } // namespace detail
@@ -1478,7 +1830,12 @@ ImageSampleCDClOMimg::ImageSampleCDClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClOMimg>(opcode);
 }
 } // namespace detail
@@ -1499,7 +1856,12 @@ ImageSampleCBClOMimg::ImageSampleCBClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBClOMimg>(opcode);
 }
 } // namespace detail
@@ -1520,7 +1882,12 @@ ImageSampleCDClG16Mimg::ImageSampleCDClG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_cl_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClG16Mimg>(opcode);
 }
 } // namespace detail
@@ -1541,7 +1908,12 @@ ImageSampleDClOG16Mimg::ImageSampleDClOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClOG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_cl_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -1562,7 +1934,12 @@ ImageSampleCDClOG16Mimg::ImageSampleCDClOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClOG16Mimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_cl_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -1583,7 +1960,12 @@ ImageSampleDClG16Mimg::ImageSampleDClG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_cl_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClG16Mimg>(opcode);
 }
 } // namespace detail
@@ -1604,7 +1986,12 @@ ImageGather4ClMimg::ImageGather4ClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4ClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4ClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4ClMimg>(opcode);
 }
 } // namespace detail
@@ -1625,7 +2012,12 @@ ImageGather4BClMimg::ImageGather4BClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4BClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4BClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4BClMimg>(opcode);
 }
 } // namespace detail
@@ -1646,7 +2038,12 @@ ImageGather4CClMimg::ImageGather4CClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CClMimg>(opcode);
 }
 } // namespace detail
@@ -1667,7 +2064,12 @@ ImageGather4CLMimg::ImageGather4CLMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLMimg>(opcode);
 }
 } // namespace detail
@@ -1688,7 +2090,12 @@ ImageGather4CBMimg::ImageGather4CBMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CBMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CBMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CBMimg>(opcode);
 }
 } // namespace detail
@@ -1709,7 +2116,12 @@ ImageGather4CBClMimg::ImageGather4CBClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CBClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CBClMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CBClMimg>(opcode);
 }
 } // namespace detail
@@ -1730,7 +2142,12 @@ ImageGather4hMimg::ImageGather4hMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4hMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4hMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4h", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4hMimg>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/mtbuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/mtbuf.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/mtbuf.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -42,7 +41,12 @@ TbufferLoadFormatXMtbuf::TbufferLoadFormatXMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -66,7 +70,12 @@ TbufferLoadFormatXyMtbuf::TbufferLoadFormatXyMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xy", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -90,7 +99,12 @@ TbufferLoadFormatXyzMtbuf::TbufferLoadFormatXyzMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xyz", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -114,7 +128,12 @@ TbufferLoadFormatXyzwMtbuf::TbufferLoadFormatXyzwMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xyzw", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -138,7 +157,12 @@ TbufferStoreFormatXMtbuf::TbufferStoreFormatXMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -162,7 +186,12 @@ TbufferStoreFormatXyMtbuf::TbufferStoreFormatXyMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xy", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -186,7 +215,12 @@ TbufferStoreFormatXyzMtbuf::TbufferStoreFormatXyzMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xyz", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -210,7 +244,12 @@ TbufferStoreFormatXyzwMtbuf::TbufferStoreFormatXyzwMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xyzw", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -234,7 +273,12 @@ TbufferLoadD16FormatXMtbuf::TbufferLoadD16FormatXMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadD16FormatXMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_d16_format_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadD16FormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -264,7 +308,13 @@ TbufferLoadD16FormatXyMtbuf::TbufferLoadD16FormatXyMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadD16FormatXyMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_d16_format_xy",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadD16FormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -288,7 +338,13 @@ TbufferLoadD16FormatXyzMtbuf::TbufferLoadD16FormatXyzMtbuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadD16FormatXyzMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_d16_format_xyz",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadD16FormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -318,7 +374,13 @@ TbufferLoadD16FormatXyzwMtbuf::TbufferLoadD16FormatXyzwMtbuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadD16FormatXyzwMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_d16_format_xyzw",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadD16FormatXyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -342,7 +404,13 @@ TbufferStoreD16FormatXMtbuf::TbufferStoreD16FormatXMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreD16FormatXMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_d16_format_x",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreD16FormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -366,7 +434,13 @@ TbufferStoreD16FormatXyMtbuf::TbufferStoreD16FormatXyMtbuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreD16FormatXyMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_d16_format_xy",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreD16FormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -390,7 +464,13 @@ TbufferStoreD16FormatXyzMtbuf::TbufferStoreD16FormatXyzMtbuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreD16FormatXyzMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_d16_format_xyz",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreD16FormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -414,7 +494,13 @@ TbufferStoreD16FormatXyzwMtbuf::TbufferStoreD16FormatXyzwMtbuf(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreD16FormatXyzwMtbuf(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_d16_format_xyzw",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreD16FormatXyzwMtbuf>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/mubuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/mubuf.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/mubuf.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -42,7 +41,12 @@ BufferLoadFormatXMubuf::BufferLoadFormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXMubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -66,7 +70,12 @@ BufferLoadFormatXyMubuf::BufferLoadFormatXyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -90,7 +99,12 @@ BufferLoadFormatXyzMubuf::BufferLoadFormatXyzMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xyz", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -114,7 +128,12 @@ BufferLoadFormatXyzwMubuf::BufferLoadFormatXyzwMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xyzw", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -138,7 +157,12 @@ BufferStoreFormatXMubuf::BufferStoreFormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -162,7 +186,12 @@ BufferStoreFormatXyMubuf::BufferStoreFormatXyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -186,7 +215,12 @@ BufferStoreFormatXyzMubuf::BufferStoreFormatXyzMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xyz", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -210,7 +244,12 @@ BufferStoreFormatXyzwMubuf::BufferStoreFormatXyzwMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xyzw", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -234,7 +273,12 @@ BufferLoadD16FormatXMubuf::BufferLoadD16FormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16FormatXMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_d16_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16FormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -264,7 +308,12 @@ BufferLoadD16FormatXyMubuf::BufferLoadD16FormatXyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16FormatXyMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_d16_format_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16FormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -288,7 +337,13 @@ BufferLoadD16FormatXyzMubuf::BufferLoadD16FormatXyzMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16FormatXyzMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_d16_format_xyz",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16FormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -318,7 +373,13 @@ BufferLoadD16FormatXyzwMubuf::BufferLoadD16FormatXyzwMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16FormatXyzwMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_d16_format_xyzw",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16FormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -342,7 +403,12 @@ BufferStoreD16FormatXMubuf::BufferStoreD16FormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16FormatXMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_d16_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16FormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -366,7 +432,13 @@ BufferStoreD16FormatXyMubuf::BufferStoreD16FormatXyMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16FormatXyMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_d16_format_xy",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16FormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -390,7 +462,13 @@ BufferStoreD16FormatXyzMubuf::BufferStoreD16FormatXyzMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16FormatXyzMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_d16_format_xyz",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16FormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -414,7 +492,13 @@ BufferStoreD16FormatXyzwMubuf::BufferStoreD16FormatXyzwMubuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16FormatXyzwMubuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_d16_format_xyzw",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16FormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -438,7 +522,12 @@ BufferLoadU8Mubuf::BufferLoadU8Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadU8Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadU8Mubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_u8", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadU8Mubuf>(opcode);
 }
 } // namespace detail
@@ -462,7 +551,12 @@ BufferLoadI8Mubuf::BufferLoadI8Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadI8Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadI8Mubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_i8", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadI8Mubuf>(opcode);
 }
 } // namespace detail
@@ -486,7 +580,12 @@ BufferLoadU16Mubuf::BufferLoadU16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadU16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadU16Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_u16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadU16Mubuf>(opcode);
 }
 } // namespace detail
@@ -510,7 +609,12 @@ BufferLoadI16Mubuf::BufferLoadI16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadI16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadI16Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_i16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadI16Mubuf>(opcode);
 }
 } // namespace detail
@@ -534,7 +638,12 @@ BufferLoadB32Mubuf::BufferLoadB32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadB32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadB32Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_b32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadB32Mubuf>(opcode);
 }
 } // namespace detail
@@ -558,7 +667,12 @@ BufferLoadB64Mubuf::BufferLoadB64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadB64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadB64Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_b64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadB64Mubuf>(opcode);
 }
 } // namespace detail
@@ -582,7 +696,12 @@ BufferLoadB96Mubuf::BufferLoadB96Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadB96Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadB96Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_b96", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadB96Mubuf>(opcode);
 }
 } // namespace detail
@@ -606,7 +725,12 @@ BufferLoadB128Mubuf::BufferLoadB128Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadB128Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadB128Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_b128", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadB128Mubuf>(opcode);
 }
 } // namespace detail
@@ -630,7 +754,12 @@ BufferStoreB8Mubuf::BufferStoreB8Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB8Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB8Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_b8", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB8Mubuf>(opcode);
 }
 } // namespace detail
@@ -654,7 +783,12 @@ BufferStoreB16Mubuf::BufferStoreB16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB16Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_b16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB16Mubuf>(opcode);
 }
 } // namespace detail
@@ -678,7 +812,12 @@ BufferStoreB32Mubuf::BufferStoreB32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB32Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_b32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB32Mubuf>(opcode);
 }
 } // namespace detail
@@ -702,7 +841,12 @@ BufferStoreB64Mubuf::BufferStoreB64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB64Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_b64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB64Mubuf>(opcode);
 }
 } // namespace detail
@@ -726,7 +870,12 @@ BufferStoreB96Mubuf::BufferStoreB96Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB96Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB96Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_b96", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB96Mubuf>(opcode);
 }
 } // namespace detail
@@ -750,7 +899,12 @@ BufferStoreB128Mubuf::BufferStoreB128Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB128Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB128Mubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_b128", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB128Mubuf>(opcode);
 }
 } // namespace detail
@@ -774,7 +928,12 @@ BufferLoadD16U8Mubuf::BufferLoadD16U8Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16U8Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16U8Mubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_d16_u8", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16U8Mubuf>(opcode);
 }
 } // namespace detail
@@ -804,7 +963,12 @@ BufferLoadD16I8Mubuf::BufferLoadD16I8Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16I8Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16I8Mubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_d16_i8", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16I8Mubuf>(opcode);
 }
 } // namespace detail
@@ -834,7 +998,12 @@ BufferLoadD16B16Mubuf::BufferLoadD16B16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16B16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16B16Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_d16_b16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16B16Mubuf>(opcode);
 }
 } // namespace detail
@@ -864,7 +1033,12 @@ BufferLoadD16HiU8Mubuf::BufferLoadD16HiU8Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16HiU8Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16HiU8Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_d16_hi_u8", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16HiU8Mubuf>(opcode);
 }
 } // namespace detail
@@ -894,7 +1068,12 @@ BufferLoadD16HiI8Mubuf::BufferLoadD16HiI8Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16HiI8Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16HiI8Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_d16_hi_i8", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16HiI8Mubuf>(opcode);
 }
 } // namespace detail
@@ -924,7 +1103,12 @@ BufferLoadD16HiB16Mubuf::BufferLoadD16HiB16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16HiB16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16HiB16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_d16_hi_b16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16HiB16Mubuf>(opcode);
 }
 } // namespace detail
@@ -954,7 +1138,12 @@ BufferStoreD16HiB8Mubuf::BufferStoreD16HiB8Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16HiB8Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16HiB8Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_d16_hi_b8", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16HiB8Mubuf>(opcode);
 }
 } // namespace detail
@@ -978,7 +1167,12 @@ BufferStoreD16HiB16Mubuf::BufferStoreD16HiB16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16HiB16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16HiB16Mubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_d16_hi_b16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16HiB16Mubuf>(opcode);
 }
 } // namespace detail
@@ -1002,7 +1196,13 @@ BufferLoadD16HiFormatXMubuf::BufferLoadD16HiFormatXMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16HiFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16HiFormatXMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_d16_hi_format_x",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16HiFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -1032,7 +1232,13 @@ BufferStoreD16HiFormatXMubuf::BufferStoreD16HiFormatXMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16HiFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16HiFormatXMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_d16_hi_format_x",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16HiFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -1045,7 +1251,12 @@ BufferGl0InvMubuf::BufferGl0InvMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferGl0InvMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferGl0InvMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_gl0_inv", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferGl0InvMubuf>(opcode);
 }
 } // namespace detail
@@ -1058,7 +1269,12 @@ BufferGl1InvMubuf::BufferGl1InvMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferGl1InvMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferGl1InvMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_gl1_inv", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferGl1InvMubuf>(opcode);
 }
 } // namespace detail
@@ -1084,7 +1300,12 @@ BufferAtomicSwapB32Mubuf::BufferAtomicSwapB32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapB32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapB32Mubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_swap_b32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapB32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1111,7 +1332,12 @@ BufferAtomicCmpswapB32Mubuf::BufferAtomicCmpswapB32Mubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapB32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapB32Mubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_cmpswap_b32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapB32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1137,7 +1363,12 @@ BufferAtomicAddU32Mubuf::BufferAtomicAddU32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddU32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_u32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddU32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1163,7 +1394,12 @@ BufferAtomicSubU32Mubuf::BufferAtomicSubU32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubU32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_sub_u32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubU32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1189,7 +1425,12 @@ BufferAtomicCsubU32Mubuf::BufferAtomicCsubU32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCsubU32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCsubU32Mubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_csub_u32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCsubU32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1215,7 +1456,12 @@ BufferAtomicMinI32Mubuf::BufferAtomicMinI32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinI32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinI32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_min_i32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinI32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1241,7 +1487,12 @@ BufferAtomicMinU32Mubuf::BufferAtomicMinU32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinU32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_min_u32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinU32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1267,7 +1518,12 @@ BufferAtomicMaxI32Mubuf::BufferAtomicMaxI32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxI32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxI32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_max_i32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxI32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1293,7 +1549,12 @@ BufferAtomicMaxU32Mubuf::BufferAtomicMaxU32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxU32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_max_u32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxU32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1319,7 +1580,12 @@ BufferAtomicAndB32Mubuf::BufferAtomicAndB32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndB32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndB32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_and_b32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndB32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1345,7 +1611,12 @@ BufferAtomicOrB32Mubuf::BufferAtomicOrB32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrB32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrB32Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_or_b32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrB32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1371,7 +1642,12 @@ BufferAtomicXorB32Mubuf::BufferAtomicXorB32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorB32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorB32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_xor_b32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorB32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1397,7 +1673,12 @@ BufferAtomicIncU32Mubuf::BufferAtomicIncU32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncU32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_inc_u32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncU32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1423,7 +1704,12 @@ BufferAtomicDecU32Mubuf::BufferAtomicDecU32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecU32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_dec_u32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecU32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1449,7 +1735,12 @@ BufferAtomicSwapB64Mubuf::BufferAtomicSwapB64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapB64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapB64Mubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_swap_b64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapB64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1476,7 +1767,12 @@ BufferAtomicCmpswapB64Mubuf::BufferAtomicCmpswapB64Mubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapB64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapB64Mubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_cmpswap_b64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapB64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1502,7 +1798,12 @@ BufferAtomicAddU64Mubuf::BufferAtomicAddU64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddU64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_u64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddU64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1528,7 +1829,12 @@ BufferAtomicSubU64Mubuf::BufferAtomicSubU64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubU64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_sub_u64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubU64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1554,7 +1860,12 @@ BufferAtomicMinI64Mubuf::BufferAtomicMinI64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinI64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinI64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_min_i64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinI64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1580,7 +1891,12 @@ BufferAtomicMinU64Mubuf::BufferAtomicMinU64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinU64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_min_u64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinU64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1606,7 +1922,12 @@ BufferAtomicMaxI64Mubuf::BufferAtomicMaxI64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxI64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxI64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_max_i64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxI64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1632,7 +1953,12 @@ BufferAtomicMaxU64Mubuf::BufferAtomicMaxU64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxU64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_max_u64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxU64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1658,7 +1984,12 @@ BufferAtomicAndB64Mubuf::BufferAtomicAndB64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndB64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndB64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_and_b64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndB64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1684,7 +2015,12 @@ BufferAtomicOrB64Mubuf::BufferAtomicOrB64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrB64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrB64Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_or_b64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrB64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1710,7 +2046,12 @@ BufferAtomicXorB64Mubuf::BufferAtomicXorB64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorB64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorB64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_xor_b64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorB64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1736,7 +2077,12 @@ BufferAtomicIncU64Mubuf::BufferAtomicIncU64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncU64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_inc_u64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncU64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1762,7 +2108,12 @@ BufferAtomicDecU64Mubuf::BufferAtomicDecU64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecU64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_dec_u64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecU64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1789,7 +2140,12 @@ BufferAtomicCmpswapF32Mubuf::BufferAtomicCmpswapF32Mubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapF32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapF32Mubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_cmpswap_f32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapF32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1815,7 +2171,12 @@ BufferAtomicMinF32Mubuf::BufferAtomicMinF32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinF32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_min_f32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinF32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1841,7 +2202,12 @@ BufferAtomicMaxF32Mubuf::BufferAtomicMaxF32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxF32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_max_f32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxF32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1867,7 +2233,12 @@ BufferAtomicAddF32Mubuf::BufferAtomicAddF32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_f32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddF32Mubuf>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/operand.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/operand.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/scalar_static_resolve.h"
-#include "util/except.h"
 #include <format>
 #include <optional>
 #include <stdexcept>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/smem.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/smem.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/smem.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -34,7 +33,11 @@ SLoadB32Smem::SLoadB32Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB32Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB32Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b32", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB32Smem>(opcode);
 }
 } // namespace detail
@@ -54,7 +57,11 @@ SLoadB64Smem::SLoadB64Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB64Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB64Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b64", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB64Smem>(opcode);
 }
 } // namespace detail
@@ -74,7 +81,11 @@ SLoadB128Smem::SLoadB128Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB128Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB128Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b128", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB128Smem>(opcode);
 }
 } // namespace detail
@@ -94,7 +105,11 @@ SLoadB256Smem::SLoadB256Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB256Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB256Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b256", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB256Smem>(opcode);
 }
 } // namespace detail
@@ -114,7 +129,11 @@ SLoadB512Smem::SLoadB512Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB512Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB512Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b512", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB512Smem>(opcode);
 }
 } // namespace detail
@@ -134,7 +153,12 @@ SBufferLoadB32Smem::SBufferLoadB32Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB32Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB32Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b32", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB32Smem>(opcode);
 }
 } // namespace detail
@@ -154,7 +178,12 @@ SBufferLoadB64Smem::SBufferLoadB64Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB64Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB64Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b64", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB64Smem>(opcode);
 }
 } // namespace detail
@@ -174,7 +203,12 @@ SBufferLoadB128Smem::SBufferLoadB128Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB128Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB128Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b128", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB128Smem>(opcode);
 }
 } // namespace detail
@@ -194,7 +228,12 @@ SBufferLoadB256Smem::SBufferLoadB256Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB256Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB256Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b256", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB256Smem>(opcode);
 }
 } // namespace detail
@@ -214,7 +253,12 @@ SBufferLoadB512Smem::SBufferLoadB512Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB512Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB512Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b512", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB512Smem>(opcode);
 }
 } // namespace detail
@@ -227,7 +271,11 @@ SGl1InvSmem::SGl1InvSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGl1InvSmem(const MachineInst *opcode) {
+DecodeResult decodeSGl1InvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_gl1_inv", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGl1InvSmem>(opcode);
 }
 } // namespace detail
@@ -240,7 +288,11 @@ SDcacheInvSmem::SDcacheInvSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_inv", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheInvSmem>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/sop1.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/sop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -29,7 +28,11 @@ SMovB32Sop1::SMovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -52,7 +55,11 @@ SMovB64Sop1::SMovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -78,7 +85,11 @@ SCmovB32Sop1::SCmovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -105,7 +116,11 @@ SCmovB64Sop1::SCmovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -126,7 +141,11 @@ SBrevB32Sop1::SBrevB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB32Sop1>(opcode);
 }
 } // namespace detail
@@ -148,7 +167,11 @@ SBrevB64Sop1::SBrevB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB64Sop1>(opcode);
 }
 } // namespace detail
@@ -169,7 +192,11 @@ SCtzI32B32Sop1::SCtzI32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCtzI32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCtzI32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ctz_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCtzI32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -191,7 +218,11 @@ SCtzI32B64Sop1::SCtzI32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCtzI32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCtzI32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ctz_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCtzI32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -212,7 +243,11 @@ SClzI32U32Sop1::SClzI32U32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClzI32U32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSClzI32U32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_clz_i32_u32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClzI32U32Sop1>(opcode);
 }
 } // namespace detail
@@ -234,7 +269,11 @@ SClzI32U64Sop1::SClzI32U64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClzI32U64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSClzI32U64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_clz_i32_u64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClzI32U64Sop1>(opcode);
 }
 } // namespace detail
@@ -255,7 +294,11 @@ SClsI32Sop1::SClsI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClsI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSClsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cls_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClsI32Sop1>(opcode);
 }
 } // namespace detail
@@ -277,7 +320,11 @@ SClsI32I64Sop1::SClsI32I64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClsI32I64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSClsI32I64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cls_i32_i64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClsI32I64Sop1>(opcode);
 }
 } // namespace detail
@@ -299,7 +346,11 @@ SSextI32I8Sop1::SSextI32I8Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i8", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I8Sop1>(opcode);
 }
 } // namespace detail
@@ -321,7 +372,12 @@ SSextI32I16Sop1::SSextI32I16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I16Sop1>(opcode);
 }
 } // namespace detail
@@ -343,7 +399,12 @@ SBitset0B32Sop1::SBitset0B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B32Sop1>(opcode);
 }
 } // namespace detail
@@ -365,7 +426,12 @@ SBitset0B64Sop1::SBitset0B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B64Sop1>(opcode);
 }
 } // namespace detail
@@ -387,7 +453,12 @@ SBitset1B32Sop1::SBitset1B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B32Sop1>(opcode);
 }
 } // namespace detail
@@ -409,7 +480,12 @@ SBitset1B64Sop1::SBitset1B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B64Sop1>(opcode);
 }
 } // namespace detail
@@ -430,7 +506,12 @@ SBitreplicateB64B32Sop1::SBitreplicateB64B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitreplicate_b64_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitreplicateB64B32Sop1>(opcode);
 }
 } // namespace detail
@@ -454,7 +535,11 @@ SAbsI32Sop1::SAbsI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_abs_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsI32Sop1>(opcode);
 }
 } // namespace detail
@@ -478,7 +563,12 @@ SBcnt0I32B32Sop1::SBcnt0I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -503,7 +593,12 @@ SBcnt0I32B64Sop1::SBcnt0I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -527,7 +622,12 @@ SBcnt1I32B32Sop1::SBcnt1I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -552,7 +652,12 @@ SBcnt1I32B64Sop1::SBcnt1I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -576,7 +681,12 @@ SQuadmaskB32Sop1::SQuadmaskB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB32Sop1>(opcode);
 }
 } // namespace detail
@@ -601,7 +711,12 @@ SQuadmaskB64Sop1::SQuadmaskB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB64Sop1>(opcode);
 }
 } // namespace detail
@@ -625,7 +740,11 @@ SWqmB32Sop1::SWqmB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB32Sop1>(opcode);
 }
 } // namespace detail
@@ -650,7 +769,11 @@ SWqmB64Sop1::SWqmB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB64Sop1>(opcode);
 }
 } // namespace detail
@@ -674,7 +797,11 @@ SNotB32Sop1::SNotB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB32Sop1>(opcode);
 }
 } // namespace detail
@@ -699,7 +826,11 @@ SNotB64Sop1::SNotB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB64Sop1>(opcode);
 }
 } // namespace detail
@@ -730,7 +861,12 @@ SAndSaveexecB32Sop1::SAndSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -762,7 +898,12 @@ SAndSaveexecB64Sop1::SAndSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -794,7 +935,12 @@ SOrSaveexecB32Sop1::SOrSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrSaveexecB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -827,7 +973,12 @@ SOrSaveexecB64Sop1::SOrSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -858,7 +1009,12 @@ SXorSaveexecB32Sop1::SXorSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xor_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -890,7 +1046,12 @@ SXorSaveexecB64Sop1::SXorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -921,7 +1082,12 @@ SNandSaveexecB32Sop1::SNandSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNandSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nand_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -953,7 +1119,12 @@ SNandSaveexecB64Sop1::SNandSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nand_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -984,7 +1155,12 @@ SNorSaveexecB32Sop1::SNorSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nor_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1016,7 +1192,12 @@ SNorSaveexecB64Sop1::SNorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1047,7 +1228,12 @@ SXnorSaveexecB32Sop1::SXnorSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXnorSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xnor_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1079,7 +1265,12 @@ SXnorSaveexecB64Sop1::SXnorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xnor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1110,7 +1301,12 @@ SAndNot0SaveexecB32Sop1::SAndNot0SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot0SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot0SaveexecB32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not0_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot0SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1142,7 +1338,12 @@ SAndNot0SaveexecB64Sop1::SAndNot0SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot0SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot0SaveexecB64Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not0_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot0SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1173,7 +1374,12 @@ SOrNot0SaveexecB32Sop1::SOrNot0SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot0SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrNot0SaveexecB32Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_not0_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot0SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1205,7 +1411,12 @@ SOrNot0SaveexecB64Sop1::SOrNot0SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot0SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrNot0SaveexecB64Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_not0_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot0SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1236,7 +1447,12 @@ SAndNot1SaveexecB32Sop1::SAndNot1SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1SaveexecB32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not1_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1268,7 +1484,12 @@ SAndNot1SaveexecB64Sop1::SAndNot1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1SaveexecB64Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1299,7 +1520,12 @@ SOrNot1SaveexecB32Sop1::SOrNot1SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot1SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrNot1SaveexecB32Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_not1_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot1SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1331,7 +1557,12 @@ SOrNot1SaveexecB64Sop1::SOrNot1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrNot1SaveexecB64Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_not1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1362,7 +1593,12 @@ SAndNot0WrexecB32Sop1::SAndNot0WrexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot0WrexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot0WrexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not0_wrexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot0WrexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1394,7 +1630,12 @@ SAndNot0WrexecB64Sop1::SAndNot0WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot0WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot0WrexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not0_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot0WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1425,7 +1666,12 @@ SAndNot1WrexecB32Sop1::SAndNot1WrexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1WrexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1WrexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not1_wrexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1WrexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1457,7 +1703,12 @@ SAndNot1WrexecB64Sop1::SAndNot1WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1WrexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not1_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1477,7 +1728,12 @@ SMovrelsB32Sop1::SMovrelsB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrels_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1497,7 +1753,12 @@ SMovrelsB64Sop1::SMovrelsB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrels_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1521,7 +1782,12 @@ SMovreldB32Sop1::SMovreldB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1546,7 +1812,12 @@ SMovreldB64Sop1::SMovreldB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1566,7 +1837,12 @@ SMovrelsd2B32Sop1::SMovrelsd2B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsd2B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsd2B32Sop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrelsd_2_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsd2B32Sop1>(opcode);
 }
 } // namespace detail
@@ -1584,7 +1860,11 @@ SGetpcB64Sop1::SGetpcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetpcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSGetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_getpc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetpcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1603,7 +1883,11 @@ SSetpcB64Sop1::SSetpcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetpcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_setpc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetpcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1626,7 +1910,11 @@ SSwappcB64Sop1::SSwappcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSwappcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSwappcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_swappc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSwappcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1644,7 +1932,11 @@ SRfeB64Sop1::SRfeB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRfeB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSRfeB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_rfe_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRfeB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1661,7 +1953,12 @@ SSendmsgRtnB32Sop1::SSendmsgRtnB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsgRtnB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSendmsgRtnB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sendmsg_rtn_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsgRtnB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1678,7 +1975,12 @@ SSendmsgRtnB64Sop1::SSendmsgRtnB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsgRtnB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSendmsgRtnB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sendmsg_rtn_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsgRtnB64Sop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/sop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/sop2.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/sop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -37,7 +36,11 @@ SAddU32Sop2::SAddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -67,7 +70,11 @@ SSubU32Sop2::SSubU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubU32Sop2>(opcode);
 }
 } // namespace detail
@@ -97,7 +104,11 @@ SAddI32Sop2::SAddI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddI32Sop2>(opcode);
 }
 } // namespace detail
@@ -127,7 +138,11 @@ SSubI32Sop2::SSubI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubI32Sop2>(opcode);
 }
 } // namespace detail
@@ -160,7 +175,11 @@ SAddcU32Sop2::SAddcU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddcU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddcU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_addc_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddcU32Sop2>(opcode);
 }
 } // namespace detail
@@ -193,7 +212,11 @@ SSubbU32Sop2::SSubbU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubbU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubbU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_subb_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubbU32Sop2>(opcode);
 }
 } // namespace detail
@@ -223,7 +246,12 @@ SAbsdiffI32Sop2::SAbsdiffI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_absdiff_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsdiffI32Sop2>(opcode);
 }
 } // namespace detail
@@ -253,7 +281,11 @@ SLshlB32Sop2::SLshlB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshlB32Sop2>(opcode);
 }
 } // namespace detail
@@ -284,7 +316,11 @@ SLshlB64Sop2::SLshlB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshlB64Sop2>(opcode);
 }
 } // namespace detail
@@ -314,7 +350,11 @@ SLshrB32Sop2::SLshrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -345,7 +385,11 @@ SLshrB64Sop2::SLshrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -375,7 +419,11 @@ SAshrI32Sop2::SAshrI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAshrI32Sop2>(opcode);
 }
 } // namespace detail
@@ -406,7 +454,11 @@ SAshrI64Sop2::SAshrI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAshrI64Sop2>(opcode);
 }
 } // namespace detail
@@ -436,7 +488,12 @@ SLshl1AddU32Sop2::SLshl1AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl1_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl1AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -466,7 +523,12 @@ SLshl2AddU32Sop2::SLshl2AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl2_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl2AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -496,7 +558,12 @@ SLshl3AddU32Sop2::SLshl3AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl3_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl3AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -526,7 +593,12 @@ SLshl4AddU32Sop2::SLshl4AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl4_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl4AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -556,7 +628,11 @@ SMinI32Sop2::SMinI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinI32Sop2>(opcode);
 }
 } // namespace detail
@@ -586,7 +662,11 @@ SMinU32Sop2::SMinU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinU32Sop2>(opcode);
 }
 } // namespace detail
@@ -616,7 +696,11 @@ SMaxI32Sop2::SMaxI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxI32Sop2>(opcode);
 }
 } // namespace detail
@@ -646,7 +730,11 @@ SMaxU32Sop2::SMaxU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxU32Sop2>(opcode);
 }
 } // namespace detail
@@ -676,7 +764,11 @@ SAndB32Sop2::SAndB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndB32Sop2>(opcode);
 }
 } // namespace detail
@@ -708,7 +800,11 @@ SAndB64Sop2::SAndB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndB64Sop2>(opcode);
 }
 } // namespace detail
@@ -739,7 +835,11 @@ SOrB32Sop2::SOrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -772,7 +872,11 @@ SOrB64Sop2::SOrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -802,7 +906,11 @@ SXorB32Sop2::SXorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -834,7 +942,11 @@ SXorB64Sop2::SXorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -864,7 +976,11 @@ SNandB32Sop2::SNandB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandB32Sop2>(opcode);
 }
 } // namespace detail
@@ -896,7 +1012,11 @@ SNandB64Sop2::SNandB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandB64Sop2>(opcode);
 }
 } // namespace detail
@@ -926,7 +1046,11 @@ SNorB32Sop2::SNorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -958,7 +1082,11 @@ SNorB64Sop2::SNorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -988,7 +1116,11 @@ SXnorB32Sop2::SXnorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1020,7 +1152,11 @@ SXnorB64Sop2::SXnorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1050,7 +1186,12 @@ SAndNot1B32Sop2::SAndNot1B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1B32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_not1_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1B32Sop2>(opcode);
 }
 } // namespace detail
@@ -1082,7 +1223,12 @@ SAndNot1B64Sop2::SAndNot1B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1B64Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_not1_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1B64Sop2>(opcode);
 }
 } // namespace detail
@@ -1112,7 +1258,11 @@ SOrNot1B32Sop2::SOrNot1B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot1B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrNot1B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_not1_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot1B32Sop2>(opcode);
 }
 } // namespace detail
@@ -1144,7 +1294,11 @@ SOrNot1B64Sop2::SOrNot1B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot1B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrNot1B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_not1_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot1B64Sop2>(opcode);
 }
 } // namespace detail
@@ -1174,7 +1328,11 @@ SBfeU32Sop2::SBfeU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1204,7 +1362,11 @@ SBfeI32Sop2::SBfeI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1235,7 +1397,11 @@ SBfeU64Sop2::SBfeU64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeU64Sop2>(opcode);
 }
 } // namespace detail
@@ -1266,7 +1432,11 @@ SBfeI64Sop2::SBfeI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeI64Sop2>(opcode);
 }
 } // namespace detail
@@ -1293,7 +1463,11 @@ SBfmB32Sop2::SBfmB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfmB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1320,7 +1494,11 @@ SBfmB64Sop2::SBfmB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfmB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1347,7 +1525,11 @@ SMulI32Sop2::SMulI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1374,7 +1556,11 @@ SMulHiU32Sop2::SMulHiU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulHiU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1401,7 +1587,11 @@ SMulHiI32Sop2::SMulHiI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulHiI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1431,7 +1621,12 @@ SCselectB32Sop2::SCselectB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCselectB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1463,7 +1658,12 @@ SCselectB64Sop2::SCselectB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCselectB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1492,7 +1692,12 @@ SPackLlB32B16Sop2::SPackLlB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_ll_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackLlB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1520,7 +1725,12 @@ SPackLhB32B16Sop2::SPackLhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_lh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackLhB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1547,7 +1757,12 @@ SPackHhB32B16Sop2::SPackHhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_hh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackHhB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1575,7 +1790,12 @@ SPackHlB32B16Sop2::SPackHlB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackHlB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackHlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_hl_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackHlB32B16Sop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/sopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/sopc.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/sopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -35,7 +34,11 @@ SCmpEqI32Sopc::SCmpEqI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqI32Sopc>(opcode);
 }
 } // namespace detail
@@ -63,7 +66,11 @@ SCmpLgI32Sopc::SCmpLgI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgI32Sopc>(opcode);
 }
 } // namespace detail
@@ -91,7 +98,11 @@ SCmpGtI32Sopc::SCmpGtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -119,7 +130,11 @@ SCmpGeI32Sopc::SCmpGeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -147,7 +162,11 @@ SCmpLtI32Sopc::SCmpLtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -175,7 +194,11 @@ SCmpLeI32Sopc::SCmpLeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -203,7 +226,11 @@ SCmpEqU32Sopc::SCmpEqU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqU32Sopc>(opcode);
 }
 } // namespace detail
@@ -231,7 +258,11 @@ SCmpLgU32Sopc::SCmpLgU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgU32Sopc>(opcode);
 }
 } // namespace detail
@@ -259,7 +290,11 @@ SCmpGtU32Sopc::SCmpGtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -287,7 +322,11 @@ SCmpGeU32Sopc::SCmpGeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -315,7 +354,11 @@ SCmpLtU32Sopc::SCmpLtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -343,7 +386,11 @@ SCmpLeU32Sopc::SCmpLeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -371,7 +418,12 @@ SBitcmp0B32Sopc::SBitcmp0B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp0B32Sopc>(opcode);
 }
 } // namespace detail
@@ -399,7 +451,12 @@ SBitcmp1B32Sopc::SBitcmp1B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp1B32Sopc>(opcode);
 }
 } // namespace detail
@@ -428,7 +485,12 @@ SBitcmp0B64Sopc::SBitcmp0B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp0B64Sopc>(opcode);
 }
 } // namespace detail
@@ -457,7 +519,12 @@ SBitcmp1B64Sopc::SBitcmp1B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp1B64Sopc>(opcode);
 }
 } // namespace detail
@@ -487,7 +554,11 @@ SCmpEqU64Sopc::SCmpEqU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqU64Sopc>(opcode);
 }
 } // namespace detail
@@ -517,7 +588,11 @@ SCmpLgU64Sopc::SCmpLgU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgU64Sopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/sopk.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -24,7 +23,11 @@ SMovkI32Sopk::SMovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_movk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -39,7 +42,11 @@ SVersionSopk::SVersionSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSVersionSopk(const MachineInst *opcode) {
+DecodeResult decodeSVersionSopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_version", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SVersionSopk>(opcode);
 }
 } // namespace detail
@@ -61,7 +68,11 @@ SCmovkI32Sopk::SCmovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmovk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -81,7 +92,11 @@ SCmpkEqI32Sopk::SCmpkEqI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkEqI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkEqI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_eq_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkEqI32Sopk>(opcode);
 }
 } // namespace detail
@@ -101,7 +116,11 @@ SCmpkLgI32Sopk::SCmpkLgI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLgI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLgI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lg_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLgI32Sopk>(opcode);
 }
 } // namespace detail
@@ -121,7 +140,11 @@ SCmpkGtI32Sopk::SCmpkGtI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGtI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_gt_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGtI32Sopk>(opcode);
 }
 } // namespace detail
@@ -141,7 +164,11 @@ SCmpkGeI32Sopk::SCmpkGeI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGeI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_ge_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGeI32Sopk>(opcode);
 }
 } // namespace detail
@@ -161,7 +188,11 @@ SCmpkLtI32Sopk::SCmpkLtI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLtI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lt_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLtI32Sopk>(opcode);
 }
 } // namespace detail
@@ -181,7 +212,11 @@ SCmpkLeI32Sopk::SCmpkLeI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLeI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_le_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLeI32Sopk>(opcode);
 }
 } // namespace detail
@@ -201,7 +236,11 @@ SCmpkEqU32Sopk::SCmpkEqU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkEqU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkEqU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_eq_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkEqU32Sopk>(opcode);
 }
 } // namespace detail
@@ -221,7 +260,11 @@ SCmpkLgU32Sopk::SCmpkLgU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLgU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLgU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lg_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLgU32Sopk>(opcode);
 }
 } // namespace detail
@@ -241,7 +284,11 @@ SCmpkGtU32Sopk::SCmpkGtU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGtU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_gt_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGtU32Sopk>(opcode);
 }
 } // namespace detail
@@ -261,7 +308,11 @@ SCmpkGeU32Sopk::SCmpkGeU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGeU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_ge_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGeU32Sopk>(opcode);
 }
 } // namespace detail
@@ -281,7 +332,11 @@ SCmpkLtU32Sopk::SCmpkLtU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLtU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lt_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLtU32Sopk>(opcode);
 }
 } // namespace detail
@@ -301,7 +356,11 @@ SCmpkLeU32Sopk::SCmpkLeU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLeU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_le_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLeU32Sopk>(opcode);
 }
 } // namespace detail
@@ -322,7 +381,11 @@ SAddkI32Sopk::SAddkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSAddkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_addk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -340,7 +403,11 @@ SMulkI32Sopk::SMulkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_mulk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -357,7 +424,11 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_getreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -374,7 +445,11 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -399,7 +474,12 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_imm32_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregImm32B32Sopk>(opcode);
 }
 } // namespace detail
@@ -428,7 +508,11 @@ SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCallB64Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCallB64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_call_b64", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCallB64Sopk>(opcode);
 }
 } // namespace detail
@@ -451,7 +535,12 @@ SWaitcntVscntSopk::SWaitcntVscntSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntVscntSopk(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntVscntSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_waitcnt_vscnt", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntVscntSopk>(opcode);
 }
 } // namespace detail
@@ -469,7 +558,12 @@ SWaitcntVmcntSopk::SWaitcntVmcntSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntVmcntSopk(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntVmcntSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_waitcnt_vmcnt", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntVmcntSopk>(opcode);
 }
 } // namespace detail
@@ -487,7 +581,12 @@ SWaitcntExpcntSopk::SWaitcntExpcntSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntExpcntSopk(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntExpcntSopk(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_waitcnt_expcnt", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntExpcntSopk>(opcode);
 }
 } // namespace detail
@@ -505,7 +604,12 @@ SWaitcntLgkmcntSopk::SWaitcntLgkmcntSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntLgkmcntSopk(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntLgkmcntSopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_waitcnt_lgkmcnt", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntLgkmcntSopk>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/sopp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/sopp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/sopp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -22,7 +21,11 @@ SNopSopp::SNopSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode) {
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_nop", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNopSopp>(opcode);
 }
 } // namespace detail
@@ -37,7 +40,11 @@ SSetkillSopp::SSetkillSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetkillSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetkillSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setkill", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetkillSopp>(opcode);
 }
 } // namespace detail
@@ -52,7 +59,11 @@ SSethaltSopp::SSethaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sethalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSethaltSopp>(opcode);
 }
 } // namespace detail
@@ -67,7 +78,11 @@ SSleepSopp::SSleepSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode) {
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sleep", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSleepSopp>(opcode);
 }
 } // namespace detail
@@ -82,7 +97,13 @@ SSetInstPrefetchDistanceSopp::SSetInstPrefetchDistanceSopp(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetInstPrefetchDistanceSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetInstPrefetchDistanceSopp(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Sopp::validate_encoding("s_set_inst_prefetch_distance",
+                              reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetInstPrefetchDistanceSopp>(opcode);
 }
 } // namespace detail
@@ -97,7 +118,11 @@ SClauseSopp::SClauseSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClauseSopp(const MachineInst *opcode) {
+DecodeResult decodeSClauseSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_clause", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClauseSopp>(opcode);
 }
 } // namespace detail
@@ -112,7 +137,11 @@ SDelayAluSopp::SDelayAluSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDelayAluSopp(const MachineInst *opcode) {
+DecodeResult decodeSDelayAluSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_delay_alu", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDelayAluSopp>(opcode);
 }
 } // namespace detail
@@ -129,7 +158,12 @@ SWaitcntDepctrSopp::SWaitcntDepctrSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntDepctrSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntDepctrSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_waitcnt_depctr", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntDepctrSopp>(opcode);
 }
 } // namespace detail
@@ -145,7 +179,11 @@ SWaitcntSopp::SWaitcntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_waitcnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntSopp>(opcode);
 }
 } // namespace detail
@@ -159,7 +197,11 @@ SWaitIdleSopp::SWaitIdleSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitIdleSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitIdleSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_idle", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitIdleSopp>(opcode);
 }
 } // namespace detail
@@ -175,7 +217,11 @@ SWaitEventSopp::SWaitEventSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitEventSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitEventSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_event", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitEventSopp>(opcode);
 }
 } // namespace detail
@@ -190,7 +236,11 @@ STrapSopp::STrapSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode) {
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_trap", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STrapSopp>(opcode);
 }
 } // namespace detail
@@ -205,7 +255,11 @@ SRoundModeSopp::SRoundModeSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRoundModeSopp(const MachineInst *opcode) {
+DecodeResult decodeSRoundModeSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_round_mode", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRoundModeSopp>(opcode);
 }
 } // namespace detail
@@ -220,7 +274,12 @@ SDenormModeSopp::SDenormModeSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDenormModeSopp(const MachineInst *opcode) {
+DecodeResult decodeSDenormModeSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_denorm_mode", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDenormModeSopp>(opcode);
 }
 } // namespace detail
@@ -233,7 +292,11 @@ SCodeEndSopp::SCodeEndSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCodeEndSopp(const MachineInst *opcode) {
+DecodeResult decodeSCodeEndSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_code_end", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCodeEndSopp>(opcode);
 }
 } // namespace detail
@@ -250,7 +313,11 @@ SBranchSopp::SBranchSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode) {
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_branch", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBranchSopp>(opcode);
 }
 } // namespace detail
@@ -275,7 +342,12 @@ SCbranchScc0Sopp::SCbranchScc0Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc0", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc0Sopp>(opcode);
 }
 } // namespace detail
@@ -300,7 +372,12 @@ SCbranchScc1Sopp::SCbranchScc1Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc1", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc1Sopp>(opcode);
 }
 } // namespace detail
@@ -325,7 +402,12 @@ SCbranchVcczSopp::SCbranchVcczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVcczSopp>(opcode);
 }
 } // namespace detail
@@ -350,7 +432,12 @@ SCbranchVccnzSopp::SCbranchVccnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVccnzSopp>(opcode);
 }
 } // namespace detail
@@ -375,7 +462,12 @@ SCbranchExeczSopp::SCbranchExeczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExeczSopp>(opcode);
 }
 } // namespace detail
@@ -400,7 +492,12 @@ SCbranchExecnzSopp::SCbranchExecnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExecnzSopp>(opcode);
 }
 } // namespace detail
@@ -420,7 +517,12 @@ SCbranchCdbgsysSopp::SCbranchCdbgsysSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysSopp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysSopp>(opcode);
 }
 } // namespace detail
@@ -435,7 +537,12 @@ SCbranchCdbguserSopp::SCbranchCdbguserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbguserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbguserSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbguser", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbguserSopp>(opcode);
 }
 } // namespace detail
@@ -450,7 +557,12 @@ SCbranchCdbgsysOrUserSopp::SCbranchCdbgsysOrUserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys_or_user", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysOrUserSopp>(opcode);
 }
 } // namespace detail
@@ -465,7 +577,12 @@ SCbranchCdbgsysAndUserSopp::SCbranchCdbgsysAndUserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys_and_user", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysAndUserSopp>(opcode);
 }
 } // namespace detail
@@ -479,7 +596,11 @@ SEndpgmSopp::SEndpgmSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSopp>(opcode);
 }
 } // namespace detail
@@ -493,7 +614,12 @@ SEndpgmSavedSopp::SEndpgmSavedSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm_saved", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSavedSopp>(opcode);
 }
 } // namespace detail
@@ -507,7 +633,12 @@ SEndpgmOrderedPsDoneSopp::SEndpgmOrderedPsDoneSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm_ordered_ps_done", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmOrderedPsDoneSopp>(opcode);
 }
 } // namespace detail
@@ -520,7 +651,11 @@ SWakeupSopp::SWakeupSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode) {
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wakeup", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWakeupSopp>(opcode);
 }
 } // namespace detail
@@ -535,7 +670,11 @@ SSetprioSopp::SSetprioSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setprio", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetprioSopp>(opcode);
 }
 } // namespace detail
@@ -553,7 +692,11 @@ SSendmsgSopp::SSendmsgSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsg", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsgSopp>(opcode);
 }
 } // namespace detail
@@ -571,7 +714,12 @@ SSendmsghaltSopp::SSendmsghaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsghalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsghaltSopp>(opcode);
 }
 } // namespace detail
@@ -586,7 +734,12 @@ SIncperflevelSopp::SIncperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_incperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIncperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -601,7 +754,12 @@ SDecperflevelSopp::SDecperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_decperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDecperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -617,7 +775,12 @@ STtracedataSopp::STtracedataSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode) {
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_ttracedata", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STtracedataSopp>(opcode);
 }
 } // namespace detail
@@ -635,7 +798,12 @@ STtracedataImmSopp::STtracedataImmSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTtracedataImmSopp(const MachineInst *opcode) {
+DecodeResult decodeSTtracedataImmSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_ttracedata_imm", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STtracedataImmSopp>(opcode);
 }
 } // namespace detail
@@ -648,7 +816,11 @@ SIcacheInvSopp::SIcacheInvSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode) {
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_icache_inv", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIcacheInvSopp>(opcode);
 }
 } // namespace detail
@@ -662,7 +834,11 @@ SBarrierSopp::SBarrierSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBarrierSopp(const MachineInst *opcode) {
+DecodeResult decodeSBarrierSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_barrier", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBarrierSopp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vinterp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vinterp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/vinterp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -28,7 +27,12 @@ VInterpP10F32Vinterp::VInterpP10F32Vinterp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP10F32Vinterp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP10F32Vinterp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vinterp::validate_encoding(
+      "v_interp_p10_f32", reinterpret_cast<const Vinterp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP10F32Vinterp>(opcode);
 }
 } // namespace detail
@@ -49,7 +53,12 @@ VInterpP2F32Vinterp::VInterpP2F32Vinterp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2F32Vinterp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2F32Vinterp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vinterp::validate_encoding(
+      "v_interp_p2_f32", reinterpret_cast<const Vinterp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2F32Vinterp>(opcode);
 }
 } // namespace detail
@@ -70,7 +79,12 @@ VInterpP10F16F32Vinterp::VInterpP10F16F32Vinterp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP10F16F32Vinterp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP10F16F32Vinterp(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vinterp::validate_encoding(
+      "v_interp_p10_f16_f32", reinterpret_cast<const Vinterp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP10F16F32Vinterp>(opcode);
 }
 } // namespace detail
@@ -91,7 +105,12 @@ VInterpP2F16F32Vinterp::VInterpP2F16F32Vinterp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2F16F32Vinterp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2F16F32Vinterp(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vinterp::validate_encoding(
+      "v_interp_p2_f16_f32", reinterpret_cast<const Vinterp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2F16F32Vinterp>(opcode);
 }
 } // namespace detail
@@ -118,7 +137,13 @@ VInterpP10RtzF16F32Vinterp::VInterpP10RtzF16F32Vinterp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP10RtzF16F32Vinterp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP10RtzF16F32Vinterp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vinterp::validate_encoding("v_interp_p10_rtz_f16_f32",
+                                 reinterpret_cast<const Vinterp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP10RtzF16F32Vinterp>(opcode);
 }
 } // namespace detail
@@ -139,7 +164,12 @@ VInterpP2RtzF16F32Vinterp::VInterpP2RtzF16F32Vinterp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2RtzF16F32Vinterp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2RtzF16F32Vinterp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vinterp::validate_encoding(
+      "v_interp_p2_rtz_f16_f32", reinterpret_cast<const Vinterp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2RtzF16F32Vinterp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop1.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/vop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -23,7 +22,15 @@ VNopVop1::VNopVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode) {
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_nop_dpp"
+          : "v_nop_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop1>(opcode);
 }
 } // namespace detail
@@ -64,7 +71,15 @@ VMovB32Vop1::VMovB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_mov_b32_dpp"
+          : "v_mov_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop1>(opcode);
 }
 } // namespace detail
@@ -81,13 +96,22 @@ VReadfirstlaneB32Vop1::VReadfirstlaneB32Vop1(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_readfirstlane_b32_dpp"
+          : "v_readfirstlane_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support DPP";
   return std::make_unique<VReadfirstlaneB32Vop1>(opcode);
 }
 } // namespace detail
@@ -109,13 +133,21 @@ VCvtI32F64Vop1::VCvtI32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_I32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f64_dpp"
+          : "v_cvt_i32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_I32_F64 does not support DPP";
   return std::make_unique<VCvtI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -136,13 +168,21 @@ VCvtF64I32Vop1::VCvtF64I32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_I32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_i32_dpp"
+          : "v_cvt_f64_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_I32 does not support DPP";
   return std::make_unique<VCvtF64I32Vop1>(opcode);
 }
 } // namespace detail
@@ -183,7 +223,15 @@ VCvtF32I32Vop1::VCvtF32I32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_i32_dpp"
+          : "v_cvt_f32_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop1>(opcode);
 }
 } // namespace detail
@@ -224,7 +272,15 @@ VCvtF32U32Vop1::VCvtF32U32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_u32_dpp"
+          : "v_cvt_f32_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop1>(opcode);
 }
 } // namespace detail
@@ -265,7 +321,15 @@ VCvtU32F32Vop1::VCvtU32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f32_dpp"
+          : "v_cvt_u32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -306,7 +370,15 @@ VCvtI32F32Vop1::VCvtI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f32_dpp"
+          : "v_cvt_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -349,7 +421,15 @@ VCvtF16F32Vop1::VCvtF16F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_f32_dpp"
+          : "v_cvt_f16_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop1>(opcode);
 }
 } // namespace detail
@@ -398,7 +478,15 @@ VCvtF32F16Vop1::VCvtF32F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f16_dpp"
+          : "v_cvt_f32_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop1>(opcode);
 }
 } // namespace detail
@@ -439,7 +527,16 @@ VCvtNearestI32F32Vop1::VCvtNearestI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNearestI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNearestI32F32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_nearest_i32_f32_dpp"
+          : "v_cvt_nearest_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNearestI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -480,7 +577,16 @@ VCvtFloorI32F32Vop1::VCvtFloorI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFloorI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtFloorI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_floor_i32_f32_dpp"
+          : "v_cvt_floor_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFloorI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -521,7 +627,16 @@ VCvtOffF32I4Vop1::VCvtOffF32I4Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_off_f32_i4_dpp"
+          : "v_cvt_off_f32_i4_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop1>(opcode);
 }
 } // namespace detail
@@ -543,13 +658,21 @@ VCvtF32F64Vop1::VCvtF32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f64_dpp"
+          : "v_cvt_f32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F32_F64 does not support DPP";
   return std::make_unique<VCvtF32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -570,13 +693,21 @@ VCvtF64F32Vop1::VCvtF64F32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_f32_dpp"
+          : "v_cvt_f64_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support DPP";
   return std::make_unique<VCvtF64F32Vop1>(opcode);
 }
 } // namespace detail
@@ -617,7 +748,16 @@ VCvtF32Ubyte0Vop1::VCvtF32Ubyte0Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte0_dpp"
+          : "v_cvt_f32_ubyte0_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop1>(opcode);
 }
 } // namespace detail
@@ -658,7 +798,16 @@ VCvtF32Ubyte1Vop1::VCvtF32Ubyte1Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte1_dpp"
+          : "v_cvt_f32_ubyte1_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop1>(opcode);
 }
 } // namespace detail
@@ -699,7 +848,16 @@ VCvtF32Ubyte2Vop1::VCvtF32Ubyte2Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte2_dpp"
+          : "v_cvt_f32_ubyte2_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop1>(opcode);
 }
 } // namespace detail
@@ -740,7 +898,16 @@ VCvtF32Ubyte3Vop1::VCvtF32Ubyte3Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte3_dpp"
+          : "v_cvt_f32_ubyte3_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop1>(opcode);
 }
 } // namespace detail
@@ -762,13 +929,21 @@ VCvtU32F64Vop1::VCvtU32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_U32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f64_dpp"
+          : "v_cvt_u32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_U32_F64 does not support DPP";
   return std::make_unique<VCvtU32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -789,13 +964,21 @@ VCvtF64U32Vop1::VCvtF64U32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_U32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_u32_dpp"
+          : "v_cvt_f64_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_U32 does not support DPP";
   return std::make_unique<VCvtF64U32Vop1>(opcode);
 }
 } // namespace detail
@@ -817,13 +1000,21 @@ VTruncF64Vop1::VTruncF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_TRUNC_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f64_dpp"
+          : "v_trunc_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_TRUNC_F64 does not support DPP";
   return std::make_unique<VTruncF64Vop1>(opcode);
 }
 } // namespace detail
@@ -845,13 +1036,21 @@ VCeilF64Vop1::VCeilF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CEIL_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f64_dpp"
+          : "v_ceil_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CEIL_F64 does not support DPP";
   return std::make_unique<VCeilF64Vop1>(opcode);
 }
 } // namespace detail
@@ -873,13 +1072,21 @@ VRndneF64Vop1::VRndneF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RNDNE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f64_dpp"
+          : "v_rndne_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support DPP";
   return std::make_unique<VRndneF64Vop1>(opcode);
 }
 } // namespace detail
@@ -901,13 +1108,21 @@ VFloorF64Vop1::VFloorF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FLOOR_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_floor_f64_dpp"
+          : "v_floor_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FLOOR_F64 does not support DPP";
   return std::make_unique<VFloorF64Vop1>(opcode);
 }
 } // namespace detail
@@ -923,7 +1138,15 @@ VPipeflushVop1::VPipeflushVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPipeflushVop1(const MachineInst *opcode) {
+DecodeResult decodeVPipeflushVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_pipeflush_dpp"
+          : "v_pipeflush_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPipeflushVop1>(opcode);
 }
 } // namespace detail
@@ -968,7 +1191,15 @@ VMovB16Vop1::VMovB16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_mov_b16_dpp"
+          : "v_mov_b16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB16Vop1>(opcode);
 }
 } // namespace detail
@@ -1015,7 +1246,15 @@ VFractF32Vop1::VFractF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_fract_f32_dpp"
+          : "v_fract_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1056,7 +1295,15 @@ VTruncF32Vop1::VTruncF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f32_dpp"
+          : "v_trunc_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1097,7 +1344,15 @@ VCeilF32Vop1::VCeilF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f32_dpp"
+          : "v_ceil_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1138,7 +1393,15 @@ VRndneF32Vop1::VRndneF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f32_dpp"
+          : "v_rndne_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1179,7 +1442,15 @@ VFloorF32Vop1::VFloorF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_floor_f32_dpp"
+          : "v_floor_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1220,7 +1491,15 @@ VExpF32Vop1::VExpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_exp_f32_dpp"
+          : "v_exp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1261,7 +1540,15 @@ VLogF32Vop1::VLogF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_log_f32_dpp"
+          : "v_log_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1302,7 +1589,15 @@ VRcpF32Vop1::VRcpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f32_dpp"
+          : "v_rcp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1343,7 +1638,16 @@ VRcpIflagF32Vop1::VRcpIflagF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_iflag_f32_dpp"
+          : "v_rcp_iflag_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1384,7 +1688,15 @@ VRsqF32Vop1::VRsqF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f32_dpp"
+          : "v_rsq_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1406,13 +1718,21 @@ VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RCP_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f64_dpp"
+          : "v_rcp_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support DPP";
   return std::make_unique<VRcpF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1434,13 +1754,21 @@ VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RSQ_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f64_dpp"
+          : "v_rsq_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support DPP";
   return std::make_unique<VRsqF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1481,7 +1809,15 @@ VSqrtF32Vop1::VSqrtF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f32_dpp"
+          : "v_sqrt_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1503,13 +1839,21 @@ VSqrtF64Vop1::VSqrtF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SQRT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f64_dpp"
+          : "v_sqrt_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support DPP";
   return std::make_unique<VSqrtF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1550,7 +1894,15 @@ VSinF32Vop1::VSinF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sin_f32_dpp"
+          : "v_sin_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1591,7 +1943,15 @@ VCosF32Vop1::VCosF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cos_f32_dpp"
+          : "v_cos_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1632,7 +1992,15 @@ VNotB32Vop1::VNotB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_not_b32_dpp"
+          : "v_not_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop1>(opcode);
 }
 } // namespace detail
@@ -1673,7 +2041,15 @@ VBfrevB32Vop1::VBfrevB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_bfrev_b32_dpp"
+          : "v_bfrev_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop1>(opcode);
 }
 } // namespace detail
@@ -1714,7 +2090,15 @@ VClzI32U32Vop1::VClzI32U32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClzI32U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVClzI32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_clz_i32_u32_dpp"
+          : "v_clz_i32_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClzI32U32Vop1>(opcode);
 }
 } // namespace detail
@@ -1755,7 +2139,15 @@ VCtzI32B32Vop1::VCtzI32B32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCtzI32B32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCtzI32B32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ctz_i32_b32_dpp"
+          : "v_ctz_i32_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCtzI32B32Vop1>(opcode);
 }
 } // namespace detail
@@ -1796,7 +2188,15 @@ VClsI32Vop1::VClsI32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClsI32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVClsI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cls_i32_dpp"
+          : "v_cls_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClsI32Vop1>(opcode);
 }
 } // namespace detail
@@ -1818,13 +2218,22 @@ VFrexpExpI32F64Vop1::VFrexpExpI32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_EXP_I32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f64_dpp"
+          : "v_frexp_exp_i32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_EXP_I32_F64 does not support DPP";
   return std::make_unique<VFrexpExpI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -1846,13 +2255,22 @@ VFrexpMantF64Vop1::VFrexpMantF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_MANT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f64_dpp"
+          : "v_frexp_mant_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_MANT_F64 does not support DPP";
   return std::make_unique<VFrexpMantF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1874,13 +2292,21 @@ VFractF64Vop1::VFractF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FRACT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_fract_f64_dpp"
+          : "v_fract_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FRACT_F64 does not support DPP";
   return std::make_unique<VFractF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1921,7 +2347,16 @@ VFrexpExpI32F32Vop1::VFrexpExpI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f32_dpp"
+          : "v_frexp_exp_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -1962,7 +2397,16 @@ VFrexpMantF32Vop1::VFrexpMantF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f32_dpp"
+          : "v_frexp_mant_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop1>(opcode);
 }
 } // namespace detail
@@ -2006,7 +2450,16 @@ VMovreldB32Vop1::VMovreldB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovreldB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovreldB32Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movreld_b32_dpp"
+          : "v_movreld_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovreldB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2046,7 +2499,16 @@ VMovrelsB32Vop1::VMovrelsB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsB32Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movrels_b32_dpp"
+          : "v_movrels_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2086,7 +2548,16 @@ VMovrelsdB32Vop1::VMovrelsdB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsdB32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_b32_dpp"
+          : "v_movrelsd_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsdB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2126,7 +2597,16 @@ VMovrelsd2B32Vop1::VMovrelsd2B32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsd2B32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_2_b32_dpp"
+          : "v_movrelsd_2_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsd2B32Vop1>(opcode);
 }
 } // namespace detail
@@ -2171,7 +2651,15 @@ VCvtF16U16Vop1::VCvtF16U16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_u16_dpp"
+          : "v_cvt_f16_u16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop1>(opcode);
 }
 } // namespace detail
@@ -2222,7 +2710,15 @@ VCvtF16I16Vop1::VCvtF16I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_i16_dpp"
+          : "v_cvt_f16_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop1>(opcode);
 }
 } // namespace detail
@@ -2273,7 +2769,15 @@ VCvtU16F16Vop1::VCvtU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u16_f16_dpp"
+          : "v_cvt_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2324,7 +2828,15 @@ VCvtI16F16Vop1::VCvtI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i16_f16_dpp"
+          : "v_cvt_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2375,7 +2887,15 @@ VRcpF16Vop1::VRcpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f16_dpp"
+          : "v_rcp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2426,7 +2946,15 @@ VSqrtF16Vop1::VSqrtF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f16_dpp"
+          : "v_sqrt_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2477,7 +3005,15 @@ VRsqF16Vop1::VRsqF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f16_dpp"
+          : "v_rsq_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2528,7 +3064,15 @@ VLogF16Vop1::VLogF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_log_f16_dpp"
+          : "v_log_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2579,7 +3123,15 @@ VExpF16Vop1::VExpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_exp_f16_dpp"
+          : "v_exp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2630,7 +3182,16 @@ VFrexpMantF16Vop1::VFrexpMantF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f16_dpp"
+          : "v_frexp_mant_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2681,7 +3242,16 @@ VFrexpExpI16F16Vop1::VFrexpExpI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i16_f16_dpp"
+          : "v_frexp_exp_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2732,7 +3302,15 @@ VFloorF16Vop1::VFloorF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_floor_f16_dpp"
+          : "v_floor_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2783,7 +3361,15 @@ VCeilF16Vop1::VCeilF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f16_dpp"
+          : "v_ceil_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2834,7 +3420,15 @@ VTruncF16Vop1::VTruncF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f16_dpp"
+          : "v_trunc_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2885,7 +3479,15 @@ VRndneF16Vop1::VRndneF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f16_dpp"
+          : "v_rndne_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2936,7 +3538,15 @@ VFractF16Vop1::VFractF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_fract_f16_dpp"
+          : "v_fract_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2987,7 +3597,15 @@ VSinF16Vop1::VSinF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sin_f16_dpp"
+          : "v_sin_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3038,7 +3656,15 @@ VCosF16Vop1::VCosF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cos_f16_dpp"
+          : "v_cos_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3087,7 +3713,16 @@ VSatPkU8I16Vop1::VSatPkU8I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sat_pk_u8_i16_dpp"
+          : "v_sat_pk_u8_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop1>(opcode);
 }
 } // namespace detail
@@ -3138,7 +3773,16 @@ VCvtNormI16F16Vop1::VCvtNormI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_i16_f16_dpp"
+          : "v_cvt_norm_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3189,7 +3833,16 @@ VCvtNormU16F16Vop1::VCvtNormU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_u16_f16_dpp"
+          : "v_cvt_norm_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3214,13 +3867,21 @@ VSwapB32Vop1::VSwapB32Vop1(const MachineInst *inst)
   dst_operands_[1] = &src0;
   num_src_ = 2;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWAP_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swap_b32_dpp"
+          : "v_swap_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B32 does not support DPP";
   return std::make_unique<VSwapB32Vop1>(opcode);
 }
 } // namespace detail
@@ -3242,13 +3903,21 @@ VSwapB16Vop1::VSwapB16Vop1(const MachineInst *inst)
   dst_operands_[1] = &src0;
   num_src_ = 2;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWAP_B16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwapB16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwapB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swap_b16_dpp"
+          : "v_swap_b16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B16 does not support DPP";
   return std::make_unique<VSwapB16Vop1>(opcode);
 }
 } // namespace detail
@@ -3273,13 +3942,22 @@ VPermlane64B32Vop1::VPermlane64B32Vop1(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANE64_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlane64B32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVPermlane64B32Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_permlane64_b32_dpp"
+          : "v_permlane64_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE64_B32 does not support DPP";
   return std::make_unique<VPermlane64B32Vop1>(opcode);
 }
 } // namespace detail
@@ -3300,14 +3978,23 @@ VSwaprelB32Vop1::VSwaprelB32Vop1(const MachineInst *inst)
   src_operands_[2] = &m0;
   num_src_ = 3;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWAPREL_B32 does not support DPP", "");
   m0.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwaprelB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwaprelB32Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swaprel_b32_dpp"
+          : "v_swaprel_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SWAPREL_B32 does not support DPP";
   return std::make_unique<VSwaprelB32Vop1>(opcode);
 }
 } // namespace detail
@@ -3352,7 +4039,15 @@ VNotB16Vop1::VNotB16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVNotB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_not_b16_dpp"
+          : "v_not_b16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB16Vop1>(opcode);
 }
 } // namespace detail
@@ -3401,7 +4096,15 @@ VCvtI32I16Vop1::VCvtI32I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_i16_dpp"
+          : "v_cvt_i32_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32I16Vop1>(opcode);
 }
 } // namespace detail
@@ -3444,7 +4147,15 @@ VCvtU32U16Vop1::VCvtU32U16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32U16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_u16_dpp"
+          : "v_cvt_u32_u16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32U16Vop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop2.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/vop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -54,7 +53,16 @@ VCndmaskB32Vop2::VCndmaskB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_cndmask_b32_dpp"
+          : "v_cndmask_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop2>(opcode);
 }
 } // namespace detail
@@ -98,7 +106,16 @@ VDot2accF32F16Vop2::VDot2accF32F16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2accF32F16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot2accF32F16Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_dot2acc_f32_f16_dpp"
+          : "v_dot2acc_f32_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2accF32F16Vop2>(opcode);
 }
 } // namespace detail
@@ -141,7 +158,15 @@ VAddF32Vop2::VAddF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_f32_dpp"
+          : "v_add_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop2>(opcode);
 }
 } // namespace detail
@@ -184,7 +209,15 @@ VSubF32Vop2::VSubF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_f32_dpp"
+          : "v_sub_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop2>(opcode);
 }
 } // namespace detail
@@ -227,7 +260,15 @@ VSubrevF32Vop2::VSubrevF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f32_dpp"
+          : "v_subrev_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop2>(opcode);
 }
 } // namespace detail
@@ -251,13 +292,22 @@ VFmacDx9ZeroF32Vop2::VFmacDx9ZeroF32Vop2(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAC_DX9_ZERO_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacDx9ZeroF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacDx9ZeroF32Vop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmac_dx9_zero_f32_dpp"
+          : "v_fmac_dx9_zero_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_DX9_ZERO_F32 does not support DPP";
   return std::make_unique<VFmacDx9ZeroF32Vop2>(opcode);
 }
 } // namespace detail
@@ -300,7 +350,16 @@ VMulDx9ZeroF32Vop2::VMulDx9ZeroF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulDx9ZeroF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulDx9ZeroF32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_dx9_zero_f32_dpp"
+          : "v_mul_dx9_zero_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulDx9ZeroF32Vop2>(opcode);
 }
 } // namespace detail
@@ -343,7 +402,15 @@ VMulF32Vop2::VMulF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_f32_dpp"
+          : "v_mul_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop2>(opcode);
 }
 } // namespace detail
@@ -386,7 +453,15 @@ VMulI32I24Vop2::VMulI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_i32_i24_dpp"
+          : "v_mul_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -429,7 +504,16 @@ VMulHiI32I24Vop2::VMulHiI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_i32_i24_dpp"
+          : "v_mul_hi_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -472,7 +556,15 @@ VMulU32U24Vop2::VMulU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_u32_u24_dpp"
+          : "v_mul_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -515,7 +607,16 @@ VMulHiU32U24Vop2::VMulHiU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_u32_u24_dpp"
+          : "v_mul_hi_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -558,7 +659,15 @@ VMinF32Vop2::VMinF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_f32_dpp"
+          : "v_min_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF32Vop2>(opcode);
 }
 } // namespace detail
@@ -601,7 +710,15 @@ VMaxF32Vop2::VMaxF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_f32_dpp"
+          : "v_max_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF32Vop2>(opcode);
 }
 } // namespace detail
@@ -644,7 +761,15 @@ VMinI32Vop2::VMinI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_i32_dpp"
+          : "v_min_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop2>(opcode);
 }
 } // namespace detail
@@ -687,7 +812,15 @@ VMaxI32Vop2::VMaxI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_i32_dpp"
+          : "v_max_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop2>(opcode);
 }
 } // namespace detail
@@ -730,7 +863,15 @@ VMinU32Vop2::VMinU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_u32_dpp"
+          : "v_min_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop2>(opcode);
 }
 } // namespace detail
@@ -773,7 +914,15 @@ VMaxU32Vop2::VMaxU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_u32_dpp"
+          : "v_max_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop2>(opcode);
 }
 } // namespace detail
@@ -816,7 +965,16 @@ VLshlrevB32Vop2::VLshlrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b32_dpp"
+          : "v_lshlrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -859,7 +1017,16 @@ VLshrrevB32Vop2::VLshrrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_lshrrev_b32_dpp"
+          : "v_lshrrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -902,7 +1069,16 @@ VAshrrevI32Vop2::VAshrrevI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_ashrrev_i32_dpp"
+          : "v_ashrrev_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop2>(opcode);
 }
 } // namespace detail
@@ -945,7 +1121,15 @@ VAndB32Vop2::VAndB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_and_b32_dpp"
+          : "v_and_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop2>(opcode);
 }
 } // namespace detail
@@ -988,7 +1172,15 @@ VOrB32Vop2::VOrB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_or_b32_dpp"
+          : "v_or_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1031,7 +1223,15 @@ VXorB32Vop2::VXorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_xor_b32_dpp"
+          : "v_xor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1074,7 +1274,15 @@ VXnorB32Vop2::VXnorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_xnor_b32_dpp"
+          : "v_xnor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1123,7 +1331,16 @@ VAddCoCiU32Vop2::VAddCoCiU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddCoCiU32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_co_ci_u32_dpp"
+          : "v_add_co_ci_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoCiU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1172,7 +1389,16 @@ VSubCoCiU32Vop2::VSubCoCiU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubCoCiU32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_co_ci_u32_dpp"
+          : "v_sub_co_ci_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoCiU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1221,7 +1447,16 @@ VSubrevCoCiU32Vop2::VSubrevCoCiU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoCiU32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_co_ci_u32_dpp"
+          : "v_subrev_co_ci_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoCiU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1264,7 +1499,15 @@ VAddNcU32Vop2::VAddNcU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_u32_dpp"
+          : "v_add_nc_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1307,7 +1550,15 @@ VSubNcU32Vop2::VSubNcU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_u32_dpp"
+          : "v_sub_nc_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1350,7 +1601,16 @@ VSubrevNcU32Vop2::VSubrevNcU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevNcU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_nc_u32_dpp"
+          : "v_subrev_nc_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevNcU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1394,7 +1654,15 @@ VFmacF32Vop2::VFmacF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f32_dpp"
+          : "v_fmac_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1422,14 +1690,22 @@ VFmamkF32Vop2::VFmamkF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAMK_F32 does not support DPP", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmamkF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmamkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmamk_f32_dpp"
+          : "v_fmamk_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F32 does not support DPP";
   return std::make_unique<VFmamkF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1457,14 +1733,22 @@ VFmaakF32Vop2::VFmaakF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAAK_F32 does not support DPP", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaakF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmaakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmaak_f32_dpp"
+          : "v_fmaak_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F32 does not support DPP";
   return std::make_unique<VFmaakF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1507,7 +1791,16 @@ VCvtPkRtzF16F32Vop2::VCvtPkRtzF16F32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkRtzF16F32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkRtzF16F32Vop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_rtz_f16_f32_dpp"
+          : "v_cvt_pk_rtz_f16_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkRtzF16F32Vop2>(opcode);
 }
 } // namespace detail
@@ -1555,7 +1848,15 @@ VAddF16Vop2::VAddF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_f16_dpp"
+          : "v_add_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1609,7 +1910,15 @@ VSubF16Vop2::VSubF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_f16_dpp"
+          : "v_sub_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1663,7 +1972,15 @@ VSubrevF16Vop2::VSubrevF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f16_dpp"
+          : "v_subrev_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1717,7 +2034,15 @@ VMulF16Vop2::VMulF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_f16_dpp"
+          : "v_mul_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1772,7 +2097,15 @@ VFmacF16Vop2::VFmacF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f16_dpp"
+          : "v_fmac_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1812,14 +2145,22 @@ VFmamkF16Vop2::VFmamkF16Vop2(const MachineInst *inst)
       Operand(16, OperandType::OPR_SIMM32,
               static_cast<int>(
                   (reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAMK_F16 does not support DPP", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmamkF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmamkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmamk_f16_dpp"
+          : "v_fmamk_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F16 does not support DPP";
   return std::make_unique<VFmamkF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1858,14 +2199,22 @@ VFmaakF16Vop2::VFmaakF16Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAAK_F16 does not support DPP", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaakF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmaakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmaak_f16_dpp"
+          : "v_fmaak_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F16 does not support DPP";
   return std::make_unique<VFmaakF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1919,7 +2268,15 @@ VMaxF16Vop2::VMaxF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_f16_dpp"
+          : "v_max_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1973,7 +2330,15 @@ VMinF16Vop2::VMinF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_f16_dpp"
+          : "v_min_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2027,7 +2392,15 @@ VLdexpF16Vop2::VLdexpF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_ldexp_f16_dpp"
+          : "v_ldexp_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2057,13 +2430,21 @@ VPkFmacF16Vop2::VPkFmacF16Vop2(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_FMAC_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_pk_fmac_f16_dpp"
+          : "v_pk_fmac_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PK_FMAC_F16 does not support DPP";
   return std::make_unique<VPkFmacF16Vop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop3.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/vop3.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -24,7 +23,15 @@ VNopVop3::VNopVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode) {
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_nop_e64_dpp"
+          : "v_nop",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop3>(opcode);
 }
 } // namespace detail
@@ -65,7 +72,15 @@ VMovB32Vop3::VMovB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mov_b32_e64_dpp"
+          : "v_mov_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop3>(opcode);
 }
 } // namespace detail
@@ -82,13 +97,22 @@ VReadfirstlaneB32Vop3::VReadfirstlaneB32Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_readfirstlane_b32_e64_dpp"
+          : "v_readfirstlane_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support DPP";
   return std::make_unique<VReadfirstlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -110,13 +134,21 @@ VCvtI32F64Vop3::VCvtI32F64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_I32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f64_e64_dpp"
+          : "v_cvt_i32_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_I32_F64 does not support DPP";
   return std::make_unique<VCvtI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -137,13 +169,21 @@ VCvtF64I32Vop3::VCvtF64I32Vop3(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_I32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_i32_e64_dpp"
+          : "v_cvt_f64_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_I32 does not support DPP";
   return std::make_unique<VCvtF64I32Vop3>(opcode);
 }
 } // namespace detail
@@ -184,7 +224,15 @@ VCvtF32I32Vop3::VCvtF32I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_i32_e64_dpp"
+          : "v_cvt_f32_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop3>(opcode);
 }
 } // namespace detail
@@ -225,7 +273,15 @@ VCvtF32U32Vop3::VCvtF32U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_u32_e64_dpp"
+          : "v_cvt_f32_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop3>(opcode);
 }
 } // namespace detail
@@ -266,7 +322,15 @@ VCvtU32F32Vop3::VCvtU32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f32_e64_dpp"
+          : "v_cvt_u32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -307,7 +371,15 @@ VCvtI32F32Vop3::VCvtI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f32_e64_dpp"
+          : "v_cvt_i32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -348,7 +420,15 @@ VCvtF16F32Vop3::VCvtF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_f32_e64_dpp"
+          : "v_cvt_f16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -399,7 +479,15 @@ VCvtF32F16Vop3::VCvtF32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f16_e64_dpp"
+          : "v_cvt_f32_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -440,7 +528,16 @@ VCvtNearestI32F32Vop3::VCvtNearestI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNearestI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNearestI32F32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_nearest_i32_f32_e64_dpp"
+          : "v_cvt_nearest_i32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNearestI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -481,7 +578,16 @@ VCvtFloorI32F32Vop3::VCvtFloorI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFloorI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtFloorI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_floor_i32_f32_e64_dpp"
+          : "v_cvt_floor_i32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFloorI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -522,7 +628,16 @@ VCvtOffF32I4Vop3::VCvtOffF32I4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_off_f32_i4_e64_dpp"
+          : "v_cvt_off_f32_i4",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop3>(opcode);
 }
 } // namespace detail
@@ -544,13 +659,21 @@ VCvtF32F64Vop3::VCvtF32F64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f64_e64_dpp"
+          : "v_cvt_f32_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F32_F64 does not support DPP";
   return std::make_unique<VCvtF32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -571,13 +694,21 @@ VCvtF64F32Vop3::VCvtF64F32Vop3(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_f32_e64_dpp"
+          : "v_cvt_f64_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support DPP";
   return std::make_unique<VCvtF64F32Vop3>(opcode);
 }
 } // namespace detail
@@ -618,7 +749,16 @@ VCvtF32Ubyte0Vop3::VCvtF32Ubyte0Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte0_e64_dpp"
+          : "v_cvt_f32_ubyte0",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop3>(opcode);
 }
 } // namespace detail
@@ -659,7 +799,16 @@ VCvtF32Ubyte1Vop3::VCvtF32Ubyte1Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte1_e64_dpp"
+          : "v_cvt_f32_ubyte1",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop3>(opcode);
 }
 } // namespace detail
@@ -700,7 +849,16 @@ VCvtF32Ubyte2Vop3::VCvtF32Ubyte2Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte2_e64_dpp"
+          : "v_cvt_f32_ubyte2",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop3>(opcode);
 }
 } // namespace detail
@@ -741,7 +899,16 @@ VCvtF32Ubyte3Vop3::VCvtF32Ubyte3Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte3_e64_dpp"
+          : "v_cvt_f32_ubyte3",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop3>(opcode);
 }
 } // namespace detail
@@ -763,13 +930,21 @@ VCvtU32F64Vop3::VCvtU32F64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_U32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f64_e64_dpp"
+          : "v_cvt_u32_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_U32_F64 does not support DPP";
   return std::make_unique<VCvtU32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -790,13 +965,21 @@ VCvtF64U32Vop3::VCvtF64U32Vop3(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_U32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_u32_e64_dpp"
+          : "v_cvt_f64_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_U32 does not support DPP";
   return std::make_unique<VCvtF64U32Vop3>(opcode);
 }
 } // namespace detail
@@ -818,13 +1001,21 @@ VTruncF64Vop3::VTruncF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_TRUNC_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f64_e64_dpp"
+          : "v_trunc_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_TRUNC_F64 does not support DPP";
   return std::make_unique<VTruncF64Vop3>(opcode);
 }
 } // namespace detail
@@ -846,13 +1037,21 @@ VCeilF64Vop3::VCeilF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CEIL_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f64_e64_dpp"
+          : "v_ceil_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CEIL_F64 does not support DPP";
   return std::make_unique<VCeilF64Vop3>(opcode);
 }
 } // namespace detail
@@ -874,13 +1073,21 @@ VRndneF64Vop3::VRndneF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RNDNE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f64_e64_dpp"
+          : "v_rndne_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support DPP";
   return std::make_unique<VRndneF64Vop3>(opcode);
 }
 } // namespace detail
@@ -902,13 +1109,21 @@ VFloorF64Vop3::VFloorF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FLOOR_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_floor_f64_e64_dpp"
+          : "v_floor_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FLOOR_F64 does not support DPP";
   return std::make_unique<VFloorF64Vop3>(opcode);
 }
 } // namespace detail
@@ -924,7 +1139,15 @@ VPipeflushVop3::VPipeflushVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPipeflushVop3(const MachineInst *opcode) {
+DecodeResult decodeVPipeflushVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_pipeflush_e64_dpp"
+          : "v_pipeflush",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPipeflushVop3>(opcode);
 }
 } // namespace detail
@@ -969,7 +1192,15 @@ VMovB16Vop3::VMovB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mov_b16_e64_dpp"
+          : "v_mov_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB16Vop3>(opcode);
 }
 } // namespace detail
@@ -1016,7 +1247,15 @@ VFractF32Vop3::VFractF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fract_f32_e64_dpp"
+          : "v_fract_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1057,7 +1296,15 @@ VTruncF32Vop3::VTruncF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f32_e64_dpp"
+          : "v_trunc_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1098,7 +1345,15 @@ VCeilF32Vop3::VCeilF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f32_e64_dpp"
+          : "v_ceil_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1139,7 +1394,15 @@ VRndneF32Vop3::VRndneF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f32_e64_dpp"
+          : "v_rndne_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1180,7 +1443,15 @@ VFloorF32Vop3::VFloorF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_floor_f32_e64_dpp"
+          : "v_floor_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1221,7 +1492,15 @@ VExpF32Vop3::VExpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_exp_f32_e64_dpp"
+          : "v_exp_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1262,7 +1541,15 @@ VLogF32Vop3::VLogF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_log_f32_e64_dpp"
+          : "v_log_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1303,7 +1590,15 @@ VRcpF32Vop3::VRcpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f32_e64_dpp"
+          : "v_rcp_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1344,7 +1639,16 @@ VRcpIflagF32Vop3::VRcpIflagF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rcp_iflag_f32_e64_dpp"
+          : "v_rcp_iflag_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1385,7 +1689,15 @@ VRsqF32Vop3::VRsqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f32_e64_dpp"
+          : "v_rsq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1407,13 +1719,21 @@ VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RCP_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f64_e64_dpp"
+          : "v_rcp_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support DPP";
   return std::make_unique<VRcpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1435,13 +1755,21 @@ VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RSQ_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f64_e64_dpp"
+          : "v_rsq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support DPP";
   return std::make_unique<VRsqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1482,7 +1810,15 @@ VSqrtF32Vop3::VSqrtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f32_e64_dpp"
+          : "v_sqrt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1504,13 +1840,21 @@ VSqrtF64Vop3::VSqrtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SQRT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f64_e64_dpp"
+          : "v_sqrt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support DPP";
   return std::make_unique<VSqrtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1551,7 +1895,15 @@ VSinF32Vop3::VSinF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sin_f32_e64_dpp"
+          : "v_sin_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1592,7 +1944,15 @@ VCosF32Vop3::VCosF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cos_f32_e64_dpp"
+          : "v_cos_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1633,7 +1993,15 @@ VNotB32Vop3::VNotB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_not_b32_e64_dpp"
+          : "v_not_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1674,7 +2042,15 @@ VBfrevB32Vop3::VBfrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfrev_b32_e64_dpp"
+          : "v_bfrev_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1715,7 +2091,15 @@ VClzI32U32Vop3::VClzI32U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClzI32U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVClzI32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_clz_i32_u32_e64_dpp"
+          : "v_clz_i32_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClzI32U32Vop3>(opcode);
 }
 } // namespace detail
@@ -1756,7 +2140,15 @@ VCtzI32B32Vop3::VCtzI32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCtzI32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCtzI32B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ctz_i32_b32_e64_dpp"
+          : "v_ctz_i32_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCtzI32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -1797,7 +2189,15 @@ VClsI32Vop3::VClsI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClsI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVClsI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cls_i32_e64_dpp"
+          : "v_cls_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClsI32Vop3>(opcode);
 }
 } // namespace detail
@@ -1819,13 +2219,22 @@ VFrexpExpI32F64Vop3::VFrexpExpI32F64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_EXP_I32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f64_e64_dpp"
+          : "v_frexp_exp_i32_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_EXP_I32_F64 does not support DPP";
   return std::make_unique<VFrexpExpI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -1847,13 +2256,22 @@ VFrexpMantF64Vop3::VFrexpMantF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_MANT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f64_e64_dpp"
+          : "v_frexp_mant_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_MANT_F64 does not support DPP";
   return std::make_unique<VFrexpMantF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1875,13 +2293,21 @@ VFractF64Vop3::VFractF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FRACT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fract_f64_e64_dpp"
+          : "v_fract_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FRACT_F64 does not support DPP";
   return std::make_unique<VFractF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1922,7 +2348,16 @@ VFrexpExpI32F32Vop3::VFrexpExpI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f32_e64_dpp"
+          : "v_frexp_exp_i32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -1963,7 +2398,16 @@ VFrexpMantF32Vop3::VFrexpMantF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f32_e64_dpp"
+          : "v_frexp_mant_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2007,7 +2451,16 @@ VMovreldB32Vop3::VMovreldB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovreldB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovreldB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_movreld_b32_e64_dpp"
+          : "v_movreld_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovreldB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2047,7 +2500,16 @@ VMovrelsB32Vop3::VMovrelsB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_movrels_b32_e64_dpp"
+          : "v_movrels_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2087,7 +2549,16 @@ VMovrelsdB32Vop3::VMovrelsdB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsdB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_b32_e64_dpp"
+          : "v_movrelsd_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsdB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2127,7 +2598,16 @@ VMovrelsd2B32Vop3::VMovrelsd2B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsd2B32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_2_b32_e64_dpp"
+          : "v_movrelsd_2_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsd2B32Vop3>(opcode);
 }
 } // namespace detail
@@ -2172,7 +2652,15 @@ VCvtF16U16Vop3::VCvtF16U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_u16_e64_dpp"
+          : "v_cvt_f16_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop3>(opcode);
 }
 } // namespace detail
@@ -2223,7 +2711,15 @@ VCvtF16I16Vop3::VCvtF16I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_i16_e64_dpp"
+          : "v_cvt_f16_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop3>(opcode);
 }
 } // namespace detail
@@ -2274,7 +2770,15 @@ VCvtU16F16Vop3::VCvtU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u16_f16_e64_dpp"
+          : "v_cvt_u16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -2325,7 +2829,15 @@ VCvtI16F16Vop3::VCvtI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i16_f16_e64_dpp"
+          : "v_cvt_i16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -2376,7 +2888,15 @@ VRcpF16Vop3::VRcpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f16_e64_dpp"
+          : "v_rcp_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2427,7 +2947,15 @@ VSqrtF16Vop3::VSqrtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f16_e64_dpp"
+          : "v_sqrt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2478,7 +3006,15 @@ VRsqF16Vop3::VRsqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f16_e64_dpp"
+          : "v_rsq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2529,7 +3065,15 @@ VLogF16Vop3::VLogF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_log_f16_e64_dpp"
+          : "v_log_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2580,7 +3124,15 @@ VExpF16Vop3::VExpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_exp_f16_e64_dpp"
+          : "v_exp_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2631,7 +3183,16 @@ VFrexpMantF16Vop3::VFrexpMantF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f16_e64_dpp"
+          : "v_frexp_mant_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2682,7 +3243,16 @@ VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i16_f16_e64_dpp"
+          : "v_frexp_exp_i16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -2733,7 +3303,15 @@ VFloorF16Vop3::VFloorF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_floor_f16_e64_dpp"
+          : "v_floor_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2784,7 +3362,15 @@ VCeilF16Vop3::VCeilF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f16_e64_dpp"
+          : "v_ceil_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2835,7 +3421,15 @@ VTruncF16Vop3::VTruncF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f16_e64_dpp"
+          : "v_trunc_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2886,7 +3480,15 @@ VRndneF16Vop3::VRndneF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f16_e64_dpp"
+          : "v_rndne_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2937,7 +3539,15 @@ VFractF16Vop3::VFractF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fract_f16_e64_dpp"
+          : "v_fract_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2988,7 +3598,15 @@ VSinF16Vop3::VSinF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sin_f16_e64_dpp"
+          : "v_sin_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3039,7 +3657,15 @@ VCosF16Vop3::VCosF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cos_f16_e64_dpp"
+          : "v_cos_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3086,7 +3712,16 @@ VSatPkU8I16Vop3::VSatPkU8I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sat_pk_u8_i16_e64_dpp"
+          : "v_sat_pk_u8_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3137,7 +3772,16 @@ VCvtNormI16F16Vop3::VCvtNormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_i16_f16_e64_dpp"
+          : "v_cvt_norm_i16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3188,7 +3832,16 @@ VCvtNormU16F16Vop3::VCvtNormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_u16_f16_e64_dpp"
+          : "v_cvt_norm_u16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3239,7 +3892,15 @@ VNotB16Vop3::VNotB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVNotB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_not_b16_e64_dpp"
+          : "v_not_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB16Vop3>(opcode);
 }
 } // namespace detail
@@ -3290,7 +3951,15 @@ VCvtI32I16Vop3::VCvtI32I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_i16_e64_dpp"
+          : "v_cvt_i32_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3335,7 +4004,15 @@ VCvtU32U16Vop3::VCvtU32U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_u16_e64_dpp"
+          : "v_cvt_u32_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3384,7 +4061,16 @@ VCndmaskB32Vop3::VCndmaskB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cndmask_b32_e64_dpp"
+          : "v_cndmask_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3431,7 +4117,15 @@ VAddF32Vop3::VAddF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_f32_e64_dpp"
+          : "v_add_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3478,7 +4172,15 @@ VSubF32Vop3::VSubF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_f32_e64_dpp"
+          : "v_sub_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3525,7 +4227,15 @@ VSubrevF32Vop3::VSubrevF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f32_e64_dpp"
+          : "v_subrev_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3553,13 +4263,22 @@ VFmacDx9ZeroF32Vop3::VFmacDx9ZeroF32Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAC_DX9_ZERO_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacDx9ZeroF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacDx9ZeroF32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fmac_dx9_zero_f32_e64_dpp"
+          : "v_fmac_dx9_zero_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_DX9_ZERO_F32 does not support DPP";
   return std::make_unique<VFmacDx9ZeroF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3606,7 +4325,16 @@ VMulDx9ZeroF32Vop3::VMulDx9ZeroF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulDx9ZeroF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulDx9ZeroF32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_dx9_zero_f32_e64_dpp"
+          : "v_mul_dx9_zero_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulDx9ZeroF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3653,7 +4381,15 @@ VMulF32Vop3::VMulF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_f32_e64_dpp"
+          : "v_mul_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3700,7 +4436,15 @@ VMulI32I24Vop3::VMulI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_i32_i24_e64_dpp"
+          : "v_mul_i32_i24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -3747,7 +4491,16 @@ VMulHiI32I24Vop3::VMulHiI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_i32_i24_e64_dpp"
+          : "v_mul_hi_i32_i24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -3794,7 +4547,15 @@ VMulU32U24Vop3::VMulU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_u32_u24_e64_dpp"
+          : "v_mul_u32_u24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -3841,7 +4602,16 @@ VMulHiU32U24Vop3::VMulHiU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_u32_u24_e64_dpp"
+          : "v_mul_hi_u32_u24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -3888,7 +4658,15 @@ VMinF32Vop3::VMinF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_f32_e64_dpp"
+          : "v_min_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3935,7 +4713,15 @@ VMaxF32Vop3::VMaxF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_f32_e64_dpp"
+          : "v_max_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3982,7 +4768,15 @@ VMinI32Vop3::VMinI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_i32_e64_dpp"
+          : "v_min_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4029,7 +4823,15 @@ VMaxI32Vop3::VMaxI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_i32_e64_dpp"
+          : "v_max_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4076,7 +4878,15 @@ VMinU32Vop3::VMinU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_u32_e64_dpp"
+          : "v_min_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4123,7 +4933,15 @@ VMaxU32Vop3::VMaxU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_u32_e64_dpp"
+          : "v_max_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4170,7 +4988,16 @@ VLshlrevB32Vop3::VLshlrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b32_e64_dpp"
+          : "v_lshlrev_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4217,7 +5044,16 @@ VLshrrevB32Vop3::VLshrrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshrrev_b32_e64_dpp"
+          : "v_lshrrev_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4264,7 +5100,16 @@ VAshrrevI32Vop3::VAshrrevI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ashrrev_i32_e64_dpp"
+          : "v_ashrrev_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4311,7 +5156,15 @@ VAndB32Vop3::VAndB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_and_b32_e64_dpp"
+          : "v_and_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4358,7 +5211,15 @@ VOrB32Vop3::VOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_or_b32_e64_dpp"
+          : "v_or_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4405,7 +5266,15 @@ VXorB32Vop3::VXorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xor_b32_e64_dpp"
+          : "v_xor_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4452,7 +5321,15 @@ VXnorB32Vop3::VXnorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xnor_b32_e64_dpp"
+          : "v_xnor_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4499,7 +5376,15 @@ VAddNcU32Vop3::VAddNcU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_u32_e64_dpp"
+          : "v_add_nc_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4546,7 +5431,15 @@ VSubNcU32Vop3::VSubNcU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_u32_e64_dpp"
+          : "v_sub_nc_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4593,7 +5486,16 @@ VSubrevNcU32Vop3::VSubrevNcU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevNcU32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_subrev_nc_u32_e64_dpp"
+          : "v_subrev_nc_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevNcU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4641,7 +5543,15 @@ VFmacF32Vop3::VFmacF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f32_e64_dpp"
+          : "v_fmac_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4688,7 +5598,16 @@ VCvtPkRtzF16F32Vop3::VCvtPkRtzF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkRtzF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkRtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_rtz_f16_f32_e64_dpp"
+          : "v_cvt_pk_rtz_f16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkRtzF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4743,7 +5662,15 @@ VAddF16Vop3::VAddF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_f16_e64_dpp"
+          : "v_add_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4804,7 +5731,15 @@ VSubF16Vop3::VSubF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_f16_e64_dpp"
+          : "v_sub_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4865,7 +5800,15 @@ VSubrevF16Vop3::VSubrevF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f16_e64_dpp"
+          : "v_subrev_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4926,7 +5869,15 @@ VMulF16Vop3::VMulF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_f16_e64_dpp"
+          : "v_mul_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4988,7 +5939,15 @@ VFmacF16Vop3::VFmacF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f16_e64_dpp"
+          : "v_fmac_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5049,7 +6008,15 @@ VMaxF16Vop3::VMaxF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_f16_e64_dpp"
+          : "v_max_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5110,7 +6077,15 @@ VMinF16Vop3::VMinF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_f16_e64_dpp"
+          : "v_min_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5171,7 +6146,15 @@ VLdexpF16Vop3::VLdexpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ldexp_f16_e64_dpp"
+          : "v_ldexp_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5230,7 +6213,16 @@ VFmaDx9ZeroF32Vop3::VFmaDx9ZeroF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaDx9ZeroF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaDx9ZeroF32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fma_dx9_zero_f32_e64_dpp"
+          : "v_fma_dx9_zero_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaDx9ZeroF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5283,7 +6275,15 @@ VMadI32I24Vop3::VMadI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_i32_i24_e64_dpp"
+          : "v_mad_i32_i24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -5336,7 +6336,15 @@ VMadU32U24Vop3::VMadU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_u32_u24_e64_dpp"
+          : "v_mad_u32_u24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -5389,7 +6397,15 @@ VCubeidF32Vop3::VCubeidF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cubeid_f32_e64_dpp"
+          : "v_cubeid_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubeidF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5442,7 +6458,15 @@ VCubescF32Vop3::VCubescF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cubesc_f32_e64_dpp"
+          : "v_cubesc_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubescF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5495,7 +6519,15 @@ VCubetcF32Vop3::VCubetcF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cubetc_f32_e64_dpp"
+          : "v_cubetc_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubetcF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5548,7 +6580,15 @@ VCubemaF32Vop3::VCubemaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cubema_f32_e64_dpp"
+          : "v_cubema_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubemaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5601,7 +6641,15 @@ VBfeU32Vop3::VBfeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfe_u32_e64_dpp"
+          : "v_bfe_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -5654,7 +6702,15 @@ VBfeI32Vop3::VBfeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfe_i32_e64_dpp"
+          : "v_bfe_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -5707,7 +6763,15 @@ VBfiB32Vop3::VBfiB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfi_b32_e64_dpp"
+          : "v_bfi_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfiB32Vop3>(opcode);
 }
 } // namespace detail
@@ -5760,7 +6824,15 @@ VFmaF32Vop3::VFmaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fma_f32_e64_dpp"
+          : "v_fma_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5796,13 +6868,21 @@ VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMA_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fma_f64_e64_dpp"
+          : "v_fma_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMA_F64 does not support DPP";
   return std::make_unique<VFmaF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5855,7 +6935,15 @@ VLerpU8Vop3::VLerpU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lerp_u8_e64_dpp"
+          : "v_lerp_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLerpU8Vop3>(opcode);
 }
 } // namespace detail
@@ -5912,7 +7000,16 @@ VAlignbitB32Vop3::VAlignbitB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_alignbit_b32_e64_dpp"
+          : "v_alignbit_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbitB32Vop3>(opcode);
 }
 } // namespace detail
@@ -5969,7 +7066,16 @@ VAlignbyteB32Vop3::VAlignbyteB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_alignbyte_b32_e64_dpp"
+          : "v_alignbyte_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbyteB32Vop3>(opcode);
 }
 } // namespace detail
@@ -6022,7 +7128,15 @@ VMullitF32Vop3::VMullitF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMullitF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMullitF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mullit_f32_e64_dpp"
+          : "v_mullit_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMullitF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6075,7 +7189,15 @@ VMin3F32Vop3::VMin3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_f32_e64_dpp"
+          : "v_min3_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6128,7 +7250,15 @@ VMin3I32Vop3::VMin3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_i32_e64_dpp"
+          : "v_min3_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -6181,7 +7311,15 @@ VMin3U32Vop3::VMin3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_u32_e64_dpp"
+          : "v_min3_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -6234,7 +7372,15 @@ VMax3F32Vop3::VMax3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_f32_e64_dpp"
+          : "v_max3_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6287,7 +7433,15 @@ VMax3I32Vop3::VMax3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_i32_e64_dpp"
+          : "v_max3_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -6340,7 +7494,15 @@ VMax3U32Vop3::VMax3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_u32_e64_dpp"
+          : "v_max3_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -6393,7 +7555,15 @@ VMed3F32Vop3::VMed3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_f32_e64_dpp"
+          : "v_med3_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6446,7 +7616,15 @@ VMed3I32Vop3::VMed3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_i32_e64_dpp"
+          : "v_med3_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -6499,7 +7677,15 @@ VMed3U32Vop3::VMed3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_u32_e64_dpp"
+          : "v_med3_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -6552,7 +7738,15 @@ VSadU8Vop3::VSadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sad_u8_e64_dpp"
+          : "v_sad_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -6605,7 +7799,15 @@ VSadHiU8Vop3::VSadHiU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sad_hi_u8_e64_dpp"
+          : "v_sad_hi_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadHiU8Vop3>(opcode);
 }
 } // namespace detail
@@ -6658,7 +7860,15 @@ VSadU16Vop3::VSadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sad_u16_e64_dpp"
+          : "v_sad_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -6711,7 +7921,15 @@ VSadU32Vop3::VSadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sad_u32_e64_dpp"
+          : "v_sad_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -6764,7 +7982,16 @@ VCvtPkU8F32Vop3::VCvtPkU8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_u8_f32_e64_dpp"
+          : "v_cvt_pk_u8_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6797,13 +8024,22 @@ VDivFixupF32Vop3::VDivFixupF32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_FIXUP_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fixup_f32_e64_dpp"
+          : "v_div_fixup_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_DIV_FIXUP_F32 does not support DPP";
   return std::make_unique<VDivFixupF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6839,13 +8075,22 @@ VDivFixupF64Vop3::VDivFixupF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_FIXUP_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fixup_f64_e64_dpp"
+          : "v_div_fixup_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_DIV_FIXUP_F64 does not support DPP";
   return std::make_unique<VDivFixupF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6880,14 +8125,23 @@ VDivFmasF32Vop3::VDivFmasF32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_FMAS_F32 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fmas_f32_e64_dpp"
+          : "v_div_fmas_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_DIV_FMAS_F32 does not support DPP";
   return std::make_unique<VDivFmasF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6925,14 +8179,23 @@ VDivFmasF64Vop3::VDivFmasF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_FMAS_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fmas_f64_e64_dpp"
+          : "v_div_fmas_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_DIV_FMAS_F64 does not support DPP";
   return std::make_unique<VDivFmasF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6985,7 +8248,15 @@ VMsadU8Vop3::VMsadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_msad_u8_e64_dpp"
+          : "v_msad_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMsadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -7020,13 +8291,22 @@ VQsadPkU16U8Vop3::VQsadPkU16U8Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_QSAD_PK_U16_U8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_qsad_pk_u16_u8_e64_dpp"
+          : "v_qsad_pk_u16_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_QSAD_PK_U16_U8 does not support DPP";
   return std::make_unique<VQsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -7061,13 +8341,22 @@ VMqsadPkU16U8Vop3::VMqsadPkU16U8Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MQSAD_PK_U16_U8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mqsad_pk_u16_u8_e64_dpp"
+          : "v_mqsad_pk_u16_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MQSAD_PK_U16_U8 does not support DPP";
   return std::make_unique<VMqsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -7097,13 +8386,22 @@ VMqsadU32U8Vop3::VMqsadU32U8Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MQSAD_U32_U8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mqsad_u32_u8_e64_dpp"
+          : "v_mqsad_u32_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MQSAD_U32_U8 does not support DPP";
   return std::make_unique<VMqsadU32U8Vop3>(opcode);
 }
 } // namespace detail
@@ -7156,7 +8454,15 @@ VXor3B32Vop3::VXor3B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXor3B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXor3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xor3_b32_e64_dpp"
+          : "v_xor3_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXor3B32Vop3>(opcode);
 }
 } // namespace detail
@@ -7221,7 +8527,15 @@ VMadU16Vop3::VMadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_u16_e64_dpp"
+          : "v_mad_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7280,7 +8594,15 @@ VPermB32Vop3::VPermB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_perm_b32_e64_dpp"
+          : "v_perm_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPermB32Vop3>(opcode);
 }
 } // namespace detail
@@ -7333,7 +8655,15 @@ VXadU32Vop3::VXadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xad_u32_e64_dpp"
+          : "v_xad_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7386,7 +8716,16 @@ VLshlAddU32Vop3::VLshlAddU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshl_add_u32_e64_dpp"
+          : "v_lshl_add_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlAddU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7439,7 +8778,16 @@ VAddLshlU32Vop3::VAddLshlU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_lshl_u32_e64_dpp"
+          : "v_add_lshl_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddLshlU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7504,7 +8852,15 @@ VFmaF16Vop3::VFmaF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fma_f16_e64_dpp"
+          : "v_fma_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF16Vop3>(opcode);
 }
 } // namespace detail
@@ -7575,7 +8931,15 @@ VMin3F16Vop3::VMin3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_f16_e64_dpp"
+          : "v_min3_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -7646,7 +9010,15 @@ VMin3I16Vop3::VMin3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_i16_e64_dpp"
+          : "v_min3_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -7717,7 +9089,15 @@ VMin3U16Vop3::VMin3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_u16_e64_dpp"
+          : "v_min3_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -7788,7 +9168,15 @@ VMax3F16Vop3::VMax3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_f16_e64_dpp"
+          : "v_max3_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -7859,7 +9247,15 @@ VMax3I16Vop3::VMax3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_i16_e64_dpp"
+          : "v_max3_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -7930,7 +9326,15 @@ VMax3U16Vop3::VMax3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_u16_e64_dpp"
+          : "v_max3_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -8001,7 +9405,15 @@ VMed3F16Vop3::VMed3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_f16_e64_dpp"
+          : "v_med3_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -8072,7 +9484,15 @@ VMed3I16Vop3::VMed3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_i16_e64_dpp"
+          : "v_med3_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -8143,7 +9563,15 @@ VMed3U16Vop3::VMed3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_u16_e64_dpp"
+          : "v_med3_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -8214,7 +9642,15 @@ VMadI16Vop3::VMadI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_i16_e64_dpp"
+          : "v_mad_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8285,7 +9721,16 @@ VDivFixupF16Vop3::VDivFixupF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fixup_f16_e64_dpp"
+          : "v_div_fixup_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF16Vop3>(opcode);
 }
 } // namespace detail
@@ -8344,7 +9789,15 @@ VAdd3U32Vop3::VAdd3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add3_u32_e64_dpp"
+          : "v_add3_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAdd3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -8397,7 +9850,15 @@ VLshlOrB32Vop3::VLshlOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshl_or_b32_e64_dpp"
+          : "v_lshl_or_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -8450,7 +9911,15 @@ VAndOrB32Vop3::VAndOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_and_or_b32_e64_dpp"
+          : "v_and_or_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -8503,7 +9972,15 @@ VOr3B32Vop3::VOr3B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_or3_b32_e64_dpp"
+          : "v_or3_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOr3B32Vop3>(opcode);
 }
 } // namespace detail
@@ -8564,7 +10041,15 @@ VMadU32U16Vop3::VMadU32U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_u32_u16_e64_dpp"
+          : "v_mad_u32_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U16Vop3>(opcode);
 }
 } // namespace detail
@@ -8625,7 +10110,15 @@ VMadI32I16Vop3::VMadI32I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_i32_i16_e64_dpp"
+          : "v_mad_i32_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I16Vop3>(opcode);
 }
 } // namespace detail
@@ -8654,13 +10147,22 @@ VPermlane16B32Vop3::VPermlane16B32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANE16_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlane16B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlane16B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_permlane16_b32_e64_dpp"
+          : "v_permlane16_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE16_B32 does not support DPP";
   return std::make_unique<VPermlane16B32Vop3>(opcode);
 }
 } // namespace detail
@@ -8689,13 +10191,22 @@ VPermlanex16B32Vop3::VPermlanex16B32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANEX16_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlanex16B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlanex16B32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_permlanex16_b32_e64_dpp"
+          : "v_permlanex16_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANEX16_B32 does not support DPP";
   return std::make_unique<VPermlanex16B32Vop3>(opcode);
 }
 } // namespace detail
@@ -8752,7 +10263,16 @@ VCndmaskB16Vop3::VCndmaskB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cndmask_b16_e64_dpp"
+          : "v_cndmask_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB16Vop3>(opcode);
 }
 } // namespace detail
@@ -8811,7 +10331,15 @@ VMaxminF32Vop3::VMaxminF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxminF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxminF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maxmin_f32_e64_dpp"
+          : "v_maxmin_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxminF32Vop3>(opcode);
 }
 } // namespace detail
@@ -8864,7 +10392,15 @@ VMinmaxF32Vop3::VMinmaxF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinmaxF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinmaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minmax_f32_e64_dpp"
+          : "v_minmax_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinmaxF32Vop3>(opcode);
 }
 } // namespace detail
@@ -8929,7 +10465,15 @@ VMaxminF16Vop3::VMaxminF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxminF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxminF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maxmin_f16_e64_dpp"
+          : "v_maxmin_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxminF16Vop3>(opcode);
 }
 } // namespace detail
@@ -9000,7 +10544,15 @@ VMinmaxF16Vop3::VMinmaxF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinmaxF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinmaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minmax_f16_e64_dpp"
+          : "v_minmax_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinmaxF16Vop3>(opcode);
 }
 } // namespace detail
@@ -9059,7 +10611,15 @@ VMaxminU32Vop3::VMaxminU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxminU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxminU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maxmin_u32_e64_dpp"
+          : "v_maxmin_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxminU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9112,7 +10672,15 @@ VMinmaxU32Vop3::VMinmaxU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinmaxU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinmaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minmax_u32_e64_dpp"
+          : "v_minmax_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinmaxU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9165,7 +10733,15 @@ VMaxminI32Vop3::VMaxminI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxminI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxminI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maxmin_i32_e64_dpp"
+          : "v_maxmin_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxminI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9218,7 +10794,15 @@ VMinmaxI32Vop3::VMinmaxI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinmaxI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinmaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minmax_i32_e64_dpp"
+          : "v_minmax_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinmaxI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9275,7 +10859,16 @@ VDot2F16F16Vop3::VDot2F16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2F16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot2F16F16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_dot2_f16_f16_e64_dpp"
+          : "v_dot2_f16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2F16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -9338,7 +10931,16 @@ VDot2Bf16Bf16Vop3::VDot2Bf16Bf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2Bf16Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot2Bf16Bf16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_dot2_bf16_bf16_e64_dpp"
+          : "v_dot2_bf16_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2Bf16Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -9399,7 +11001,15 @@ VAddNcU16Vop3::VAddNcU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_u16_e64_dpp"
+          : "v_add_nc_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9460,7 +11070,15 @@ VSubNcU16Vop3::VSubNcU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_u16_e64_dpp"
+          : "v_sub_nc_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9521,7 +11139,15 @@ VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_lo_u16_e64_dpp"
+          : "v_mul_lo_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9574,7 +11200,16 @@ VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkI16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkI16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_i16_f32_e64_dpp"
+          : "v_cvt_pk_i16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkI16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -9621,7 +11256,16 @@ VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_u16_f32_e64_dpp"
+          : "v_cvt_pk_u16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -9676,7 +11320,15 @@ VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_u16_e64_dpp"
+          : "v_max_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9737,7 +11389,15 @@ VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_i16_e64_dpp"
+          : "v_max_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI16Vop3>(opcode);
 }
 } // namespace detail
@@ -9798,7 +11458,15 @@ VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_u16_e64_dpp"
+          : "v_min_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9859,7 +11527,15 @@ VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_i16_e64_dpp"
+          : "v_min_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI16Vop3>(opcode);
 }
 } // namespace detail
@@ -9920,7 +11596,15 @@ VAddNcI16Vop3::VAddNcI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_i16_e64_dpp"
+          : "v_add_nc_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcI16Vop3>(opcode);
 }
 } // namespace detail
@@ -9981,7 +11665,15 @@ VSubNcI16Vop3::VSubNcI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_i16_e64_dpp"
+          : "v_sub_nc_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcI16Vop3>(opcode);
 }
 } // namespace detail
@@ -10042,7 +11734,16 @@ VPackB32F16Vop3::VPackB32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_pack_b32_f16_e64_dpp"
+          : "v_pack_b32_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPackB32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -10097,7 +11798,16 @@ VCvtPkNormI16F16Vop3::VCvtPkNormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkNormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkNormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_norm_i16_f16_e64_dpp"
+          : "v_cvt_pk_norm_i16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkNormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -10152,7 +11862,16 @@ VCvtPkNormU16F16Vop3::VCvtPkNormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkNormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkNormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_norm_u16_f16_e64_dpp"
+          : "v_cvt_pk_norm_u16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkNormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -10199,7 +11918,15 @@ VLdexpF32Vop3::VLdexpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ldexp_f32_e64_dpp"
+          : "v_ldexp_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -10246,7 +11973,15 @@ VBfmB32Vop3::VBfmB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfm_b32_e64_dpp"
+          : "v_bfm_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfmB32Vop3>(opcode);
 }
 } // namespace detail
@@ -10293,7 +12028,16 @@ VBcntU32B32Vop3::VBcntU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bcnt_u32_b32_e64_dpp"
+          : "v_bcnt_u32_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBcntU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -10340,7 +12084,16 @@ VMbcntLoU32B32Vop3::VMbcntLoU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mbcnt_lo_u32_b32_e64_dpp"
+          : "v_mbcnt_lo_u32_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntLoU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -10387,7 +12140,16 @@ VMbcntHiU32B32Vop3::VMbcntHiU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mbcnt_hi_u32_b32_e64_dpp"
+          : "v_mbcnt_hi_u32_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntHiU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -10434,7 +12196,16 @@ VCvtPkNormI16F32Vop3::VCvtPkNormI16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkNormI16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkNormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_norm_i16_f32_e64_dpp"
+          : "v_cvt_pk_norm_i16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkNormI16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -10481,7 +12252,16 @@ VCvtPkNormU16F32Vop3::VCvtPkNormU16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkNormU16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkNormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_norm_u16_f32_e64_dpp"
+          : "v_cvt_pk_norm_u16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkNormU16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -10528,7 +12308,16 @@ VCvtPkU16U32Vop3::VCvtPkU16U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_u16_u32_e64_dpp"
+          : "v_cvt_pk_u16_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU16U32Vop3>(opcode);
 }
 } // namespace detail
@@ -10575,7 +12364,16 @@ VCvtPkI16I32Vop3::VCvtPkI16I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_i16_i32_e64_dpp"
+          : "v_cvt_pk_i16_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkI16I32Vop3>(opcode);
 }
 } // namespace detail
@@ -10622,7 +12420,15 @@ VSubNcI32Vop3::VSubNcI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_i32_e64_dpp"
+          : "v_sub_nc_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcI32Vop3>(opcode);
 }
 } // namespace detail
@@ -10669,7 +12475,15 @@ VAddNcI32Vop3::VAddNcI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_i32_e64_dpp"
+          : "v_add_nc_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcI32Vop3>(opcode);
 }
 } // namespace detail
@@ -10698,13 +12512,21 @@ VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_ADD_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_f64_e64_dpp"
+          : "v_add_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_ADD_F64 does not support DPP";
   return std::make_unique<VAddF64Vop3>(opcode);
 }
 } // namespace detail
@@ -10733,13 +12555,21 @@ VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_f64_e64_dpp"
+          : "v_mul_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_F64 does not support DPP";
   return std::make_unique<VMulF64Vop3>(opcode);
 }
 } // namespace detail
@@ -10768,13 +12598,21 @@ VMinF64Vop3::VMinF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MIN_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_f64_e64_dpp"
+          : "v_min_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MIN_F64 does not support DPP";
   return std::make_unique<VMinF64Vop3>(opcode);
 }
 } // namespace detail
@@ -10803,13 +12641,21 @@ VMaxF64Vop3::VMaxF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAX_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_f64_e64_dpp"
+          : "v_max_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MAX_F64 does not support DPP";
   return std::make_unique<VMaxF64Vop3>(opcode);
 }
 } // namespace detail
@@ -10837,13 +12683,21 @@ VLdexpF64Vop3::VLdexpF64Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_LDEXP_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ldexp_f64_e64_dpp"
+          : "v_ldexp_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_LDEXP_F64 does not support DPP";
   return std::make_unique<VLdexpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -10870,13 +12724,21 @@ VMulLoU32Vop3::VMulLoU32Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_LO_U32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_lo_u32_e64_dpp"
+          : "v_mul_lo_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_LO_U32 does not support DPP";
   return std::make_unique<VMulLoU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10903,13 +12765,21 @@ VMulHiU32Vop3::VMulHiU32Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_HI_U32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_u32_e64_dpp"
+          : "v_mul_hi_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_HI_U32 does not support DPP";
   return std::make_unique<VMulHiU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10936,13 +12806,21 @@ VMulHiI32Vop3::VMulHiI32Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_HI_I32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_i32_e64_dpp"
+          : "v_mul_hi_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_HI_I32 does not support DPP";
   return std::make_unique<VMulHiI32Vop3>(opcode);
 }
 } // namespace detail
@@ -10970,13 +12848,22 @@ VTrigPreopF64Vop3::VTrigPreopF64Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_TRIG_PREOP_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_trig_preop_f64_e64_dpp"
+          : "v_trig_preop_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_TRIG_PREOP_F64 does not support DPP";
   return std::make_unique<VTrigPreopF64Vop3>(opcode);
 }
 } // namespace detail
@@ -11031,7 +12918,16 @@ VLshlrevB16Vop3::VLshlrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b16_e64_dpp"
+          : "v_lshlrev_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -11092,7 +12988,16 @@ VLshrrevB16Vop3::VLshrrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshrrev_b16_e64_dpp"
+          : "v_lshrrev_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -11153,7 +13058,16 @@ VAshrrevI16Vop3::VAshrrevI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ashrrev_i16_e64_dpp"
+          : "v_ashrrev_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI16Vop3>(opcode);
 }
 } // namespace detail
@@ -11187,13 +13101,22 @@ VLshlrevB64Vop3::VLshlrevB64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_LSHLREV_B64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b64_e64_dpp"
+          : "v_lshlrev_b64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_LSHLREV_B64 does not support DPP";
   return std::make_unique<VLshlrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -11221,13 +13144,22 @@ VLshrrevB64Vop3::VLshrrevB64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_LSHRREV_B64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshrrev_b64_e64_dpp"
+          : "v_lshrrev_b64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_LSHRREV_B64 does not support DPP";
   return std::make_unique<VLshrrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -11255,13 +13187,22 @@ VAshrrevI64Vop3::VAshrrevI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_ASHRREV_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ashrrev_i64_e64_dpp"
+          : "v_ashrrev_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_ASHRREV_I64 does not support DPP";
   return std::make_unique<VAshrrevI64Vop3>(opcode);
 }
 } // namespace detail
@@ -11280,13 +13221,22 @@ VReadlaneB32Vop3::VReadlaneB32Vop3(const MachineInst *inst)
   src_operands_[1] = &src1;
   num_src_ = 2;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_READLANE_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_readlane_b32_e64_dpp"
+          : "v_readlane_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_READLANE_B32 does not support DPP";
   return std::make_unique<VReadlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -11310,13 +13260,22 @@ VWritelaneB32Vop3::VWritelaneB32Vop3(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WRITELANE_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_writelane_b32_e64_dpp"
+          : "v_writelane_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_WRITELANE_B32 does not support DPP";
   return std::make_unique<VWritelaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -11371,7 +13330,15 @@ VAndB16Vop3::VAndB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_and_b16_e64_dpp"
+          : "v_and_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB16Vop3>(opcode);
 }
 } // namespace detail
@@ -11432,7 +13399,15 @@ VOrB16Vop3::VOrB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOrB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_or_b16_e64_dpp"
+          : "v_or_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB16Vop3>(opcode);
 }
 } // namespace detail
@@ -11493,7 +13468,15 @@ VXorB16Vop3::VXorB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXorB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xor_b16_e64_dpp"
+          : "v_xor_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB16Vop3>(opcode);
 }
 } // namespace detail
@@ -11554,7 +13537,15 @@ VCmpFF16Vop3::VCmpFF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_f16_e64_dpp"
+          : "v_cmp_f_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11609,7 +13600,15 @@ VCmpLtF16Vop3::VCmpLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f16_e64_dpp"
+          : "v_cmp_lt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11664,7 +13663,15 @@ VCmpEqF16Vop3::VCmpEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f16_e64_dpp"
+          : "v_cmp_eq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11719,7 +13726,15 @@ VCmpLeF16Vop3::VCmpLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f16_e64_dpp"
+          : "v_cmp_le_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11774,7 +13789,15 @@ VCmpGtF16Vop3::VCmpGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f16_e64_dpp"
+          : "v_cmp_gt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11829,7 +13852,15 @@ VCmpLgF16Vop3::VCmpLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f16_e64_dpp"
+          : "v_cmp_lg_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11884,7 +13915,15 @@ VCmpGeF16Vop3::VCmpGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f16_e64_dpp"
+          : "v_cmp_ge_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11939,7 +13978,15 @@ VCmpOF16Vop3::VCmpOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f16_e64_dpp"
+          : "v_cmp_o_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11994,7 +14041,15 @@ VCmpUF16Vop3::VCmpUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f16_e64_dpp"
+          : "v_cmp_u_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12049,7 +14104,15 @@ VCmpNgeF16Vop3::VCmpNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f16_e64_dpp"
+          : "v_cmp_nge_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12104,7 +14167,15 @@ VCmpNlgF16Vop3::VCmpNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f16_e64_dpp"
+          : "v_cmp_nlg_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12159,7 +14230,15 @@ VCmpNgtF16Vop3::VCmpNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f16_e64_dpp"
+          : "v_cmp_ngt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12214,7 +14293,15 @@ VCmpNleF16Vop3::VCmpNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f16_e64_dpp"
+          : "v_cmp_nle_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12269,7 +14356,15 @@ VCmpNeqF16Vop3::VCmpNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f16_e64_dpp"
+          : "v_cmp_neq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12324,7 +14419,15 @@ VCmpNltF16Vop3::VCmpNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f16_e64_dpp"
+          : "v_cmp_nlt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12379,7 +14482,15 @@ VCmpTF16Vop3::VCmpTF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_f16_e64_dpp"
+          : "v_cmp_t_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12426,7 +14537,15 @@ VCmpFF32Vop3::VCmpFF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_f32_e64_dpp"
+          : "v_cmp_f_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12473,7 +14592,15 @@ VCmpLtF32Vop3::VCmpLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f32_e64_dpp"
+          : "v_cmp_lt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12520,7 +14647,15 @@ VCmpEqF32Vop3::VCmpEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f32_e64_dpp"
+          : "v_cmp_eq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12567,7 +14702,15 @@ VCmpLeF32Vop3::VCmpLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f32_e64_dpp"
+          : "v_cmp_le_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12614,7 +14757,15 @@ VCmpGtF32Vop3::VCmpGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f32_e64_dpp"
+          : "v_cmp_gt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12661,7 +14812,15 @@ VCmpLgF32Vop3::VCmpLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f32_e64_dpp"
+          : "v_cmp_lg_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12708,7 +14867,15 @@ VCmpGeF32Vop3::VCmpGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f32_e64_dpp"
+          : "v_cmp_ge_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12755,7 +14922,15 @@ VCmpOF32Vop3::VCmpOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f32_e64_dpp"
+          : "v_cmp_o_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12802,7 +14977,15 @@ VCmpUF32Vop3::VCmpUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f32_e64_dpp"
+          : "v_cmp_u_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12849,7 +15032,15 @@ VCmpNgeF32Vop3::VCmpNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f32_e64_dpp"
+          : "v_cmp_nge_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12896,7 +15087,15 @@ VCmpNlgF32Vop3::VCmpNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f32_e64_dpp"
+          : "v_cmp_nlg_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12943,7 +15142,15 @@ VCmpNgtF32Vop3::VCmpNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f32_e64_dpp"
+          : "v_cmp_ngt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12990,7 +15197,15 @@ VCmpNleF32Vop3::VCmpNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f32_e64_dpp"
+          : "v_cmp_nle_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -13037,7 +15252,15 @@ VCmpNeqF32Vop3::VCmpNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f32_e64_dpp"
+          : "v_cmp_neq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -13084,7 +15307,15 @@ VCmpNltF32Vop3::VCmpNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f32_e64_dpp"
+          : "v_cmp_nlt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -13131,7 +15362,15 @@ VCmpTF32Vop3::VCmpTF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_f32_e64_dpp"
+          : "v_cmp_t_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTF32Vop3>(opcode);
 }
 } // namespace detail
@@ -13160,13 +15399,21 @@ VCmpFF64Vop3::VCmpFF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_f64_e64_dpp"
+          : "v_cmp_f_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F64 does not support DPP";
   return std::make_unique<VCmpFF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13195,13 +15442,21 @@ VCmpLtF64Vop3::VCmpLtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f64_e64_dpp"
+          : "v_cmp_lt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support DPP";
   return std::make_unique<VCmpLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13230,13 +15485,21 @@ VCmpEqF64Vop3::VCmpEqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f64_e64_dpp"
+          : "v_cmp_eq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support DPP";
   return std::make_unique<VCmpEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13265,13 +15528,21 @@ VCmpLeF64Vop3::VCmpLeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f64_e64_dpp"
+          : "v_cmp_le_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support DPP";
   return std::make_unique<VCmpLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13300,13 +15571,21 @@ VCmpGtF64Vop3::VCmpGtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f64_e64_dpp"
+          : "v_cmp_gt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support DPP";
   return std::make_unique<VCmpGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13335,13 +15614,21 @@ VCmpLgF64Vop3::VCmpLgF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LG_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f64_e64_dpp"
+          : "v_cmp_lg_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support DPP";
   return std::make_unique<VCmpLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13370,13 +15657,21 @@ VCmpGeF64Vop3::VCmpGeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f64_e64_dpp"
+          : "v_cmp_ge_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support DPP";
   return std::make_unique<VCmpGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13405,13 +15700,21 @@ VCmpOF64Vop3::VCmpOF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_O_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f64_e64_dpp"
+          : "v_cmp_o_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support DPP";
   return std::make_unique<VCmpOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13440,13 +15743,21 @@ VCmpUF64Vop3::VCmpUF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_U_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f64_e64_dpp"
+          : "v_cmp_u_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support DPP";
   return std::make_unique<VCmpUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13475,13 +15786,21 @@ VCmpNgeF64Vop3::VCmpNgeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f64_e64_dpp"
+          : "v_cmp_nge_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support DPP";
   return std::make_unique<VCmpNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13510,13 +15829,21 @@ VCmpNlgF64Vop3::VCmpNlgF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f64_e64_dpp"
+          : "v_cmp_nlg_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support DPP";
   return std::make_unique<VCmpNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13545,13 +15872,21 @@ VCmpNgtF64Vop3::VCmpNgtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f64_e64_dpp"
+          : "v_cmp_ngt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support DPP";
   return std::make_unique<VCmpNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13580,13 +15915,21 @@ VCmpNleF64Vop3::VCmpNleF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f64_e64_dpp"
+          : "v_cmp_nle_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support DPP";
   return std::make_unique<VCmpNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13615,13 +15958,21 @@ VCmpNeqF64Vop3::VCmpNeqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f64_e64_dpp"
+          : "v_cmp_neq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support DPP";
   return std::make_unique<VCmpNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13650,13 +16001,21 @@ VCmpNltF64Vop3::VCmpNltF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f64_e64_dpp"
+          : "v_cmp_nlt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support DPP";
   return std::make_unique<VCmpNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13685,13 +16044,21 @@ VCmpTF64Vop3::VCmpTF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_f64_e64_dpp"
+          : "v_cmp_t_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_F64 does not support DPP";
   return std::make_unique<VCmpTF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13746,7 +16113,15 @@ VCmpLtI16Vop3::VCmpLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i16_e64_dpp"
+          : "v_cmp_lt_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -13801,7 +16176,15 @@ VCmpEqI16Vop3::VCmpEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i16_e64_dpp"
+          : "v_cmp_eq_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -13856,7 +16239,15 @@ VCmpLeI16Vop3::VCmpLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i16_e64_dpp"
+          : "v_cmp_le_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -13911,7 +16302,15 @@ VCmpGtI16Vop3::VCmpGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i16_e64_dpp"
+          : "v_cmp_gt_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -13966,7 +16365,15 @@ VCmpNeI16Vop3::VCmpNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i16_e64_dpp"
+          : "v_cmp_ne_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -14021,7 +16428,15 @@ VCmpGeI16Vop3::VCmpGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i16_e64_dpp"
+          : "v_cmp_ge_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -14076,7 +16491,15 @@ VCmpLtU16Vop3::VCmpLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u16_e64_dpp"
+          : "v_cmp_lt_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -14131,7 +16554,15 @@ VCmpEqU16Vop3::VCmpEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u16_e64_dpp"
+          : "v_cmp_eq_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -14186,7 +16617,15 @@ VCmpLeU16Vop3::VCmpLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u16_e64_dpp"
+          : "v_cmp_le_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -14241,7 +16680,15 @@ VCmpGtU16Vop3::VCmpGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u16_e64_dpp"
+          : "v_cmp_gt_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -14296,7 +16743,15 @@ VCmpNeU16Vop3::VCmpNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u16_e64_dpp"
+          : "v_cmp_ne_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -14351,7 +16806,15 @@ VCmpGeU16Vop3::VCmpGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u16_e64_dpp"
+          : "v_cmp_ge_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -14398,7 +16861,15 @@ VCmpFI32Vop3::VCmpFI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_i32_e64_dpp"
+          : "v_cmp_f_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI32Vop3>(opcode);
 }
 } // namespace detail
@@ -14445,7 +16916,15 @@ VCmpLtI32Vop3::VCmpLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i32_e64_dpp"
+          : "v_cmp_lt_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -14492,7 +16971,15 @@ VCmpEqI32Vop3::VCmpEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i32_e64_dpp"
+          : "v_cmp_eq_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -14539,7 +17026,15 @@ VCmpLeI32Vop3::VCmpLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i32_e64_dpp"
+          : "v_cmp_le_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -14586,7 +17081,15 @@ VCmpGtI32Vop3::VCmpGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i32_e64_dpp"
+          : "v_cmp_gt_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -14633,7 +17136,15 @@ VCmpNeI32Vop3::VCmpNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i32_e64_dpp"
+          : "v_cmp_ne_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -14680,7 +17191,15 @@ VCmpGeI32Vop3::VCmpGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i32_e64_dpp"
+          : "v_cmp_ge_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -14727,7 +17246,15 @@ VCmpTI32Vop3::VCmpTI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_i32_e64_dpp"
+          : "v_cmp_t_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI32Vop3>(opcode);
 }
 } // namespace detail
@@ -14774,7 +17301,15 @@ VCmpFU32Vop3::VCmpFU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_u32_e64_dpp"
+          : "v_cmp_f_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU32Vop3>(opcode);
 }
 } // namespace detail
@@ -14821,7 +17356,15 @@ VCmpLtU32Vop3::VCmpLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u32_e64_dpp"
+          : "v_cmp_lt_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -14868,7 +17411,15 @@ VCmpEqU32Vop3::VCmpEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u32_e64_dpp"
+          : "v_cmp_eq_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -14915,7 +17466,15 @@ VCmpLeU32Vop3::VCmpLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u32_e64_dpp"
+          : "v_cmp_le_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -14962,7 +17521,15 @@ VCmpGtU32Vop3::VCmpGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u32_e64_dpp"
+          : "v_cmp_gt_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -15009,7 +17576,15 @@ VCmpNeU32Vop3::VCmpNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u32_e64_dpp"
+          : "v_cmp_ne_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -15056,7 +17631,15 @@ VCmpGeU32Vop3::VCmpGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u32_e64_dpp"
+          : "v_cmp_ge_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -15103,7 +17686,15 @@ VCmpTU32Vop3::VCmpTU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_u32_e64_dpp"
+          : "v_cmp_t_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU32Vop3>(opcode);
 }
 } // namespace detail
@@ -15132,13 +17723,21 @@ VCmpFI64Vop3::VCmpFI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_i64_e64_dpp"
+          : "v_cmp_f_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I64 does not support DPP";
   return std::make_unique<VCmpFI64Vop3>(opcode);
 }
 } // namespace detail
@@ -15167,13 +17766,21 @@ VCmpLtI64Vop3::VCmpLtI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i64_e64_dpp"
+          : "v_cmp_lt_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support DPP";
   return std::make_unique<VCmpLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -15202,13 +17809,21 @@ VCmpEqI64Vop3::VCmpEqI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i64_e64_dpp"
+          : "v_cmp_eq_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support DPP";
   return std::make_unique<VCmpEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -15237,13 +17852,21 @@ VCmpLeI64Vop3::VCmpLeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i64_e64_dpp"
+          : "v_cmp_le_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support DPP";
   return std::make_unique<VCmpLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -15272,13 +17895,21 @@ VCmpGtI64Vop3::VCmpGtI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i64_e64_dpp"
+          : "v_cmp_gt_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support DPP";
   return std::make_unique<VCmpGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -15307,13 +17938,21 @@ VCmpNeI64Vop3::VCmpNeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i64_e64_dpp"
+          : "v_cmp_ne_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support DPP";
   return std::make_unique<VCmpNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -15342,13 +17981,21 @@ VCmpGeI64Vop3::VCmpGeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i64_e64_dpp"
+          : "v_cmp_ge_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support DPP";
   return std::make_unique<VCmpGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -15377,13 +18024,21 @@ VCmpTI64Vop3::VCmpTI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_i64_e64_dpp"
+          : "v_cmp_t_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I64 does not support DPP";
   return std::make_unique<VCmpTI64Vop3>(opcode);
 }
 } // namespace detail
@@ -15412,13 +18067,21 @@ VCmpFU64Vop3::VCmpFU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_u64_e64_dpp"
+          : "v_cmp_f_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U64 does not support DPP";
   return std::make_unique<VCmpFU64Vop3>(opcode);
 }
 } // namespace detail
@@ -15447,13 +18110,21 @@ VCmpLtU64Vop3::VCmpLtU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u64_e64_dpp"
+          : "v_cmp_lt_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support DPP";
   return std::make_unique<VCmpLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -15482,13 +18153,21 @@ VCmpEqU64Vop3::VCmpEqU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u64_e64_dpp"
+          : "v_cmp_eq_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support DPP";
   return std::make_unique<VCmpEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -15517,13 +18196,21 @@ VCmpLeU64Vop3::VCmpLeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u64_e64_dpp"
+          : "v_cmp_le_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support DPP";
   return std::make_unique<VCmpLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -15552,13 +18239,21 @@ VCmpGtU64Vop3::VCmpGtU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u64_e64_dpp"
+          : "v_cmp_gt_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support DPP";
   return std::make_unique<VCmpGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -15587,13 +18282,21 @@ VCmpNeU64Vop3::VCmpNeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u64_e64_dpp"
+          : "v_cmp_ne_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support DPP";
   return std::make_unique<VCmpNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -15622,13 +18325,21 @@ VCmpGeU64Vop3::VCmpGeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u64_e64_dpp"
+          : "v_cmp_ge_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support DPP";
   return std::make_unique<VCmpGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -15657,13 +18368,21 @@ VCmpTU64Vop3::VCmpTU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_u64_e64_dpp"
+          : "v_cmp_t_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U64 does not support DPP";
   return std::make_unique<VCmpTU64Vop3>(opcode);
 }
 } // namespace detail
@@ -15718,7 +18437,16 @@ VCmpClassF16Vop3::VCmpClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f16_e64_dpp"
+          : "v_cmp_class_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -15765,7 +18493,16 @@ VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f32_e64_dpp"
+          : "v_cmp_class_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -15793,13 +18530,22 @@ VCmpClassF64Vop3::VCmpClassF64Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f64_e64_dpp"
+          : "v_cmp_class_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support DPP";
   return std::make_unique<VCmpClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -15858,7 +18604,15 @@ VCmpxFF16Vop3::VCmpxFF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_f16_e64_dpp"
+          : "v_cmpx_f_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF16Vop3>(opcode);
 }
 } // namespace detail
@@ -15917,7 +18671,15 @@ VCmpxLtF16Vop3::VCmpxLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f16_e64_dpp"
+          : "v_cmpx_lt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -15976,7 +18738,15 @@ VCmpxEqF16Vop3::VCmpxEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f16_e64_dpp"
+          : "v_cmpx_eq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16035,7 +18805,15 @@ VCmpxLeF16Vop3::VCmpxLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f16_e64_dpp"
+          : "v_cmpx_le_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16094,7 +18872,15 @@ VCmpxGtF16Vop3::VCmpxGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f16_e64_dpp"
+          : "v_cmpx_gt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16153,7 +18939,15 @@ VCmpxLgF16Vop3::VCmpxLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f16_e64_dpp"
+          : "v_cmpx_lg_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16212,7 +19006,15 @@ VCmpxGeF16Vop3::VCmpxGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f16_e64_dpp"
+          : "v_cmpx_ge_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16271,7 +19073,15 @@ VCmpxOF16Vop3::VCmpxOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f16_e64_dpp"
+          : "v_cmpx_o_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16330,7 +19140,15 @@ VCmpxUF16Vop3::VCmpxUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f16_e64_dpp"
+          : "v_cmpx_u_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16389,7 +19207,16 @@ VCmpxNgeF16Vop3::VCmpxNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f16_e64_dpp"
+          : "v_cmpx_nge_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16448,7 +19275,16 @@ VCmpxNlgF16Vop3::VCmpxNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f16_e64_dpp"
+          : "v_cmpx_nlg_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16507,7 +19343,16 @@ VCmpxNgtF16Vop3::VCmpxNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f16_e64_dpp"
+          : "v_cmpx_ngt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16566,7 +19411,16 @@ VCmpxNleF16Vop3::VCmpxNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f16_e64_dpp"
+          : "v_cmpx_nle_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16625,7 +19479,16 @@ VCmpxNeqF16Vop3::VCmpxNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f16_e64_dpp"
+          : "v_cmpx_neq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16684,7 +19547,16 @@ VCmpxNltF16Vop3::VCmpxNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f16_e64_dpp"
+          : "v_cmpx_nlt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16743,7 +19615,15 @@ VCmpxTF16Vop3::VCmpxTF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_f16_e64_dpp"
+          : "v_cmpx_t_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16794,7 +19674,15 @@ VCmpxFF32Vop3::VCmpxFF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_f32_e64_dpp"
+          : "v_cmpx_f_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF32Vop3>(opcode);
 }
 } // namespace detail
@@ -16845,7 +19733,15 @@ VCmpxLtF32Vop3::VCmpxLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f32_e64_dpp"
+          : "v_cmpx_lt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -16896,7 +19792,15 @@ VCmpxEqF32Vop3::VCmpxEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f32_e64_dpp"
+          : "v_cmpx_eq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -16947,7 +19851,15 @@ VCmpxLeF32Vop3::VCmpxLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f32_e64_dpp"
+          : "v_cmpx_le_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -16998,7 +19910,15 @@ VCmpxGtF32Vop3::VCmpxGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f32_e64_dpp"
+          : "v_cmpx_gt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17049,7 +19969,15 @@ VCmpxLgF32Vop3::VCmpxLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f32_e64_dpp"
+          : "v_cmpx_lg_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17100,7 +20028,15 @@ VCmpxGeF32Vop3::VCmpxGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f32_e64_dpp"
+          : "v_cmpx_ge_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17151,7 +20087,15 @@ VCmpxOF32Vop3::VCmpxOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f32_e64_dpp"
+          : "v_cmpx_o_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17202,7 +20146,15 @@ VCmpxUF32Vop3::VCmpxUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f32_e64_dpp"
+          : "v_cmpx_u_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17253,7 +20205,16 @@ VCmpxNgeF32Vop3::VCmpxNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f32_e64_dpp"
+          : "v_cmpx_nge_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17304,7 +20265,16 @@ VCmpxNlgF32Vop3::VCmpxNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f32_e64_dpp"
+          : "v_cmpx_nlg_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17355,7 +20325,16 @@ VCmpxNgtF32Vop3::VCmpxNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f32_e64_dpp"
+          : "v_cmpx_ngt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17406,7 +20385,16 @@ VCmpxNleF32Vop3::VCmpxNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f32_e64_dpp"
+          : "v_cmpx_nle_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17457,7 +20445,16 @@ VCmpxNeqF32Vop3::VCmpxNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f32_e64_dpp"
+          : "v_cmpx_neq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17508,7 +20505,16 @@ VCmpxNltF32Vop3::VCmpxNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f32_e64_dpp"
+          : "v_cmpx_nlt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17559,7 +20565,15 @@ VCmpxTF32Vop3::VCmpxTF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_f32_e64_dpp"
+          : "v_cmpx_t_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17590,15 +20604,23 @@ VCmpxFF64Vop3::VCmpxFF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_f64_e64_dpp"
+          : "v_cmpx_f_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F64 does not support DPP";
   return std::make_unique<VCmpxFF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17629,15 +20651,23 @@ VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f64_e64_dpp"
+          : "v_cmpx_lt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support DPP";
   return std::make_unique<VCmpxLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17668,15 +20698,23 @@ VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f64_e64_dpp"
+          : "v_cmpx_eq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support DPP";
   return std::make_unique<VCmpxEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17707,15 +20745,23 @@ VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f64_e64_dpp"
+          : "v_cmpx_le_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support DPP";
   return std::make_unique<VCmpxLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17746,15 +20792,23 @@ VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f64_e64_dpp"
+          : "v_cmpx_gt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support DPP";
   return std::make_unique<VCmpxGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17785,15 +20839,23 @@ VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f64_e64_dpp"
+          : "v_cmpx_lg_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support DPP";
   return std::make_unique<VCmpxLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17824,15 +20886,23 @@ VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f64_e64_dpp"
+          : "v_cmpx_ge_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support DPP";
   return std::make_unique<VCmpxGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17863,15 +20933,23 @@ VCmpxOF64Vop3::VCmpxOF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_O_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f64_e64_dpp"
+          : "v_cmpx_o_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support DPP";
   return std::make_unique<VCmpxOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17902,15 +20980,23 @@ VCmpxUF64Vop3::VCmpxUF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_U_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f64_e64_dpp"
+          : "v_cmpx_u_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support DPP";
   return std::make_unique<VCmpxUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17941,15 +21027,24 @@ VCmpxNgeF64Vop3::VCmpxNgeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f64_e64_dpp"
+          : "v_cmpx_nge_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support DPP";
   return std::make_unique<VCmpxNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17980,15 +21075,24 @@ VCmpxNlgF64Vop3::VCmpxNlgF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f64_e64_dpp"
+          : "v_cmpx_nlg_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support DPP";
   return std::make_unique<VCmpxNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18019,15 +21123,24 @@ VCmpxNgtF64Vop3::VCmpxNgtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f64_e64_dpp"
+          : "v_cmpx_ngt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support DPP";
   return std::make_unique<VCmpxNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18058,15 +21171,24 @@ VCmpxNleF64Vop3::VCmpxNleF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f64_e64_dpp"
+          : "v_cmpx_nle_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support DPP";
   return std::make_unique<VCmpxNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18097,15 +21219,24 @@ VCmpxNeqF64Vop3::VCmpxNeqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f64_e64_dpp"
+          : "v_cmpx_neq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support DPP";
   return std::make_unique<VCmpxNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18136,15 +21267,24 @@ VCmpxNltF64Vop3::VCmpxNltF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f64_e64_dpp"
+          : "v_cmpx_nlt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support DPP";
   return std::make_unique<VCmpxNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18175,15 +21315,23 @@ VCmpxTF64Vop3::VCmpxTF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_f64_e64_dpp"
+          : "v_cmpx_t_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_F64 does not support DPP";
   return std::make_unique<VCmpxTF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18242,7 +21390,15 @@ VCmpxLtI16Vop3::VCmpxLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i16_e64_dpp"
+          : "v_cmpx_lt_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -18301,7 +21457,15 @@ VCmpxEqI16Vop3::VCmpxEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i16_e64_dpp"
+          : "v_cmpx_eq_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -18360,7 +21524,15 @@ VCmpxLeI16Vop3::VCmpxLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i16_e64_dpp"
+          : "v_cmpx_le_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -18419,7 +21591,15 @@ VCmpxGtI16Vop3::VCmpxGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i16_e64_dpp"
+          : "v_cmpx_gt_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -18478,7 +21658,15 @@ VCmpxNeI16Vop3::VCmpxNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i16_e64_dpp"
+          : "v_cmpx_ne_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -18537,7 +21725,15 @@ VCmpxGeI16Vop3::VCmpxGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i16_e64_dpp"
+          : "v_cmpx_ge_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -18596,7 +21792,15 @@ VCmpxLtU16Vop3::VCmpxLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u16_e64_dpp"
+          : "v_cmpx_lt_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -18655,7 +21859,15 @@ VCmpxEqU16Vop3::VCmpxEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u16_e64_dpp"
+          : "v_cmpx_eq_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -18714,7 +21926,15 @@ VCmpxLeU16Vop3::VCmpxLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u16_e64_dpp"
+          : "v_cmpx_le_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -18773,7 +21993,15 @@ VCmpxGtU16Vop3::VCmpxGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u16_e64_dpp"
+          : "v_cmpx_gt_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -18832,7 +22060,15 @@ VCmpxNeU16Vop3::VCmpxNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u16_e64_dpp"
+          : "v_cmpx_ne_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -18891,7 +22127,15 @@ VCmpxGeU16Vop3::VCmpxGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u16_e64_dpp"
+          : "v_cmpx_ge_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -18942,7 +22186,15 @@ VCmpxFI32Vop3::VCmpxFI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_i32_e64_dpp"
+          : "v_cmpx_f_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI32Vop3>(opcode);
 }
 } // namespace detail
@@ -18993,7 +22245,15 @@ VCmpxLtI32Vop3::VCmpxLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i32_e64_dpp"
+          : "v_cmpx_lt_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19044,7 +22304,15 @@ VCmpxEqI32Vop3::VCmpxEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i32_e64_dpp"
+          : "v_cmpx_eq_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19095,7 +22363,15 @@ VCmpxLeI32Vop3::VCmpxLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i32_e64_dpp"
+          : "v_cmpx_le_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19146,7 +22422,15 @@ VCmpxGtI32Vop3::VCmpxGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i32_e64_dpp"
+          : "v_cmpx_gt_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19197,7 +22481,15 @@ VCmpxNeI32Vop3::VCmpxNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i32_e64_dpp"
+          : "v_cmpx_ne_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19248,7 +22540,15 @@ VCmpxGeI32Vop3::VCmpxGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i32_e64_dpp"
+          : "v_cmpx_ge_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19299,7 +22599,15 @@ VCmpxTI32Vop3::VCmpxTI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_i32_e64_dpp"
+          : "v_cmpx_t_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19350,7 +22658,15 @@ VCmpxFU32Vop3::VCmpxFU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_u32_e64_dpp"
+          : "v_cmpx_f_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19401,7 +22717,15 @@ VCmpxLtU32Vop3::VCmpxLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u32_e64_dpp"
+          : "v_cmpx_lt_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19452,7 +22776,15 @@ VCmpxEqU32Vop3::VCmpxEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u32_e64_dpp"
+          : "v_cmpx_eq_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19503,7 +22835,15 @@ VCmpxLeU32Vop3::VCmpxLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u32_e64_dpp"
+          : "v_cmpx_le_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19554,7 +22894,15 @@ VCmpxGtU32Vop3::VCmpxGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u32_e64_dpp"
+          : "v_cmpx_gt_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19605,7 +22953,15 @@ VCmpxNeU32Vop3::VCmpxNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u32_e64_dpp"
+          : "v_cmpx_ne_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19656,7 +23012,15 @@ VCmpxGeU32Vop3::VCmpxGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u32_e64_dpp"
+          : "v_cmpx_ge_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19707,7 +23071,15 @@ VCmpxTU32Vop3::VCmpxTU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_u32_e64_dpp"
+          : "v_cmpx_t_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19738,15 +23110,23 @@ VCmpxFI64Vop3::VCmpxFI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_i64_e64_dpp"
+          : "v_cmpx_f_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I64 does not support DPP";
   return std::make_unique<VCmpxFI64Vop3>(opcode);
 }
 } // namespace detail
@@ -19777,15 +23157,23 @@ VCmpxLtI64Vop3::VCmpxLtI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i64_e64_dpp"
+          : "v_cmpx_lt_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support DPP";
   return std::make_unique<VCmpxLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -19816,15 +23204,23 @@ VCmpxEqI64Vop3::VCmpxEqI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i64_e64_dpp"
+          : "v_cmpx_eq_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support DPP";
   return std::make_unique<VCmpxEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -19855,15 +23251,23 @@ VCmpxLeI64Vop3::VCmpxLeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i64_e64_dpp"
+          : "v_cmpx_le_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support DPP";
   return std::make_unique<VCmpxLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -19894,15 +23298,23 @@ VCmpxGtI64Vop3::VCmpxGtI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i64_e64_dpp"
+          : "v_cmpx_gt_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support DPP";
   return std::make_unique<VCmpxGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -19933,15 +23345,23 @@ VCmpxNeI64Vop3::VCmpxNeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i64_e64_dpp"
+          : "v_cmpx_ne_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support DPP";
   return std::make_unique<VCmpxNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -19972,15 +23392,23 @@ VCmpxGeI64Vop3::VCmpxGeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i64_e64_dpp"
+          : "v_cmpx_ge_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support DPP";
   return std::make_unique<VCmpxGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -20011,15 +23439,23 @@ VCmpxTI64Vop3::VCmpxTI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_i64_e64_dpp"
+          : "v_cmpx_t_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I64 does not support DPP";
   return std::make_unique<VCmpxTI64Vop3>(opcode);
 }
 } // namespace detail
@@ -20050,15 +23486,23 @@ VCmpxFU64Vop3::VCmpxFU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_u64_e64_dpp"
+          : "v_cmpx_f_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U64 does not support DPP";
   return std::make_unique<VCmpxFU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20089,15 +23533,23 @@ VCmpxLtU64Vop3::VCmpxLtU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u64_e64_dpp"
+          : "v_cmpx_lt_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support DPP";
   return std::make_unique<VCmpxLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20128,15 +23580,23 @@ VCmpxEqU64Vop3::VCmpxEqU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u64_e64_dpp"
+          : "v_cmpx_eq_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support DPP";
   return std::make_unique<VCmpxEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20167,15 +23627,23 @@ VCmpxLeU64Vop3::VCmpxLeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u64_e64_dpp"
+          : "v_cmpx_le_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support DPP";
   return std::make_unique<VCmpxLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20206,15 +23674,23 @@ VCmpxGtU64Vop3::VCmpxGtU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u64_e64_dpp"
+          : "v_cmpx_gt_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support DPP";
   return std::make_unique<VCmpxGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20245,15 +23721,23 @@ VCmpxNeU64Vop3::VCmpxNeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u64_e64_dpp"
+          : "v_cmpx_ne_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support DPP";
   return std::make_unique<VCmpxNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20284,15 +23768,23 @@ VCmpxGeU64Vop3::VCmpxGeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u64_e64_dpp"
+          : "v_cmpx_ge_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support DPP";
   return std::make_unique<VCmpxGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20323,15 +23815,23 @@ VCmpxTU64Vop3::VCmpxTU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_u64_e64_dpp"
+          : "v_cmpx_t_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U64 does not support DPP";
   return std::make_unique<VCmpxTU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20390,7 +23890,16 @@ VCmpxClassF16Vop3::VCmpxClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f16_e64_dpp"
+          : "v_cmpx_class_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -20441,7 +23950,16 @@ VCmpxClassF32Vop3::VCmpxClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f32_e64_dpp"
+          : "v_cmpx_class_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -20471,15 +23989,24 @@ VCmpxClassF64Vop3::VCmpxClassF64Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f64_e64_dpp"
+          : "v_cmpx_class_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support DPP";
   return std::make_unique<VCmpxClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -20530,7 +24057,16 @@ VAddCoCiU32Vop3SdstEnc::VAddCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_add_co_ci_u32_e64_dpp"
+          : "v_add_co_ci_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoCiU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20581,7 +24117,16 @@ VSubCoCiU32Vop3SdstEnc::VSubCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_sub_co_ci_u32_e64_dpp"
+          : "v_sub_co_ci_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoCiU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20632,7 +24177,16 @@ VSubrevCoCiU32Vop3SdstEnc::VSubrevCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_subrev_co_ci_u32_e64_dpp"
+          : "v_subrev_co_ci_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoCiU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20667,13 +24221,23 @@ VDivScaleF32Vop3SdstEnc::VDivScaleF32Vop3SdstEnc(const MachineInst *inst)
     src2 = Operand(32, OperandType::OPR_SIMM32,
                    static_cast<int>(
                        reinterpret_cast<const Vop3SdstEncInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_SCALE_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_div_scale_f32_e64_dpp"
+          : "v_div_scale_f32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DIV_SCALE_F32 does not support DPP";
   return std::make_unique<VDivScaleF32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20714,13 +24278,23 @@ VDivScaleF64Vop3SdstEnc::VDivScaleF64Vop3SdstEnc(const MachineInst *inst)
         static_cast<uint32_t>(
             reinterpret_cast<const Vop3SdstEncInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_SCALE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_div_scale_f64_e64_dpp"
+          : "v_div_scale_f64",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DIV_SCALE_F64 does not support DPP";
   return std::make_unique<VDivScaleF64Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20757,13 +24331,23 @@ VMadU64U32Vop3SdstEnc::VMadU64U32Vop3SdstEnc(const MachineInst *inst)
         static_cast<uint32_t>(
             reinterpret_cast<const Vop3SdstEncInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAD_U64_U32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_mad_u64_u32_e64_dpp"
+          : "v_mad_u64_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_MAD_U64_U32 does not support DPP";
   return std::make_unique<VMadU64U32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20800,13 +24384,23 @@ VMadI64I32Vop3SdstEnc::VMadI64I32Vop3SdstEnc(const MachineInst *inst)
         static_cast<uint32_t>(
             reinterpret_cast<const Vop3SdstEncInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAD_I64_I32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_mad_i64_i32_e64_dpp"
+          : "v_mad_i64_i32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_MAD_I64_I32 does not support DPP";
   return std::make_unique<VMadI64I32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20855,7 +24449,16 @@ VAddCoU32Vop3SdstEnc::VAddCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_add_co_u32_e64_dpp"
+          : "v_add_co_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20904,7 +24507,16 @@ VSubCoU32Vop3SdstEnc::VSubCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_sub_co_u32_e64_dpp"
+          : "v_sub_co_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20953,7 +24565,16 @@ VSubrevCoU32Vop3SdstEnc::VSubrevCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_subrev_co_u32_e64_dpp"
+          : "v_subrev_co_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop3p.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -41,13 +40,22 @@ VPkMadI16Vop3p::VPkMadI16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAD_I16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_mad_i16_e64_dpp"
+          : "v_pk_mad_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAD_I16 does not support DPP";
   return std::make_unique<VPkMadI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -74,13 +82,23 @@ VPkMulLoU16Vop3p::VPkMulLoU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MUL_LO_U16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_mul_lo_u16_e64_dpp"
+          : "v_pk_mul_lo_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MUL_LO_U16 does not support DPP";
   return std::make_unique<VPkMulLoU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -107,13 +125,22 @@ VPkAddI16Vop3p::VPkAddI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ADD_I16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_add_i16_e64_dpp"
+          : "v_pk_add_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ADD_I16 does not support DPP";
   return std::make_unique<VPkAddI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -140,13 +167,22 @@ VPkSubI16Vop3p::VPkSubI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_SUB_I16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_sub_i16_e64_dpp"
+          : "v_pk_sub_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_SUB_I16 does not support DPP";
   return std::make_unique<VPkSubI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -173,13 +209,23 @@ VPkLshlrevB16Vop3p::VPkLshlrevB16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_LSHLREV_B16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_lshlrev_b16_e64_dpp"
+          : "v_pk_lshlrev_b16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_LSHLREV_B16 does not support DPP";
   return std::make_unique<VPkLshlrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -206,13 +252,23 @@ VPkLshrrevB16Vop3p::VPkLshrrevB16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_LSHRREV_B16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_lshrrev_b16_e64_dpp"
+          : "v_pk_lshrrev_b16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_LSHRREV_B16 does not support DPP";
   return std::make_unique<VPkLshrrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -239,13 +295,23 @@ VPkAshrrevI16Vop3p::VPkAshrrevI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ASHRREV_I16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_ashrrev_i16_e64_dpp"
+          : "v_pk_ashrrev_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ASHRREV_I16 does not support DPP";
   return std::make_unique<VPkAshrrevI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -272,13 +338,22 @@ VPkMaxI16Vop3p::VPkMaxI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAX_I16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_max_i16_e64_dpp"
+          : "v_pk_max_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAX_I16 does not support DPP";
   return std::make_unique<VPkMaxI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -305,13 +380,22 @@ VPkMinI16Vop3p::VPkMinI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MIN_I16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_min_i16_e64_dpp"
+          : "v_pk_min_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MIN_I16 does not support DPP";
   return std::make_unique<VPkMinI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -344,13 +428,22 @@ VPkMadU16Vop3p::VPkMadU16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAD_U16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_mad_u16_e64_dpp"
+          : "v_pk_mad_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAD_U16 does not support DPP";
   return std::make_unique<VPkMadU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -377,13 +470,22 @@ VPkAddU16Vop3p::VPkAddU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ADD_U16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_add_u16_e64_dpp"
+          : "v_pk_add_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ADD_U16 does not support DPP";
   return std::make_unique<VPkAddU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -410,13 +512,22 @@ VPkSubU16Vop3p::VPkSubU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_SUB_U16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_sub_u16_e64_dpp"
+          : "v_pk_sub_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_SUB_U16 does not support DPP";
   return std::make_unique<VPkSubU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -443,13 +554,22 @@ VPkMaxU16Vop3p::VPkMaxU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAX_U16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_max_u16_e64_dpp"
+          : "v_pk_max_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAX_U16 does not support DPP";
   return std::make_unique<VPkMaxU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -476,13 +596,22 @@ VPkMinU16Vop3p::VPkMinU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MIN_U16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_min_u16_e64_dpp"
+          : "v_pk_min_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MIN_U16 does not support DPP";
   return std::make_unique<VPkMinU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -515,13 +644,22 @@ VPkFmaF16Vop3p::VPkFmaF16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_FMA_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_fma_f16_e64_dpp"
+          : "v_pk_fma_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_FMA_F16 does not support DPP";
   return std::make_unique<VPkFmaF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -548,13 +686,22 @@ VPkAddF16Vop3p::VPkAddF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ADD_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_add_f16_e64_dpp"
+          : "v_pk_add_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ADD_F16 does not support DPP";
   return std::make_unique<VPkAddF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -581,13 +728,22 @@ VPkMulF16Vop3p::VPkMulF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MUL_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_mul_f16_e64_dpp"
+          : "v_pk_mul_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MUL_F16 does not support DPP";
   return std::make_unique<VPkMulF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -614,13 +770,22 @@ VPkMinF16Vop3p::VPkMinF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MIN_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_min_f16_e64_dpp"
+          : "v_pk_min_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MIN_F16 does not support DPP";
   return std::make_unique<VPkMinF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -647,13 +812,22 @@ VPkMaxF16Vop3p::VPkMaxF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAX_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_max_f16_e64_dpp"
+          : "v_pk_max_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAX_F16 does not support DPP";
   return std::make_unique<VPkMaxF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -706,7 +880,16 @@ VDot2F32F16Vop3p::VDot2F32F16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2F32F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2F32F16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot2_f32_f16_e64_dpp"
+          : "v_dot2_f32_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2F32F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -739,13 +922,23 @@ VDot4I32Iu8Vop3p::VDot4I32Iu8Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT4_I32_IU8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4I32Iu8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4I32Iu8Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot4_i32_iu8_e64_dpp"
+          : "v_dot4_i32_iu8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT4_I32_IU8 does not support DPP";
   return std::make_unique<VDot4I32Iu8Vop3p>(opcode);
 }
 } // namespace detail
@@ -778,13 +971,23 @@ VDot4U32U8Vop3p::VDot4U32U8Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT4_U32_U8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot4_u32_u8_e64_dpp"
+          : "v_dot4_u32_u8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT4_U32_U8 does not support DPP";
   return std::make_unique<VDot4U32U8Vop3p>(opcode);
 }
 } // namespace detail
@@ -817,13 +1020,23 @@ VDot8I32Iu4Vop3p::VDot8I32Iu4Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT8_I32_IU4 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8I32Iu4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8I32Iu4Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot8_i32_iu4_e64_dpp"
+          : "v_dot8_i32_iu4",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT8_I32_IU4 does not support DPP";
   return std::make_unique<VDot8I32Iu4Vop3p>(opcode);
 }
 } // namespace detail
@@ -856,13 +1069,23 @@ VDot8U32U4Vop3p::VDot8U32U4Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT8_U32_U4 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot8_u32_u4_e64_dpp"
+          : "v_dot8_u32_u4",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT8_U32_U4 does not support DPP";
   return std::make_unique<VDot8U32U4Vop3p>(opcode);
 }
 } // namespace detail
@@ -915,7 +1138,16 @@ VDot2F32Bf16Vop3p::VDot2F32Bf16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2F32Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2F32Bf16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot2_f32_bf16_e64_dpp"
+          : "v_dot2_f32_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2F32Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -968,7 +1200,16 @@ VFmaMixF32Vop3p::VFmaMixF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixF32Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_fma_mix_f32_e64_dpp"
+          : "v_fma_mix_f32",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -1022,7 +1263,16 @@ VFmaMixloF16Vop3p::VFmaMixloF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixloF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_fma_mixlo_f16_e64_dpp"
+          : "v_fma_mixlo_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixloF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1082,7 +1332,16 @@ VFmaMixhiF16Vop3p::VFmaMixhiF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixhiF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_fma_mixhi_f16_e64_dpp"
+          : "v_fma_mixhi_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixhiF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1110,13 +1369,23 @@ VWmmaF3216x16x16F16Vop3p::VWmmaF3216x16x16F16Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X16_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x16F16Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x16_f16_e64_dpp"
+          : "v_wmma_f32_16x16x16_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X16_F16 does not support DPP";
   return std::make_unique<VWmmaF3216x16x16F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1138,13 +1407,23 @@ VWmmaF3216x16x16Bf16Vop3p::VWmmaF3216x16x16Bf16Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X16_BF16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x16Bf16Vop3p(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x16_bf16_e64_dpp"
+          : "v_wmma_f32_16x16x16_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X16_BF16 does not support DPP";
   return std::make_unique<VWmmaF3216x16x16Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1166,13 +1445,23 @@ VWmmaF1616x16x16F16Vop3p::VWmmaF1616x16x16F16Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F16_16X16X16_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x16F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF1616x16x16F16Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f16_16x16x16_f16_e64_dpp"
+          : "v_wmma_f16_16x16x16_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F16_16X16X16_F16 does not support DPP";
   return std::make_unique<VWmmaF1616x16x16F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1194,13 +1483,23 @@ VWmmaBf1616x16x16Bf16Vop3p::VWmmaBf1616x16x16Bf16Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_BF16_16X16X16_BF16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaBf1616x16x16Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaBf1616x16x16Bf16Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_bf16_16x16x16_bf16_e64_dpp"
+          : "v_wmma_bf16_16x16x16_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_BF16_16X16X16_BF16 does not support DPP";
   return std::make_unique<VWmmaBf1616x16x16Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1222,13 +1521,23 @@ VWmmaI3216x16x16Iu8Vop3p::VWmmaI3216x16x16Iu8Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_I32_16X16X16_IU8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaI3216x16x16Iu8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaI3216x16x16Iu8Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_i32_16x16x16_iu8_e64_dpp"
+          : "v_wmma_i32_16x16x16_iu8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_I32_16X16X16_IU8 does not support DPP";
   return std::make_unique<VWmmaI3216x16x16Iu8Vop3p>(opcode);
 }
 } // namespace detail
@@ -1250,13 +1559,23 @@ VWmmaI3216x16x16Iu4Vop3p::VWmmaI3216x16x16Iu4Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_I32_16X16X16_IU4 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaI3216x16x16Iu4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaI3216x16x16Iu4Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_i32_16x16x16_iu4_e64_dpp"
+          : "v_wmma_i32_16x16x16_iu4",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_I32_16X16X16_IU4 does not support DPP";
   return std::make_unique<VWmmaI3216x16x16Iu4Vop3p>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vopc.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/vopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -55,7 +54,15 @@ VCmpFF16Vopc::VCmpFF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_f16_dpp"
+          : "v_cmp_f_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF16Vopc>(opcode);
 }
 } // namespace detail
@@ -102,7 +109,15 @@ VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f16_dpp"
+          : "v_cmp_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -149,7 +164,15 @@ VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f16_dpp"
+          : "v_cmp_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -196,7 +219,15 @@ VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f16_dpp"
+          : "v_cmp_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -243,7 +274,15 @@ VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f16_dpp"
+          : "v_cmp_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -290,7 +329,15 @@ VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f16_dpp"
+          : "v_cmp_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -337,7 +384,15 @@ VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f16_dpp"
+          : "v_cmp_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -384,7 +439,15 @@ VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f16_dpp"
+          : "v_cmp_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -431,7 +494,15 @@ VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f16_dpp"
+          : "v_cmp_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -478,7 +549,15 @@ VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f16_dpp"
+          : "v_cmp_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -525,7 +604,15 @@ VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f16_dpp"
+          : "v_cmp_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -572,7 +659,15 @@ VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f16_dpp"
+          : "v_cmp_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -619,7 +714,15 @@ VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f16_dpp"
+          : "v_cmp_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -666,7 +769,15 @@ VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f16_dpp"
+          : "v_cmp_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -713,7 +824,15 @@ VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f16_dpp"
+          : "v_cmp_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -760,7 +879,15 @@ VCmpTF16Vopc::VCmpTF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_f16_dpp"
+          : "v_cmp_t_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTF16Vopc>(opcode);
 }
 } // namespace detail
@@ -804,7 +931,15 @@ VCmpFF32Vopc::VCmpFF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_f32_dpp"
+          : "v_cmp_f_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF32Vopc>(opcode);
 }
 } // namespace detail
@@ -848,7 +983,15 @@ VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f32_dpp"
+          : "v_cmp_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -892,7 +1035,15 @@ VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f32_dpp"
+          : "v_cmp_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -936,7 +1087,15 @@ VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f32_dpp"
+          : "v_cmp_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -980,7 +1139,15 @@ VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f32_dpp"
+          : "v_cmp_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1024,7 +1191,15 @@ VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f32_dpp"
+          : "v_cmp_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1068,7 +1243,15 @@ VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f32_dpp"
+          : "v_cmp_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1112,7 +1295,15 @@ VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f32_dpp"
+          : "v_cmp_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1156,7 +1347,15 @@ VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f32_dpp"
+          : "v_cmp_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1200,7 +1399,15 @@ VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f32_dpp"
+          : "v_cmp_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1244,7 +1451,15 @@ VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f32_dpp"
+          : "v_cmp_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1288,7 +1503,15 @@ VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f32_dpp"
+          : "v_cmp_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1332,7 +1555,15 @@ VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f32_dpp"
+          : "v_cmp_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1376,7 +1607,15 @@ VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f32_dpp"
+          : "v_cmp_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1420,7 +1659,15 @@ VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f32_dpp"
+          : "v_cmp_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1464,7 +1711,15 @@ VCmpTF32Vopc::VCmpTF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_f32_dpp"
+          : "v_cmp_t_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1488,14 +1743,22 @@ VCmpFF64Vopc::VCmpFF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_f64_dpp"
+          : "v_cmp_f_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F64 does not support DPP";
   return std::make_unique<VCmpFF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1519,14 +1782,22 @@ VCmpLtF64Vopc::VCmpLtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f64_dpp"
+          : "v_cmp_lt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support DPP";
   return std::make_unique<VCmpLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1550,14 +1821,22 @@ VCmpEqF64Vopc::VCmpEqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f64_dpp"
+          : "v_cmp_eq_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support DPP";
   return std::make_unique<VCmpEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1581,14 +1860,22 @@ VCmpLeF64Vopc::VCmpLeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f64_dpp"
+          : "v_cmp_le_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support DPP";
   return std::make_unique<VCmpLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1612,14 +1899,22 @@ VCmpGtF64Vopc::VCmpGtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f64_dpp"
+          : "v_cmp_gt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support DPP";
   return std::make_unique<VCmpGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1643,14 +1938,22 @@ VCmpLgF64Vopc::VCmpLgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LG_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f64_dpp"
+          : "v_cmp_lg_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support DPP";
   return std::make_unique<VCmpLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1674,14 +1977,22 @@ VCmpGeF64Vopc::VCmpGeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f64_dpp"
+          : "v_cmp_ge_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support DPP";
   return std::make_unique<VCmpGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1705,14 +2016,22 @@ VCmpOF64Vopc::VCmpOF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_O_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f64_dpp"
+          : "v_cmp_o_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support DPP";
   return std::make_unique<VCmpOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1736,14 +2055,22 @@ VCmpUF64Vopc::VCmpUF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_U_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f64_dpp"
+          : "v_cmp_u_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support DPP";
   return std::make_unique<VCmpUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1767,14 +2094,22 @@ VCmpNgeF64Vopc::VCmpNgeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f64_dpp"
+          : "v_cmp_nge_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support DPP";
   return std::make_unique<VCmpNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1798,14 +2133,22 @@ VCmpNlgF64Vopc::VCmpNlgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f64_dpp"
+          : "v_cmp_nlg_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support DPP";
   return std::make_unique<VCmpNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1829,14 +2172,22 @@ VCmpNgtF64Vopc::VCmpNgtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f64_dpp"
+          : "v_cmp_ngt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support DPP";
   return std::make_unique<VCmpNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1860,14 +2211,22 @@ VCmpNleF64Vopc::VCmpNleF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f64_dpp"
+          : "v_cmp_nle_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support DPP";
   return std::make_unique<VCmpNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1891,14 +2250,22 @@ VCmpNeqF64Vopc::VCmpNeqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f64_dpp"
+          : "v_cmp_neq_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support DPP";
   return std::make_unique<VCmpNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1922,14 +2289,22 @@ VCmpNltF64Vopc::VCmpNltF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f64_dpp"
+          : "v_cmp_nlt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support DPP";
   return std::make_unique<VCmpNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1953,14 +2328,22 @@ VCmpTF64Vopc::VCmpTF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_f64_dpp"
+          : "v_cmp_t_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_F64 does not support DPP";
   return std::make_unique<VCmpTF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2007,7 +2390,15 @@ VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i16_dpp"
+          : "v_cmp_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2054,7 +2445,15 @@ VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i16_dpp"
+          : "v_cmp_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2101,7 +2500,15 @@ VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i16_dpp"
+          : "v_cmp_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2148,7 +2555,15 @@ VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i16_dpp"
+          : "v_cmp_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2195,7 +2610,15 @@ VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i16_dpp"
+          : "v_cmp_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2242,7 +2665,15 @@ VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i16_dpp"
+          : "v_cmp_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2289,7 +2720,15 @@ VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u16_dpp"
+          : "v_cmp_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2336,7 +2775,15 @@ VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u16_dpp"
+          : "v_cmp_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2383,7 +2830,15 @@ VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u16_dpp"
+          : "v_cmp_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2430,7 +2885,15 @@ VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u16_dpp"
+          : "v_cmp_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2477,7 +2940,15 @@ VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u16_dpp"
+          : "v_cmp_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2524,7 +2995,15 @@ VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u16_dpp"
+          : "v_cmp_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2568,7 +3047,15 @@ VCmpFI32Vopc::VCmpFI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_i32_dpp"
+          : "v_cmp_f_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2612,7 +3099,15 @@ VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i32_dpp"
+          : "v_cmp_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2656,7 +3151,15 @@ VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i32_dpp"
+          : "v_cmp_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2700,7 +3203,15 @@ VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i32_dpp"
+          : "v_cmp_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2744,7 +3255,15 @@ VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i32_dpp"
+          : "v_cmp_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2788,7 +3307,15 @@ VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i32_dpp"
+          : "v_cmp_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2832,7 +3359,15 @@ VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i32_dpp"
+          : "v_cmp_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2876,7 +3411,15 @@ VCmpTI32Vopc::VCmpTI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_i32_dpp"
+          : "v_cmp_t_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2920,7 +3463,15 @@ VCmpFU32Vopc::VCmpFU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_u32_dpp"
+          : "v_cmp_f_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU32Vopc>(opcode);
 }
 } // namespace detail
@@ -2964,7 +3515,15 @@ VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u32_dpp"
+          : "v_cmp_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3008,7 +3567,15 @@ VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u32_dpp"
+          : "v_cmp_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3052,7 +3619,15 @@ VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u32_dpp"
+          : "v_cmp_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3096,7 +3671,15 @@ VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u32_dpp"
+          : "v_cmp_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3140,7 +3723,15 @@ VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u32_dpp"
+          : "v_cmp_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3184,7 +3775,15 @@ VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u32_dpp"
+          : "v_cmp_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3228,7 +3827,15 @@ VCmpTU32Vopc::VCmpTU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_u32_dpp"
+          : "v_cmp_t_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3252,14 +3859,22 @@ VCmpFI64Vopc::VCmpFI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_i64_dpp"
+          : "v_cmp_f_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I64 does not support DPP";
   return std::make_unique<VCmpFI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3283,14 +3898,22 @@ VCmpLtI64Vopc::VCmpLtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i64_dpp"
+          : "v_cmp_lt_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support DPP";
   return std::make_unique<VCmpLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3314,14 +3937,22 @@ VCmpEqI64Vopc::VCmpEqI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i64_dpp"
+          : "v_cmp_eq_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support DPP";
   return std::make_unique<VCmpEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3345,14 +3976,22 @@ VCmpLeI64Vopc::VCmpLeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i64_dpp"
+          : "v_cmp_le_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support DPP";
   return std::make_unique<VCmpLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3376,14 +4015,22 @@ VCmpGtI64Vopc::VCmpGtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i64_dpp"
+          : "v_cmp_gt_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support DPP";
   return std::make_unique<VCmpGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3407,14 +4054,22 @@ VCmpNeI64Vopc::VCmpNeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i64_dpp"
+          : "v_cmp_ne_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support DPP";
   return std::make_unique<VCmpNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3438,14 +4093,22 @@ VCmpGeI64Vopc::VCmpGeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i64_dpp"
+          : "v_cmp_ge_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support DPP";
   return std::make_unique<VCmpGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3469,14 +4132,22 @@ VCmpTI64Vopc::VCmpTI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_i64_dpp"
+          : "v_cmp_t_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I64 does not support DPP";
   return std::make_unique<VCmpTI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3500,14 +4171,22 @@ VCmpFU64Vopc::VCmpFU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_u64_dpp"
+          : "v_cmp_f_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U64 does not support DPP";
   return std::make_unique<VCmpFU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3531,14 +4210,22 @@ VCmpLtU64Vopc::VCmpLtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u64_dpp"
+          : "v_cmp_lt_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support DPP";
   return std::make_unique<VCmpLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3562,14 +4249,22 @@ VCmpEqU64Vopc::VCmpEqU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u64_dpp"
+          : "v_cmp_eq_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support DPP";
   return std::make_unique<VCmpEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3593,14 +4288,22 @@ VCmpLeU64Vopc::VCmpLeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u64_dpp"
+          : "v_cmp_le_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support DPP";
   return std::make_unique<VCmpLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3624,14 +4327,22 @@ VCmpGtU64Vopc::VCmpGtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u64_dpp"
+          : "v_cmp_gt_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support DPP";
   return std::make_unique<VCmpGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3655,14 +4366,22 @@ VCmpNeU64Vopc::VCmpNeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u64_dpp"
+          : "v_cmp_ne_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support DPP";
   return std::make_unique<VCmpNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3686,14 +4405,22 @@ VCmpGeU64Vopc::VCmpGeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u64_dpp"
+          : "v_cmp_ge_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support DPP";
   return std::make_unique<VCmpGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3717,14 +4444,22 @@ VCmpTU64Vopc::VCmpTU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_u64_dpp"
+          : "v_cmp_t_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U64 does not support DPP";
   return std::make_unique<VCmpTU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3771,7 +4506,16 @@ VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f16_dpp"
+          : "v_cmp_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3815,7 +4559,16 @@ VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f32_dpp"
+          : "v_cmp_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3839,14 +4592,23 @@ VCmpClassF64Vopc::VCmpClassF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f64_dpp"
+          : "v_cmp_class_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support DPP";
   return std::make_unique<VCmpClassF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3897,7 +4659,15 @@ VCmpxFF16Vopc::VCmpxFF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_f16_dpp"
+          : "v_cmpx_f_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3948,7 +4718,15 @@ VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f16_dpp"
+          : "v_cmpx_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3999,7 +4777,15 @@ VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f16_dpp"
+          : "v_cmpx_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4050,7 +4836,15 @@ VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f16_dpp"
+          : "v_cmpx_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4101,7 +4895,15 @@ VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f16_dpp"
+          : "v_cmpx_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4152,7 +4954,15 @@ VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f16_dpp"
+          : "v_cmpx_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4203,7 +5013,15 @@ VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f16_dpp"
+          : "v_cmpx_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4254,7 +5072,15 @@ VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f16_dpp"
+          : "v_cmpx_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4305,7 +5131,15 @@ VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f16_dpp"
+          : "v_cmpx_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4356,7 +5190,16 @@ VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f16_dpp"
+          : "v_cmpx_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4407,7 +5250,16 @@ VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f16_dpp"
+          : "v_cmpx_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4458,7 +5310,16 @@ VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f16_dpp"
+          : "v_cmpx_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4509,7 +5370,16 @@ VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f16_dpp"
+          : "v_cmpx_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4560,7 +5430,16 @@ VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f16_dpp"
+          : "v_cmpx_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4611,7 +5490,16 @@ VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f16_dpp"
+          : "v_cmpx_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4662,7 +5550,15 @@ VCmpxTF16Vopc::VCmpxTF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_f16_dpp"
+          : "v_cmpx_t_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4710,7 +5606,15 @@ VCmpxFF32Vopc::VCmpxFF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_f32_dpp"
+          : "v_cmpx_f_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4758,7 +5662,15 @@ VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f32_dpp"
+          : "v_cmpx_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4806,7 +5718,15 @@ VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f32_dpp"
+          : "v_cmpx_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4854,7 +5774,15 @@ VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f32_dpp"
+          : "v_cmpx_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4902,7 +5830,15 @@ VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f32_dpp"
+          : "v_cmpx_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4950,7 +5886,15 @@ VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f32_dpp"
+          : "v_cmpx_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4998,7 +5942,15 @@ VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f32_dpp"
+          : "v_cmpx_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5046,7 +5998,15 @@ VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f32_dpp"
+          : "v_cmpx_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5094,7 +6054,15 @@ VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f32_dpp"
+          : "v_cmpx_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5142,7 +6110,16 @@ VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f32_dpp"
+          : "v_cmpx_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5190,7 +6167,16 @@ VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f32_dpp"
+          : "v_cmpx_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5238,7 +6224,16 @@ VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f32_dpp"
+          : "v_cmpx_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5286,7 +6281,16 @@ VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f32_dpp"
+          : "v_cmpx_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5334,7 +6338,16 @@ VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f32_dpp"
+          : "v_cmpx_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5382,7 +6395,16 @@ VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f32_dpp"
+          : "v_cmpx_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5430,7 +6452,15 @@ VCmpxTF32Vopc::VCmpxTF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_f32_dpp"
+          : "v_cmpx_t_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5456,16 +6486,24 @@ VCmpxFF64Vopc::VCmpxFF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_f64_dpp"
+          : "v_cmpx_f_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F64 does not support DPP";
   return std::make_unique<VCmpxFF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5491,16 +6529,24 @@ VCmpxLtF64Vopc::VCmpxLtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f64_dpp"
+          : "v_cmpx_lt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support DPP";
   return std::make_unique<VCmpxLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5526,16 +6572,24 @@ VCmpxEqF64Vopc::VCmpxEqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f64_dpp"
+          : "v_cmpx_eq_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support DPP";
   return std::make_unique<VCmpxEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5561,16 +6615,24 @@ VCmpxLeF64Vopc::VCmpxLeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f64_dpp"
+          : "v_cmpx_le_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support DPP";
   return std::make_unique<VCmpxLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5596,16 +6658,24 @@ VCmpxGtF64Vopc::VCmpxGtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f64_dpp"
+          : "v_cmpx_gt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support DPP";
   return std::make_unique<VCmpxGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5631,16 +6701,24 @@ VCmpxLgF64Vopc::VCmpxLgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f64_dpp"
+          : "v_cmpx_lg_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support DPP";
   return std::make_unique<VCmpxLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5666,16 +6744,24 @@ VCmpxGeF64Vopc::VCmpxGeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f64_dpp"
+          : "v_cmpx_ge_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support DPP";
   return std::make_unique<VCmpxGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5701,16 +6787,24 @@ VCmpxOF64Vopc::VCmpxOF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_O_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f64_dpp"
+          : "v_cmpx_o_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support DPP";
   return std::make_unique<VCmpxOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5736,16 +6830,24 @@ VCmpxUF64Vopc::VCmpxUF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_U_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f64_dpp"
+          : "v_cmpx_u_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support DPP";
   return std::make_unique<VCmpxUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5771,16 +6873,25 @@ VCmpxNgeF64Vopc::VCmpxNgeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f64_dpp"
+          : "v_cmpx_nge_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support DPP";
   return std::make_unique<VCmpxNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5806,16 +6917,25 @@ VCmpxNlgF64Vopc::VCmpxNlgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f64_dpp"
+          : "v_cmpx_nlg_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support DPP";
   return std::make_unique<VCmpxNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5841,16 +6961,25 @@ VCmpxNgtF64Vopc::VCmpxNgtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f64_dpp"
+          : "v_cmpx_ngt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support DPP";
   return std::make_unique<VCmpxNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5876,16 +7005,25 @@ VCmpxNleF64Vopc::VCmpxNleF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f64_dpp"
+          : "v_cmpx_nle_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support DPP";
   return std::make_unique<VCmpxNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5911,16 +7049,25 @@ VCmpxNeqF64Vopc::VCmpxNeqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f64_dpp"
+          : "v_cmpx_neq_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support DPP";
   return std::make_unique<VCmpxNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5946,16 +7093,25 @@ VCmpxNltF64Vopc::VCmpxNltF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f64_dpp"
+          : "v_cmpx_nlt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support DPP";
   return std::make_unique<VCmpxNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5981,16 +7137,24 @@ VCmpxTF64Vopc::VCmpxTF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_f64_dpp"
+          : "v_cmpx_t_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_F64 does not support DPP";
   return std::make_unique<VCmpxTF64Vopc>(opcode);
 }
 } // namespace detail
@@ -6041,7 +7205,15 @@ VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i16_dpp"
+          : "v_cmpx_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6092,7 +7264,15 @@ VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i16_dpp"
+          : "v_cmpx_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6143,7 +7323,15 @@ VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i16_dpp"
+          : "v_cmpx_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6194,7 +7382,15 @@ VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i16_dpp"
+          : "v_cmpx_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6245,7 +7441,15 @@ VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i16_dpp"
+          : "v_cmpx_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6296,7 +7500,15 @@ VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i16_dpp"
+          : "v_cmpx_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6347,7 +7559,15 @@ VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u16_dpp"
+          : "v_cmpx_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6398,7 +7618,15 @@ VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u16_dpp"
+          : "v_cmpx_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6449,7 +7677,15 @@ VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u16_dpp"
+          : "v_cmpx_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6500,7 +7736,15 @@ VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u16_dpp"
+          : "v_cmpx_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6551,7 +7795,15 @@ VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u16_dpp"
+          : "v_cmpx_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6602,7 +7854,15 @@ VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u16_dpp"
+          : "v_cmpx_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6650,7 +7910,15 @@ VCmpxFI32Vopc::VCmpxFI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_i32_dpp"
+          : "v_cmpx_f_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6698,7 +7966,15 @@ VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i32_dpp"
+          : "v_cmpx_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6746,7 +8022,15 @@ VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i32_dpp"
+          : "v_cmpx_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6794,7 +8078,15 @@ VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i32_dpp"
+          : "v_cmpx_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6842,7 +8134,15 @@ VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i32_dpp"
+          : "v_cmpx_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6890,7 +8190,15 @@ VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i32_dpp"
+          : "v_cmpx_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6938,7 +8246,15 @@ VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i32_dpp"
+          : "v_cmpx_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6986,7 +8302,15 @@ VCmpxTI32Vopc::VCmpxTI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_i32_dpp"
+          : "v_cmpx_t_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7034,7 +8358,15 @@ VCmpxFU32Vopc::VCmpxFU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_u32_dpp"
+          : "v_cmpx_f_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7082,7 +8414,15 @@ VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u32_dpp"
+          : "v_cmpx_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7130,7 +8470,15 @@ VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u32_dpp"
+          : "v_cmpx_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7178,7 +8526,15 @@ VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u32_dpp"
+          : "v_cmpx_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7226,7 +8582,15 @@ VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u32_dpp"
+          : "v_cmpx_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7274,7 +8638,15 @@ VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u32_dpp"
+          : "v_cmpx_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7322,7 +8694,15 @@ VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u32_dpp"
+          : "v_cmpx_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7370,7 +8750,15 @@ VCmpxTU32Vopc::VCmpxTU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_u32_dpp"
+          : "v_cmpx_t_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7396,16 +8784,24 @@ VCmpxFI64Vopc::VCmpxFI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_i64_dpp"
+          : "v_cmpx_f_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I64 does not support DPP";
   return std::make_unique<VCmpxFI64Vopc>(opcode);
 }
 } // namespace detail
@@ -7431,16 +8827,24 @@ VCmpxLtI64Vopc::VCmpxLtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i64_dpp"
+          : "v_cmpx_lt_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support DPP";
   return std::make_unique<VCmpxLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -7466,16 +8870,24 @@ VCmpxEqI64Vopc::VCmpxEqI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i64_dpp"
+          : "v_cmpx_eq_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support DPP";
   return std::make_unique<VCmpxEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -7501,16 +8913,24 @@ VCmpxLeI64Vopc::VCmpxLeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i64_dpp"
+          : "v_cmpx_le_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support DPP";
   return std::make_unique<VCmpxLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -7536,16 +8956,24 @@ VCmpxGtI64Vopc::VCmpxGtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i64_dpp"
+          : "v_cmpx_gt_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support DPP";
   return std::make_unique<VCmpxGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -7571,16 +8999,24 @@ VCmpxNeI64Vopc::VCmpxNeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i64_dpp"
+          : "v_cmpx_ne_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support DPP";
   return std::make_unique<VCmpxNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -7606,16 +9042,24 @@ VCmpxGeI64Vopc::VCmpxGeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i64_dpp"
+          : "v_cmpx_ge_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support DPP";
   return std::make_unique<VCmpxGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -7641,16 +9085,24 @@ VCmpxTI64Vopc::VCmpxTI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_i64_dpp"
+          : "v_cmpx_t_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I64 does not support DPP";
   return std::make_unique<VCmpxTI64Vopc>(opcode);
 }
 } // namespace detail
@@ -7676,16 +9128,24 @@ VCmpxFU64Vopc::VCmpxFU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_u64_dpp"
+          : "v_cmpx_f_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U64 does not support DPP";
   return std::make_unique<VCmpxFU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7711,16 +9171,24 @@ VCmpxLtU64Vopc::VCmpxLtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u64_dpp"
+          : "v_cmpx_lt_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support DPP";
   return std::make_unique<VCmpxLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7746,16 +9214,24 @@ VCmpxEqU64Vopc::VCmpxEqU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u64_dpp"
+          : "v_cmpx_eq_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support DPP";
   return std::make_unique<VCmpxEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7781,16 +9257,24 @@ VCmpxLeU64Vopc::VCmpxLeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u64_dpp"
+          : "v_cmpx_le_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support DPP";
   return std::make_unique<VCmpxLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7816,16 +9300,24 @@ VCmpxGtU64Vopc::VCmpxGtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u64_dpp"
+          : "v_cmpx_gt_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support DPP";
   return std::make_unique<VCmpxGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7851,16 +9343,24 @@ VCmpxNeU64Vopc::VCmpxNeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u64_dpp"
+          : "v_cmpx_ne_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support DPP";
   return std::make_unique<VCmpxNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7886,16 +9386,24 @@ VCmpxGeU64Vopc::VCmpxGeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u64_dpp"
+          : "v_cmpx_ge_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support DPP";
   return std::make_unique<VCmpxGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7921,16 +9429,24 @@ VCmpxTU64Vopc::VCmpxTU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_u64_dpp"
+          : "v_cmpx_t_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U64 does not support DPP";
   return std::make_unique<VCmpxTU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7981,7 +9497,16 @@ VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f16_dpp"
+          : "v_cmpx_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8029,7 +9554,16 @@ VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f32_dpp"
+          : "v_cmpx_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -8055,16 +9589,25 @@ VCmpxClassF64Vopc::VCmpxClassF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f64_dpp"
+          : "v_cmpx_class_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support DPP";
   return std::make_unique<VCmpxClassF64Vopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vopd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vopd.cpp
@@ -95,6 +95,24 @@ const char *Vopd::op_name(uint16_t op) {
   }
 }
 
+Result Vopd::validate_encoding(const MachineInst *inst, const util::DiagnosticEmitter &emit_error) {
+  const auto *words = reinterpret_cast<const uint32_t *>(inst);
+  const uint32_t word0 = words[0];
+  const uint32_t word1 = words[1];
+
+  const uint16_t opx = static_cast<uint16_t>((word0 >> 22) & 0xF);
+  const uint16_t opy = static_cast<uint16_t>((word0 >> 17) & 0x1F);
+  if (!is_valid_opcode(opx, kVopdXOpcodeMask)) [[unlikely]]
+    return emit_error.emit() << "invalid VOPD X opcode";
+  if (!is_valid_opcode(opy, kVopdYOpcodeMask)) [[unlikely]]
+    return emit_error.emit() << "invalid VOPD Y opcode";
+  const uint16_t srcx0 = static_cast<uint16_t>(word0 & 0x1FF);
+  const uint16_t srcy0 = static_cast<uint16_t>(word1 & 0x1FF);
+  if (srcx0 == 254 || srcy0 == 254) [[unlikely]]
+    return emit_error.emit() << "VOPD does not support 64-bit literals";
+  return Result::success();
+}
+
 Vopd::Vopd(const MachineInst *inst)
     : IsaInstruction<Isa>("vopd", selected_exec_fn(InstructionExecutionId::Vopd)),
       dstx_(32, OperandType::OPR_VGPR, 0), dsty_(32, OperandType::OPR_VGPR, 0),
@@ -110,16 +128,10 @@ Vopd::Vopd(const MachineInst *inst)
   encoding_id_ = 0x32;
   opx_ = static_cast<uint16_t>((word0_ >> 22) & 0xF);
   opy_ = static_cast<uint16_t>((word0_ >> 17) & 0x1F);
-  if (!is_valid_opcode(opx_, kVopdXOpcodeMask))
-    throw util::InvalidInst("invalid VOPD X opcode", "");
-  if (!is_valid_opcode(opy_, kVopdYOpcodeMask))
-    throw util::InvalidInst("invalid VOPD Y opcode", "");
   uint16_t srcx0 = static_cast<uint16_t>(word0_ & 0x1FF);
   uint16_t vsrcx1 = static_cast<uint16_t>((word0_ >> 9) & 0xFF);
   uint16_t srcy0 = static_cast<uint16_t>(word1_ & 0x1FF);
   uint16_t vsrcy1 = static_cast<uint16_t>((word1_ >> 9) & 0xFF);
-  if (srcx0 == 254 || srcy0 == 254)
-    throw util::InvalidInst("VOPD does not support 64-bit literals", "");
   uint16_t vdstx = static_cast<uint16_t>((word1_ >> 24) & 0xFF);
   uint16_t vdsty_hi = static_cast<uint16_t>((word1_ >> 17) & 0x7F);
   uint16_t vdsty = static_cast<uint16_t>((vdsty_hi << 1) | ((~vdstx) & 1u));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vopd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vopd.h
@@ -9,6 +9,7 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/encodings.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/operand.h"
+#include "rocjitsu/isa/decode_result.h"
 #include <cstdint>
 #include <string>
 
@@ -18,6 +19,8 @@ namespace rdna3 {
 class Vopd : public IsaInstruction<Isa> {
 public:
   explicit Vopd(const MachineInst *inst);
+  static Result validate_encoding(const MachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error);
   void execute_impl(amdgpu::Wavefront &wf);
 
 private:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/decoder.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/decoder.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vopd.h"
-#include "util/except.h"
 #include <array>
 #include <bit>
 #include <format>
@@ -16,1463 +15,1920 @@ namespace rocjitsu {
 namespace rdna3_5 {
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddU32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddU64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndB32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndB64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapB32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapB64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapF32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCsubU32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecU32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecU64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncU32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncU64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxF32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxI32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxI64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxU32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxU64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinF32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinI32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinI64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinU32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinU64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrB32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrB64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubU32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubU64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapB32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapB64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorB32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorB64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferGl0InvMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferGl1InvMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadB128Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadB32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadB64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadB96Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16B16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16HiB16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16HiFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16HiI8Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16HiU8Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16I8Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16U8Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadI16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadI8Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadLdsB32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadLdsFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadLdsI16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadLdsI8Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadLdsU16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadLdsU8Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadU16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadU8Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB128Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB32Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB64Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB8Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB96Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16HiB16Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16HiB8Mubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16HiFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddGsRegRtnDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAppendDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsBpermuteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsBvhStackRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsConsumeDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsBarrierDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsInitDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaBrDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaPDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsGwsSemaVDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoad2addrB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoad2addrB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoad2addrStride64B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoad2addrStride64B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadAddtidB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadB128Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadB96Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadI16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadI8D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadI8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadI8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU16D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU16D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU8D16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnF32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnF64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsNopDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrderedCountDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPermuteB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStore2addrB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStore2addrB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStore2addrStride64B32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStore2addrStride64B64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreAddtidB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB128Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB16D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB16Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB8D16HiDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB8Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB96Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchg2addrRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchg2addrRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchg2addrStride64RtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchg2addrStride64RtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchgRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchgRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubGsRegRtnDs(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSwizzleB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsWrapRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB32Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB64Ds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeExpExp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddF32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddU32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddU64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndB32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndB64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapB32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapB64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapF32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecU32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecU64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncU32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncU64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxF32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxI32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxI64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxU32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxU64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinF32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinI32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinI64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinU32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinU64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrB32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrB64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubU32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubU64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapB32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapB64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorB32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorB64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadB128Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadB32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadB64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadB96Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16B16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16HiB16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16HiI8Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16HiU8Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16I8Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16U8Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadI16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadI8Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadU16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadU8Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB128Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB32Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB64Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB8Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB96Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreD16HiB16Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreD16HiB8Flat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicAddMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicAndMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicCmpswapMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicDecMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicIncMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicOrMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSmaxMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSminMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSubMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSwapMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicUmaxMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicUminMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicXorMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageBvh64IntersectRayMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageBvhIntersectRayMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4BClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4BMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CBClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CBMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4ClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4OMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4hMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGetLodMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGetResinfoMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipPckSgnMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadPckSgnMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageMsaaLoadMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDOG16Mimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLzMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLzOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleOMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipPckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStorePckMimg(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeLdsDirectLoadLdsdir(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeLdsParamLoadLdsdir(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddcU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot0SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot0SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot0WrexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot0WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1WrexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtcProbeBufferSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtcProbeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBarrierSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB128Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB256Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB32Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB512Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB64Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCallB64Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchCdbguserSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCeilF16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCeilF32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClauseSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClsI32I64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClsI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClzI32U32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClzI32U64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNeqF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNeqF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNgeF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNgeF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNgtF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNgtF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNleF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNleF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNlgF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNlgF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNltF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNltF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpOF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpOF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpUF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpUF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkEqI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkEqU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGeI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGeU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGtI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkGtU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLeI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLeU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLgI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLgU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLtI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpkLtU32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCodeEndSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCtzI32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCtzI32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtF16F32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtF32F16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtF32I32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtF32U32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtHiF32F16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtI32F32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtPkRtzF16F32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtU32F32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDelayAluSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDenormModeSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFloorF16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFloorF32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFmaakF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFmacF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFmacF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFmamkF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetpcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGl1InvSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB128Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB256Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB32Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB512Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB64Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsd2B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot0SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot0SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot1B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot1B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot1SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackHlB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRfeB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRndneF16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRndneF32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRoundModeSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsgRtnB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsgRtnB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetInstPrefetchDistanceSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetkillSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetpcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubbU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSwappcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTruncF16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTruncF32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTtracedataImmSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSVersionSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitEventSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitIdleSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntDepctrSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntExpcntSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntLgkmcntSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntVmcntSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntVscntSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClsI32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClsI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClzI32U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClzI32U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpFU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpTU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxFU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxTU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCtzI32B32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCtzI32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFloorI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFloorI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNearestI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNearestI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkI16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkNormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkNormI16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkNormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkNormU16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkRtzF16F32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkRtzF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32U16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2Bf16Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2F16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2F32Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2F32F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2accF32F16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4I32Iu8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8I32Iu4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaDx9ZeroF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixhiF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixloF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaakF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaakF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacDx9ZeroF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacDx9ZeroF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmamkF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmamkF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP10F16F32Vinterp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP10F32Vinterp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP10RtzF16F32Vinterp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2F16F32Vinterp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2F32Vinterp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2RtzF16F32Vinterp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxminF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxminF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxminI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxminU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinmaxF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinmaxF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinmaxI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinmaxU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovreldB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovreldB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulDx9ZeroF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulDx9ZeroF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMullitF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlane16B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlane64B32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlanex16B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPipeflushVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPipeflushVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwapB16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwaprelB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaBf1616x16x16Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x16F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaI3216x16x16Iu4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaI3216x16x16Iu8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXor3B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode);
+DecodeResult decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndB32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndB64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapB32Mubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapB64Mubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapF32Mubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCsubU32Mubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxI32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxI64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinI32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinI64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrB32Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrB64Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapB32Mubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapB64Mubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorB32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorB64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferGl0InvMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferGl1InvMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadB128Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadB32Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadB64Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadB96Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16B16Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16FormatXMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16FormatXyMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16FormatXyzMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16FormatXyzwMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16HiB16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16HiFormatXMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16HiI8Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16HiU8Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16I8Mubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16U8Mubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXMubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadI16Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadI8Mubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadLdsB32Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadLdsFormatXMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadLdsI16Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadLdsI8Mubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadLdsU16Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadLdsU8Mubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadU16Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadU8Mubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB128Mubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB16Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB32Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB64Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB8Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB96Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16FormatXMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16FormatXyMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16FormatXyzMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16FormatXyzwMubuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16HiB16Mubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16HiB8Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16HiFormatXMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddGsRegRtnDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAppendDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsBpermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsBvhStackRtnB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreRtnB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreRtnB64Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreRtnF32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreRtnF64Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsConsumeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsBarrierDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsInitDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaBrDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaPDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsGwsSemaVDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoad2addrB32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoad2addrB64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoad2addrStride64B32Ds(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoad2addrStride64B64Ds(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadAddtidB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadI16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadI8D16HiDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadI8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU16D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU16D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU8D16HiDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsNopDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrderedCountDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStore2addrB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStore2addrB64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStore2addrStride64B32Ds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStore2addrStride64B64Ds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreAddtidB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB16D16HiDs(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB8D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchg2addrRtnB32Ds(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchg2addrRtnB64Ds(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchg2addrStride64RtnB32Ds(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchg2addrStride64RtnB64Ds(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchgRtnB32Ds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchgRtnB64Ds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubGsRegRtnDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSwizzleB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsWrapRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeExpExp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddF32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndB32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndB64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapB32Flat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapB64Flat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapF32Flat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxF32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxI32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxI64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinF32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinI32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinI64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrB32Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrB64Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapB32Flat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapB64Flat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorB32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorB64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadB128Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadB32Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadB64Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadB96Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16B16Flat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16HiB16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16HiI8Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16HiU8Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16I8Flat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16U8Flat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadI16Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadI8Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadU16Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadU8Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB128Flat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB16Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB32Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB64Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB8Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB96Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreD16HiB16Flat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreD16HiB8Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicAddMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicAndMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicCmpswapMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicDecMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicIncMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicOrMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSubMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSwapMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicUmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicUminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicXorMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageBvh64IntersectRayMimg(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageBvhIntersectRayMimg(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4BClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4BMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CBClMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CBMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLzMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLzOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4ClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4Mimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4OMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4hMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGetLodMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGetResinfoMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipPckMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipPckSgnMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadPckMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadPckSgnMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageMsaaLoadMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClOG16Mimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDOG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleClMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleClOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClOG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDG16Mimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDOG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLzMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLzOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleOMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStorePckMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeLdsDirectLoadLdsdir(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeLdsParamLoadLdsdir(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddcU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot0SaveexecB32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot0SaveexecB64Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot0WrexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot0WrexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1SaveexecB32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1SaveexecB64Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1WrexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1WrexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtcProbeBufferSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtcProbeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBarrierSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB128Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB256Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB32Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB512Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB64Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCallB64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbgsysSopp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchCdbguserSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCeilF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCeilF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClauseSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClsI32I64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClzI32U32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClzI32U64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNeqF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNeqF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNgeF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNgeF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNgtF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNgtF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNleF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNleF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNlgF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNlgF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNltF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNltF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpOF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpOF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpUF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpUF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkEqI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkEqU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkGtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLgI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLgU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpkLtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCodeEndSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCtzI32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCtzI32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtF16F32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtF32F16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtF32I32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtF32U32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtHiF32F16Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtI32F32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtPkRtzF16F32Sop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtU32F32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDelayAluSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDenormModeSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFloorF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFloorF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFmaakF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFmacF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFmacF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFmamkF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGl1InvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB128Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB256Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB32Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB512Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB64Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsd2B32Sop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot0SaveexecB32Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot0SaveexecB64Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot1B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot1B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot1SaveexecB32Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot1SaveexecB64Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrSaveexecB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackHlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRfeB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRndneF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRndneF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRoundModeSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsgRtnB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsgRtnB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetInstPrefetchDistanceSopp(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetkillSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubbU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSwappcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTruncF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTruncF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTtracedataImmSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSVersionSopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitEventSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitIdleSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntDepctrSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntExpcntSopk(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntLgkmcntSopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntVmcntSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntVscntSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadD16FormatXMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadD16FormatXyMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadD16FormatXyzMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadD16FormatXyzwMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreD16FormatXMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreD16FormatXyMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreD16FormatXyzMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreD16FormatXyzwMtbuf(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoCiU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClsI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClsI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClzI32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClzI32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCtzI32B32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCtzI32B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFloorI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFloorI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNearestI32F32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNearestI32F32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkI16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkNormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkNormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkNormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkNormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkRtzF16F32Vop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkRtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2Bf16Bf16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2F16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2F32Bf16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2F32F16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2accF32F16Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4I32Iu8Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8I32Iu4Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaDx9ZeroF32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacDx9ZeroF32Vop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacDx9ZeroF32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmamkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmamkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP10F16F32Vinterp(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP10F32Vinterp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP10RtzF16F32Vinterp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2F16F32Vinterp(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2F32Vinterp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2RtzF16F32Vinterp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxminF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxminF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxminI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxminU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinmaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinmaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinmaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinmaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovreldB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovreldB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsd2B32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsd2B32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsdB32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsdB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulDx9ZeroF32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulDx9ZeroF32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMullitF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlane16B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlane64B32Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlanex16B32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPipeflushVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPipeflushVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoCiU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoCiU32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevNcU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevNcU32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwapB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwaprelB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaBf1616x16x16Bf16Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF1616x16x16F16Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x16Bf16Vop3p(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x16F16Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaI3216x16x16Iu4Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaI3216x16x16Iu8Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXor3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 } // namespace detail
 
 struct DecoderImpl {
 public:
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 
 private:
-  using DecodeFunc = std::unique_ptr<Instruction> (*)(const MachineInst *);
-  static std::unique_ptr<Instruction> decodeInvalid(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> decodeVopd(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopp(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3p(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVinterp(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeLdsdir(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeDs(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeFlat(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMubuf(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMtbuf(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeMimg(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSmem(const MachineInst *opcode);
+  using DecodeFunc = DecodeResult (*)(const MachineInst *, const DecodeErrorEmitter &);
+  static DecodeResult decodeInvalid(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult decodeVopd(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVinterp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeLdsdir(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeFlat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMtbuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
   static const std::array<DecodeFunc, 512> primary_decode_table;
   static const std::array<DecodeFunc, 256> sub_decode_vopc;
   static const std::array<DecodeFunc, 256> sub_decode_vop1;
@@ -1491,97 +1947,116 @@ private:
   static const std::array<DecodeFunc, 256> sub_decode_smem;
 };
 
-std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
-  return DecoderImpl::decode(opcode);
+DecodeResult Decoder::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  return DecoderImpl::decode(opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decode(const MachineInst *opcode) {
+DecodeResult DecoderImpl::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
   Sop1MachineInst op = std::bit_cast<decltype(op)>(*opcode);
-  return primary_decode_table[op.encoding](opcode);
+  return primary_decode_table[op.encoding](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decodeInvalid(const MachineInst *opcode) {
-  throw util::InvalidInst(std::format("{:X}", *opcode));
-  return nullptr;
+DecodeResult DecoderImpl::decodeInvalid(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  return emit_error.emit() << "Invalid instruction opcode: " << std::format("{:X}", *opcode);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decodeVopd(const MachineInst *opcode) {
+DecodeResult DecoderImpl::decodeVopd(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vopd::validate_encoding(opcode, emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<Vopd>(opcode);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vopc[op.op](opcode);
+  return sub_decode_vopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop1[op.op](opcode);
+  return sub_decode_vop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sop1[op.op](opcode);
+  return sub_decode_sop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopc[op.op](opcode);
+  return sub_decode_sopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopp(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopp::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopp[op.op](opcode);
+  return sub_decode_sopp[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3p(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3p(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Vop3p::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3p[op.op](opcode);
+  return sub_decode_vop3p[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVinterp(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVinterp(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
   Vinterp::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vinterp[op.op](opcode);
+  return sub_decode_vinterp[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeLdsdir(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeLdsdir(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
   Ldsdir::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_ldsdir[op.op](opcode);
+  return sub_decode_ldsdir[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop3::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3[op.op](opcode);
+  return sub_decode_vop3[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeDs(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeDs(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
   Ds::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_ds[op.op](opcode);
+  return sub_decode_ds[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeFlat(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeFlat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Flat::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_flat[op.op](opcode);
+  return sub_decode_flat[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMubuf(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Mubuf::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mubuf[op.op](opcode);
+  return sub_decode_mubuf[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMtbuf(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMtbuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Mtbuf::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mtbuf[op.op](opcode);
+  return sub_decode_mtbuf[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeMimg(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Mimg::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_mimg[op.op](opcode);
+  return sub_decode_mimg[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSmem(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Smem::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_smem[op.op](opcode);
+  return sub_decode_smem[op.op](opcode, emit_error);
 }
 
 const std::array<DecoderImpl::DecodeFunc, 512> DecoderImpl::primary_decode_table = {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/decoder.h
@@ -8,6 +8,7 @@
 #define ROCJITSU_ISA_ARCH_AMDGPU_RDNA3_5_DECODER_H_
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/machine_insts.h"
+#include "rocjitsu/isa/decode_result.h"
 #include <array>
 #include <cstddef>
 #include <memory>
@@ -21,7 +22,7 @@ namespace rdna3_5 {
 class Decoder {
 public:
   static constexpr std::size_t kMaxInstructionWords = 3;
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 };
 
 } // namespace rdna3_5

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/ds.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/ds.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/ds.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -31,7 +30,11 @@ DsAddU32Ds::DsAddU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU32Ds>(opcode);
 }
 } // namespace detail
@@ -54,7 +57,11 @@ DsSubU32Ds::DsSubU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU32Ds>(opcode);
 }
 } // namespace detail
@@ -77,7 +84,11 @@ DsRsubU32Ds::DsRsubU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU32Ds>(opcode);
 }
 } // namespace detail
@@ -100,7 +111,11 @@ DsIncU32Ds::DsIncU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU32Ds>(opcode);
 }
 } // namespace detail
@@ -123,7 +138,11 @@ DsDecU32Ds::DsDecU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU32Ds>(opcode);
 }
 } // namespace detail
@@ -146,7 +165,11 @@ DsMinI32Ds::DsMinI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI32Ds>(opcode);
 }
 } // namespace detail
@@ -169,7 +192,11 @@ DsMaxI32Ds::DsMaxI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI32Ds>(opcode);
 }
 } // namespace detail
@@ -192,7 +219,11 @@ DsMinU32Ds::DsMinU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU32Ds>(opcode);
 }
 } // namespace detail
@@ -215,7 +246,11 @@ DsMaxU32Ds::DsMaxU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU32Ds>(opcode);
 }
 } // namespace detail
@@ -238,7 +273,11 @@ DsAndB32Ds::DsAndB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB32Ds>(opcode);
 }
 } // namespace detail
@@ -261,7 +300,11 @@ DsOrB32Ds::DsOrB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB32Ds>(opcode);
 }
 } // namespace detail
@@ -284,7 +327,11 @@ DsXorB32Ds::DsXorB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB32Ds>(opcode);
 }
 } // namespace detail
@@ -309,7 +356,11 @@ DsMskorB32Ds::DsMskorB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB32Ds>(opcode);
 }
 } // namespace detail
@@ -330,7 +381,11 @@ DsStoreB32Ds::DsStoreB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB32Ds>(opcode);
 }
 } // namespace detail
@@ -353,7 +408,12 @@ DsStore2addrB32Ds::DsStore2addrB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStore2addrB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStore2addrB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_2addr_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStore2addrB32Ds>(opcode);
 }
 } // namespace detail
@@ -376,7 +436,12 @@ DsStore2addrStride64B32Ds::DsStore2addrStride64B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStore2addrStride64B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStore2addrStride64B32Ds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_2addr_stride64_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStore2addrStride64B32Ds>(opcode);
 }
 } // namespace detail
@@ -401,7 +466,12 @@ DsCmpstoreB32Ds::DsCmpstoreB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpstore_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreB32Ds>(opcode);
 }
 } // namespace detail
@@ -426,7 +496,12 @@ DsCmpstoreF32Ds::DsCmpstoreF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreF32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpstore_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreF32Ds>(opcode);
 }
 } // namespace detail
@@ -449,7 +524,11 @@ DsMinF32Ds::DsMinF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinF32Ds>(opcode);
 }
 } // namespace detail
@@ -472,7 +551,11 @@ DsMaxF32Ds::DsMaxF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxF32Ds>(opcode);
 }
 } // namespace detail
@@ -485,7 +568,11 @@ DsNopDs::DsNopDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsNopDs(const MachineInst *opcode) {
+DecodeResult decodeDsNopDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Ds::validate_encoding("ds_nop", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsNopDs>(opcode);
 }
 } // namespace detail
@@ -508,7 +595,11 @@ DsAddF32Ds::DsAddF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddF32Ds>(opcode);
 }
 } // namespace detail
@@ -521,7 +612,12 @@ DsGwsSemaReleaseAllDs::DsGwsSemaReleaseAllDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaReleaseAllDs(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_release_all", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaReleaseAllDs>(opcode);
 }
 } // namespace detail
@@ -536,7 +632,11 @@ DsGwsInitDs::DsGwsInitDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsInitDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsInitDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_init", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsInitDs>(opcode);
 }
 } // namespace detail
@@ -549,7 +649,11 @@ DsGwsSemaVDs::DsGwsSemaVDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaVDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaVDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_v", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaVDs>(opcode);
 }
 } // namespace detail
@@ -564,7 +668,11 @@ DsGwsSemaBrDs::DsGwsSemaBrDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaBrDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaBrDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_br", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaBrDs>(opcode);
 }
 } // namespace detail
@@ -577,7 +685,11 @@ DsGwsSemaPDs::DsGwsSemaPDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsSemaPDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsSemaPDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_sema_p", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsSemaPDs>(opcode);
 }
 } // namespace detail
@@ -592,7 +704,11 @@ DsGwsBarrierDs::DsGwsBarrierDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsGwsBarrierDs(const MachineInst *opcode) {
+DecodeResult decodeDsGwsBarrierDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_gws_barrier", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsGwsBarrierDs>(opcode);
 }
 } // namespace detail
@@ -613,7 +729,11 @@ DsStoreB8Ds::DsStoreB8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_b8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB8Ds>(opcode);
 }
 } // namespace detail
@@ -634,7 +754,11 @@ DsStoreB16Ds::DsStoreB16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_b16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB16Ds>(opcode);
 }
 } // namespace detail
@@ -659,7 +783,11 @@ DsAddRtnU32Ds::DsAddRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -684,7 +812,11 @@ DsSubRtnU32Ds::DsSubRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -709,7 +841,11 @@ DsRsubRtnU32Ds::DsRsubRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -734,7 +870,11 @@ DsIncRtnU32Ds::DsIncRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -759,7 +899,11 @@ DsDecRtnU32Ds::DsDecRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -784,7 +928,11 @@ DsMinRtnI32Ds::DsMinRtnI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI32Ds>(opcode);
 }
 } // namespace detail
@@ -809,7 +957,11 @@ DsMaxRtnI32Ds::DsMaxRtnI32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_i32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI32Ds>(opcode);
 }
 } // namespace detail
@@ -834,7 +986,11 @@ DsMinRtnU32Ds::DsMinRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -859,7 +1015,11 @@ DsMaxRtnU32Ds::DsMaxRtnU32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_u32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU32Ds>(opcode);
 }
 } // namespace detail
@@ -884,7 +1044,11 @@ DsAndRtnB32Ds::DsAndRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -909,7 +1073,11 @@ DsOrRtnB32Ds::DsOrRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -934,7 +1102,11 @@ DsXorRtnB32Ds::DsXorRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -961,7 +1133,12 @@ DsMskorRtnB32Ds::DsMskorRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -986,7 +1163,12 @@ DsStorexchgRtnB32Ds::DsStorexchgRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchgRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchgRtnB32Ds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_storexchg_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchgRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1013,7 +1195,12 @@ DsStorexchg2addrRtnB32Ds::DsStorexchg2addrRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchg2addrRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchg2addrRtnB32Ds(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_storexchg_2addr_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchg2addrRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1040,7 +1227,13 @@ DsStorexchg2addrStride64RtnB32Ds::DsStorexchg2addrStride64RtnB32Ds(const Machine
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchg2addrStride64RtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchg2addrStride64RtnB32Ds(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Ds::validate_encoding("ds_storexchg_2addr_stride64_rtn_b32",
+                            reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchg2addrStride64RtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1067,7 +1260,12 @@ DsCmpstoreRtnB32Ds::DsCmpstoreRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreRtnB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpstore_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1094,7 +1292,12 @@ DsCmpstoreRtnF32Ds::DsCmpstoreRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreRtnF32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpstore_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1119,7 +1322,11 @@ DsMinRtnF32Ds::DsMinRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1144,7 +1351,11 @@ DsMaxRtnF32Ds::DsMaxRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -1170,7 +1381,11 @@ DsWrapRtnB32Ds::DsWrapRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsWrapRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsWrapRtnB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_wrap_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsWrapRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -1187,7 +1402,11 @@ DsSwizzleB32Ds::DsSwizzleB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSwizzleB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSwizzleB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_swizzle_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSwizzleB32Ds>(opcode);
 }
 } // namespace detail
@@ -1208,7 +1427,11 @@ DsLoadB32Ds::DsLoadB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadB32Ds>(opcode);
 }
 } // namespace detail
@@ -1229,7 +1452,12 @@ DsLoad2addrB32Ds::DsLoad2addrB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoad2addrB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoad2addrB32Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_2addr_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoad2addrB32Ds>(opcode);
 }
 } // namespace detail
@@ -1250,7 +1478,12 @@ DsLoad2addrStride64B32Ds::DsLoad2addrStride64B32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoad2addrStride64B32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoad2addrStride64B32Ds(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_2addr_stride64_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoad2addrStride64B32Ds>(opcode);
 }
 } // namespace detail
@@ -1271,7 +1504,11 @@ DsLoadI8Ds::DsLoadI8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadI8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadI8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_i8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadI8Ds>(opcode);
 }
 } // namespace detail
@@ -1292,7 +1529,11 @@ DsLoadU8Ds::DsLoadU8Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU8Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU8Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_u8", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU8Ds>(opcode);
 }
 } // namespace detail
@@ -1313,7 +1554,11 @@ DsLoadI16Ds::DsLoadI16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadI16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadI16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_i16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadI16Ds>(opcode);
 }
 } // namespace detail
@@ -1334,7 +1579,11 @@ DsLoadU16Ds::DsLoadU16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_u16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU16Ds>(opcode);
 }
 } // namespace detail
@@ -1355,7 +1604,11 @@ DsConsumeDs::DsConsumeDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsConsumeDs(const MachineInst *opcode) {
+DecodeResult decodeDsConsumeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_consume", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsConsumeDs>(opcode);
 }
 } // namespace detail
@@ -1376,7 +1629,11 @@ DsAppendDs::DsAppendDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAppendDs(const MachineInst *opcode) {
+DecodeResult decodeDsAppendDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_append", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAppendDs>(opcode);
 }
 } // namespace detail
@@ -1401,7 +1658,12 @@ DsOrderedCountDs::DsOrderedCountDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrderedCountDs(const MachineInst *opcode) {
+DecodeResult decodeDsOrderedCountDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_ordered_count", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrderedCountDs>(opcode);
 }
 } // namespace detail
@@ -1424,7 +1686,11 @@ DsAddU64Ds::DsAddU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU64Ds>(opcode);
 }
 } // namespace detail
@@ -1447,7 +1713,11 @@ DsSubU64Ds::DsSubU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU64Ds>(opcode);
 }
 } // namespace detail
@@ -1470,7 +1740,11 @@ DsRsubU64Ds::DsRsubU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU64Ds>(opcode);
 }
 } // namespace detail
@@ -1493,7 +1767,11 @@ DsIncU64Ds::DsIncU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU64Ds>(opcode);
 }
 } // namespace detail
@@ -1516,7 +1794,11 @@ DsDecU64Ds::DsDecU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU64Ds>(opcode);
 }
 } // namespace detail
@@ -1539,7 +1821,11 @@ DsMinI64Ds::DsMinI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI64Ds>(opcode);
 }
 } // namespace detail
@@ -1562,7 +1848,11 @@ DsMaxI64Ds::DsMaxI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI64Ds>(opcode);
 }
 } // namespace detail
@@ -1585,7 +1875,11 @@ DsMinU64Ds::DsMinU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU64Ds>(opcode);
 }
 } // namespace detail
@@ -1608,7 +1902,11 @@ DsMaxU64Ds::DsMaxU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU64Ds>(opcode);
 }
 } // namespace detail
@@ -1631,7 +1929,11 @@ DsAndB64Ds::DsAndB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB64Ds>(opcode);
 }
 } // namespace detail
@@ -1654,7 +1956,11 @@ DsOrB64Ds::DsOrB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB64Ds>(opcode);
 }
 } // namespace detail
@@ -1677,7 +1983,11 @@ DsXorB64Ds::DsXorB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB64Ds>(opcode);
 }
 } // namespace detail
@@ -1702,7 +2012,11 @@ DsMskorB64Ds::DsMskorB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB64Ds>(opcode);
 }
 } // namespace detail
@@ -1723,7 +2037,11 @@ DsStoreB64Ds::DsStoreB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB64Ds>(opcode);
 }
 } // namespace detail
@@ -1746,7 +2064,12 @@ DsStore2addrB64Ds::DsStore2addrB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStore2addrB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStore2addrB64Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_2addr_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStore2addrB64Ds>(opcode);
 }
 } // namespace detail
@@ -1769,7 +2092,12 @@ DsStore2addrStride64B64Ds::DsStore2addrStride64B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStore2addrStride64B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStore2addrStride64B64Ds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_2addr_stride64_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStore2addrStride64B64Ds>(opcode);
 }
 } // namespace detail
@@ -1794,7 +2122,12 @@ DsCmpstoreB64Ds::DsCmpstoreB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreB64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpstore_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreB64Ds>(opcode);
 }
 } // namespace detail
@@ -1819,7 +2152,12 @@ DsCmpstoreF64Ds::DsCmpstoreF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreF64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpstore_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreF64Ds>(opcode);
 }
 } // namespace detail
@@ -1842,7 +2180,11 @@ DsMinF64Ds::DsMinF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinF64Ds>(opcode);
 }
 } // namespace detail
@@ -1865,7 +2207,11 @@ DsMaxF64Ds::DsMaxF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxF64Ds>(opcode);
 }
 } // namespace detail
@@ -1890,7 +2236,11 @@ DsAddRtnU64Ds::DsAddRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -1915,7 +2265,11 @@ DsSubRtnU64Ds::DsSubRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -1940,7 +2294,11 @@ DsRsubRtnU64Ds::DsRsubRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_rsub_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -1965,7 +2323,11 @@ DsIncRtnU64Ds::DsIncRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_inc_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -1990,7 +2352,11 @@ DsDecRtnU64Ds::DsDecRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_dec_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2015,7 +2381,11 @@ DsMinRtnI64Ds::DsMinRtnI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI64Ds>(opcode);
 }
 } // namespace detail
@@ -2040,7 +2410,11 @@ DsMaxRtnI64Ds::DsMaxRtnI64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_i64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI64Ds>(opcode);
 }
 } // namespace detail
@@ -2065,7 +2439,11 @@ DsMinRtnU64Ds::DsMinRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2090,7 +2468,11 @@ DsMaxRtnU64Ds::DsMaxRtnU64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_u64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU64Ds>(opcode);
 }
 } // namespace detail
@@ -2115,7 +2497,11 @@ DsAndRtnB64Ds::DsAndRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_and_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2140,7 +2526,11 @@ DsOrRtnB64Ds::DsOrRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_or_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2165,7 +2555,11 @@ DsXorRtnB64Ds::DsXorRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_xor_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2192,7 +2586,12 @@ DsMskorRtnB64Ds::DsMskorRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB64Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_mskor_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2217,7 +2616,12 @@ DsStorexchgRtnB64Ds::DsStorexchgRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchgRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchgRtnB64Ds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_storexchg_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchgRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2244,7 +2648,12 @@ DsStorexchg2addrRtnB64Ds::DsStorexchg2addrRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchg2addrRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchg2addrRtnB64Ds(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_storexchg_2addr_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchg2addrRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2271,7 +2680,13 @@ DsStorexchg2addrStride64RtnB64Ds::DsStorexchg2addrStride64RtnB64Ds(const Machine
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchg2addrStride64RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchg2addrStride64RtnB64Ds(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Ds::validate_encoding("ds_storexchg_2addr_stride64_rtn_b64",
+                            reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchg2addrStride64RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2298,7 +2713,12 @@ DsCmpstoreRtnB64Ds::DsCmpstoreRtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreRtnB64Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpstore_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreRtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2325,7 +2745,12 @@ DsCmpstoreRtnF64Ds::DsCmpstoreRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreRtnF64Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_cmpstore_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -2350,7 +2775,11 @@ DsMinRtnF64Ds::DsMinRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_min_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -2375,7 +2804,11 @@ DsMaxRtnF64Ds::DsMaxRtnF64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnF64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnF64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_max_rtn_f64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnF64Ds>(opcode);
 }
 } // namespace detail
@@ -2396,7 +2829,11 @@ DsLoadB64Ds::DsLoadB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadB64Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadB64Ds>(opcode);
 }
 } // namespace detail
@@ -2417,7 +2854,12 @@ DsLoad2addrB64Ds::DsLoad2addrB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoad2addrB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoad2addrB64Ds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_2addr_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoad2addrB64Ds>(opcode);
 }
 } // namespace detail
@@ -2438,7 +2880,12 @@ DsLoad2addrStride64B64Ds::DsLoad2addrStride64B64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoad2addrStride64B64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoad2addrStride64B64Ds(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_2addr_stride64_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoad2addrStride64B64Ds>(opcode);
 }
 } // namespace detail
@@ -2463,7 +2910,11 @@ DsAddRtnF32Ds::DsAddRtnF32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnF32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnF32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_rtn_f32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnF32Ds>(opcode);
 }
 } // namespace detail
@@ -2480,7 +2931,12 @@ DsAddGsRegRtnDs::DsAddGsRegRtnDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddGsRegRtnDs(const MachineInst *opcode) {
+DecodeResult decodeDsAddGsRegRtnDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_add_gs_reg_rtn", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddGsRegRtnDs>(opcode);
 }
 } // namespace detail
@@ -2497,7 +2953,12 @@ DsSubGsRegRtnDs::DsSubGsRegRtnDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubGsRegRtnDs(const MachineInst *opcode) {
+DecodeResult decodeDsSubGsRegRtnDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_sub_gs_reg_rtn", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubGsRegRtnDs>(opcode);
 }
 } // namespace detail
@@ -2522,7 +2983,12 @@ DsCondxchg32RtnB64Ds::DsCondxchg32RtnB64Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode) {
+DecodeResult decodeDsCondxchg32RtnB64Ds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_condxchg32_rtn_b64", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCondxchg32RtnB64Ds>(opcode);
 }
 } // namespace detail
@@ -2543,7 +3009,12 @@ DsStoreB8D16HiDs::DsStoreB8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB8D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_b8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2564,7 +3035,12 @@ DsStoreB16D16HiDs::DsStoreB16D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB16D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB16D16HiDs(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_b16_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB16D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2585,7 +3061,11 @@ DsLoadU8D16Ds::DsLoadU8D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU8D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_u8_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU8D16Ds>(opcode);
 }
 } // namespace detail
@@ -2612,7 +3092,12 @@ DsLoadU8D16HiDs::DsLoadU8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU8D16HiDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_u8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2639,7 +3124,11 @@ DsLoadI8D16Ds::DsLoadI8D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadI8D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_i8_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadI8D16Ds>(opcode);
 }
 } // namespace detail
@@ -2666,7 +3155,12 @@ DsLoadI8D16HiDs::DsLoadI8D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadI8D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsLoadI8D16HiDs(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_i8_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadI8D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2693,7 +3187,11 @@ DsLoadU16D16Ds::DsLoadU16D16Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU16D16Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU16D16Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_u16_d16", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU16D16Ds>(opcode);
 }
 } // namespace detail
@@ -2720,7 +3218,12 @@ DsLoadU16D16HiDs::DsLoadU16D16HiDs(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU16D16HiDs(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU16D16HiDs(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_u16_d16_hi", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU16D16HiDs>(opcode);
 }
 } // namespace detail
@@ -2753,7 +3256,12 @@ DsBvhStackRtnB32Ds::DsBvhStackRtnB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsBvhStackRtnB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsBvhStackRtnB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_bvh_stack_rtn_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsBvhStackRtnB32Ds>(opcode);
 }
 } // namespace detail
@@ -2774,7 +3282,12 @@ DsStoreAddtidB32Ds::DsStoreAddtidB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreAddtidB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreAddtidB32Ds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_addtid_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreAddtidB32Ds>(opcode);
 }
 } // namespace detail
@@ -2795,7 +3308,12 @@ DsLoadAddtidB32Ds::DsLoadAddtidB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadAddtidB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadAddtidB32Ds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_addtid_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadAddtidB32Ds>(opcode);
 }
 } // namespace detail
@@ -2814,7 +3332,11 @@ DsPermuteB32Ds::DsPermuteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPermuteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsPermuteB32Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_permute_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPermuteB32Ds>(opcode);
 }
 } // namespace detail
@@ -2833,7 +3355,12 @@ DsBpermuteB32Ds::DsBpermuteB32Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsBpermuteB32Ds(const MachineInst *opcode) {
+DecodeResult decodeDsBpermuteB32Ds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_bpermute_b32", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsBpermuteB32Ds>(opcode);
 }
 } // namespace detail
@@ -2854,7 +3381,11 @@ DsStoreB96Ds::DsStoreB96Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB96Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_b96", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB96Ds>(opcode);
 }
 } // namespace detail
@@ -2875,7 +3406,11 @@ DsStoreB128Ds::DsStoreB128Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB128Ds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_store_b128", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB128Ds>(opcode);
 }
 } // namespace detail
@@ -2896,7 +3431,11 @@ DsLoadB96Ds::DsLoadB96Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadB96Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadB96Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_b96", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadB96Ds>(opcode);
 }
 } // namespace detail
@@ -2917,7 +3456,11 @@ DsLoadB128Ds::DsLoadB128Ds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadB128Ds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadB128Ds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Ds::validate_encoding(
+      "ds_load_b128", reinterpret_cast<const Ds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadB128Ds>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/encodings.cpp
@@ -5,7 +5,6 @@
 // See lib/python/amdisa/README.md for regeneration instructions.
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/encodings.h"
-#include "util/except.h"
 #include <cstring>
 #include <string>
 
@@ -1219,9 +1218,6 @@ Vop3::Vop3(std::string_view mnemonic, const Vop3MachineInst *inst, ExecuteFn exe
   raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
-  if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
-      (has_encoded_literal32()))
-    throw util::InvalidInst("DPP and literal operands cannot be combined", "");
   if (has_encoded_literal32())
     size_ += sizeof(MachineInst);
   if (inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0))
@@ -1319,9 +1315,6 @@ Vop3p::Vop3p(std::string_view mnemonic, const Vop3pMachineInst *inst, ExecuteFn 
   raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
-  if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
-      (has_encoded_literal32()))
-    throw util::InvalidInst("DPP and literal operands cannot be combined", "");
   if (has_encoded_literal32())
     size_ += sizeof(MachineInst);
   if (inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0))
@@ -1528,9 +1521,6 @@ Vop3SdstEnc::Vop3SdstEnc(std::string_view mnemonic, const Vop3SdstEncMachineInst
   raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
-  if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
-      (has_encoded_literal32()))
-    throw util::InvalidInst("DPP and literal operands cannot be combined", "");
   if (has_encoded_literal32())
     size_ += sizeof(MachineInst);
   if (inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/encodings.h
@@ -10,6 +10,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna3_5/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
+#include "rocjitsu/isa/decode_result.h"
 #include "rocjitsu/isa/instruction.h"
 #include <array>
 #include <cstdint>
@@ -518,6 +519,15 @@ class Vop3 : public IsaInstruction<Isa> {
 public:
   Vop3(std::string_view mnemonic, const Vop3MachineInst *inst, ExecuteFn exec_fn);
   bool has_encoded_literal32() const;
+  static Result validate_encoding([[maybe_unused]] std::string_view mnemonic,
+                                  const Vop3MachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error) {
+    const auto &inst_ = *inst;
+    if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
+        (inst_.src0 == 255 || inst_.src1 == 255 || inst_.src2 == 255)) [[unlikely]]
+      return emit_error.emit() << "DPP and literal operands cannot be combined";
+    return Result::success();
+  }
   void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool has_lit_0();
@@ -544,6 +554,15 @@ class Vop3p : public IsaInstruction<Isa> {
 public:
   Vop3p(std::string_view mnemonic, const Vop3pMachineInst *inst, ExecuteFn exec_fn);
   bool has_encoded_literal32() const;
+  static Result validate_encoding([[maybe_unused]] std::string_view mnemonic,
+                                  const Vop3pMachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error) {
+    const auto &inst_ = *inst;
+    if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
+        (inst_.src0 == 255 || inst_.src1 == 255 || inst_.src2 == 255)) [[unlikely]]
+      return emit_error.emit() << "DPP and literal operands cannot be combined";
+    return Result::success();
+  }
   void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool has_lit_0();
@@ -633,6 +652,15 @@ class Vop3SdstEnc : public IsaInstruction<Isa> {
 public:
   Vop3SdstEnc(std::string_view mnemonic, const Vop3SdstEncMachineInst *inst, ExecuteFn exec_fn);
   bool has_encoded_literal32() const;
+  static Result validate_encoding([[maybe_unused]] std::string_view mnemonic,
+                                  const Vop3SdstEncMachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error) {
+    const auto &inst_ = *inst;
+    if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
+        (inst_.src0 == 255 || inst_.src1 == 255 || inst_.src2 == 255)) [[unlikely]]
+      return emit_error.emit() << "DPP and literal operands cannot be combined";
+    return Result::success();
+  }
   void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool has_lit_0();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/exp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/exp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/exp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -35,7 +34,11 @@ ExpExp::ExpExp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeExpExp(const MachineInst *opcode) {
+DecodeResult decodeExpExp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Exp::validate_encoding("exp", reinterpret_cast<const Exp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ExpExp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/flat.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/flat.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/flat.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -40,7 +39,11 @@ FlatLoadU8Flat::FlatLoadU8Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadU8Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadU8Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_u8", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadU8Flat>(opcode);
 }
 } // namespace detail
@@ -72,7 +75,11 @@ FlatLoadI8Flat::FlatLoadI8Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadI8Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadI8Flat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_i8", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadI8Flat>(opcode);
 }
 } // namespace detail
@@ -104,7 +111,12 @@ FlatLoadU16Flat::FlatLoadU16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadU16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadU16Flat(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_u16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadU16Flat>(opcode);
 }
 } // namespace detail
@@ -136,7 +148,12 @@ FlatLoadI16Flat::FlatLoadI16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadI16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadI16Flat(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_i16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadI16Flat>(opcode);
 }
 } // namespace detail
@@ -168,7 +185,12 @@ FlatLoadB32Flat::FlatLoadB32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadB32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadB32Flat(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_b32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadB32Flat>(opcode);
 }
 } // namespace detail
@@ -200,7 +222,12 @@ FlatLoadB64Flat::FlatLoadB64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadB64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadB64Flat(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_b64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadB64Flat>(opcode);
 }
 } // namespace detail
@@ -232,7 +259,12 @@ FlatLoadB96Flat::FlatLoadB96Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadB96Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadB96Flat(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_b96", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadB96Flat>(opcode);
 }
 } // namespace detail
@@ -264,7 +296,12 @@ FlatLoadB128Flat::FlatLoadB128Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadB128Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadB128Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_b128", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadB128Flat>(opcode);
 }
 } // namespace detail
@@ -296,7 +333,12 @@ FlatStoreB8Flat::FlatStoreB8Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB8Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB8Flat(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_b8", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB8Flat>(opcode);
 }
 } // namespace detail
@@ -328,7 +370,12 @@ FlatStoreB16Flat::FlatStoreB16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB16Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_b16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB16Flat>(opcode);
 }
 } // namespace detail
@@ -360,7 +407,12 @@ FlatStoreB32Flat::FlatStoreB32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB32Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_b32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB32Flat>(opcode);
 }
 } // namespace detail
@@ -392,7 +444,12 @@ FlatStoreB64Flat::FlatStoreB64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB64Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_b64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB64Flat>(opcode);
 }
 } // namespace detail
@@ -424,7 +481,12 @@ FlatStoreB96Flat::FlatStoreB96Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB96Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB96Flat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_b96", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB96Flat>(opcode);
 }
 } // namespace detail
@@ -456,7 +518,12 @@ FlatStoreB128Flat::FlatStoreB128Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB128Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB128Flat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_b128", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB128Flat>(opcode);
 }
 } // namespace detail
@@ -488,7 +555,12 @@ FlatLoadD16U8Flat::FlatLoadD16U8Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16U8Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16U8Flat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_d16_u8", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16U8Flat>(opcode);
 }
 } // namespace detail
@@ -526,7 +598,12 @@ FlatLoadD16I8Flat::FlatLoadD16I8Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16I8Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16I8Flat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_d16_i8", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16I8Flat>(opcode);
 }
 } // namespace detail
@@ -564,7 +641,12 @@ FlatLoadD16B16Flat::FlatLoadD16B16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16B16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16B16Flat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_d16_b16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16B16Flat>(opcode);
 }
 } // namespace detail
@@ -602,7 +684,12 @@ FlatLoadD16HiU8Flat::FlatLoadD16HiU8Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16HiU8Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16HiU8Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_d16_hi_u8", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16HiU8Flat>(opcode);
 }
 } // namespace detail
@@ -640,7 +727,12 @@ FlatLoadD16HiI8Flat::FlatLoadD16HiI8Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16HiI8Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16HiI8Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_d16_hi_i8", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16HiI8Flat>(opcode);
 }
 } // namespace detail
@@ -678,7 +770,12 @@ FlatLoadD16HiB16Flat::FlatLoadD16HiB16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16HiB16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16HiB16Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_load_d16_hi_b16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16HiB16Flat>(opcode);
 }
 } // namespace detail
@@ -716,7 +813,12 @@ FlatStoreD16HiB8Flat::FlatStoreD16HiB8Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreD16HiB8Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreD16HiB8Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_d16_hi_b8", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreD16HiB8Flat>(opcode);
 }
 } // namespace detail
@@ -748,7 +850,12 @@ FlatStoreD16HiB16Flat::FlatStoreD16HiB16Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreD16HiB16Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreD16HiB16Flat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_store_d16_hi_b16", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreD16HiB16Flat>(opcode);
 }
 } // namespace detail
@@ -783,7 +890,12 @@ FlatAtomicSwapB32Flat::FlatAtomicSwapB32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapB32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapB32Flat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_swap_b32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapB32Flat>(opcode);
 }
 } // namespace detail
@@ -818,7 +930,12 @@ FlatAtomicCmpswapB32Flat::FlatAtomicCmpswapB32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapB32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapB32Flat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_cmpswap_b32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapB32Flat>(opcode);
 }
 } // namespace detail
@@ -853,7 +970,12 @@ FlatAtomicAddU32Flat::FlatAtomicAddU32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddU32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add_u32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddU32Flat>(opcode);
 }
 } // namespace detail
@@ -888,7 +1010,12 @@ FlatAtomicSubU32Flat::FlatAtomicSubU32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubU32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_sub_u32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubU32Flat>(opcode);
 }
 } // namespace detail
@@ -923,7 +1050,12 @@ FlatAtomicMinI32Flat::FlatAtomicMinI32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinI32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinI32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_min_i32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinI32Flat>(opcode);
 }
 } // namespace detail
@@ -958,7 +1090,12 @@ FlatAtomicMinU32Flat::FlatAtomicMinU32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinU32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_min_u32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinU32Flat>(opcode);
 }
 } // namespace detail
@@ -993,7 +1130,12 @@ FlatAtomicMaxI32Flat::FlatAtomicMaxI32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxI32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxI32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_max_i32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxI32Flat>(opcode);
 }
 } // namespace detail
@@ -1028,7 +1170,12 @@ FlatAtomicMaxU32Flat::FlatAtomicMaxU32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxU32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_max_u32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxU32Flat>(opcode);
 }
 } // namespace detail
@@ -1063,7 +1210,12 @@ FlatAtomicAndB32Flat::FlatAtomicAndB32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndB32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndB32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_and_b32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndB32Flat>(opcode);
 }
 } // namespace detail
@@ -1098,7 +1250,12 @@ FlatAtomicOrB32Flat::FlatAtomicOrB32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrB32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrB32Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_or_b32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrB32Flat>(opcode);
 }
 } // namespace detail
@@ -1133,7 +1290,12 @@ FlatAtomicXorB32Flat::FlatAtomicXorB32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorB32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorB32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_xor_b32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorB32Flat>(opcode);
 }
 } // namespace detail
@@ -1168,7 +1330,12 @@ FlatAtomicIncU32Flat::FlatAtomicIncU32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncU32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_inc_u32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncU32Flat>(opcode);
 }
 } // namespace detail
@@ -1203,7 +1370,12 @@ FlatAtomicDecU32Flat::FlatAtomicDecU32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecU32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecU32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_dec_u32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecU32Flat>(opcode);
 }
 } // namespace detail
@@ -1238,7 +1410,12 @@ FlatAtomicSwapB64Flat::FlatAtomicSwapB64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapB64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapB64Flat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_swap_b64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapB64Flat>(opcode);
 }
 } // namespace detail
@@ -1273,7 +1450,12 @@ FlatAtomicCmpswapB64Flat::FlatAtomicCmpswapB64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapB64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapB64Flat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_cmpswap_b64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapB64Flat>(opcode);
 }
 } // namespace detail
@@ -1308,7 +1490,12 @@ FlatAtomicAddU64Flat::FlatAtomicAddU64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddU64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add_u64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddU64Flat>(opcode);
 }
 } // namespace detail
@@ -1343,7 +1530,12 @@ FlatAtomicSubU64Flat::FlatAtomicSubU64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubU64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_sub_u64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubU64Flat>(opcode);
 }
 } // namespace detail
@@ -1378,7 +1570,12 @@ FlatAtomicMinI64Flat::FlatAtomicMinI64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinI64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinI64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_min_i64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinI64Flat>(opcode);
 }
 } // namespace detail
@@ -1413,7 +1610,12 @@ FlatAtomicMinU64Flat::FlatAtomicMinU64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinU64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_min_u64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinU64Flat>(opcode);
 }
 } // namespace detail
@@ -1448,7 +1650,12 @@ FlatAtomicMaxI64Flat::FlatAtomicMaxI64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxI64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxI64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_max_i64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxI64Flat>(opcode);
 }
 } // namespace detail
@@ -1483,7 +1690,12 @@ FlatAtomicMaxU64Flat::FlatAtomicMaxU64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxU64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_max_u64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxU64Flat>(opcode);
 }
 } // namespace detail
@@ -1518,7 +1730,12 @@ FlatAtomicAndB64Flat::FlatAtomicAndB64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndB64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndB64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_and_b64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndB64Flat>(opcode);
 }
 } // namespace detail
@@ -1553,7 +1770,12 @@ FlatAtomicOrB64Flat::FlatAtomicOrB64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrB64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrB64Flat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_or_b64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrB64Flat>(opcode);
 }
 } // namespace detail
@@ -1588,7 +1810,12 @@ FlatAtomicXorB64Flat::FlatAtomicXorB64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorB64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorB64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_xor_b64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorB64Flat>(opcode);
 }
 } // namespace detail
@@ -1623,7 +1850,12 @@ FlatAtomicIncU64Flat::FlatAtomicIncU64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncU64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_inc_u64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncU64Flat>(opcode);
 }
 } // namespace detail
@@ -1658,7 +1890,12 @@ FlatAtomicDecU64Flat::FlatAtomicDecU64Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecU64Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecU64Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_dec_u64", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecU64Flat>(opcode);
 }
 } // namespace detail
@@ -1693,7 +1930,12 @@ FlatAtomicCmpswapF32Flat::FlatAtomicCmpswapF32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapF32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapF32Flat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_cmpswap_f32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapF32Flat>(opcode);
 }
 } // namespace detail
@@ -1728,7 +1970,12 @@ FlatAtomicMinF32Flat::FlatAtomicMinF32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinF32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinF32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_min_f32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinF32Flat>(opcode);
 }
 } // namespace detail
@@ -1763,7 +2010,12 @@ FlatAtomicMaxF32Flat::FlatAtomicMaxF32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxF32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxF32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_max_f32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxF32Flat>(opcode);
 }
 } // namespace detail
@@ -1798,7 +2050,12 @@ FlatAtomicAddF32Flat::FlatAtomicAddF32Flat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddF32Flat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddF32Flat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Flat::validate_encoding(
+      "flat_atomic_add_f32", reinterpret_cast<const Flat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddF32Flat>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/ldsdir.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/ldsdir.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/ldsdir.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -29,7 +28,12 @@ LdsParamLoadLdsdir::LdsParamLoadLdsdir(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeLdsParamLoadLdsdir(const MachineInst *opcode) {
+DecodeResult decodeLdsParamLoadLdsdir(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Ldsdir::validate_encoding(
+      "lds_param_load", reinterpret_cast<const Ldsdir::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<LdsParamLoadLdsdir>(opcode);
 }
 } // namespace detail
@@ -49,7 +53,12 @@ LdsDirectLoadLdsdir::LdsDirectLoadLdsdir(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeLdsDirectLoadLdsdir(const MachineInst *opcode) {
+DecodeResult decodeLdsDirectLoadLdsdir(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Ldsdir::validate_encoding(
+      "lds_direct_load", reinterpret_cast<const Ldsdir::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<LdsDirectLoadLdsdir>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/mimg.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/mimg.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/mimg.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -26,7 +25,11 @@ ImageLoadMimg::ImageLoadMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMimg>(opcode);
 }
 } // namespace detail
@@ -45,7 +48,12 @@ ImageLoadMipMimg::ImageLoadMipMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipMimg>(opcode);
 }
 } // namespace detail
@@ -64,7 +72,12 @@ ImageLoadPckMimg::ImageLoadPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadPckMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadPckMimg>(opcode);
 }
 } // namespace detail
@@ -83,7 +96,12 @@ ImageLoadPckSgnMimg::ImageLoadPckSgnMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadPckSgnMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadPckSgnMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_pck_sgn", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadPckSgnMimg>(opcode);
 }
 } // namespace detail
@@ -102,7 +120,12 @@ ImageLoadMipPckMimg::ImageLoadMipPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipPckMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipPckMimg>(opcode);
 }
 } // namespace detail
@@ -121,7 +144,12 @@ ImageLoadMipPckSgnMimg::ImageLoadMipPckSgnMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipPckSgnMimg(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipPckSgnMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_load_mip_pck_sgn", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipPckSgnMimg>(opcode);
 }
 } // namespace detail
@@ -140,7 +168,11 @@ ImageStoreMimg::ImageStoreMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMimg(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMimg>(opcode);
 }
 } // namespace detail
@@ -159,7 +191,12 @@ ImageStoreMipMimg::ImageStoreMipMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipMimg>(opcode);
 }
 } // namespace detail
@@ -178,7 +215,12 @@ ImageStorePckMimg::ImageStorePckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStorePckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStorePckMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStorePckMimg>(opcode);
 }
 } // namespace detail
@@ -197,7 +239,12 @@ ImageStoreMipPckMimg::ImageStoreMipPckMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipPckMimg(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipPckMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_store_mip_pck", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipPckMimg>(opcode);
 }
 } // namespace detail
@@ -217,7 +264,12 @@ ImageAtomicSwapMimg::ImageAtomicSwapMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSwapMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSwapMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_swap", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSwapMimg>(opcode);
 }
 } // namespace detail
@@ -237,7 +289,12 @@ ImageAtomicCmpswapMimg::ImageAtomicCmpswapMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicCmpswapMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicCmpswapMimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_cmpswap", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicCmpswapMimg>(opcode);
 }
 } // namespace detail
@@ -257,7 +314,12 @@ ImageAtomicAddMimg::ImageAtomicAddMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicAddMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicAddMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_add", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicAddMimg>(opcode);
 }
 } // namespace detail
@@ -277,7 +339,12 @@ ImageAtomicSubMimg::ImageAtomicSubMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSubMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSubMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_sub", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSubMimg>(opcode);
 }
 } // namespace detail
@@ -297,7 +364,12 @@ ImageAtomicSminMimg::ImageAtomicSminMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSminMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_smin", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSminMimg>(opcode);
 }
 } // namespace detail
@@ -317,7 +389,12 @@ ImageAtomicUminMimg::ImageAtomicUminMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicUminMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicUminMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_umin", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicUminMimg>(opcode);
 }
 } // namespace detail
@@ -337,7 +414,12 @@ ImageAtomicSmaxMimg::ImageAtomicSmaxMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSmaxMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_smax", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSmaxMimg>(opcode);
 }
 } // namespace detail
@@ -357,7 +439,12 @@ ImageAtomicUmaxMimg::ImageAtomicUmaxMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicUmaxMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicUmaxMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_umax", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicUmaxMimg>(opcode);
 }
 } // namespace detail
@@ -377,7 +464,12 @@ ImageAtomicAndMimg::ImageAtomicAndMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicAndMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicAndMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_and", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicAndMimg>(opcode);
 }
 } // namespace detail
@@ -397,7 +489,12 @@ ImageAtomicOrMimg::ImageAtomicOrMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicOrMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicOrMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_or", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicOrMimg>(opcode);
 }
 } // namespace detail
@@ -417,7 +514,12 @@ ImageAtomicXorMimg::ImageAtomicXorMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicXorMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicXorMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_xor", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicXorMimg>(opcode);
 }
 } // namespace detail
@@ -437,7 +539,12 @@ ImageAtomicIncMimg::ImageAtomicIncMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicIncMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicIncMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_inc", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicIncMimg>(opcode);
 }
 } // namespace detail
@@ -457,7 +564,12 @@ ImageAtomicDecMimg::ImageAtomicDecMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicDecMimg(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicDecMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_atomic_dec", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicDecMimg>(opcode);
 }
 } // namespace detail
@@ -476,7 +588,12 @@ ImageGetResinfoMimg::ImageGetResinfoMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGetResinfoMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGetResinfoMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_get_resinfo", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGetResinfoMimg>(opcode);
 }
 } // namespace detail
@@ -495,7 +612,12 @@ ImageMsaaLoadMimg::ImageMsaaLoadMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageMsaaLoadMimg(const MachineInst *opcode) {
+DecodeResult decodeImageMsaaLoadMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_msaa_load", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageMsaaLoadMimg>(opcode);
 }
 } // namespace detail
@@ -514,7 +636,12 @@ ImageBvhIntersectRayMimg::ImageBvhIntersectRayMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageBvhIntersectRayMimg(const MachineInst *opcode) {
+DecodeResult decodeImageBvhIntersectRayMimg(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_bvh_intersect_ray", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageBvhIntersectRayMimg>(opcode);
 }
 } // namespace detail
@@ -533,7 +660,12 @@ ImageBvh64IntersectRayMimg::ImageBvh64IntersectRayMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageBvh64IntersectRayMimg(const MachineInst *opcode) {
+DecodeResult decodeImageBvh64IntersectRayMimg(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_bvh64_intersect_ray", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageBvh64IntersectRayMimg>(opcode);
 }
 } // namespace detail
@@ -554,7 +686,12 @@ ImageSampleMimg::ImageSampleMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleMimg(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleMimg>(opcode);
 }
 } // namespace detail
@@ -575,7 +712,12 @@ ImageSampleDMimg::ImageSampleDMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDMimg>(opcode);
 }
 } // namespace detail
@@ -596,7 +738,12 @@ ImageSampleLMimg::ImageSampleLMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLMimg>(opcode);
 }
 } // namespace detail
@@ -617,7 +764,12 @@ ImageSampleBMimg::ImageSampleBMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBMimg>(opcode);
 }
 } // namespace detail
@@ -638,7 +790,12 @@ ImageSampleLzMimg::ImageSampleLzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLzMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLzMimg>(opcode);
 }
 } // namespace detail
@@ -659,7 +816,12 @@ ImageSampleCMimg::ImageSampleCMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCMimg>(opcode);
 }
 } // namespace detail
@@ -680,7 +842,12 @@ ImageSampleCDMimg::ImageSampleCDMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDMimg>(opcode);
 }
 } // namespace detail
@@ -701,7 +868,12 @@ ImageSampleCLMimg::ImageSampleCLMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLMimg>(opcode);
 }
 } // namespace detail
@@ -722,7 +894,12 @@ ImageSampleCBMimg::ImageSampleCBMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBMimg>(opcode);
 }
 } // namespace detail
@@ -743,7 +920,12 @@ ImageSampleCLzMimg::ImageSampleCLzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLzMimg>(opcode);
 }
 } // namespace detail
@@ -764,7 +946,12 @@ ImageSampleOMimg::ImageSampleOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleOMimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleOMimg>(opcode);
 }
 } // namespace detail
@@ -785,7 +972,12 @@ ImageSampleDOMimg::ImageSampleDOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDOMimg>(opcode);
 }
 } // namespace detail
@@ -806,7 +998,12 @@ ImageSampleLOMimg::ImageSampleLOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_l_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLOMimg>(opcode);
 }
 } // namespace detail
@@ -827,7 +1024,12 @@ ImageSampleBOMimg::ImageSampleBOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBOMimg>(opcode);
 }
 } // namespace detail
@@ -848,7 +1050,12 @@ ImageSampleLzOMimg::ImageSampleLzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLzOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLzOMimg>(opcode);
 }
 } // namespace detail
@@ -869,7 +1076,12 @@ ImageSampleCOMimg::ImageSampleCOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCOMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCOMimg>(opcode);
 }
 } // namespace detail
@@ -890,7 +1102,12 @@ ImageSampleCDOMimg::ImageSampleCDOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDOMimg>(opcode);
 }
 } // namespace detail
@@ -911,7 +1128,12 @@ ImageSampleCLOMimg::ImageSampleCLOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_l_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLOMimg>(opcode);
 }
 } // namespace detail
@@ -932,7 +1154,12 @@ ImageSampleCBOMimg::ImageSampleCBOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBOMimg>(opcode);
 }
 } // namespace detail
@@ -953,7 +1180,12 @@ ImageSampleCLzOMimg::ImageSampleCLzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLzOMimg>(opcode);
 }
 } // namespace detail
@@ -974,7 +1206,12 @@ ImageGather4Mimg::ImageGather4Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4Mimg(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4Mimg>(opcode);
 }
 } // namespace detail
@@ -995,7 +1232,12 @@ ImageGather4LMimg::ImageGather4LMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LMimg>(opcode);
 }
 } // namespace detail
@@ -1016,7 +1258,12 @@ ImageGather4BMimg::ImageGather4BMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4BMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4BMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4BMimg>(opcode);
 }
 } // namespace detail
@@ -1037,7 +1284,12 @@ ImageGather4LzMimg::ImageGather4LzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LzMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LzMimg>(opcode);
 }
 } // namespace detail
@@ -1058,7 +1310,12 @@ ImageGather4CMimg::ImageGather4CMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CMimg>(opcode);
 }
 } // namespace detail
@@ -1079,7 +1336,12 @@ ImageGather4CLzMimg::ImageGather4CLzMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLzMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLzMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_lz", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLzMimg>(opcode);
 }
 } // namespace detail
@@ -1100,7 +1362,12 @@ ImageGather4OMimg::ImageGather4OMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4OMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4OMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4OMimg>(opcode);
 }
 } // namespace detail
@@ -1121,7 +1388,12 @@ ImageGather4LzOMimg::ImageGather4LzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LzOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LzOMimg>(opcode);
 }
 } // namespace detail
@@ -1142,7 +1414,12 @@ ImageGather4CLzOMimg::ImageGather4CLzOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLzOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLzOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_lz_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLzOMimg>(opcode);
 }
 } // namespace detail
@@ -1163,7 +1440,12 @@ ImageGetLodMimg::ImageGetLodMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGetLodMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGetLodMimg(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_get_lod", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGetLodMimg>(opcode);
 }
 } // namespace detail
@@ -1184,7 +1466,12 @@ ImageSampleDG16Mimg::ImageSampleDG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDG16Mimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDG16Mimg>(opcode);
 }
 } // namespace detail
@@ -1205,7 +1492,12 @@ ImageSampleCDG16Mimg::ImageSampleCDG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDG16Mimg>(opcode);
 }
 } // namespace detail
@@ -1226,7 +1518,12 @@ ImageSampleDOG16Mimg::ImageSampleDOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDOG16Mimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -1247,7 +1544,12 @@ ImageSampleCDOG16Mimg::ImageSampleCDOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDOG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -1268,7 +1570,12 @@ ImageSampleClMimg::ImageSampleClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleClMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleClMimg>(opcode);
 }
 } // namespace detail
@@ -1289,7 +1596,12 @@ ImageSampleDClMimg::ImageSampleDClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClMimg>(opcode);
 }
 } // namespace detail
@@ -1310,7 +1622,12 @@ ImageSampleBClMimg::ImageSampleBClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBClMimg>(opcode);
 }
 } // namespace detail
@@ -1331,7 +1648,12 @@ ImageSampleCClMimg::ImageSampleCClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCClMimg>(opcode);
 }
 } // namespace detail
@@ -1352,7 +1674,12 @@ ImageSampleCDClMimg::ImageSampleCDClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClMimg>(opcode);
 }
 } // namespace detail
@@ -1373,7 +1700,12 @@ ImageSampleCBClMimg::ImageSampleCBClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBClMimg>(opcode);
 }
 } // namespace detail
@@ -1394,7 +1726,12 @@ ImageSampleClOMimg::ImageSampleClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleClOMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleClOMimg>(opcode);
 }
 } // namespace detail
@@ -1415,7 +1752,12 @@ ImageSampleDClOMimg::ImageSampleDClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClOMimg>(opcode);
 }
 } // namespace detail
@@ -1436,7 +1778,12 @@ ImageSampleBClOMimg::ImageSampleBClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_b_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBClOMimg>(opcode);
 }
 } // namespace detail
@@ -1457,7 +1804,12 @@ ImageSampleCClOMimg::ImageSampleCClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCClOMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCClOMimg>(opcode);
 }
 } // namespace detail
@@ -1478,7 +1830,12 @@ ImageSampleCDClOMimg::ImageSampleCDClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClOMimg>(opcode);
 }
 } // namespace detail
@@ -1499,7 +1856,12 @@ ImageSampleCBClOMimg::ImageSampleCBClOMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBClOMimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBClOMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_b_cl_o", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBClOMimg>(opcode);
 }
 } // namespace detail
@@ -1520,7 +1882,12 @@ ImageSampleCDClG16Mimg::ImageSampleCDClG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_cl_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClG16Mimg>(opcode);
 }
 } // namespace detail
@@ -1541,7 +1908,12 @@ ImageSampleDClOG16Mimg::ImageSampleDClOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClOG16Mimg(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_cl_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -1562,7 +1934,12 @@ ImageSampleCDClOG16Mimg::ImageSampleCDClOG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClOG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClOG16Mimg(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_c_d_cl_o_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClOG16Mimg>(opcode);
 }
 } // namespace detail
@@ -1583,7 +1960,12 @@ ImageSampleDClG16Mimg::ImageSampleDClG16Mimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClG16Mimg(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClG16Mimg(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_sample_d_cl_g16", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClG16Mimg>(opcode);
 }
 } // namespace detail
@@ -1604,7 +1986,12 @@ ImageGather4ClMimg::ImageGather4ClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4ClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4ClMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4ClMimg>(opcode);
 }
 } // namespace detail
@@ -1625,7 +2012,12 @@ ImageGather4BClMimg::ImageGather4BClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4BClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4BClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4BClMimg>(opcode);
 }
 } // namespace detail
@@ -1646,7 +2038,12 @@ ImageGather4CClMimg::ImageGather4CClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CClMimg(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CClMimg>(opcode);
 }
 } // namespace detail
@@ -1667,7 +2064,12 @@ ImageGather4CLMimg::ImageGather4CLMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_l", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLMimg>(opcode);
 }
 } // namespace detail
@@ -1688,7 +2090,12 @@ ImageGather4CBMimg::ImageGather4CBMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CBMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CBMimg(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_b", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CBMimg>(opcode);
 }
 } // namespace detail
@@ -1709,7 +2116,12 @@ ImageGather4CBClMimg::ImageGather4CBClMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CBClMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CBClMimg(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4_c_b_cl", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CBClMimg>(opcode);
 }
 } // namespace detail
@@ -1730,7 +2142,12 @@ ImageGather4hMimg::ImageGather4hMimg(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4hMimg(const MachineInst *opcode) {
+DecodeResult decodeImageGather4hMimg(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mimg::validate_encoding(
+      "image_gather4h", reinterpret_cast<const Mimg::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4hMimg>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/mtbuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/mtbuf.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/mtbuf.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -42,7 +41,12 @@ TbufferLoadFormatXMtbuf::TbufferLoadFormatXMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXMtbuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -66,7 +70,12 @@ TbufferLoadFormatXyMtbuf::TbufferLoadFormatXyMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xy", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -90,7 +99,12 @@ TbufferLoadFormatXyzMtbuf::TbufferLoadFormatXyzMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyzMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xyz", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -114,7 +128,12 @@ TbufferLoadFormatXyzwMtbuf::TbufferLoadFormatXyzwMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyzwMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_format_xyzw", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -138,7 +157,12 @@ TbufferStoreFormatXMtbuf::TbufferStoreFormatXMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXMtbuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -162,7 +186,12 @@ TbufferStoreFormatXyMtbuf::TbufferStoreFormatXyMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyMtbuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xy", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -186,7 +215,12 @@ TbufferStoreFormatXyzMtbuf::TbufferStoreFormatXyzMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyzMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xyz", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -210,7 +244,12 @@ TbufferStoreFormatXyzwMtbuf::TbufferStoreFormatXyzwMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyzwMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_store_format_xyzw", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -234,7 +273,12 @@ TbufferLoadD16FormatXMtbuf::TbufferLoadD16FormatXMtbuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadD16FormatXMtbuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mtbuf::validate_encoding(
+      "tbuffer_load_d16_format_x", reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadD16FormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -264,7 +308,13 @@ TbufferLoadD16FormatXyMtbuf::TbufferLoadD16FormatXyMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadD16FormatXyMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_d16_format_xy",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadD16FormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -288,7 +338,13 @@ TbufferLoadD16FormatXyzMtbuf::TbufferLoadD16FormatXyzMtbuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadD16FormatXyzMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_d16_format_xyz",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadD16FormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -318,7 +374,13 @@ TbufferLoadD16FormatXyzwMtbuf::TbufferLoadD16FormatXyzwMtbuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadD16FormatXyzwMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_load_d16_format_xyzw",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadD16FormatXyzwMtbuf>(opcode);
 }
 } // namespace detail
@@ -342,7 +404,13 @@ TbufferStoreD16FormatXMtbuf::TbufferStoreD16FormatXMtbuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreD16FormatXMtbuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_d16_format_x",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreD16FormatXMtbuf>(opcode);
 }
 } // namespace detail
@@ -366,7 +434,13 @@ TbufferStoreD16FormatXyMtbuf::TbufferStoreD16FormatXyMtbuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXyMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreD16FormatXyMtbuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_d16_format_xy",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreD16FormatXyMtbuf>(opcode);
 }
 } // namespace detail
@@ -390,7 +464,13 @@ TbufferStoreD16FormatXyzMtbuf::TbufferStoreD16FormatXyzMtbuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXyzMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreD16FormatXyzMtbuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_d16_format_xyz",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreD16FormatXyzMtbuf>(opcode);
 }
 } // namespace detail
@@ -414,7 +494,13 @@ TbufferStoreD16FormatXyzwMtbuf::TbufferStoreD16FormatXyzwMtbuf(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXyzwMtbuf(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreD16FormatXyzwMtbuf(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mtbuf::validate_encoding("tbuffer_store_d16_format_xyzw",
+                               reinterpret_cast<const Mtbuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreD16FormatXyzwMtbuf>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/mubuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/mubuf.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/mubuf.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -42,7 +41,12 @@ BufferLoadFormatXMubuf::BufferLoadFormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXMubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -66,7 +70,12 @@ BufferLoadFormatXyMubuf::BufferLoadFormatXyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -90,7 +99,12 @@ BufferLoadFormatXyzMubuf::BufferLoadFormatXyzMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyzMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xyz", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -114,7 +128,12 @@ BufferLoadFormatXyzwMubuf::BufferLoadFormatXyzwMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyzwMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_format_xyzw", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -138,7 +157,12 @@ BufferStoreFormatXMubuf::BufferStoreFormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXMubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -162,7 +186,12 @@ BufferStoreFormatXyMubuf::BufferStoreFormatXyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyMubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -186,7 +215,12 @@ BufferStoreFormatXyzMubuf::BufferStoreFormatXyzMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyzMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xyz", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -210,7 +244,12 @@ BufferStoreFormatXyzwMubuf::BufferStoreFormatXyzwMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyzwMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_format_xyzw", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -234,7 +273,12 @@ BufferLoadD16FormatXMubuf::BufferLoadD16FormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16FormatXMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_d16_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16FormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -264,7 +308,12 @@ BufferLoadD16FormatXyMubuf::BufferLoadD16FormatXyMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16FormatXyMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_d16_format_xy", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16FormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -288,7 +337,13 @@ BufferLoadD16FormatXyzMubuf::BufferLoadD16FormatXyzMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16FormatXyzMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_d16_format_xyz",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16FormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -318,7 +373,13 @@ BufferLoadD16FormatXyzwMubuf::BufferLoadD16FormatXyzwMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16FormatXyzwMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_d16_format_xyzw",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16FormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -342,7 +403,12 @@ BufferStoreD16FormatXMubuf::BufferStoreD16FormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16FormatXMubuf(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_d16_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16FormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -366,7 +432,13 @@ BufferStoreD16FormatXyMubuf::BufferStoreD16FormatXyMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXyMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16FormatXyMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_d16_format_xy",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16FormatXyMubuf>(opcode);
 }
 } // namespace detail
@@ -390,7 +462,13 @@ BufferStoreD16FormatXyzMubuf::BufferStoreD16FormatXyzMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXyzMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16FormatXyzMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_d16_format_xyz",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16FormatXyzMubuf>(opcode);
 }
 } // namespace detail
@@ -414,7 +492,13 @@ BufferStoreD16FormatXyzwMubuf::BufferStoreD16FormatXyzwMubuf(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXyzwMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16FormatXyzwMubuf(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_d16_format_xyzw",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16FormatXyzwMubuf>(opcode);
 }
 } // namespace detail
@@ -438,7 +522,12 @@ BufferLoadU8Mubuf::BufferLoadU8Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadU8Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadU8Mubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_u8", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadU8Mubuf>(opcode);
 }
 } // namespace detail
@@ -462,7 +551,12 @@ BufferLoadI8Mubuf::BufferLoadI8Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadI8Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadI8Mubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_i8", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadI8Mubuf>(opcode);
 }
 } // namespace detail
@@ -486,7 +580,12 @@ BufferLoadU16Mubuf::BufferLoadU16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadU16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadU16Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_u16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadU16Mubuf>(opcode);
 }
 } // namespace detail
@@ -510,7 +609,12 @@ BufferLoadI16Mubuf::BufferLoadI16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadI16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadI16Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_i16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadI16Mubuf>(opcode);
 }
 } // namespace detail
@@ -534,7 +638,12 @@ BufferLoadB32Mubuf::BufferLoadB32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadB32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadB32Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_b32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadB32Mubuf>(opcode);
 }
 } // namespace detail
@@ -558,7 +667,12 @@ BufferLoadB64Mubuf::BufferLoadB64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadB64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadB64Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_b64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadB64Mubuf>(opcode);
 }
 } // namespace detail
@@ -582,7 +696,12 @@ BufferLoadB96Mubuf::BufferLoadB96Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadB96Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadB96Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_b96", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadB96Mubuf>(opcode);
 }
 } // namespace detail
@@ -606,7 +725,12 @@ BufferLoadB128Mubuf::BufferLoadB128Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadB128Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadB128Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_b128", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadB128Mubuf>(opcode);
 }
 } // namespace detail
@@ -630,7 +754,12 @@ BufferStoreB8Mubuf::BufferStoreB8Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB8Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB8Mubuf(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_b8", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB8Mubuf>(opcode);
 }
 } // namespace detail
@@ -654,7 +783,12 @@ BufferStoreB16Mubuf::BufferStoreB16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB16Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_b16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB16Mubuf>(opcode);
 }
 } // namespace detail
@@ -678,7 +812,12 @@ BufferStoreB32Mubuf::BufferStoreB32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB32Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_b32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB32Mubuf>(opcode);
 }
 } // namespace detail
@@ -702,7 +841,12 @@ BufferStoreB64Mubuf::BufferStoreB64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB64Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_b64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB64Mubuf>(opcode);
 }
 } // namespace detail
@@ -726,7 +870,12 @@ BufferStoreB96Mubuf::BufferStoreB96Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB96Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB96Mubuf(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_b96", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB96Mubuf>(opcode);
 }
 } // namespace detail
@@ -750,7 +899,12 @@ BufferStoreB128Mubuf::BufferStoreB128Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB128Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB128Mubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_b128", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB128Mubuf>(opcode);
 }
 } // namespace detail
@@ -774,7 +928,12 @@ BufferLoadD16U8Mubuf::BufferLoadD16U8Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16U8Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16U8Mubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_d16_u8", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16U8Mubuf>(opcode);
 }
 } // namespace detail
@@ -804,7 +963,12 @@ BufferLoadD16I8Mubuf::BufferLoadD16I8Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16I8Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16I8Mubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_d16_i8", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16I8Mubuf>(opcode);
 }
 } // namespace detail
@@ -834,7 +998,12 @@ BufferLoadD16B16Mubuf::BufferLoadD16B16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16B16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16B16Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_d16_b16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16B16Mubuf>(opcode);
 }
 } // namespace detail
@@ -864,7 +1033,12 @@ BufferLoadD16HiU8Mubuf::BufferLoadD16HiU8Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16HiU8Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16HiU8Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_d16_hi_u8", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16HiU8Mubuf>(opcode);
 }
 } // namespace detail
@@ -894,7 +1068,12 @@ BufferLoadD16HiI8Mubuf::BufferLoadD16HiI8Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16HiI8Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16HiI8Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_d16_hi_i8", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16HiI8Mubuf>(opcode);
 }
 } // namespace detail
@@ -924,7 +1103,12 @@ BufferLoadD16HiB16Mubuf::BufferLoadD16HiB16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16HiB16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16HiB16Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_d16_hi_b16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16HiB16Mubuf>(opcode);
 }
 } // namespace detail
@@ -954,7 +1138,12 @@ BufferStoreD16HiB8Mubuf::BufferStoreD16HiB8Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16HiB8Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16HiB8Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_d16_hi_b8", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16HiB8Mubuf>(opcode);
 }
 } // namespace detail
@@ -978,7 +1167,12 @@ BufferStoreD16HiB16Mubuf::BufferStoreD16HiB16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16HiB16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16HiB16Mubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_store_d16_hi_b16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16HiB16Mubuf>(opcode);
 }
 } // namespace detail
@@ -1002,7 +1196,13 @@ BufferLoadD16HiFormatXMubuf::BufferLoadD16HiFormatXMubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16HiFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16HiFormatXMubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_load_d16_hi_format_x",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16HiFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -1032,7 +1232,13 @@ BufferStoreD16HiFormatXMubuf::BufferStoreD16HiFormatXMubuf(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16HiFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16HiFormatXMubuf(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Mubuf::validate_encoding("buffer_store_d16_hi_format_x",
+                               reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16HiFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -1045,7 +1251,12 @@ BufferGl0InvMubuf::BufferGl0InvMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferGl0InvMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferGl0InvMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_gl0_inv", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferGl0InvMubuf>(opcode);
 }
 } // namespace detail
@@ -1058,7 +1269,12 @@ BufferGl1InvMubuf::BufferGl1InvMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferGl1InvMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferGl1InvMubuf(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_gl1_inv", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferGl1InvMubuf>(opcode);
 }
 } // namespace detail
@@ -1082,7 +1298,12 @@ BufferLoadLdsU8Mubuf::BufferLoadLdsU8Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadLdsU8Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadLdsU8Mubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_lds_u8", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadLdsU8Mubuf>(opcode);
 }
 } // namespace detail
@@ -1106,7 +1327,12 @@ BufferLoadLdsI8Mubuf::BufferLoadLdsI8Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadLdsI8Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadLdsI8Mubuf(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_lds_i8", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadLdsI8Mubuf>(opcode);
 }
 } // namespace detail
@@ -1130,7 +1356,12 @@ BufferLoadLdsU16Mubuf::BufferLoadLdsU16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadLdsU16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadLdsU16Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_lds_u16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadLdsU16Mubuf>(opcode);
 }
 } // namespace detail
@@ -1154,7 +1385,12 @@ BufferLoadLdsI16Mubuf::BufferLoadLdsI16Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadLdsI16Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadLdsI16Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_lds_i16", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadLdsI16Mubuf>(opcode);
 }
 } // namespace detail
@@ -1178,7 +1414,12 @@ BufferLoadLdsB32Mubuf::BufferLoadLdsB32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadLdsB32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadLdsB32Mubuf(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_lds_b32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadLdsB32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1202,7 +1443,12 @@ BufferLoadLdsFormatXMubuf::BufferLoadLdsFormatXMubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadLdsFormatXMubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadLdsFormatXMubuf(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_load_lds_format_x", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadLdsFormatXMubuf>(opcode);
 }
 } // namespace detail
@@ -1228,7 +1474,12 @@ BufferAtomicSwapB32Mubuf::BufferAtomicSwapB32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapB32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapB32Mubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_swap_b32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapB32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1255,7 +1506,12 @@ BufferAtomicCmpswapB32Mubuf::BufferAtomicCmpswapB32Mubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapB32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapB32Mubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_cmpswap_b32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapB32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1281,7 +1537,12 @@ BufferAtomicAddU32Mubuf::BufferAtomicAddU32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddU32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_u32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddU32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1307,7 +1568,12 @@ BufferAtomicSubU32Mubuf::BufferAtomicSubU32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubU32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_sub_u32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubU32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1333,7 +1599,12 @@ BufferAtomicCsubU32Mubuf::BufferAtomicCsubU32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCsubU32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCsubU32Mubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_csub_u32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCsubU32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1359,7 +1630,12 @@ BufferAtomicMinI32Mubuf::BufferAtomicMinI32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinI32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinI32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_min_i32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinI32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1385,7 +1661,12 @@ BufferAtomicMinU32Mubuf::BufferAtomicMinU32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinU32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_min_u32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinU32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1411,7 +1692,12 @@ BufferAtomicMaxI32Mubuf::BufferAtomicMaxI32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxI32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxI32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_max_i32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxI32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1437,7 +1723,12 @@ BufferAtomicMaxU32Mubuf::BufferAtomicMaxU32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxU32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_max_u32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxU32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1463,7 +1754,12 @@ BufferAtomicAndB32Mubuf::BufferAtomicAndB32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndB32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndB32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_and_b32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndB32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1489,7 +1785,12 @@ BufferAtomicOrB32Mubuf::BufferAtomicOrB32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrB32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrB32Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_or_b32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrB32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1515,7 +1816,12 @@ BufferAtomicXorB32Mubuf::BufferAtomicXorB32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorB32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorB32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_xor_b32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorB32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1541,7 +1847,12 @@ BufferAtomicIncU32Mubuf::BufferAtomicIncU32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncU32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_inc_u32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncU32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1567,7 +1878,12 @@ BufferAtomicDecU32Mubuf::BufferAtomicDecU32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecU32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecU32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_dec_u32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecU32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1593,7 +1909,12 @@ BufferAtomicSwapB64Mubuf::BufferAtomicSwapB64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapB64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapB64Mubuf(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_swap_b64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapB64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1620,7 +1941,12 @@ BufferAtomicCmpswapB64Mubuf::BufferAtomicCmpswapB64Mubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapB64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapB64Mubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_cmpswap_b64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapB64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1646,7 +1972,12 @@ BufferAtomicAddU64Mubuf::BufferAtomicAddU64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddU64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_u64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddU64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1672,7 +2003,12 @@ BufferAtomicSubU64Mubuf::BufferAtomicSubU64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubU64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_sub_u64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubU64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1698,7 +2034,12 @@ BufferAtomicMinI64Mubuf::BufferAtomicMinI64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinI64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinI64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_min_i64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinI64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1724,7 +2065,12 @@ BufferAtomicMinU64Mubuf::BufferAtomicMinU64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinU64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_min_u64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinU64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1750,7 +2096,12 @@ BufferAtomicMaxI64Mubuf::BufferAtomicMaxI64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxI64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxI64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_max_i64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxI64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1776,7 +2127,12 @@ BufferAtomicMaxU64Mubuf::BufferAtomicMaxU64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxU64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_max_u64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxU64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1802,7 +2158,12 @@ BufferAtomicAndB64Mubuf::BufferAtomicAndB64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndB64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndB64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_and_b64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndB64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1828,7 +2189,12 @@ BufferAtomicOrB64Mubuf::BufferAtomicOrB64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrB64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrB64Mubuf(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_or_b64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrB64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1854,7 +2220,12 @@ BufferAtomicXorB64Mubuf::BufferAtomicXorB64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorB64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorB64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_xor_b64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorB64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1880,7 +2251,12 @@ BufferAtomicIncU64Mubuf::BufferAtomicIncU64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncU64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_inc_u64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncU64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1906,7 +2282,12 @@ BufferAtomicDecU64Mubuf::BufferAtomicDecU64Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecU64Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecU64Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_dec_u64", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecU64Mubuf>(opcode);
 }
 } // namespace detail
@@ -1933,7 +2314,12 @@ BufferAtomicCmpswapF32Mubuf::BufferAtomicCmpswapF32Mubuf(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapF32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapF32Mubuf(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_cmpswap_f32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapF32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1959,7 +2345,12 @@ BufferAtomicMinF32Mubuf::BufferAtomicMinF32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinF32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_min_f32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinF32Mubuf>(opcode);
 }
 } // namespace detail
@@ -1985,7 +2376,12 @@ BufferAtomicMaxF32Mubuf::BufferAtomicMaxF32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxF32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_max_f32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxF32Mubuf>(opcode);
 }
 } // namespace detail
@@ -2011,7 +2407,12 @@ BufferAtomicAddF32Mubuf::BufferAtomicAddF32Mubuf(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddF32Mubuf(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Mubuf::validate_encoding(
+      "buffer_atomic_add_f32", reinterpret_cast<const Mubuf::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddF32Mubuf>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/operand.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/operand.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/scalar_static_resolve.h"
-#include "util/except.h"
 #include <format>
 #include <optional>
 #include <stdexcept>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/smem.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/smem.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/smem.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -34,7 +33,11 @@ SLoadB32Smem::SLoadB32Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB32Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB32Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b32", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB32Smem>(opcode);
 }
 } // namespace detail
@@ -54,7 +57,11 @@ SLoadB64Smem::SLoadB64Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB64Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB64Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b64", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB64Smem>(opcode);
 }
 } // namespace detail
@@ -74,7 +81,11 @@ SLoadB128Smem::SLoadB128Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB128Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB128Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b128", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB128Smem>(opcode);
 }
 } // namespace detail
@@ -94,7 +105,11 @@ SLoadB256Smem::SLoadB256Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB256Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB256Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b256", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB256Smem>(opcode);
 }
 } // namespace detail
@@ -114,7 +129,11 @@ SLoadB512Smem::SLoadB512Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB512Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB512Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b512", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB512Smem>(opcode);
 }
 } // namespace detail
@@ -134,7 +153,12 @@ SBufferLoadB32Smem::SBufferLoadB32Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB32Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB32Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b32", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB32Smem>(opcode);
 }
 } // namespace detail
@@ -154,7 +178,12 @@ SBufferLoadB64Smem::SBufferLoadB64Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB64Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB64Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b64", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB64Smem>(opcode);
 }
 } // namespace detail
@@ -174,7 +203,12 @@ SBufferLoadB128Smem::SBufferLoadB128Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB128Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB128Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b128", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB128Smem>(opcode);
 }
 } // namespace detail
@@ -194,7 +228,12 @@ SBufferLoadB256Smem::SBufferLoadB256Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB256Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB256Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b256", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB256Smem>(opcode);
 }
 } // namespace detail
@@ -214,7 +253,12 @@ SBufferLoadB512Smem::SBufferLoadB512Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB512Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB512Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b512", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB512Smem>(opcode);
 }
 } // namespace detail
@@ -227,7 +271,11 @@ SGl1InvSmem::SGl1InvSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGl1InvSmem(const MachineInst *opcode) {
+DecodeResult decodeSGl1InvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_gl1_inv", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGl1InvSmem>(opcode);
 }
 } // namespace detail
@@ -240,7 +288,11 @@ SDcacheInvSmem::SDcacheInvSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_inv", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheInvSmem>(opcode);
 }
 } // namespace detail
@@ -259,7 +311,11 @@ SAtcProbeSmem::SAtcProbeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtcProbeSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtcProbeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atc_probe", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtcProbeSmem>(opcode);
 }
 } // namespace detail
@@ -278,7 +334,12 @@ SAtcProbeBufferSmem::SAtcProbeBufferSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtcProbeBufferSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtcProbeBufferSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atc_probe_buffer", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtcProbeBufferSmem>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/sop1.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/sop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -29,7 +28,11 @@ SMovB32Sop1::SMovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -52,7 +55,11 @@ SMovB64Sop1::SMovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -78,7 +85,11 @@ SCmovB32Sop1::SCmovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -105,7 +116,11 @@ SCmovB64Sop1::SCmovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -126,7 +141,11 @@ SBrevB32Sop1::SBrevB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB32Sop1>(opcode);
 }
 } // namespace detail
@@ -148,7 +167,11 @@ SBrevB64Sop1::SBrevB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB64Sop1>(opcode);
 }
 } // namespace detail
@@ -169,7 +192,11 @@ SCtzI32B32Sop1::SCtzI32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCtzI32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCtzI32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ctz_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCtzI32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -191,7 +218,11 @@ SCtzI32B64Sop1::SCtzI32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCtzI32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCtzI32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ctz_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCtzI32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -212,7 +243,11 @@ SClzI32U32Sop1::SClzI32U32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClzI32U32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSClzI32U32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_clz_i32_u32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClzI32U32Sop1>(opcode);
 }
 } // namespace detail
@@ -234,7 +269,11 @@ SClzI32U64Sop1::SClzI32U64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClzI32U64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSClzI32U64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_clz_i32_u64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClzI32U64Sop1>(opcode);
 }
 } // namespace detail
@@ -255,7 +294,11 @@ SClsI32Sop1::SClsI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClsI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSClsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cls_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClsI32Sop1>(opcode);
 }
 } // namespace detail
@@ -277,7 +320,11 @@ SClsI32I64Sop1::SClsI32I64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClsI32I64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSClsI32I64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cls_i32_i64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClsI32I64Sop1>(opcode);
 }
 } // namespace detail
@@ -299,7 +346,11 @@ SSextI32I8Sop1::SSextI32I8Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i8", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I8Sop1>(opcode);
 }
 } // namespace detail
@@ -321,7 +372,12 @@ SSextI32I16Sop1::SSextI32I16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I16Sop1>(opcode);
 }
 } // namespace detail
@@ -343,7 +399,12 @@ SBitset0B32Sop1::SBitset0B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B32Sop1>(opcode);
 }
 } // namespace detail
@@ -365,7 +426,12 @@ SBitset0B64Sop1::SBitset0B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B64Sop1>(opcode);
 }
 } // namespace detail
@@ -387,7 +453,12 @@ SBitset1B32Sop1::SBitset1B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B32Sop1>(opcode);
 }
 } // namespace detail
@@ -409,7 +480,12 @@ SBitset1B64Sop1::SBitset1B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B64Sop1>(opcode);
 }
 } // namespace detail
@@ -430,7 +506,12 @@ SBitreplicateB64B32Sop1::SBitreplicateB64B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitreplicate_b64_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitreplicateB64B32Sop1>(opcode);
 }
 } // namespace detail
@@ -454,7 +535,11 @@ SAbsI32Sop1::SAbsI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_abs_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsI32Sop1>(opcode);
 }
 } // namespace detail
@@ -478,7 +563,12 @@ SBcnt0I32B32Sop1::SBcnt0I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -503,7 +593,12 @@ SBcnt0I32B64Sop1::SBcnt0I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -527,7 +622,12 @@ SBcnt1I32B32Sop1::SBcnt1I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -552,7 +652,12 @@ SBcnt1I32B64Sop1::SBcnt1I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -576,7 +681,12 @@ SQuadmaskB32Sop1::SQuadmaskB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB32Sop1>(opcode);
 }
 } // namespace detail
@@ -601,7 +711,12 @@ SQuadmaskB64Sop1::SQuadmaskB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB64Sop1>(opcode);
 }
 } // namespace detail
@@ -625,7 +740,11 @@ SWqmB32Sop1::SWqmB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB32Sop1>(opcode);
 }
 } // namespace detail
@@ -650,7 +769,11 @@ SWqmB64Sop1::SWqmB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB64Sop1>(opcode);
 }
 } // namespace detail
@@ -674,7 +797,11 @@ SNotB32Sop1::SNotB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB32Sop1>(opcode);
 }
 } // namespace detail
@@ -699,7 +826,11 @@ SNotB64Sop1::SNotB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB64Sop1>(opcode);
 }
 } // namespace detail
@@ -730,7 +861,12 @@ SAndSaveexecB32Sop1::SAndSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -762,7 +898,12 @@ SAndSaveexecB64Sop1::SAndSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -794,7 +935,12 @@ SOrSaveexecB32Sop1::SOrSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrSaveexecB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -827,7 +973,12 @@ SOrSaveexecB64Sop1::SOrSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -858,7 +1009,12 @@ SXorSaveexecB32Sop1::SXorSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xor_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -890,7 +1046,12 @@ SXorSaveexecB64Sop1::SXorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -921,7 +1082,12 @@ SNandSaveexecB32Sop1::SNandSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNandSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nand_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -953,7 +1119,12 @@ SNandSaveexecB64Sop1::SNandSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nand_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -984,7 +1155,12 @@ SNorSaveexecB32Sop1::SNorSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nor_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1016,7 +1192,12 @@ SNorSaveexecB64Sop1::SNorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1047,7 +1228,12 @@ SXnorSaveexecB32Sop1::SXnorSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXnorSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xnor_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1079,7 +1265,12 @@ SXnorSaveexecB64Sop1::SXnorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xnor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1110,7 +1301,12 @@ SAndNot0SaveexecB32Sop1::SAndNot0SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot0SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot0SaveexecB32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not0_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot0SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1142,7 +1338,12 @@ SAndNot0SaveexecB64Sop1::SAndNot0SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot0SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot0SaveexecB64Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not0_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot0SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1173,7 +1374,12 @@ SOrNot0SaveexecB32Sop1::SOrNot0SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot0SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrNot0SaveexecB32Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_not0_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot0SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1205,7 +1411,12 @@ SOrNot0SaveexecB64Sop1::SOrNot0SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot0SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrNot0SaveexecB64Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_not0_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot0SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1236,7 +1447,12 @@ SAndNot1SaveexecB32Sop1::SAndNot1SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1SaveexecB32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not1_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1268,7 +1484,12 @@ SAndNot1SaveexecB64Sop1::SAndNot1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1SaveexecB64Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1299,7 +1520,12 @@ SOrNot1SaveexecB32Sop1::SOrNot1SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot1SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrNot1SaveexecB32Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_not1_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot1SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1331,7 +1557,12 @@ SOrNot1SaveexecB64Sop1::SOrNot1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrNot1SaveexecB64Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_not1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1362,7 +1593,12 @@ SAndNot0WrexecB32Sop1::SAndNot0WrexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot0WrexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot0WrexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not0_wrexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot0WrexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1394,7 +1630,12 @@ SAndNot0WrexecB64Sop1::SAndNot0WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot0WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot0WrexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not0_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot0WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1425,7 +1666,12 @@ SAndNot1WrexecB32Sop1::SAndNot1WrexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1WrexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1WrexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not1_wrexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1WrexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1457,7 +1703,12 @@ SAndNot1WrexecB64Sop1::SAndNot1WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1WrexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not1_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1477,7 +1728,12 @@ SMovrelsB32Sop1::SMovrelsB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrels_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1497,7 +1753,12 @@ SMovrelsB64Sop1::SMovrelsB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrels_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1521,7 +1782,12 @@ SMovreldB32Sop1::SMovreldB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1546,7 +1812,12 @@ SMovreldB64Sop1::SMovreldB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1566,7 +1837,12 @@ SMovrelsd2B32Sop1::SMovrelsd2B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsd2B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsd2B32Sop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrelsd_2_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsd2B32Sop1>(opcode);
 }
 } // namespace detail
@@ -1584,7 +1860,11 @@ SGetpcB64Sop1::SGetpcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetpcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSGetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_getpc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetpcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1603,7 +1883,11 @@ SSetpcB64Sop1::SSetpcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetpcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_setpc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetpcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1626,7 +1910,11 @@ SSwappcB64Sop1::SSwappcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSwappcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSwappcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_swappc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSwappcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1644,7 +1932,11 @@ SRfeB64Sop1::SRfeB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRfeB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSRfeB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_rfe_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRfeB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1661,7 +1953,12 @@ SSendmsgRtnB32Sop1::SSendmsgRtnB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsgRtnB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSendmsgRtnB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sendmsg_rtn_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsgRtnB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1678,7 +1975,12 @@ SSendmsgRtnB64Sop1::SSendmsgRtnB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsgRtnB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSendmsgRtnB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sendmsg_rtn_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsgRtnB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1699,7 +2001,11 @@ SCeilF32Sop1::SCeilF32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCeilF32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCeilF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ceil_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCeilF32Sop1>(opcode);
 }
 } // namespace detail
@@ -1720,7 +2026,11 @@ SFloorF32Sop1::SFloorF32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFloorF32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFloorF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_floor_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFloorF32Sop1>(opcode);
 }
 } // namespace detail
@@ -1741,7 +2051,11 @@ STruncF32Sop1::STruncF32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTruncF32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSTruncF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_trunc_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STruncF32Sop1>(opcode);
 }
 } // namespace detail
@@ -1762,7 +2076,11 @@ SRndneF32Sop1::SRndneF32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRndneF32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSRndneF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_rndne_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRndneF32Sop1>(opcode);
 }
 } // namespace detail
@@ -1783,7 +2101,11 @@ SCvtF32I32Sop1::SCvtF32I32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtF32I32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtF32I32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_f32_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtF32I32Sop1>(opcode);
 }
 } // namespace detail
@@ -1804,7 +2126,11 @@ SCvtF32U32Sop1::SCvtF32U32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtF32U32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtF32U32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_f32_u32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtF32U32Sop1>(opcode);
 }
 } // namespace detail
@@ -1825,7 +2151,11 @@ SCvtI32F32Sop1::SCvtI32F32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtI32F32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtI32F32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_i32_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtI32F32Sop1>(opcode);
 }
 } // namespace detail
@@ -1846,7 +2176,11 @@ SCvtU32F32Sop1::SCvtU32F32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtU32F32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtU32F32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_u32_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtU32F32Sop1>(opcode);
 }
 } // namespace detail
@@ -1867,7 +2201,11 @@ SCvtF16F32Sop1::SCvtF16F32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtF16F32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtF16F32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_f16_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtF16F32Sop1>(opcode);
 }
 } // namespace detail
@@ -1895,7 +2233,11 @@ SCvtF32F16Sop1::SCvtF32F16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtF32F16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtF32F16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_f32_f16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtF32F16Sop1>(opcode);
 }
 } // namespace detail
@@ -1917,7 +2259,12 @@ SCvtHiF32F16Sop1::SCvtHiF32F16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtHiF32F16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtHiF32F16Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_hi_f32_f16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtHiF32F16Sop1>(opcode);
 }
 } // namespace detail
@@ -1939,7 +2286,11 @@ SCeilF16Sop1::SCeilF16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCeilF16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCeilF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ceil_f16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCeilF16Sop1>(opcode);
 }
 } // namespace detail
@@ -1967,7 +2318,11 @@ SFloorF16Sop1::SFloorF16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFloorF16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFloorF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_floor_f16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFloorF16Sop1>(opcode);
 }
 } // namespace detail
@@ -1995,7 +2350,11 @@ STruncF16Sop1::STruncF16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTruncF16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSTruncF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_trunc_f16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STruncF16Sop1>(opcode);
 }
 } // namespace detail
@@ -2023,7 +2382,11 @@ SRndneF16Sop1::SRndneF16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRndneF16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSRndneF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_rndne_f16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRndneF16Sop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/sop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/sop2.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/sop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -37,7 +36,11 @@ SAddU32Sop2::SAddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -67,7 +70,11 @@ SSubU32Sop2::SSubU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubU32Sop2>(opcode);
 }
 } // namespace detail
@@ -97,7 +104,11 @@ SAddI32Sop2::SAddI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddI32Sop2>(opcode);
 }
 } // namespace detail
@@ -127,7 +138,11 @@ SSubI32Sop2::SSubI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubI32Sop2>(opcode);
 }
 } // namespace detail
@@ -160,7 +175,11 @@ SAddcU32Sop2::SAddcU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddcU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddcU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_addc_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddcU32Sop2>(opcode);
 }
 } // namespace detail
@@ -193,7 +212,11 @@ SSubbU32Sop2::SSubbU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubbU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubbU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_subb_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubbU32Sop2>(opcode);
 }
 } // namespace detail
@@ -223,7 +246,12 @@ SAbsdiffI32Sop2::SAbsdiffI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_absdiff_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsdiffI32Sop2>(opcode);
 }
 } // namespace detail
@@ -253,7 +281,11 @@ SLshlB32Sop2::SLshlB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshlB32Sop2>(opcode);
 }
 } // namespace detail
@@ -284,7 +316,11 @@ SLshlB64Sop2::SLshlB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshlB64Sop2>(opcode);
 }
 } // namespace detail
@@ -314,7 +350,11 @@ SLshrB32Sop2::SLshrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -345,7 +385,11 @@ SLshrB64Sop2::SLshrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -375,7 +419,11 @@ SAshrI32Sop2::SAshrI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAshrI32Sop2>(opcode);
 }
 } // namespace detail
@@ -406,7 +454,11 @@ SAshrI64Sop2::SAshrI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAshrI64Sop2>(opcode);
 }
 } // namespace detail
@@ -436,7 +488,12 @@ SLshl1AddU32Sop2::SLshl1AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl1_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl1AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -466,7 +523,12 @@ SLshl2AddU32Sop2::SLshl2AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl2_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl2AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -496,7 +558,12 @@ SLshl3AddU32Sop2::SLshl3AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl3_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl3AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -526,7 +593,12 @@ SLshl4AddU32Sop2::SLshl4AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl4_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl4AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -556,7 +628,11 @@ SMinI32Sop2::SMinI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinI32Sop2>(opcode);
 }
 } // namespace detail
@@ -586,7 +662,11 @@ SMinU32Sop2::SMinU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinU32Sop2>(opcode);
 }
 } // namespace detail
@@ -616,7 +696,11 @@ SMaxI32Sop2::SMaxI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxI32Sop2>(opcode);
 }
 } // namespace detail
@@ -646,7 +730,11 @@ SMaxU32Sop2::SMaxU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxU32Sop2>(opcode);
 }
 } // namespace detail
@@ -676,7 +764,11 @@ SAndB32Sop2::SAndB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndB32Sop2>(opcode);
 }
 } // namespace detail
@@ -708,7 +800,11 @@ SAndB64Sop2::SAndB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndB64Sop2>(opcode);
 }
 } // namespace detail
@@ -739,7 +835,11 @@ SOrB32Sop2::SOrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -772,7 +872,11 @@ SOrB64Sop2::SOrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -802,7 +906,11 @@ SXorB32Sop2::SXorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -834,7 +942,11 @@ SXorB64Sop2::SXorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -864,7 +976,11 @@ SNandB32Sop2::SNandB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandB32Sop2>(opcode);
 }
 } // namespace detail
@@ -896,7 +1012,11 @@ SNandB64Sop2::SNandB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandB64Sop2>(opcode);
 }
 } // namespace detail
@@ -926,7 +1046,11 @@ SNorB32Sop2::SNorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -958,7 +1082,11 @@ SNorB64Sop2::SNorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -988,7 +1116,11 @@ SXnorB32Sop2::SXnorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1020,7 +1152,11 @@ SXnorB64Sop2::SXnorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1050,7 +1186,12 @@ SAndNot1B32Sop2::SAndNot1B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1B32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_not1_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1B32Sop2>(opcode);
 }
 } // namespace detail
@@ -1082,7 +1223,12 @@ SAndNot1B64Sop2::SAndNot1B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1B64Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_not1_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1B64Sop2>(opcode);
 }
 } // namespace detail
@@ -1112,7 +1258,11 @@ SOrNot1B32Sop2::SOrNot1B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot1B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrNot1B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_not1_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot1B32Sop2>(opcode);
 }
 } // namespace detail
@@ -1144,7 +1294,11 @@ SOrNot1B64Sop2::SOrNot1B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot1B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrNot1B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_not1_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot1B64Sop2>(opcode);
 }
 } // namespace detail
@@ -1174,7 +1328,11 @@ SBfeU32Sop2::SBfeU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1204,7 +1362,11 @@ SBfeI32Sop2::SBfeI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1235,7 +1397,11 @@ SBfeU64Sop2::SBfeU64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeU64Sop2>(opcode);
 }
 } // namespace detail
@@ -1266,7 +1432,11 @@ SBfeI64Sop2::SBfeI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeI64Sop2>(opcode);
 }
 } // namespace detail
@@ -1293,7 +1463,11 @@ SBfmB32Sop2::SBfmB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfmB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1320,7 +1494,11 @@ SBfmB64Sop2::SBfmB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfmB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1347,7 +1525,11 @@ SMulI32Sop2::SMulI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1374,7 +1556,11 @@ SMulHiU32Sop2::SMulHiU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulHiU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1401,7 +1587,11 @@ SMulHiI32Sop2::SMulHiI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulHiI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1431,7 +1621,12 @@ SCselectB32Sop2::SCselectB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCselectB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1463,7 +1658,12 @@ SCselectB64Sop2::SCselectB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCselectB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1492,7 +1692,12 @@ SPackLlB32B16Sop2::SPackLlB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_ll_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackLlB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1520,7 +1725,12 @@ SPackLhB32B16Sop2::SPackLhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_lh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackLhB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1547,7 +1757,12 @@ SPackHhB32B16Sop2::SPackHhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_hh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackHhB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1575,7 +1790,12 @@ SPackHlB32B16Sop2::SPackHlB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackHlB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackHlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_hl_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackHlB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1602,7 +1822,11 @@ SAddF32Sop2::SAddF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddF32Sop2>(opcode);
 }
 } // namespace detail
@@ -1629,7 +1853,11 @@ SSubF32Sop2::SSubF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubF32Sop2>(opcode);
 }
 } // namespace detail
@@ -1656,7 +1884,11 @@ SMinF32Sop2::SMinF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinF32Sop2>(opcode);
 }
 } // namespace detail
@@ -1683,7 +1915,11 @@ SMaxF32Sop2::SMaxF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxF32Sop2>(opcode);
 }
 } // namespace detail
@@ -1710,7 +1946,11 @@ SMulF32Sop2::SMulF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulF32Sop2>(opcode);
 }
 } // namespace detail
@@ -1743,7 +1983,11 @@ SFmaakF32Sop2::SFmaakF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFmaakF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSFmaakF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_fmaak_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFmaakF32Sop2>(opcode);
 }
 } // namespace detail
@@ -1776,7 +2020,11 @@ SFmamkF32Sop2::SFmamkF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFmamkF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSFmamkF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_fmamk_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFmamkF32Sop2>(opcode);
 }
 } // namespace detail
@@ -1804,7 +2052,11 @@ SFmacF32Sop2::SFmacF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFmacF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSFmacF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_fmac_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFmacF32Sop2>(opcode);
 }
 } // namespace detail
@@ -1831,7 +2083,12 @@ SCvtPkRtzF16F32Sop2::SCvtPkRtzF16F32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtPkRtzF16F32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCvtPkRtzF16F32Sop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cvt_pk_rtz_f16_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtPkRtzF16F32Sop2>(opcode);
 }
 } // namespace detail
@@ -1866,7 +2123,11 @@ SAddF16Sop2::SAddF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddF16Sop2>(opcode);
 }
 } // namespace detail
@@ -1901,7 +2162,11 @@ SSubF16Sop2::SSubF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubF16Sop2>(opcode);
 }
 } // namespace detail
@@ -1936,7 +2201,11 @@ SMinF16Sop2::SMinF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinF16Sop2>(opcode);
 }
 } // namespace detail
@@ -1971,7 +2240,11 @@ SMaxF16Sop2::SMaxF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxF16Sop2>(opcode);
 }
 } // namespace detail
@@ -2006,7 +2279,11 @@ SMulF16Sop2::SMulF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulF16Sop2>(opcode);
 }
 } // namespace detail
@@ -2042,7 +2319,11 @@ SFmacF16Sop2::SFmacF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFmacF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSFmacF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_fmac_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFmacF16Sop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/sopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/sopc.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/sopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -35,7 +34,11 @@ SCmpEqI32Sopc::SCmpEqI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqI32Sopc>(opcode);
 }
 } // namespace detail
@@ -63,7 +66,11 @@ SCmpLgI32Sopc::SCmpLgI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgI32Sopc>(opcode);
 }
 } // namespace detail
@@ -91,7 +98,11 @@ SCmpGtI32Sopc::SCmpGtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -119,7 +130,11 @@ SCmpGeI32Sopc::SCmpGeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -147,7 +162,11 @@ SCmpLtI32Sopc::SCmpLtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -175,7 +194,11 @@ SCmpLeI32Sopc::SCmpLeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -203,7 +226,11 @@ SCmpEqU32Sopc::SCmpEqU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqU32Sopc>(opcode);
 }
 } // namespace detail
@@ -231,7 +258,11 @@ SCmpLgU32Sopc::SCmpLgU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgU32Sopc>(opcode);
 }
 } // namespace detail
@@ -259,7 +290,11 @@ SCmpGtU32Sopc::SCmpGtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -287,7 +322,11 @@ SCmpGeU32Sopc::SCmpGeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -315,7 +354,11 @@ SCmpLtU32Sopc::SCmpLtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -343,7 +386,11 @@ SCmpLeU32Sopc::SCmpLeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -371,7 +418,12 @@ SBitcmp0B32Sopc::SBitcmp0B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp0B32Sopc>(opcode);
 }
 } // namespace detail
@@ -399,7 +451,12 @@ SBitcmp1B32Sopc::SBitcmp1B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp1B32Sopc>(opcode);
 }
 } // namespace detail
@@ -428,7 +485,12 @@ SBitcmp0B64Sopc::SBitcmp0B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp0B64Sopc>(opcode);
 }
 } // namespace detail
@@ -457,7 +519,12 @@ SBitcmp1B64Sopc::SBitcmp1B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp1B64Sopc>(opcode);
 }
 } // namespace detail
@@ -487,7 +554,11 @@ SCmpEqU64Sopc::SCmpEqU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqU64Sopc>(opcode);
 }
 } // namespace detail
@@ -517,7 +588,11 @@ SCmpLgU64Sopc::SCmpLgU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgU64Sopc>(opcode);
 }
 } // namespace detail
@@ -545,7 +620,11 @@ SCmpLtF32Sopc::SCmpLtF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtF32Sopc>(opcode);
 }
 } // namespace detail
@@ -575,7 +654,11 @@ SCmpLtF16Sopc::SCmpLtF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtF16Sopc>(opcode);
 }
 } // namespace detail
@@ -603,7 +686,11 @@ SCmpEqF32Sopc::SCmpEqF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqF32Sopc>(opcode);
 }
 } // namespace detail
@@ -633,7 +720,11 @@ SCmpEqF16Sopc::SCmpEqF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqF16Sopc>(opcode);
 }
 } // namespace detail
@@ -661,7 +752,11 @@ SCmpLeF32Sopc::SCmpLeF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeF32Sopc>(opcode);
 }
 } // namespace detail
@@ -691,7 +786,11 @@ SCmpLeF16Sopc::SCmpLeF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeF16Sopc>(opcode);
 }
 } // namespace detail
@@ -719,7 +818,11 @@ SCmpGtF32Sopc::SCmpGtF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtF32Sopc>(opcode);
 }
 } // namespace detail
@@ -749,7 +852,11 @@ SCmpGtF16Sopc::SCmpGtF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtF16Sopc>(opcode);
 }
 } // namespace detail
@@ -777,7 +884,11 @@ SCmpLgF32Sopc::SCmpLgF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgF32Sopc>(opcode);
 }
 } // namespace detail
@@ -807,7 +918,11 @@ SCmpLgF16Sopc::SCmpLgF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgF16Sopc>(opcode);
 }
 } // namespace detail
@@ -835,7 +950,11 @@ SCmpGeF32Sopc::SCmpGeF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeF32Sopc>(opcode);
 }
 } // namespace detail
@@ -865,7 +984,11 @@ SCmpGeF16Sopc::SCmpGeF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeF16Sopc>(opcode);
 }
 } // namespace detail
@@ -893,7 +1016,11 @@ SCmpOF32Sopc::SCmpOF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpOF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpOF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_o_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpOF32Sopc>(opcode);
 }
 } // namespace detail
@@ -923,7 +1050,11 @@ SCmpOF16Sopc::SCmpOF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpOF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpOF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_o_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpOF16Sopc>(opcode);
 }
 } // namespace detail
@@ -951,7 +1082,11 @@ SCmpUF32Sopc::SCmpUF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpUF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpUF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_u_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpUF32Sopc>(opcode);
 }
 } // namespace detail
@@ -981,7 +1116,11 @@ SCmpUF16Sopc::SCmpUF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpUF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpUF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_u_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpUF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1009,7 +1148,11 @@ SCmpNgeF32Sopc::SCmpNgeF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNgeF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNgeF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nge_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNgeF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1039,7 +1182,11 @@ SCmpNgeF16Sopc::SCmpNgeF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNgeF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNgeF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nge_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNgeF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1067,7 +1214,11 @@ SCmpNlgF32Sopc::SCmpNlgF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNlgF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNlgF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nlg_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNlgF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1097,7 +1248,11 @@ SCmpNlgF16Sopc::SCmpNlgF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNlgF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNlgF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nlg_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNlgF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1125,7 +1280,11 @@ SCmpNgtF32Sopc::SCmpNgtF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNgtF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNgtF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ngt_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNgtF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1155,7 +1314,11 @@ SCmpNgtF16Sopc::SCmpNgtF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNgtF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNgtF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ngt_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNgtF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1183,7 +1346,11 @@ SCmpNleF32Sopc::SCmpNleF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNleF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNleF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nle_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNleF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1213,7 +1380,11 @@ SCmpNleF16Sopc::SCmpNleF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNleF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNleF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nle_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNleF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1241,7 +1412,11 @@ SCmpNeqF32Sopc::SCmpNeqF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNeqF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNeqF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_neq_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNeqF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1271,7 +1446,11 @@ SCmpNeqF16Sopc::SCmpNeqF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNeqF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNeqF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_neq_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNeqF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1299,7 +1478,11 @@ SCmpNltF32Sopc::SCmpNltF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNltF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNltF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nlt_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNltF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1329,7 +1512,11 @@ SCmpNltF16Sopc::SCmpNltF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNltF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNltF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nlt_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNltF16Sopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/sopk.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -24,7 +23,11 @@ SMovkI32Sopk::SMovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_movk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -39,7 +42,11 @@ SVersionSopk::SVersionSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSVersionSopk(const MachineInst *opcode) {
+DecodeResult decodeSVersionSopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_version", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SVersionSopk>(opcode);
 }
 } // namespace detail
@@ -61,7 +68,11 @@ SCmovkI32Sopk::SCmovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmovk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -81,7 +92,11 @@ SCmpkEqI32Sopk::SCmpkEqI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkEqI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkEqI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_eq_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkEqI32Sopk>(opcode);
 }
 } // namespace detail
@@ -101,7 +116,11 @@ SCmpkLgI32Sopk::SCmpkLgI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLgI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLgI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lg_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLgI32Sopk>(opcode);
 }
 } // namespace detail
@@ -121,7 +140,11 @@ SCmpkGtI32Sopk::SCmpkGtI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGtI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_gt_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGtI32Sopk>(opcode);
 }
 } // namespace detail
@@ -141,7 +164,11 @@ SCmpkGeI32Sopk::SCmpkGeI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGeI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_ge_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGeI32Sopk>(opcode);
 }
 } // namespace detail
@@ -161,7 +188,11 @@ SCmpkLtI32Sopk::SCmpkLtI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLtI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLtI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lt_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLtI32Sopk>(opcode);
 }
 } // namespace detail
@@ -181,7 +212,11 @@ SCmpkLeI32Sopk::SCmpkLeI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLeI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLeI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_le_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLeI32Sopk>(opcode);
 }
 } // namespace detail
@@ -201,7 +236,11 @@ SCmpkEqU32Sopk::SCmpkEqU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkEqU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkEqU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_eq_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkEqU32Sopk>(opcode);
 }
 } // namespace detail
@@ -221,7 +260,11 @@ SCmpkLgU32Sopk::SCmpkLgU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLgU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLgU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lg_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLgU32Sopk>(opcode);
 }
 } // namespace detail
@@ -241,7 +284,11 @@ SCmpkGtU32Sopk::SCmpkGtU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGtU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_gt_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGtU32Sopk>(opcode);
 }
 } // namespace detail
@@ -261,7 +308,11 @@ SCmpkGeU32Sopk::SCmpkGeU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkGeU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkGeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_ge_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkGeU32Sopk>(opcode);
 }
 } // namespace detail
@@ -281,7 +332,11 @@ SCmpkLtU32Sopk::SCmpkLtU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLtU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLtU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_lt_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLtU32Sopk>(opcode);
 }
 } // namespace detail
@@ -301,7 +356,11 @@ SCmpkLeU32Sopk::SCmpkLeU32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpkLeU32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmpkLeU32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmpk_le_u32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpkLeU32Sopk>(opcode);
 }
 } // namespace detail
@@ -322,7 +381,11 @@ SAddkI32Sopk::SAddkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSAddkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_addk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -340,7 +403,11 @@ SMulkI32Sopk::SMulkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_mulk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -357,7 +424,11 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_getreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -374,7 +445,11 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -399,7 +474,12 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_imm32_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregImm32B32Sopk>(opcode);
 }
 } // namespace detail
@@ -428,7 +508,11 @@ SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCallB64Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCallB64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_call_b64", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCallB64Sopk>(opcode);
 }
 } // namespace detail
@@ -451,7 +535,12 @@ SWaitcntVscntSopk::SWaitcntVscntSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntVscntSopk(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntVscntSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_waitcnt_vscnt", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntVscntSopk>(opcode);
 }
 } // namespace detail
@@ -469,7 +558,12 @@ SWaitcntVmcntSopk::SWaitcntVmcntSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntVmcntSopk(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntVmcntSopk(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_waitcnt_vmcnt", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntVmcntSopk>(opcode);
 }
 } // namespace detail
@@ -487,7 +581,12 @@ SWaitcntExpcntSopk::SWaitcntExpcntSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntExpcntSopk(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntExpcntSopk(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_waitcnt_expcnt", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntExpcntSopk>(opcode);
 }
 } // namespace detail
@@ -505,7 +604,12 @@ SWaitcntLgkmcntSopk::SWaitcntLgkmcntSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntLgkmcntSopk(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntLgkmcntSopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_waitcnt_lgkmcnt", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntLgkmcntSopk>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/sopp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/sopp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/sopp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -22,7 +21,11 @@ SNopSopp::SNopSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode) {
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_nop", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNopSopp>(opcode);
 }
 } // namespace detail
@@ -37,7 +40,11 @@ SSetkillSopp::SSetkillSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetkillSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetkillSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setkill", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetkillSopp>(opcode);
 }
 } // namespace detail
@@ -52,7 +59,11 @@ SSethaltSopp::SSethaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sethalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSethaltSopp>(opcode);
 }
 } // namespace detail
@@ -67,7 +78,11 @@ SSleepSopp::SSleepSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode) {
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sleep", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSleepSopp>(opcode);
 }
 } // namespace detail
@@ -82,7 +97,13 @@ SSetInstPrefetchDistanceSopp::SSetInstPrefetchDistanceSopp(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetInstPrefetchDistanceSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetInstPrefetchDistanceSopp(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Sopp::validate_encoding("s_set_inst_prefetch_distance",
+                              reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetInstPrefetchDistanceSopp>(opcode);
 }
 } // namespace detail
@@ -97,7 +118,11 @@ SClauseSopp::SClauseSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClauseSopp(const MachineInst *opcode) {
+DecodeResult decodeSClauseSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_clause", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClauseSopp>(opcode);
 }
 } // namespace detail
@@ -112,7 +137,11 @@ SDelayAluSopp::SDelayAluSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDelayAluSopp(const MachineInst *opcode) {
+DecodeResult decodeSDelayAluSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_delay_alu", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDelayAluSopp>(opcode);
 }
 } // namespace detail
@@ -129,7 +158,12 @@ SWaitcntDepctrSopp::SWaitcntDepctrSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntDepctrSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntDepctrSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_waitcnt_depctr", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntDepctrSopp>(opcode);
 }
 } // namespace detail
@@ -145,7 +179,11 @@ SWaitcntSopp::SWaitcntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_waitcnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntSopp>(opcode);
 }
 } // namespace detail
@@ -159,7 +197,11 @@ SWaitIdleSopp::SWaitIdleSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitIdleSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitIdleSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_idle", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitIdleSopp>(opcode);
 }
 } // namespace detail
@@ -175,7 +217,11 @@ SWaitEventSopp::SWaitEventSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitEventSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitEventSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_event", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitEventSopp>(opcode);
 }
 } // namespace detail
@@ -190,7 +236,11 @@ STrapSopp::STrapSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode) {
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_trap", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STrapSopp>(opcode);
 }
 } // namespace detail
@@ -205,7 +255,11 @@ SRoundModeSopp::SRoundModeSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRoundModeSopp(const MachineInst *opcode) {
+DecodeResult decodeSRoundModeSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_round_mode", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRoundModeSopp>(opcode);
 }
 } // namespace detail
@@ -220,7 +274,12 @@ SDenormModeSopp::SDenormModeSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDenormModeSopp(const MachineInst *opcode) {
+DecodeResult decodeSDenormModeSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_denorm_mode", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDenormModeSopp>(opcode);
 }
 } // namespace detail
@@ -233,7 +292,11 @@ SCodeEndSopp::SCodeEndSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCodeEndSopp(const MachineInst *opcode) {
+DecodeResult decodeSCodeEndSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_code_end", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCodeEndSopp>(opcode);
 }
 } // namespace detail
@@ -250,7 +313,11 @@ SBranchSopp::SBranchSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode) {
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_branch", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBranchSopp>(opcode);
 }
 } // namespace detail
@@ -275,7 +342,12 @@ SCbranchScc0Sopp::SCbranchScc0Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc0", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc0Sopp>(opcode);
 }
 } // namespace detail
@@ -300,7 +372,12 @@ SCbranchScc1Sopp::SCbranchScc1Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc1", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc1Sopp>(opcode);
 }
 } // namespace detail
@@ -325,7 +402,12 @@ SCbranchVcczSopp::SCbranchVcczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVcczSopp>(opcode);
 }
 } // namespace detail
@@ -350,7 +432,12 @@ SCbranchVccnzSopp::SCbranchVccnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVccnzSopp>(opcode);
 }
 } // namespace detail
@@ -375,7 +462,12 @@ SCbranchExeczSopp::SCbranchExeczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExeczSopp>(opcode);
 }
 } // namespace detail
@@ -400,7 +492,12 @@ SCbranchExecnzSopp::SCbranchExecnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExecnzSopp>(opcode);
 }
 } // namespace detail
@@ -420,7 +517,12 @@ SCbranchCdbgsysSopp::SCbranchCdbgsysSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysSopp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysSopp>(opcode);
 }
 } // namespace detail
@@ -435,7 +537,12 @@ SCbranchCdbguserSopp::SCbranchCdbguserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbguserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbguserSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbguser", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbguserSopp>(opcode);
 }
 } // namespace detail
@@ -450,7 +557,12 @@ SCbranchCdbgsysOrUserSopp::SCbranchCdbgsysOrUserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysOrUserSopp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys_or_user", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysOrUserSopp>(opcode);
 }
 } // namespace detail
@@ -465,7 +577,12 @@ SCbranchCdbgsysAndUserSopp::SCbranchCdbgsysAndUserSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchCdbgsysAndUserSopp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_cdbgsys_and_user", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchCdbgsysAndUserSopp>(opcode);
 }
 } // namespace detail
@@ -479,7 +596,11 @@ SEndpgmSopp::SEndpgmSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSopp>(opcode);
 }
 } // namespace detail
@@ -493,7 +614,12 @@ SEndpgmSavedSopp::SEndpgmSavedSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm_saved", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSavedSopp>(opcode);
 }
 } // namespace detail
@@ -507,7 +633,12 @@ SEndpgmOrderedPsDoneSopp::SEndpgmOrderedPsDoneSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmOrderedPsDoneSopp(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm_ordered_ps_done", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmOrderedPsDoneSopp>(opcode);
 }
 } // namespace detail
@@ -520,7 +651,11 @@ SWakeupSopp::SWakeupSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode) {
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wakeup", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWakeupSopp>(opcode);
 }
 } // namespace detail
@@ -535,7 +670,11 @@ SSetprioSopp::SSetprioSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setprio", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetprioSopp>(opcode);
 }
 } // namespace detail
@@ -553,7 +692,11 @@ SSendmsgSopp::SSendmsgSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsg", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsgSopp>(opcode);
 }
 } // namespace detail
@@ -571,7 +714,12 @@ SSendmsghaltSopp::SSendmsghaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsghalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsghaltSopp>(opcode);
 }
 } // namespace detail
@@ -586,7 +734,12 @@ SIncperflevelSopp::SIncperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_incperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIncperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -601,7 +754,12 @@ SDecperflevelSopp::SDecperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_decperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDecperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -617,7 +775,12 @@ STtracedataSopp::STtracedataSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode) {
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_ttracedata", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STtracedataSopp>(opcode);
 }
 } // namespace detail
@@ -635,7 +798,12 @@ STtracedataImmSopp::STtracedataImmSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTtracedataImmSopp(const MachineInst *opcode) {
+DecodeResult decodeSTtracedataImmSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_ttracedata_imm", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STtracedataImmSopp>(opcode);
 }
 } // namespace detail
@@ -648,7 +816,11 @@ SIcacheInvSopp::SIcacheInvSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode) {
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_icache_inv", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIcacheInvSopp>(opcode);
 }
 } // namespace detail
@@ -662,7 +834,11 @@ SBarrierSopp::SBarrierSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBarrierSopp(const MachineInst *opcode) {
+DecodeResult decodeSBarrierSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_barrier", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBarrierSopp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vinterp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vinterp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vinterp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -28,7 +27,12 @@ VInterpP10F32Vinterp::VInterpP10F32Vinterp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP10F32Vinterp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP10F32Vinterp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vinterp::validate_encoding(
+      "v_interp_p10_f32", reinterpret_cast<const Vinterp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP10F32Vinterp>(opcode);
 }
 } // namespace detail
@@ -49,7 +53,12 @@ VInterpP2F32Vinterp::VInterpP2F32Vinterp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2F32Vinterp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2F32Vinterp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vinterp::validate_encoding(
+      "v_interp_p2_f32", reinterpret_cast<const Vinterp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2F32Vinterp>(opcode);
 }
 } // namespace detail
@@ -70,7 +79,12 @@ VInterpP10F16F32Vinterp::VInterpP10F16F32Vinterp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP10F16F32Vinterp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP10F16F32Vinterp(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vinterp::validate_encoding(
+      "v_interp_p10_f16_f32", reinterpret_cast<const Vinterp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP10F16F32Vinterp>(opcode);
 }
 } // namespace detail
@@ -91,7 +105,12 @@ VInterpP2F16F32Vinterp::VInterpP2F16F32Vinterp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2F16F32Vinterp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2F16F32Vinterp(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vinterp::validate_encoding(
+      "v_interp_p2_f16_f32", reinterpret_cast<const Vinterp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2F16F32Vinterp>(opcode);
 }
 } // namespace detail
@@ -118,7 +137,13 @@ VInterpP10RtzF16F32Vinterp::VInterpP10RtzF16F32Vinterp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP10RtzF16F32Vinterp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP10RtzF16F32Vinterp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vinterp::validate_encoding("v_interp_p10_rtz_f16_f32",
+                                 reinterpret_cast<const Vinterp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP10RtzF16F32Vinterp>(opcode);
 }
 } // namespace detail
@@ -139,7 +164,12 @@ VInterpP2RtzF16F32Vinterp::VInterpP2RtzF16F32Vinterp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2RtzF16F32Vinterp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2RtzF16F32Vinterp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vinterp::validate_encoding(
+      "v_interp_p2_rtz_f16_f32", reinterpret_cast<const Vinterp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2RtzF16F32Vinterp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop1.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -23,7 +22,15 @@ VNopVop1::VNopVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode) {
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_nop_dpp"
+          : "v_nop_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop1>(opcode);
 }
 } // namespace detail
@@ -64,7 +71,15 @@ VMovB32Vop1::VMovB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_mov_b32_dpp"
+          : "v_mov_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop1>(opcode);
 }
 } // namespace detail
@@ -81,13 +96,22 @@ VReadfirstlaneB32Vop1::VReadfirstlaneB32Vop1(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_readfirstlane_b32_dpp"
+          : "v_readfirstlane_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support DPP";
   return std::make_unique<VReadfirstlaneB32Vop1>(opcode);
 }
 } // namespace detail
@@ -109,13 +133,21 @@ VCvtI32F64Vop1::VCvtI32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_I32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f64_dpp"
+          : "v_cvt_i32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_I32_F64 does not support DPP";
   return std::make_unique<VCvtI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -136,13 +168,21 @@ VCvtF64I32Vop1::VCvtF64I32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_I32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_i32_dpp"
+          : "v_cvt_f64_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_I32 does not support DPP";
   return std::make_unique<VCvtF64I32Vop1>(opcode);
 }
 } // namespace detail
@@ -183,7 +223,15 @@ VCvtF32I32Vop1::VCvtF32I32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_i32_dpp"
+          : "v_cvt_f32_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop1>(opcode);
 }
 } // namespace detail
@@ -224,7 +272,15 @@ VCvtF32U32Vop1::VCvtF32U32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_u32_dpp"
+          : "v_cvt_f32_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop1>(opcode);
 }
 } // namespace detail
@@ -265,7 +321,15 @@ VCvtU32F32Vop1::VCvtU32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f32_dpp"
+          : "v_cvt_u32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -306,7 +370,15 @@ VCvtI32F32Vop1::VCvtI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f32_dpp"
+          : "v_cvt_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -349,7 +421,15 @@ VCvtF16F32Vop1::VCvtF16F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_f32_dpp"
+          : "v_cvt_f16_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop1>(opcode);
 }
 } // namespace detail
@@ -398,7 +478,15 @@ VCvtF32F16Vop1::VCvtF32F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f16_dpp"
+          : "v_cvt_f32_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop1>(opcode);
 }
 } // namespace detail
@@ -439,7 +527,16 @@ VCvtNearestI32F32Vop1::VCvtNearestI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNearestI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNearestI32F32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_nearest_i32_f32_dpp"
+          : "v_cvt_nearest_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNearestI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -480,7 +577,16 @@ VCvtFloorI32F32Vop1::VCvtFloorI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFloorI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtFloorI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_floor_i32_f32_dpp"
+          : "v_cvt_floor_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFloorI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -521,7 +627,16 @@ VCvtOffF32I4Vop1::VCvtOffF32I4Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_off_f32_i4_dpp"
+          : "v_cvt_off_f32_i4_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop1>(opcode);
 }
 } // namespace detail
@@ -543,13 +658,21 @@ VCvtF32F64Vop1::VCvtF32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f64_dpp"
+          : "v_cvt_f32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F32_F64 does not support DPP";
   return std::make_unique<VCvtF32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -570,13 +693,21 @@ VCvtF64F32Vop1::VCvtF64F32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_f32_dpp"
+          : "v_cvt_f64_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support DPP";
   return std::make_unique<VCvtF64F32Vop1>(opcode);
 }
 } // namespace detail
@@ -617,7 +748,16 @@ VCvtF32Ubyte0Vop1::VCvtF32Ubyte0Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte0_dpp"
+          : "v_cvt_f32_ubyte0_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop1>(opcode);
 }
 } // namespace detail
@@ -658,7 +798,16 @@ VCvtF32Ubyte1Vop1::VCvtF32Ubyte1Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte1_dpp"
+          : "v_cvt_f32_ubyte1_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop1>(opcode);
 }
 } // namespace detail
@@ -699,7 +848,16 @@ VCvtF32Ubyte2Vop1::VCvtF32Ubyte2Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte2_dpp"
+          : "v_cvt_f32_ubyte2_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop1>(opcode);
 }
 } // namespace detail
@@ -740,7 +898,16 @@ VCvtF32Ubyte3Vop1::VCvtF32Ubyte3Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte3_dpp"
+          : "v_cvt_f32_ubyte3_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop1>(opcode);
 }
 } // namespace detail
@@ -762,13 +929,21 @@ VCvtU32F64Vop1::VCvtU32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_U32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f64_dpp"
+          : "v_cvt_u32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_U32_F64 does not support DPP";
   return std::make_unique<VCvtU32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -789,13 +964,21 @@ VCvtF64U32Vop1::VCvtF64U32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_U32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_u32_dpp"
+          : "v_cvt_f64_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_U32 does not support DPP";
   return std::make_unique<VCvtF64U32Vop1>(opcode);
 }
 } // namespace detail
@@ -817,13 +1000,21 @@ VTruncF64Vop1::VTruncF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_TRUNC_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f64_dpp"
+          : "v_trunc_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_TRUNC_F64 does not support DPP";
   return std::make_unique<VTruncF64Vop1>(opcode);
 }
 } // namespace detail
@@ -845,13 +1036,21 @@ VCeilF64Vop1::VCeilF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CEIL_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f64_dpp"
+          : "v_ceil_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CEIL_F64 does not support DPP";
   return std::make_unique<VCeilF64Vop1>(opcode);
 }
 } // namespace detail
@@ -873,13 +1072,21 @@ VRndneF64Vop1::VRndneF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RNDNE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f64_dpp"
+          : "v_rndne_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support DPP";
   return std::make_unique<VRndneF64Vop1>(opcode);
 }
 } // namespace detail
@@ -901,13 +1108,21 @@ VFloorF64Vop1::VFloorF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FLOOR_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_floor_f64_dpp"
+          : "v_floor_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FLOOR_F64 does not support DPP";
   return std::make_unique<VFloorF64Vop1>(opcode);
 }
 } // namespace detail
@@ -923,7 +1138,15 @@ VPipeflushVop1::VPipeflushVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPipeflushVop1(const MachineInst *opcode) {
+DecodeResult decodeVPipeflushVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_pipeflush_dpp"
+          : "v_pipeflush_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPipeflushVop1>(opcode);
 }
 } // namespace detail
@@ -968,7 +1191,15 @@ VMovB16Vop1::VMovB16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_mov_b16_dpp"
+          : "v_mov_b16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB16Vop1>(opcode);
 }
 } // namespace detail
@@ -1015,7 +1246,15 @@ VFractF32Vop1::VFractF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_fract_f32_dpp"
+          : "v_fract_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1056,7 +1295,15 @@ VTruncF32Vop1::VTruncF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f32_dpp"
+          : "v_trunc_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1097,7 +1344,15 @@ VCeilF32Vop1::VCeilF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f32_dpp"
+          : "v_ceil_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1138,7 +1393,15 @@ VRndneF32Vop1::VRndneF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f32_dpp"
+          : "v_rndne_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1179,7 +1442,15 @@ VFloorF32Vop1::VFloorF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_floor_f32_dpp"
+          : "v_floor_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1220,7 +1491,15 @@ VExpF32Vop1::VExpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_exp_f32_dpp"
+          : "v_exp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1261,7 +1540,15 @@ VLogF32Vop1::VLogF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_log_f32_dpp"
+          : "v_log_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1302,7 +1589,15 @@ VRcpF32Vop1::VRcpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f32_dpp"
+          : "v_rcp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1343,7 +1638,16 @@ VRcpIflagF32Vop1::VRcpIflagF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_iflag_f32_dpp"
+          : "v_rcp_iflag_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1384,7 +1688,15 @@ VRsqF32Vop1::VRsqF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f32_dpp"
+          : "v_rsq_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1406,13 +1718,21 @@ VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RCP_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f64_dpp"
+          : "v_rcp_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support DPP";
   return std::make_unique<VRcpF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1434,13 +1754,21 @@ VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RSQ_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f64_dpp"
+          : "v_rsq_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support DPP";
   return std::make_unique<VRsqF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1481,7 +1809,15 @@ VSqrtF32Vop1::VSqrtF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f32_dpp"
+          : "v_sqrt_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1503,13 +1839,21 @@ VSqrtF64Vop1::VSqrtF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SQRT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f64_dpp"
+          : "v_sqrt_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support DPP";
   return std::make_unique<VSqrtF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1550,7 +1894,15 @@ VSinF32Vop1::VSinF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sin_f32_dpp"
+          : "v_sin_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1591,7 +1943,15 @@ VCosF32Vop1::VCosF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cos_f32_dpp"
+          : "v_cos_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1632,7 +1992,15 @@ VNotB32Vop1::VNotB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_not_b32_dpp"
+          : "v_not_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop1>(opcode);
 }
 } // namespace detail
@@ -1673,7 +2041,15 @@ VBfrevB32Vop1::VBfrevB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_bfrev_b32_dpp"
+          : "v_bfrev_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop1>(opcode);
 }
 } // namespace detail
@@ -1714,7 +2090,15 @@ VClzI32U32Vop1::VClzI32U32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClzI32U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVClzI32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_clz_i32_u32_dpp"
+          : "v_clz_i32_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClzI32U32Vop1>(opcode);
 }
 } // namespace detail
@@ -1755,7 +2139,15 @@ VCtzI32B32Vop1::VCtzI32B32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCtzI32B32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCtzI32B32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ctz_i32_b32_dpp"
+          : "v_ctz_i32_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCtzI32B32Vop1>(opcode);
 }
 } // namespace detail
@@ -1796,7 +2188,15 @@ VClsI32Vop1::VClsI32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClsI32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVClsI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cls_i32_dpp"
+          : "v_cls_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClsI32Vop1>(opcode);
 }
 } // namespace detail
@@ -1818,13 +2218,22 @@ VFrexpExpI32F64Vop1::VFrexpExpI32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_EXP_I32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f64_dpp"
+          : "v_frexp_exp_i32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_EXP_I32_F64 does not support DPP";
   return std::make_unique<VFrexpExpI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -1846,13 +2255,22 @@ VFrexpMantF64Vop1::VFrexpMantF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_MANT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f64_dpp"
+          : "v_frexp_mant_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_MANT_F64 does not support DPP";
   return std::make_unique<VFrexpMantF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1874,13 +2292,21 @@ VFractF64Vop1::VFractF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FRACT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_fract_f64_dpp"
+          : "v_fract_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FRACT_F64 does not support DPP";
   return std::make_unique<VFractF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1921,7 +2347,16 @@ VFrexpExpI32F32Vop1::VFrexpExpI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f32_dpp"
+          : "v_frexp_exp_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -1962,7 +2397,16 @@ VFrexpMantF32Vop1::VFrexpMantF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f32_dpp"
+          : "v_frexp_mant_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop1>(opcode);
 }
 } // namespace detail
@@ -2006,7 +2450,16 @@ VMovreldB32Vop1::VMovreldB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovreldB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovreldB32Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movreld_b32_dpp"
+          : "v_movreld_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovreldB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2046,7 +2499,16 @@ VMovrelsB32Vop1::VMovrelsB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsB32Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movrels_b32_dpp"
+          : "v_movrels_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2086,7 +2548,16 @@ VMovrelsdB32Vop1::VMovrelsdB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsdB32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_b32_dpp"
+          : "v_movrelsd_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsdB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2126,7 +2597,16 @@ VMovrelsd2B32Vop1::VMovrelsd2B32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsd2B32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_2_b32_dpp"
+          : "v_movrelsd_2_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsd2B32Vop1>(opcode);
 }
 } // namespace detail
@@ -2171,7 +2651,15 @@ VCvtF16U16Vop1::VCvtF16U16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_u16_dpp"
+          : "v_cvt_f16_u16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop1>(opcode);
 }
 } // namespace detail
@@ -2222,7 +2710,15 @@ VCvtF16I16Vop1::VCvtF16I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_i16_dpp"
+          : "v_cvt_f16_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop1>(opcode);
 }
 } // namespace detail
@@ -2273,7 +2769,15 @@ VCvtU16F16Vop1::VCvtU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u16_f16_dpp"
+          : "v_cvt_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2324,7 +2828,15 @@ VCvtI16F16Vop1::VCvtI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i16_f16_dpp"
+          : "v_cvt_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2375,7 +2887,15 @@ VRcpF16Vop1::VRcpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f16_dpp"
+          : "v_rcp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2426,7 +2946,15 @@ VSqrtF16Vop1::VSqrtF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f16_dpp"
+          : "v_sqrt_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2477,7 +3005,15 @@ VRsqF16Vop1::VRsqF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f16_dpp"
+          : "v_rsq_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2528,7 +3064,15 @@ VLogF16Vop1::VLogF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_log_f16_dpp"
+          : "v_log_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2579,7 +3123,15 @@ VExpF16Vop1::VExpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_exp_f16_dpp"
+          : "v_exp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2630,7 +3182,16 @@ VFrexpMantF16Vop1::VFrexpMantF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f16_dpp"
+          : "v_frexp_mant_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2681,7 +3242,16 @@ VFrexpExpI16F16Vop1::VFrexpExpI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i16_f16_dpp"
+          : "v_frexp_exp_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2732,7 +3302,15 @@ VFloorF16Vop1::VFloorF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_floor_f16_dpp"
+          : "v_floor_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2783,7 +3361,15 @@ VCeilF16Vop1::VCeilF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f16_dpp"
+          : "v_ceil_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2834,7 +3420,15 @@ VTruncF16Vop1::VTruncF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f16_dpp"
+          : "v_trunc_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2885,7 +3479,15 @@ VRndneF16Vop1::VRndneF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f16_dpp"
+          : "v_rndne_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2936,7 +3538,15 @@ VFractF16Vop1::VFractF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_fract_f16_dpp"
+          : "v_fract_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2987,7 +3597,15 @@ VSinF16Vop1::VSinF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sin_f16_dpp"
+          : "v_sin_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3038,7 +3656,15 @@ VCosF16Vop1::VCosF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cos_f16_dpp"
+          : "v_cos_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3087,7 +3713,16 @@ VSatPkU8I16Vop1::VSatPkU8I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sat_pk_u8_i16_dpp"
+          : "v_sat_pk_u8_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop1>(opcode);
 }
 } // namespace detail
@@ -3138,7 +3773,16 @@ VCvtNormI16F16Vop1::VCvtNormI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_i16_f16_dpp"
+          : "v_cvt_norm_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3189,7 +3833,16 @@ VCvtNormU16F16Vop1::VCvtNormU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_u16_f16_dpp"
+          : "v_cvt_norm_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3214,13 +3867,21 @@ VSwapB32Vop1::VSwapB32Vop1(const MachineInst *inst)
   dst_operands_[1] = &src0;
   num_src_ = 2;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWAP_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swap_b32_dpp"
+          : "v_swap_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B32 does not support DPP";
   return std::make_unique<VSwapB32Vop1>(opcode);
 }
 } // namespace detail
@@ -3242,13 +3903,21 @@ VSwapB16Vop1::VSwapB16Vop1(const MachineInst *inst)
   dst_operands_[1] = &src0;
   num_src_ = 2;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWAP_B16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwapB16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwapB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swap_b16_dpp"
+          : "v_swap_b16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B16 does not support DPP";
   return std::make_unique<VSwapB16Vop1>(opcode);
 }
 } // namespace detail
@@ -3273,13 +3942,22 @@ VPermlane64B32Vop1::VPermlane64B32Vop1(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANE64_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlane64B32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVPermlane64B32Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_permlane64_b32_dpp"
+          : "v_permlane64_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE64_B32 does not support DPP";
   return std::make_unique<VPermlane64B32Vop1>(opcode);
 }
 } // namespace detail
@@ -3300,14 +3978,23 @@ VSwaprelB32Vop1::VSwaprelB32Vop1(const MachineInst *inst)
   src_operands_[2] = &m0;
   num_src_ = 3;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWAPREL_B32 does not support DPP", "");
   m0.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwaprelB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwaprelB32Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swaprel_b32_dpp"
+          : "v_swaprel_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SWAPREL_B32 does not support DPP";
   return std::make_unique<VSwaprelB32Vop1>(opcode);
 }
 } // namespace detail
@@ -3352,7 +4039,15 @@ VNotB16Vop1::VNotB16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVNotB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_not_b16_dpp"
+          : "v_not_b16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB16Vop1>(opcode);
 }
 } // namespace detail
@@ -3401,7 +4096,15 @@ VCvtI32I16Vop1::VCvtI32I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_i16_dpp"
+          : "v_cvt_i32_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32I16Vop1>(opcode);
 }
 } // namespace detail
@@ -3444,7 +4147,15 @@ VCvtU32U16Vop1::VCvtU32U16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32U16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_u16_dpp"
+          : "v_cvt_u32_u16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32U16Vop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop2.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -54,7 +53,16 @@ VCndmaskB32Vop2::VCndmaskB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_cndmask_b32_dpp"
+          : "v_cndmask_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop2>(opcode);
 }
 } // namespace detail
@@ -98,7 +106,16 @@ VDot2accF32F16Vop2::VDot2accF32F16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2accF32F16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVDot2accF32F16Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_dot2acc_f32_f16_dpp"
+          : "v_dot2acc_f32_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2accF32F16Vop2>(opcode);
 }
 } // namespace detail
@@ -141,7 +158,15 @@ VAddF32Vop2::VAddF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_f32_dpp"
+          : "v_add_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop2>(opcode);
 }
 } // namespace detail
@@ -184,7 +209,15 @@ VSubF32Vop2::VSubF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_f32_dpp"
+          : "v_sub_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop2>(opcode);
 }
 } // namespace detail
@@ -227,7 +260,15 @@ VSubrevF32Vop2::VSubrevF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f32_dpp"
+          : "v_subrev_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop2>(opcode);
 }
 } // namespace detail
@@ -251,13 +292,22 @@ VFmacDx9ZeroF32Vop2::VFmacDx9ZeroF32Vop2(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAC_DX9_ZERO_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacDx9ZeroF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacDx9ZeroF32Vop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmac_dx9_zero_f32_dpp"
+          : "v_fmac_dx9_zero_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_DX9_ZERO_F32 does not support DPP";
   return std::make_unique<VFmacDx9ZeroF32Vop2>(opcode);
 }
 } // namespace detail
@@ -300,7 +350,16 @@ VMulDx9ZeroF32Vop2::VMulDx9ZeroF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulDx9ZeroF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulDx9ZeroF32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_dx9_zero_f32_dpp"
+          : "v_mul_dx9_zero_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulDx9ZeroF32Vop2>(opcode);
 }
 } // namespace detail
@@ -343,7 +402,15 @@ VMulF32Vop2::VMulF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_f32_dpp"
+          : "v_mul_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop2>(opcode);
 }
 } // namespace detail
@@ -386,7 +453,15 @@ VMulI32I24Vop2::VMulI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_i32_i24_dpp"
+          : "v_mul_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -429,7 +504,16 @@ VMulHiI32I24Vop2::VMulHiI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_i32_i24_dpp"
+          : "v_mul_hi_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -472,7 +556,15 @@ VMulU32U24Vop2::VMulU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_u32_u24_dpp"
+          : "v_mul_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -515,7 +607,16 @@ VMulHiU32U24Vop2::VMulHiU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_u32_u24_dpp"
+          : "v_mul_hi_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -558,7 +659,15 @@ VMinF32Vop2::VMinF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_f32_dpp"
+          : "v_min_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF32Vop2>(opcode);
 }
 } // namespace detail
@@ -601,7 +710,15 @@ VMaxF32Vop2::VMaxF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_f32_dpp"
+          : "v_max_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF32Vop2>(opcode);
 }
 } // namespace detail
@@ -644,7 +761,15 @@ VMinI32Vop2::VMinI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_i32_dpp"
+          : "v_min_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop2>(opcode);
 }
 } // namespace detail
@@ -687,7 +812,15 @@ VMaxI32Vop2::VMaxI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_i32_dpp"
+          : "v_max_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop2>(opcode);
 }
 } // namespace detail
@@ -730,7 +863,15 @@ VMinU32Vop2::VMinU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_u32_dpp"
+          : "v_min_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop2>(opcode);
 }
 } // namespace detail
@@ -773,7 +914,15 @@ VMaxU32Vop2::VMaxU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_u32_dpp"
+          : "v_max_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop2>(opcode);
 }
 } // namespace detail
@@ -816,7 +965,16 @@ VLshlrevB32Vop2::VLshlrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b32_dpp"
+          : "v_lshlrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -859,7 +1017,16 @@ VLshrrevB32Vop2::VLshrrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_lshrrev_b32_dpp"
+          : "v_lshrrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -902,7 +1069,16 @@ VAshrrevI32Vop2::VAshrrevI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_ashrrev_i32_dpp"
+          : "v_ashrrev_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop2>(opcode);
 }
 } // namespace detail
@@ -945,7 +1121,15 @@ VAndB32Vop2::VAndB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_and_b32_dpp"
+          : "v_and_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop2>(opcode);
 }
 } // namespace detail
@@ -988,7 +1172,15 @@ VOrB32Vop2::VOrB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_or_b32_dpp"
+          : "v_or_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1031,7 +1223,15 @@ VXorB32Vop2::VXorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_xor_b32_dpp"
+          : "v_xor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1074,7 +1274,15 @@ VXnorB32Vop2::VXnorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_xnor_b32_dpp"
+          : "v_xnor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1123,7 +1331,16 @@ VAddCoCiU32Vop2::VAddCoCiU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddCoCiU32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_co_ci_u32_dpp"
+          : "v_add_co_ci_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoCiU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1172,7 +1389,16 @@ VSubCoCiU32Vop2::VSubCoCiU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubCoCiU32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_co_ci_u32_dpp"
+          : "v_sub_co_ci_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoCiU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1221,7 +1447,16 @@ VSubrevCoCiU32Vop2::VSubrevCoCiU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoCiU32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_co_ci_u32_dpp"
+          : "v_subrev_co_ci_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoCiU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1264,7 +1499,15 @@ VAddNcU32Vop2::VAddNcU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_u32_dpp"
+          : "v_add_nc_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1307,7 +1550,15 @@ VSubNcU32Vop2::VSubNcU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_u32_dpp"
+          : "v_sub_nc_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1350,7 +1601,16 @@ VSubrevNcU32Vop2::VSubrevNcU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevNcU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_nc_u32_dpp"
+          : "v_subrev_nc_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevNcU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1394,7 +1654,15 @@ VFmacF32Vop2::VFmacF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f32_dpp"
+          : "v_fmac_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1422,14 +1690,22 @@ VFmamkF32Vop2::VFmamkF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAMK_F32 does not support DPP", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmamkF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmamkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmamk_f32_dpp"
+          : "v_fmamk_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F32 does not support DPP";
   return std::make_unique<VFmamkF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1457,14 +1733,22 @@ VFmaakF32Vop2::VFmaakF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAAK_F32 does not support DPP", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaakF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmaakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmaak_f32_dpp"
+          : "v_fmaak_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F32 does not support DPP";
   return std::make_unique<VFmaakF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1507,7 +1791,16 @@ VCvtPkRtzF16F32Vop2::VCvtPkRtzF16F32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkRtzF16F32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkRtzF16F32Vop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_rtz_f16_f32_dpp"
+          : "v_cvt_pk_rtz_f16_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkRtzF16F32Vop2>(opcode);
 }
 } // namespace detail
@@ -1555,7 +1848,15 @@ VAddF16Vop2::VAddF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_f16_dpp"
+          : "v_add_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1609,7 +1910,15 @@ VSubF16Vop2::VSubF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_f16_dpp"
+          : "v_sub_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1663,7 +1972,15 @@ VSubrevF16Vop2::VSubrevF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f16_dpp"
+          : "v_subrev_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1717,7 +2034,15 @@ VMulF16Vop2::VMulF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_f16_dpp"
+          : "v_mul_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1772,7 +2097,15 @@ VFmacF16Vop2::VFmacF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f16_dpp"
+          : "v_fmac_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1812,14 +2145,22 @@ VFmamkF16Vop2::VFmamkF16Vop2(const MachineInst *inst)
       Operand(16, OperandType::OPR_SIMM32,
               static_cast<int>(
                   (reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAMK_F16 does not support DPP", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmamkF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmamkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmamk_f16_dpp"
+          : "v_fmamk_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F16 does not support DPP";
   return std::make_unique<VFmamkF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1858,14 +2199,22 @@ VFmaakF16Vop2::VFmaakF16Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAAK_F16 does not support DPP", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaakF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmaakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmaak_f16_dpp"
+          : "v_fmaak_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F16 does not support DPP";
   return std::make_unique<VFmaakF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1919,7 +2268,15 @@ VMaxF16Vop2::VMaxF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_f16_dpp"
+          : "v_max_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1973,7 +2330,15 @@ VMinF16Vop2::VMinF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_f16_dpp"
+          : "v_min_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2027,7 +2392,15 @@ VLdexpF16Vop2::VLdexpF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_ldexp_f16_dpp"
+          : "v_ldexp_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2057,13 +2430,21 @@ VPkFmacF16Vop2::VPkFmacF16Vop2(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_FMAC_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_pk_fmac_f16_dpp"
+          : "v_pk_fmac_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PK_FMAC_F16 does not support DPP";
   return std::make_unique<VPkFmacF16Vop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop3.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop3.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -24,7 +23,15 @@ VNopVop3::VNopVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode) {
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_nop_e64_dpp"
+          : "v_nop",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop3>(opcode);
 }
 } // namespace detail
@@ -65,7 +72,15 @@ VMovB32Vop3::VMovB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mov_b32_e64_dpp"
+          : "v_mov_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop3>(opcode);
 }
 } // namespace detail
@@ -82,13 +97,22 @@ VReadfirstlaneB32Vop3::VReadfirstlaneB32Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_readfirstlane_b32_e64_dpp"
+          : "v_readfirstlane_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support DPP";
   return std::make_unique<VReadfirstlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -110,13 +134,21 @@ VCvtI32F64Vop3::VCvtI32F64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_I32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f64_e64_dpp"
+          : "v_cvt_i32_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_I32_F64 does not support DPP";
   return std::make_unique<VCvtI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -137,13 +169,21 @@ VCvtF64I32Vop3::VCvtF64I32Vop3(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_I32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_i32_e64_dpp"
+          : "v_cvt_f64_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_I32 does not support DPP";
   return std::make_unique<VCvtF64I32Vop3>(opcode);
 }
 } // namespace detail
@@ -184,7 +224,15 @@ VCvtF32I32Vop3::VCvtF32I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_i32_e64_dpp"
+          : "v_cvt_f32_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop3>(opcode);
 }
 } // namespace detail
@@ -225,7 +273,15 @@ VCvtF32U32Vop3::VCvtF32U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_u32_e64_dpp"
+          : "v_cvt_f32_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop3>(opcode);
 }
 } // namespace detail
@@ -266,7 +322,15 @@ VCvtU32F32Vop3::VCvtU32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f32_e64_dpp"
+          : "v_cvt_u32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -307,7 +371,15 @@ VCvtI32F32Vop3::VCvtI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f32_e64_dpp"
+          : "v_cvt_i32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -348,7 +420,15 @@ VCvtF16F32Vop3::VCvtF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_f32_e64_dpp"
+          : "v_cvt_f16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -399,7 +479,15 @@ VCvtF32F16Vop3::VCvtF32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f16_e64_dpp"
+          : "v_cvt_f32_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -440,7 +528,16 @@ VCvtNearestI32F32Vop3::VCvtNearestI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNearestI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNearestI32F32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_nearest_i32_f32_e64_dpp"
+          : "v_cvt_nearest_i32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNearestI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -481,7 +578,16 @@ VCvtFloorI32F32Vop3::VCvtFloorI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFloorI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtFloorI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_floor_i32_f32_e64_dpp"
+          : "v_cvt_floor_i32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFloorI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -522,7 +628,16 @@ VCvtOffF32I4Vop3::VCvtOffF32I4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_off_f32_i4_e64_dpp"
+          : "v_cvt_off_f32_i4",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop3>(opcode);
 }
 } // namespace detail
@@ -544,13 +659,21 @@ VCvtF32F64Vop3::VCvtF32F64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f64_e64_dpp"
+          : "v_cvt_f32_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F32_F64 does not support DPP";
   return std::make_unique<VCvtF32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -571,13 +694,21 @@ VCvtF64F32Vop3::VCvtF64F32Vop3(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_f32_e64_dpp"
+          : "v_cvt_f64_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support DPP";
   return std::make_unique<VCvtF64F32Vop3>(opcode);
 }
 } // namespace detail
@@ -618,7 +749,16 @@ VCvtF32Ubyte0Vop3::VCvtF32Ubyte0Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte0_e64_dpp"
+          : "v_cvt_f32_ubyte0",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop3>(opcode);
 }
 } // namespace detail
@@ -659,7 +799,16 @@ VCvtF32Ubyte1Vop3::VCvtF32Ubyte1Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte1_e64_dpp"
+          : "v_cvt_f32_ubyte1",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop3>(opcode);
 }
 } // namespace detail
@@ -700,7 +849,16 @@ VCvtF32Ubyte2Vop3::VCvtF32Ubyte2Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte2_e64_dpp"
+          : "v_cvt_f32_ubyte2",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop3>(opcode);
 }
 } // namespace detail
@@ -741,7 +899,16 @@ VCvtF32Ubyte3Vop3::VCvtF32Ubyte3Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte3_e64_dpp"
+          : "v_cvt_f32_ubyte3",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop3>(opcode);
 }
 } // namespace detail
@@ -763,13 +930,21 @@ VCvtU32F64Vop3::VCvtU32F64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_U32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f64_e64_dpp"
+          : "v_cvt_u32_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_U32_F64 does not support DPP";
   return std::make_unique<VCvtU32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -790,13 +965,21 @@ VCvtF64U32Vop3::VCvtF64U32Vop3(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_U32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_u32_e64_dpp"
+          : "v_cvt_f64_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_U32 does not support DPP";
   return std::make_unique<VCvtF64U32Vop3>(opcode);
 }
 } // namespace detail
@@ -818,13 +1001,21 @@ VTruncF64Vop3::VTruncF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_TRUNC_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f64_e64_dpp"
+          : "v_trunc_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_TRUNC_F64 does not support DPP";
   return std::make_unique<VTruncF64Vop3>(opcode);
 }
 } // namespace detail
@@ -846,13 +1037,21 @@ VCeilF64Vop3::VCeilF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CEIL_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f64_e64_dpp"
+          : "v_ceil_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CEIL_F64 does not support DPP";
   return std::make_unique<VCeilF64Vop3>(opcode);
 }
 } // namespace detail
@@ -874,13 +1073,21 @@ VRndneF64Vop3::VRndneF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RNDNE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f64_e64_dpp"
+          : "v_rndne_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support DPP";
   return std::make_unique<VRndneF64Vop3>(opcode);
 }
 } // namespace detail
@@ -902,13 +1109,21 @@ VFloorF64Vop3::VFloorF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FLOOR_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_floor_f64_e64_dpp"
+          : "v_floor_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FLOOR_F64 does not support DPP";
   return std::make_unique<VFloorF64Vop3>(opcode);
 }
 } // namespace detail
@@ -924,7 +1139,15 @@ VPipeflushVop3::VPipeflushVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPipeflushVop3(const MachineInst *opcode) {
+DecodeResult decodeVPipeflushVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_pipeflush_e64_dpp"
+          : "v_pipeflush",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPipeflushVop3>(opcode);
 }
 } // namespace detail
@@ -969,7 +1192,15 @@ VMovB16Vop3::VMovB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mov_b16_e64_dpp"
+          : "v_mov_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB16Vop3>(opcode);
 }
 } // namespace detail
@@ -1016,7 +1247,15 @@ VFractF32Vop3::VFractF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fract_f32_e64_dpp"
+          : "v_fract_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1057,7 +1296,15 @@ VTruncF32Vop3::VTruncF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f32_e64_dpp"
+          : "v_trunc_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1098,7 +1345,15 @@ VCeilF32Vop3::VCeilF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f32_e64_dpp"
+          : "v_ceil_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1139,7 +1394,15 @@ VRndneF32Vop3::VRndneF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f32_e64_dpp"
+          : "v_rndne_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1180,7 +1443,15 @@ VFloorF32Vop3::VFloorF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_floor_f32_e64_dpp"
+          : "v_floor_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1221,7 +1492,15 @@ VExpF32Vop3::VExpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_exp_f32_e64_dpp"
+          : "v_exp_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1262,7 +1541,15 @@ VLogF32Vop3::VLogF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_log_f32_e64_dpp"
+          : "v_log_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1303,7 +1590,15 @@ VRcpF32Vop3::VRcpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f32_e64_dpp"
+          : "v_rcp_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1344,7 +1639,16 @@ VRcpIflagF32Vop3::VRcpIflagF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rcp_iflag_f32_e64_dpp"
+          : "v_rcp_iflag_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1385,7 +1689,15 @@ VRsqF32Vop3::VRsqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f32_e64_dpp"
+          : "v_rsq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1407,13 +1719,21 @@ VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RCP_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f64_e64_dpp"
+          : "v_rcp_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support DPP";
   return std::make_unique<VRcpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1435,13 +1755,21 @@ VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RSQ_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f64_e64_dpp"
+          : "v_rsq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support DPP";
   return std::make_unique<VRsqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1482,7 +1810,15 @@ VSqrtF32Vop3::VSqrtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f32_e64_dpp"
+          : "v_sqrt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1504,13 +1840,21 @@ VSqrtF64Vop3::VSqrtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SQRT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f64_e64_dpp"
+          : "v_sqrt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support DPP";
   return std::make_unique<VSqrtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1551,7 +1895,15 @@ VSinF32Vop3::VSinF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sin_f32_e64_dpp"
+          : "v_sin_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1592,7 +1944,15 @@ VCosF32Vop3::VCosF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cos_f32_e64_dpp"
+          : "v_cos_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1633,7 +1993,15 @@ VNotB32Vop3::VNotB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_not_b32_e64_dpp"
+          : "v_not_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1674,7 +2042,15 @@ VBfrevB32Vop3::VBfrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfrev_b32_e64_dpp"
+          : "v_bfrev_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1715,7 +2091,15 @@ VClzI32U32Vop3::VClzI32U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClzI32U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVClzI32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_clz_i32_u32_e64_dpp"
+          : "v_clz_i32_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClzI32U32Vop3>(opcode);
 }
 } // namespace detail
@@ -1756,7 +2140,15 @@ VCtzI32B32Vop3::VCtzI32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCtzI32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCtzI32B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ctz_i32_b32_e64_dpp"
+          : "v_ctz_i32_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCtzI32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -1797,7 +2189,15 @@ VClsI32Vop3::VClsI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClsI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVClsI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cls_i32_e64_dpp"
+          : "v_cls_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClsI32Vop3>(opcode);
 }
 } // namespace detail
@@ -1819,13 +2219,22 @@ VFrexpExpI32F64Vop3::VFrexpExpI32F64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_EXP_I32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f64_e64_dpp"
+          : "v_frexp_exp_i32_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_EXP_I32_F64 does not support DPP";
   return std::make_unique<VFrexpExpI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -1847,13 +2256,22 @@ VFrexpMantF64Vop3::VFrexpMantF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_MANT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f64_e64_dpp"
+          : "v_frexp_mant_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_MANT_F64 does not support DPP";
   return std::make_unique<VFrexpMantF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1875,13 +2293,21 @@ VFractF64Vop3::VFractF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FRACT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fract_f64_e64_dpp"
+          : "v_fract_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FRACT_F64 does not support DPP";
   return std::make_unique<VFractF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1922,7 +2348,16 @@ VFrexpExpI32F32Vop3::VFrexpExpI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f32_e64_dpp"
+          : "v_frexp_exp_i32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -1963,7 +2398,16 @@ VFrexpMantF32Vop3::VFrexpMantF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f32_e64_dpp"
+          : "v_frexp_mant_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2007,7 +2451,16 @@ VMovreldB32Vop3::VMovreldB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovreldB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovreldB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_movreld_b32_e64_dpp"
+          : "v_movreld_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovreldB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2047,7 +2500,16 @@ VMovrelsB32Vop3::VMovrelsB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_movrels_b32_e64_dpp"
+          : "v_movrels_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2087,7 +2549,16 @@ VMovrelsdB32Vop3::VMovrelsdB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsdB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_b32_e64_dpp"
+          : "v_movrelsd_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsdB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2127,7 +2598,16 @@ VMovrelsd2B32Vop3::VMovrelsd2B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsd2B32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_2_b32_e64_dpp"
+          : "v_movrelsd_2_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsd2B32Vop3>(opcode);
 }
 } // namespace detail
@@ -2172,7 +2652,15 @@ VCvtF16U16Vop3::VCvtF16U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_u16_e64_dpp"
+          : "v_cvt_f16_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop3>(opcode);
 }
 } // namespace detail
@@ -2223,7 +2711,15 @@ VCvtF16I16Vop3::VCvtF16I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_i16_e64_dpp"
+          : "v_cvt_f16_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop3>(opcode);
 }
 } // namespace detail
@@ -2274,7 +2770,15 @@ VCvtU16F16Vop3::VCvtU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u16_f16_e64_dpp"
+          : "v_cvt_u16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -2325,7 +2829,15 @@ VCvtI16F16Vop3::VCvtI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i16_f16_e64_dpp"
+          : "v_cvt_i16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -2376,7 +2888,15 @@ VRcpF16Vop3::VRcpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f16_e64_dpp"
+          : "v_rcp_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2427,7 +2947,15 @@ VSqrtF16Vop3::VSqrtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f16_e64_dpp"
+          : "v_sqrt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2478,7 +3006,15 @@ VRsqF16Vop3::VRsqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f16_e64_dpp"
+          : "v_rsq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2529,7 +3065,15 @@ VLogF16Vop3::VLogF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_log_f16_e64_dpp"
+          : "v_log_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2580,7 +3124,15 @@ VExpF16Vop3::VExpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_exp_f16_e64_dpp"
+          : "v_exp_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2631,7 +3183,16 @@ VFrexpMantF16Vop3::VFrexpMantF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f16_e64_dpp"
+          : "v_frexp_mant_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2682,7 +3243,16 @@ VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i16_f16_e64_dpp"
+          : "v_frexp_exp_i16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -2733,7 +3303,15 @@ VFloorF16Vop3::VFloorF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_floor_f16_e64_dpp"
+          : "v_floor_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2784,7 +3362,15 @@ VCeilF16Vop3::VCeilF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f16_e64_dpp"
+          : "v_ceil_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2835,7 +3421,15 @@ VTruncF16Vop3::VTruncF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f16_e64_dpp"
+          : "v_trunc_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2886,7 +3480,15 @@ VRndneF16Vop3::VRndneF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f16_e64_dpp"
+          : "v_rndne_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2937,7 +3539,15 @@ VFractF16Vop3::VFractF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fract_f16_e64_dpp"
+          : "v_fract_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2988,7 +3598,15 @@ VSinF16Vop3::VSinF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sin_f16_e64_dpp"
+          : "v_sin_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3039,7 +3657,15 @@ VCosF16Vop3::VCosF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cos_f16_e64_dpp"
+          : "v_cos_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3086,7 +3712,16 @@ VSatPkU8I16Vop3::VSatPkU8I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sat_pk_u8_i16_e64_dpp"
+          : "v_sat_pk_u8_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3137,7 +3772,16 @@ VCvtNormI16F16Vop3::VCvtNormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_i16_f16_e64_dpp"
+          : "v_cvt_norm_i16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3188,7 +3832,16 @@ VCvtNormU16F16Vop3::VCvtNormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_u16_f16_e64_dpp"
+          : "v_cvt_norm_u16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3239,7 +3892,15 @@ VNotB16Vop3::VNotB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVNotB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_not_b16_e64_dpp"
+          : "v_not_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB16Vop3>(opcode);
 }
 } // namespace detail
@@ -3290,7 +3951,15 @@ VCvtI32I16Vop3::VCvtI32I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_i16_e64_dpp"
+          : "v_cvt_i32_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3335,7 +4004,15 @@ VCvtU32U16Vop3::VCvtU32U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_u16_e64_dpp"
+          : "v_cvt_u32_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3384,7 +4061,16 @@ VCndmaskB32Vop3::VCndmaskB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cndmask_b32_e64_dpp"
+          : "v_cndmask_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3431,7 +4117,15 @@ VAddF32Vop3::VAddF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_f32_e64_dpp"
+          : "v_add_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3478,7 +4172,15 @@ VSubF32Vop3::VSubF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_f32_e64_dpp"
+          : "v_sub_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3525,7 +4227,15 @@ VSubrevF32Vop3::VSubrevF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f32_e64_dpp"
+          : "v_subrev_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3553,13 +4263,22 @@ VFmacDx9ZeroF32Vop3::VFmacDx9ZeroF32Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAC_DX9_ZERO_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacDx9ZeroF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacDx9ZeroF32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fmac_dx9_zero_f32_e64_dpp"
+          : "v_fmac_dx9_zero_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAC_DX9_ZERO_F32 does not support DPP";
   return std::make_unique<VFmacDx9ZeroF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3606,7 +4325,16 @@ VMulDx9ZeroF32Vop3::VMulDx9ZeroF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulDx9ZeroF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulDx9ZeroF32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_dx9_zero_f32_e64_dpp"
+          : "v_mul_dx9_zero_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulDx9ZeroF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3653,7 +4381,15 @@ VMulF32Vop3::VMulF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_f32_e64_dpp"
+          : "v_mul_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3700,7 +4436,15 @@ VMulI32I24Vop3::VMulI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_i32_i24_e64_dpp"
+          : "v_mul_i32_i24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -3747,7 +4491,16 @@ VMulHiI32I24Vop3::VMulHiI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_i32_i24_e64_dpp"
+          : "v_mul_hi_i32_i24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -3794,7 +4547,15 @@ VMulU32U24Vop3::VMulU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_u32_u24_e64_dpp"
+          : "v_mul_u32_u24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -3841,7 +4602,16 @@ VMulHiU32U24Vop3::VMulHiU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_u32_u24_e64_dpp"
+          : "v_mul_hi_u32_u24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -3888,7 +4658,15 @@ VMinF32Vop3::VMinF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_f32_e64_dpp"
+          : "v_min_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3935,7 +4713,15 @@ VMaxF32Vop3::VMaxF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_f32_e64_dpp"
+          : "v_max_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3982,7 +4768,15 @@ VMinI32Vop3::VMinI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_i32_e64_dpp"
+          : "v_min_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4029,7 +4823,15 @@ VMaxI32Vop3::VMaxI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_i32_e64_dpp"
+          : "v_max_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4076,7 +4878,15 @@ VMinU32Vop3::VMinU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_u32_e64_dpp"
+          : "v_min_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4123,7 +4933,15 @@ VMaxU32Vop3::VMaxU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_u32_e64_dpp"
+          : "v_max_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4170,7 +4988,16 @@ VLshlrevB32Vop3::VLshlrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b32_e64_dpp"
+          : "v_lshlrev_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4217,7 +5044,16 @@ VLshrrevB32Vop3::VLshrrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshrrev_b32_e64_dpp"
+          : "v_lshrrev_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4264,7 +5100,16 @@ VAshrrevI32Vop3::VAshrrevI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ashrrev_i32_e64_dpp"
+          : "v_ashrrev_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4311,7 +5156,15 @@ VAndB32Vop3::VAndB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_and_b32_e64_dpp"
+          : "v_and_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4358,7 +5211,15 @@ VOrB32Vop3::VOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_or_b32_e64_dpp"
+          : "v_or_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4405,7 +5266,15 @@ VXorB32Vop3::VXorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xor_b32_e64_dpp"
+          : "v_xor_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4452,7 +5321,15 @@ VXnorB32Vop3::VXnorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xnor_b32_e64_dpp"
+          : "v_xnor_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4499,7 +5376,15 @@ VAddNcU32Vop3::VAddNcU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_u32_e64_dpp"
+          : "v_add_nc_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4546,7 +5431,15 @@ VSubNcU32Vop3::VSubNcU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_u32_e64_dpp"
+          : "v_sub_nc_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4593,7 +5486,16 @@ VSubrevNcU32Vop3::VSubrevNcU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevNcU32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_subrev_nc_u32_e64_dpp"
+          : "v_subrev_nc_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevNcU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4641,7 +5543,15 @@ VFmacF32Vop3::VFmacF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f32_e64_dpp"
+          : "v_fmac_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4688,7 +5598,16 @@ VCvtPkRtzF16F32Vop3::VCvtPkRtzF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkRtzF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkRtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_rtz_f16_f32_e64_dpp"
+          : "v_cvt_pk_rtz_f16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkRtzF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -4743,7 +5662,15 @@ VAddF16Vop3::VAddF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_f16_e64_dpp"
+          : "v_add_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4804,7 +5731,15 @@ VSubF16Vop3::VSubF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_f16_e64_dpp"
+          : "v_sub_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4865,7 +5800,15 @@ VSubrevF16Vop3::VSubrevF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f16_e64_dpp"
+          : "v_subrev_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4926,7 +5869,15 @@ VMulF16Vop3::VMulF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_f16_e64_dpp"
+          : "v_mul_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop3>(opcode);
 }
 } // namespace detail
@@ -4988,7 +5939,15 @@ VFmacF16Vop3::VFmacF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f16_e64_dpp"
+          : "v_fmac_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5049,7 +6008,15 @@ VMaxF16Vop3::VMaxF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_f16_e64_dpp"
+          : "v_max_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5110,7 +6077,15 @@ VMinF16Vop3::VMinF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_f16_e64_dpp"
+          : "v_min_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5171,7 +6146,15 @@ VLdexpF16Vop3::VLdexpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ldexp_f16_e64_dpp"
+          : "v_ldexp_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5230,7 +6213,16 @@ VFmaDx9ZeroF32Vop3::VFmaDx9ZeroF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaDx9ZeroF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaDx9ZeroF32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fma_dx9_zero_f32_e64_dpp"
+          : "v_fma_dx9_zero_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaDx9ZeroF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5283,7 +6275,15 @@ VMadI32I24Vop3::VMadI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_i32_i24_e64_dpp"
+          : "v_mad_i32_i24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -5336,7 +6336,15 @@ VMadU32U24Vop3::VMadU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_u32_u24_e64_dpp"
+          : "v_mad_u32_u24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -5389,7 +6397,15 @@ VCubeidF32Vop3::VCubeidF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cubeid_f32_e64_dpp"
+          : "v_cubeid_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubeidF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5442,7 +6458,15 @@ VCubescF32Vop3::VCubescF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cubesc_f32_e64_dpp"
+          : "v_cubesc_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubescF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5495,7 +6519,15 @@ VCubetcF32Vop3::VCubetcF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cubetc_f32_e64_dpp"
+          : "v_cubetc_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubetcF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5548,7 +6580,15 @@ VCubemaF32Vop3::VCubemaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cubema_f32_e64_dpp"
+          : "v_cubema_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubemaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5601,7 +6641,15 @@ VBfeU32Vop3::VBfeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfe_u32_e64_dpp"
+          : "v_bfe_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -5654,7 +6702,15 @@ VBfeI32Vop3::VBfeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfe_i32_e64_dpp"
+          : "v_bfe_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -5707,7 +6763,15 @@ VBfiB32Vop3::VBfiB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfi_b32_e64_dpp"
+          : "v_bfi_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfiB32Vop3>(opcode);
 }
 } // namespace detail
@@ -5760,7 +6824,15 @@ VFmaF32Vop3::VFmaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fma_f32_e64_dpp"
+          : "v_fma_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5796,13 +6868,21 @@ VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMA_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fma_f64_e64_dpp"
+          : "v_fma_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMA_F64 does not support DPP";
   return std::make_unique<VFmaF64Vop3>(opcode);
 }
 } // namespace detail
@@ -5855,7 +6935,15 @@ VLerpU8Vop3::VLerpU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lerp_u8_e64_dpp"
+          : "v_lerp_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLerpU8Vop3>(opcode);
 }
 } // namespace detail
@@ -5912,7 +7000,16 @@ VAlignbitB32Vop3::VAlignbitB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_alignbit_b32_e64_dpp"
+          : "v_alignbit_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbitB32Vop3>(opcode);
 }
 } // namespace detail
@@ -5969,7 +7066,16 @@ VAlignbyteB32Vop3::VAlignbyteB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_alignbyte_b32_e64_dpp"
+          : "v_alignbyte_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbyteB32Vop3>(opcode);
 }
 } // namespace detail
@@ -6022,7 +7128,15 @@ VMullitF32Vop3::VMullitF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMullitF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMullitF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mullit_f32_e64_dpp"
+          : "v_mullit_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMullitF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6075,7 +7189,15 @@ VMin3F32Vop3::VMin3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_f32_e64_dpp"
+          : "v_min3_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6128,7 +7250,15 @@ VMin3I32Vop3::VMin3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_i32_e64_dpp"
+          : "v_min3_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -6181,7 +7311,15 @@ VMin3U32Vop3::VMin3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_u32_e64_dpp"
+          : "v_min3_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -6234,7 +7372,15 @@ VMax3F32Vop3::VMax3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_f32_e64_dpp"
+          : "v_max3_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6287,7 +7433,15 @@ VMax3I32Vop3::VMax3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_i32_e64_dpp"
+          : "v_max3_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -6340,7 +7494,15 @@ VMax3U32Vop3::VMax3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_u32_e64_dpp"
+          : "v_max3_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -6393,7 +7555,15 @@ VMed3F32Vop3::VMed3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_f32_e64_dpp"
+          : "v_med3_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6446,7 +7616,15 @@ VMed3I32Vop3::VMed3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_i32_e64_dpp"
+          : "v_med3_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -6499,7 +7677,15 @@ VMed3U32Vop3::VMed3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_u32_e64_dpp"
+          : "v_med3_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -6552,7 +7738,15 @@ VSadU8Vop3::VSadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sad_u8_e64_dpp"
+          : "v_sad_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -6605,7 +7799,15 @@ VSadHiU8Vop3::VSadHiU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sad_hi_u8_e64_dpp"
+          : "v_sad_hi_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadHiU8Vop3>(opcode);
 }
 } // namespace detail
@@ -6658,7 +7860,15 @@ VSadU16Vop3::VSadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sad_u16_e64_dpp"
+          : "v_sad_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -6711,7 +7921,15 @@ VSadU32Vop3::VSadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sad_u32_e64_dpp"
+          : "v_sad_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -6764,7 +7982,16 @@ VCvtPkU8F32Vop3::VCvtPkU8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_u8_f32_e64_dpp"
+          : "v_cvt_pk_u8_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6797,13 +8024,22 @@ VDivFixupF32Vop3::VDivFixupF32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_FIXUP_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fixup_f32_e64_dpp"
+          : "v_div_fixup_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_DIV_FIXUP_F32 does not support DPP";
   return std::make_unique<VDivFixupF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6839,13 +8075,22 @@ VDivFixupF64Vop3::VDivFixupF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_FIXUP_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fixup_f64_e64_dpp"
+          : "v_div_fixup_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_DIV_FIXUP_F64 does not support DPP";
   return std::make_unique<VDivFixupF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6880,14 +8125,23 @@ VDivFmasF32Vop3::VDivFmasF32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_FMAS_F32 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fmas_f32_e64_dpp"
+          : "v_div_fmas_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_DIV_FMAS_F32 does not support DPP";
   return std::make_unique<VDivFmasF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6925,14 +8179,23 @@ VDivFmasF64Vop3::VDivFmasF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_FMAS_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fmas_f64_e64_dpp"
+          : "v_div_fmas_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_DIV_FMAS_F64 does not support DPP";
   return std::make_unique<VDivFmasF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6985,7 +8248,15 @@ VMsadU8Vop3::VMsadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_msad_u8_e64_dpp"
+          : "v_msad_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMsadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -7020,13 +8291,22 @@ VQsadPkU16U8Vop3::VQsadPkU16U8Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_QSAD_PK_U16_U8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_qsad_pk_u16_u8_e64_dpp"
+          : "v_qsad_pk_u16_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_QSAD_PK_U16_U8 does not support DPP";
   return std::make_unique<VQsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -7061,13 +8341,22 @@ VMqsadPkU16U8Vop3::VMqsadPkU16U8Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MQSAD_PK_U16_U8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mqsad_pk_u16_u8_e64_dpp"
+          : "v_mqsad_pk_u16_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MQSAD_PK_U16_U8 does not support DPP";
   return std::make_unique<VMqsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -7097,13 +8386,22 @@ VMqsadU32U8Vop3::VMqsadU32U8Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MQSAD_U32_U8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mqsad_u32_u8_e64_dpp"
+          : "v_mqsad_u32_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MQSAD_U32_U8 does not support DPP";
   return std::make_unique<VMqsadU32U8Vop3>(opcode);
 }
 } // namespace detail
@@ -7156,7 +8454,15 @@ VXor3B32Vop3::VXor3B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXor3B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXor3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xor3_b32_e64_dpp"
+          : "v_xor3_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXor3B32Vop3>(opcode);
 }
 } // namespace detail
@@ -7221,7 +8527,15 @@ VMadU16Vop3::VMadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_u16_e64_dpp"
+          : "v_mad_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -7280,7 +8594,15 @@ VPermB32Vop3::VPermB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_perm_b32_e64_dpp"
+          : "v_perm_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPermB32Vop3>(opcode);
 }
 } // namespace detail
@@ -7333,7 +8655,15 @@ VXadU32Vop3::VXadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xad_u32_e64_dpp"
+          : "v_xad_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7386,7 +8716,16 @@ VLshlAddU32Vop3::VLshlAddU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshl_add_u32_e64_dpp"
+          : "v_lshl_add_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlAddU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7439,7 +8778,16 @@ VAddLshlU32Vop3::VAddLshlU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_lshl_u32_e64_dpp"
+          : "v_add_lshl_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddLshlU32Vop3>(opcode);
 }
 } // namespace detail
@@ -7504,7 +8852,15 @@ VFmaF16Vop3::VFmaF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fma_f16_e64_dpp"
+          : "v_fma_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF16Vop3>(opcode);
 }
 } // namespace detail
@@ -7575,7 +8931,15 @@ VMin3F16Vop3::VMin3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_f16_e64_dpp"
+          : "v_min3_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -7646,7 +9010,15 @@ VMin3I16Vop3::VMin3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_i16_e64_dpp"
+          : "v_min3_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -7717,7 +9089,15 @@ VMin3U16Vop3::VMin3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_u16_e64_dpp"
+          : "v_min3_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -7788,7 +9168,15 @@ VMax3F16Vop3::VMax3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_f16_e64_dpp"
+          : "v_max3_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -7859,7 +9247,15 @@ VMax3I16Vop3::VMax3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_i16_e64_dpp"
+          : "v_max3_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -7930,7 +9326,15 @@ VMax3U16Vop3::VMax3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_u16_e64_dpp"
+          : "v_max3_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -8001,7 +9405,15 @@ VMed3F16Vop3::VMed3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_f16_e64_dpp"
+          : "v_med3_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -8072,7 +9484,15 @@ VMed3I16Vop3::VMed3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_i16_e64_dpp"
+          : "v_med3_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -8143,7 +9563,15 @@ VMed3U16Vop3::VMed3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_u16_e64_dpp"
+          : "v_med3_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -8214,7 +9642,15 @@ VMadI16Vop3::VMadI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_i16_e64_dpp"
+          : "v_mad_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8285,7 +9721,16 @@ VDivFixupF16Vop3::VDivFixupF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fixup_f16_e64_dpp"
+          : "v_div_fixup_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF16Vop3>(opcode);
 }
 } // namespace detail
@@ -8344,7 +9789,15 @@ VAdd3U32Vop3::VAdd3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add3_u32_e64_dpp"
+          : "v_add3_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAdd3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -8397,7 +9850,15 @@ VLshlOrB32Vop3::VLshlOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshl_or_b32_e64_dpp"
+          : "v_lshl_or_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -8450,7 +9911,15 @@ VAndOrB32Vop3::VAndOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_and_or_b32_e64_dpp"
+          : "v_and_or_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -8503,7 +9972,15 @@ VOr3B32Vop3::VOr3B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_or3_b32_e64_dpp"
+          : "v_or3_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOr3B32Vop3>(opcode);
 }
 } // namespace detail
@@ -8564,7 +10041,15 @@ VMadU32U16Vop3::VMadU32U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_u32_u16_e64_dpp"
+          : "v_mad_u32_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U16Vop3>(opcode);
 }
 } // namespace detail
@@ -8625,7 +10110,15 @@ VMadI32I16Vop3::VMadI32I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_i32_i16_e64_dpp"
+          : "v_mad_i32_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I16Vop3>(opcode);
 }
 } // namespace detail
@@ -8654,13 +10147,22 @@ VPermlane16B32Vop3::VPermlane16B32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANE16_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlane16B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlane16B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_permlane16_b32_e64_dpp"
+          : "v_permlane16_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE16_B32 does not support DPP";
   return std::make_unique<VPermlane16B32Vop3>(opcode);
 }
 } // namespace detail
@@ -8689,13 +10191,22 @@ VPermlanex16B32Vop3::VPermlanex16B32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANEX16_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlanex16B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlanex16B32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_permlanex16_b32_e64_dpp"
+          : "v_permlanex16_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANEX16_B32 does not support DPP";
   return std::make_unique<VPermlanex16B32Vop3>(opcode);
 }
 } // namespace detail
@@ -8752,7 +10263,16 @@ VCndmaskB16Vop3::VCndmaskB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cndmask_b16_e64_dpp"
+          : "v_cndmask_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB16Vop3>(opcode);
 }
 } // namespace detail
@@ -8811,7 +10331,15 @@ VMaxminF32Vop3::VMaxminF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxminF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxminF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maxmin_f32_e64_dpp"
+          : "v_maxmin_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxminF32Vop3>(opcode);
 }
 } // namespace detail
@@ -8864,7 +10392,15 @@ VMinmaxF32Vop3::VMinmaxF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinmaxF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinmaxF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minmax_f32_e64_dpp"
+          : "v_minmax_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinmaxF32Vop3>(opcode);
 }
 } // namespace detail
@@ -8929,7 +10465,15 @@ VMaxminF16Vop3::VMaxminF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxminF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxminF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maxmin_f16_e64_dpp"
+          : "v_maxmin_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxminF16Vop3>(opcode);
 }
 } // namespace detail
@@ -9000,7 +10544,15 @@ VMinmaxF16Vop3::VMinmaxF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinmaxF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinmaxF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minmax_f16_e64_dpp"
+          : "v_minmax_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinmaxF16Vop3>(opcode);
 }
 } // namespace detail
@@ -9059,7 +10611,15 @@ VMaxminU32Vop3::VMaxminU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxminU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxminU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maxmin_u32_e64_dpp"
+          : "v_maxmin_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxminU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9112,7 +10672,15 @@ VMinmaxU32Vop3::VMinmaxU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinmaxU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinmaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minmax_u32_e64_dpp"
+          : "v_minmax_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinmaxU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9165,7 +10733,15 @@ VMaxminI32Vop3::VMaxminI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxminI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxminI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maxmin_i32_e64_dpp"
+          : "v_maxmin_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxminI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9218,7 +10794,15 @@ VMinmaxI32Vop3::VMinmaxI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinmaxI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinmaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minmax_i32_e64_dpp"
+          : "v_minmax_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinmaxI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9275,7 +10859,16 @@ VDot2F16F16Vop3::VDot2F16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2F16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot2F16F16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_dot2_f16_f16_e64_dpp"
+          : "v_dot2_f16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2F16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -9338,7 +10931,16 @@ VDot2Bf16Bf16Vop3::VDot2Bf16Bf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2Bf16Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot2Bf16Bf16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_dot2_bf16_bf16_e64_dpp"
+          : "v_dot2_bf16_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2Bf16Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -9399,7 +11001,15 @@ VAddNcU16Vop3::VAddNcU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_u16_e64_dpp"
+          : "v_add_nc_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9460,7 +11070,15 @@ VSubNcU16Vop3::VSubNcU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_u16_e64_dpp"
+          : "v_sub_nc_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9521,7 +11139,15 @@ VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_lo_u16_e64_dpp"
+          : "v_mul_lo_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9574,7 +11200,16 @@ VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkI16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkI16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_i16_f32_e64_dpp"
+          : "v_cvt_pk_i16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkI16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -9621,7 +11256,16 @@ VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_u16_f32_e64_dpp"
+          : "v_cvt_pk_u16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -9676,7 +11320,15 @@ VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_u16_e64_dpp"
+          : "v_max_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9737,7 +11389,15 @@ VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_i16_e64_dpp"
+          : "v_max_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI16Vop3>(opcode);
 }
 } // namespace detail
@@ -9798,7 +11458,15 @@ VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_u16_e64_dpp"
+          : "v_min_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU16Vop3>(opcode);
 }
 } // namespace detail
@@ -9859,7 +11527,15 @@ VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_i16_e64_dpp"
+          : "v_min_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI16Vop3>(opcode);
 }
 } // namespace detail
@@ -9920,7 +11596,15 @@ VAddNcI16Vop3::VAddNcI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_i16_e64_dpp"
+          : "v_add_nc_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcI16Vop3>(opcode);
 }
 } // namespace detail
@@ -9981,7 +11665,15 @@ VSubNcI16Vop3::VSubNcI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_i16_e64_dpp"
+          : "v_sub_nc_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcI16Vop3>(opcode);
 }
 } // namespace detail
@@ -10042,7 +11734,16 @@ VPackB32F16Vop3::VPackB32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_pack_b32_f16_e64_dpp"
+          : "v_pack_b32_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPackB32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -10097,7 +11798,16 @@ VCvtPkNormI16F16Vop3::VCvtPkNormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkNormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkNormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_norm_i16_f16_e64_dpp"
+          : "v_cvt_pk_norm_i16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkNormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -10152,7 +11862,16 @@ VCvtPkNormU16F16Vop3::VCvtPkNormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkNormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkNormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_norm_u16_f16_e64_dpp"
+          : "v_cvt_pk_norm_u16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkNormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -10199,7 +11918,15 @@ VLdexpF32Vop3::VLdexpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ldexp_f32_e64_dpp"
+          : "v_ldexp_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -10246,7 +11973,15 @@ VBfmB32Vop3::VBfmB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfm_b32_e64_dpp"
+          : "v_bfm_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfmB32Vop3>(opcode);
 }
 } // namespace detail
@@ -10293,7 +12028,16 @@ VBcntU32B32Vop3::VBcntU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bcnt_u32_b32_e64_dpp"
+          : "v_bcnt_u32_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBcntU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -10340,7 +12084,16 @@ VMbcntLoU32B32Vop3::VMbcntLoU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mbcnt_lo_u32_b32_e64_dpp"
+          : "v_mbcnt_lo_u32_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntLoU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -10387,7 +12140,16 @@ VMbcntHiU32B32Vop3::VMbcntHiU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mbcnt_hi_u32_b32_e64_dpp"
+          : "v_mbcnt_hi_u32_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntHiU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -10434,7 +12196,16 @@ VCvtPkNormI16F32Vop3::VCvtPkNormI16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkNormI16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkNormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_norm_i16_f32_e64_dpp"
+          : "v_cvt_pk_norm_i16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkNormI16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -10481,7 +12252,16 @@ VCvtPkNormU16F32Vop3::VCvtPkNormU16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkNormU16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkNormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_norm_u16_f32_e64_dpp"
+          : "v_cvt_pk_norm_u16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkNormU16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -10528,7 +12308,16 @@ VCvtPkU16U32Vop3::VCvtPkU16U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_u16_u32_e64_dpp"
+          : "v_cvt_pk_u16_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU16U32Vop3>(opcode);
 }
 } // namespace detail
@@ -10575,7 +12364,16 @@ VCvtPkI16I32Vop3::VCvtPkI16I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_i16_i32_e64_dpp"
+          : "v_cvt_pk_i16_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkI16I32Vop3>(opcode);
 }
 } // namespace detail
@@ -10622,7 +12420,15 @@ VSubNcI32Vop3::VSubNcI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_i32_e64_dpp"
+          : "v_sub_nc_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcI32Vop3>(opcode);
 }
 } // namespace detail
@@ -10669,7 +12475,15 @@ VAddNcI32Vop3::VAddNcI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_i32_e64_dpp"
+          : "v_add_nc_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcI32Vop3>(opcode);
 }
 } // namespace detail
@@ -10698,13 +12512,21 @@ VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_ADD_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_f64_e64_dpp"
+          : "v_add_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_ADD_F64 does not support DPP";
   return std::make_unique<VAddF64Vop3>(opcode);
 }
 } // namespace detail
@@ -10733,13 +12555,21 @@ VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_f64_e64_dpp"
+          : "v_mul_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_F64 does not support DPP";
   return std::make_unique<VMulF64Vop3>(opcode);
 }
 } // namespace detail
@@ -10768,13 +12598,21 @@ VMinF64Vop3::VMinF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MIN_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_f64_e64_dpp"
+          : "v_min_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MIN_F64 does not support DPP";
   return std::make_unique<VMinF64Vop3>(opcode);
 }
 } // namespace detail
@@ -10803,13 +12641,21 @@ VMaxF64Vop3::VMaxF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAX_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_f64_e64_dpp"
+          : "v_max_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MAX_F64 does not support DPP";
   return std::make_unique<VMaxF64Vop3>(opcode);
 }
 } // namespace detail
@@ -10837,13 +12683,21 @@ VLdexpF64Vop3::VLdexpF64Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_LDEXP_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ldexp_f64_e64_dpp"
+          : "v_ldexp_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_LDEXP_F64 does not support DPP";
   return std::make_unique<VLdexpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -10870,13 +12724,21 @@ VMulLoU32Vop3::VMulLoU32Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_LO_U32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_lo_u32_e64_dpp"
+          : "v_mul_lo_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_LO_U32 does not support DPP";
   return std::make_unique<VMulLoU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10903,13 +12765,21 @@ VMulHiU32Vop3::VMulHiU32Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_HI_U32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_u32_e64_dpp"
+          : "v_mul_hi_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_HI_U32 does not support DPP";
   return std::make_unique<VMulHiU32Vop3>(opcode);
 }
 } // namespace detail
@@ -10936,13 +12806,21 @@ VMulHiI32Vop3::VMulHiI32Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_HI_I32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_i32_e64_dpp"
+          : "v_mul_hi_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_HI_I32 does not support DPP";
   return std::make_unique<VMulHiI32Vop3>(opcode);
 }
 } // namespace detail
@@ -10970,13 +12848,22 @@ VTrigPreopF64Vop3::VTrigPreopF64Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_TRIG_PREOP_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_trig_preop_f64_e64_dpp"
+          : "v_trig_preop_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_TRIG_PREOP_F64 does not support DPP";
   return std::make_unique<VTrigPreopF64Vop3>(opcode);
 }
 } // namespace detail
@@ -11031,7 +12918,16 @@ VLshlrevB16Vop3::VLshlrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b16_e64_dpp"
+          : "v_lshlrev_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -11092,7 +12988,16 @@ VLshrrevB16Vop3::VLshrrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshrrev_b16_e64_dpp"
+          : "v_lshrrev_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -11153,7 +13058,16 @@ VAshrrevI16Vop3::VAshrrevI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ashrrev_i16_e64_dpp"
+          : "v_ashrrev_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI16Vop3>(opcode);
 }
 } // namespace detail
@@ -11187,13 +13101,22 @@ VLshlrevB64Vop3::VLshlrevB64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_LSHLREV_B64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b64_e64_dpp"
+          : "v_lshlrev_b64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_LSHLREV_B64 does not support DPP";
   return std::make_unique<VLshlrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -11221,13 +13144,22 @@ VLshrrevB64Vop3::VLshrrevB64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_LSHRREV_B64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshrrev_b64_e64_dpp"
+          : "v_lshrrev_b64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_LSHRREV_B64 does not support DPP";
   return std::make_unique<VLshrrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -11255,13 +13187,22 @@ VAshrrevI64Vop3::VAshrrevI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_ASHRREV_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ashrrev_i64_e64_dpp"
+          : "v_ashrrev_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_ASHRREV_I64 does not support DPP";
   return std::make_unique<VAshrrevI64Vop3>(opcode);
 }
 } // namespace detail
@@ -11280,13 +13221,22 @@ VReadlaneB32Vop3::VReadlaneB32Vop3(const MachineInst *inst)
   src_operands_[1] = &src1;
   num_src_ = 2;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_READLANE_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_readlane_b32_e64_dpp"
+          : "v_readlane_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_READLANE_B32 does not support DPP";
   return std::make_unique<VReadlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -11310,13 +13260,22 @@ VWritelaneB32Vop3::VWritelaneB32Vop3(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WRITELANE_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_writelane_b32_e64_dpp"
+          : "v_writelane_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_WRITELANE_B32 does not support DPP";
   return std::make_unique<VWritelaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -11371,7 +13330,15 @@ VAndB16Vop3::VAndB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_and_b16_e64_dpp"
+          : "v_and_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB16Vop3>(opcode);
 }
 } // namespace detail
@@ -11432,7 +13399,15 @@ VOrB16Vop3::VOrB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOrB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_or_b16_e64_dpp"
+          : "v_or_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB16Vop3>(opcode);
 }
 } // namespace detail
@@ -11493,7 +13468,15 @@ VXorB16Vop3::VXorB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXorB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xor_b16_e64_dpp"
+          : "v_xor_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB16Vop3>(opcode);
 }
 } // namespace detail
@@ -11554,7 +13537,15 @@ VCmpFF16Vop3::VCmpFF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_f16_e64_dpp"
+          : "v_cmp_f_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11609,7 +13600,15 @@ VCmpLtF16Vop3::VCmpLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f16_e64_dpp"
+          : "v_cmp_lt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11664,7 +13663,15 @@ VCmpEqF16Vop3::VCmpEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f16_e64_dpp"
+          : "v_cmp_eq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11719,7 +13726,15 @@ VCmpLeF16Vop3::VCmpLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f16_e64_dpp"
+          : "v_cmp_le_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11774,7 +13789,15 @@ VCmpGtF16Vop3::VCmpGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f16_e64_dpp"
+          : "v_cmp_gt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11829,7 +13852,15 @@ VCmpLgF16Vop3::VCmpLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f16_e64_dpp"
+          : "v_cmp_lg_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11884,7 +13915,15 @@ VCmpGeF16Vop3::VCmpGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f16_e64_dpp"
+          : "v_cmp_ge_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11939,7 +13978,15 @@ VCmpOF16Vop3::VCmpOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f16_e64_dpp"
+          : "v_cmp_o_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -11994,7 +14041,15 @@ VCmpUF16Vop3::VCmpUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f16_e64_dpp"
+          : "v_cmp_u_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12049,7 +14104,15 @@ VCmpNgeF16Vop3::VCmpNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f16_e64_dpp"
+          : "v_cmp_nge_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12104,7 +14167,15 @@ VCmpNlgF16Vop3::VCmpNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f16_e64_dpp"
+          : "v_cmp_nlg_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12159,7 +14230,15 @@ VCmpNgtF16Vop3::VCmpNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f16_e64_dpp"
+          : "v_cmp_ngt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12214,7 +14293,15 @@ VCmpNleF16Vop3::VCmpNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f16_e64_dpp"
+          : "v_cmp_nle_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12269,7 +14356,15 @@ VCmpNeqF16Vop3::VCmpNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f16_e64_dpp"
+          : "v_cmp_neq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12324,7 +14419,15 @@ VCmpNltF16Vop3::VCmpNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f16_e64_dpp"
+          : "v_cmp_nlt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12379,7 +14482,15 @@ VCmpTF16Vop3::VCmpTF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_f16_e64_dpp"
+          : "v_cmp_t_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12426,7 +14537,15 @@ VCmpFF32Vop3::VCmpFF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_f32_e64_dpp"
+          : "v_cmp_f_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12473,7 +14592,15 @@ VCmpLtF32Vop3::VCmpLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f32_e64_dpp"
+          : "v_cmp_lt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12520,7 +14647,15 @@ VCmpEqF32Vop3::VCmpEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f32_e64_dpp"
+          : "v_cmp_eq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12567,7 +14702,15 @@ VCmpLeF32Vop3::VCmpLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f32_e64_dpp"
+          : "v_cmp_le_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12614,7 +14757,15 @@ VCmpGtF32Vop3::VCmpGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f32_e64_dpp"
+          : "v_cmp_gt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12661,7 +14812,15 @@ VCmpLgF32Vop3::VCmpLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f32_e64_dpp"
+          : "v_cmp_lg_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12708,7 +14867,15 @@ VCmpGeF32Vop3::VCmpGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f32_e64_dpp"
+          : "v_cmp_ge_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12755,7 +14922,15 @@ VCmpOF32Vop3::VCmpOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f32_e64_dpp"
+          : "v_cmp_o_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12802,7 +14977,15 @@ VCmpUF32Vop3::VCmpUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f32_e64_dpp"
+          : "v_cmp_u_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12849,7 +15032,15 @@ VCmpNgeF32Vop3::VCmpNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f32_e64_dpp"
+          : "v_cmp_nge_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12896,7 +15087,15 @@ VCmpNlgF32Vop3::VCmpNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f32_e64_dpp"
+          : "v_cmp_nlg_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12943,7 +15142,15 @@ VCmpNgtF32Vop3::VCmpNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f32_e64_dpp"
+          : "v_cmp_ngt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12990,7 +15197,15 @@ VCmpNleF32Vop3::VCmpNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f32_e64_dpp"
+          : "v_cmp_nle_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -13037,7 +15252,15 @@ VCmpNeqF32Vop3::VCmpNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f32_e64_dpp"
+          : "v_cmp_neq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -13084,7 +15307,15 @@ VCmpNltF32Vop3::VCmpNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f32_e64_dpp"
+          : "v_cmp_nlt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -13131,7 +15362,15 @@ VCmpTF32Vop3::VCmpTF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_f32_e64_dpp"
+          : "v_cmp_t_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTF32Vop3>(opcode);
 }
 } // namespace detail
@@ -13160,13 +15399,21 @@ VCmpFF64Vop3::VCmpFF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_f64_e64_dpp"
+          : "v_cmp_f_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F64 does not support DPP";
   return std::make_unique<VCmpFF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13195,13 +15442,21 @@ VCmpLtF64Vop3::VCmpLtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f64_e64_dpp"
+          : "v_cmp_lt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support DPP";
   return std::make_unique<VCmpLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13230,13 +15485,21 @@ VCmpEqF64Vop3::VCmpEqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f64_e64_dpp"
+          : "v_cmp_eq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support DPP";
   return std::make_unique<VCmpEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13265,13 +15528,21 @@ VCmpLeF64Vop3::VCmpLeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f64_e64_dpp"
+          : "v_cmp_le_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support DPP";
   return std::make_unique<VCmpLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13300,13 +15571,21 @@ VCmpGtF64Vop3::VCmpGtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f64_e64_dpp"
+          : "v_cmp_gt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support DPP";
   return std::make_unique<VCmpGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13335,13 +15614,21 @@ VCmpLgF64Vop3::VCmpLgF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LG_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f64_e64_dpp"
+          : "v_cmp_lg_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support DPP";
   return std::make_unique<VCmpLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13370,13 +15657,21 @@ VCmpGeF64Vop3::VCmpGeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f64_e64_dpp"
+          : "v_cmp_ge_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support DPP";
   return std::make_unique<VCmpGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13405,13 +15700,21 @@ VCmpOF64Vop3::VCmpOF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_O_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f64_e64_dpp"
+          : "v_cmp_o_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support DPP";
   return std::make_unique<VCmpOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13440,13 +15743,21 @@ VCmpUF64Vop3::VCmpUF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_U_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f64_e64_dpp"
+          : "v_cmp_u_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support DPP";
   return std::make_unique<VCmpUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13475,13 +15786,21 @@ VCmpNgeF64Vop3::VCmpNgeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f64_e64_dpp"
+          : "v_cmp_nge_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support DPP";
   return std::make_unique<VCmpNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13510,13 +15829,21 @@ VCmpNlgF64Vop3::VCmpNlgF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f64_e64_dpp"
+          : "v_cmp_nlg_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support DPP";
   return std::make_unique<VCmpNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13545,13 +15872,21 @@ VCmpNgtF64Vop3::VCmpNgtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f64_e64_dpp"
+          : "v_cmp_ngt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support DPP";
   return std::make_unique<VCmpNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13580,13 +15915,21 @@ VCmpNleF64Vop3::VCmpNleF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f64_e64_dpp"
+          : "v_cmp_nle_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support DPP";
   return std::make_unique<VCmpNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13615,13 +15958,21 @@ VCmpNeqF64Vop3::VCmpNeqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f64_e64_dpp"
+          : "v_cmp_neq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support DPP";
   return std::make_unique<VCmpNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13650,13 +16001,21 @@ VCmpNltF64Vop3::VCmpNltF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f64_e64_dpp"
+          : "v_cmp_nlt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support DPP";
   return std::make_unique<VCmpNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13685,13 +16044,21 @@ VCmpTF64Vop3::VCmpTF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_f64_e64_dpp"
+          : "v_cmp_t_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_F64 does not support DPP";
   return std::make_unique<VCmpTF64Vop3>(opcode);
 }
 } // namespace detail
@@ -13746,7 +16113,15 @@ VCmpLtI16Vop3::VCmpLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i16_e64_dpp"
+          : "v_cmp_lt_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -13801,7 +16176,15 @@ VCmpEqI16Vop3::VCmpEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i16_e64_dpp"
+          : "v_cmp_eq_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -13856,7 +16239,15 @@ VCmpLeI16Vop3::VCmpLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i16_e64_dpp"
+          : "v_cmp_le_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -13911,7 +16302,15 @@ VCmpGtI16Vop3::VCmpGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i16_e64_dpp"
+          : "v_cmp_gt_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -13966,7 +16365,15 @@ VCmpNeI16Vop3::VCmpNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i16_e64_dpp"
+          : "v_cmp_ne_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -14021,7 +16428,15 @@ VCmpGeI16Vop3::VCmpGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i16_e64_dpp"
+          : "v_cmp_ge_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -14076,7 +16491,15 @@ VCmpLtU16Vop3::VCmpLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u16_e64_dpp"
+          : "v_cmp_lt_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -14131,7 +16554,15 @@ VCmpEqU16Vop3::VCmpEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u16_e64_dpp"
+          : "v_cmp_eq_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -14186,7 +16617,15 @@ VCmpLeU16Vop3::VCmpLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u16_e64_dpp"
+          : "v_cmp_le_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -14241,7 +16680,15 @@ VCmpGtU16Vop3::VCmpGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u16_e64_dpp"
+          : "v_cmp_gt_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -14296,7 +16743,15 @@ VCmpNeU16Vop3::VCmpNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u16_e64_dpp"
+          : "v_cmp_ne_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -14351,7 +16806,15 @@ VCmpGeU16Vop3::VCmpGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u16_e64_dpp"
+          : "v_cmp_ge_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -14398,7 +16861,15 @@ VCmpFI32Vop3::VCmpFI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_i32_e64_dpp"
+          : "v_cmp_f_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI32Vop3>(opcode);
 }
 } // namespace detail
@@ -14445,7 +16916,15 @@ VCmpLtI32Vop3::VCmpLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i32_e64_dpp"
+          : "v_cmp_lt_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -14492,7 +16971,15 @@ VCmpEqI32Vop3::VCmpEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i32_e64_dpp"
+          : "v_cmp_eq_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -14539,7 +17026,15 @@ VCmpLeI32Vop3::VCmpLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i32_e64_dpp"
+          : "v_cmp_le_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -14586,7 +17081,15 @@ VCmpGtI32Vop3::VCmpGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i32_e64_dpp"
+          : "v_cmp_gt_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -14633,7 +17136,15 @@ VCmpNeI32Vop3::VCmpNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i32_e64_dpp"
+          : "v_cmp_ne_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -14680,7 +17191,15 @@ VCmpGeI32Vop3::VCmpGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i32_e64_dpp"
+          : "v_cmp_ge_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -14727,7 +17246,15 @@ VCmpTI32Vop3::VCmpTI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_i32_e64_dpp"
+          : "v_cmp_t_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI32Vop3>(opcode);
 }
 } // namespace detail
@@ -14774,7 +17301,15 @@ VCmpFU32Vop3::VCmpFU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_u32_e64_dpp"
+          : "v_cmp_f_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU32Vop3>(opcode);
 }
 } // namespace detail
@@ -14821,7 +17356,15 @@ VCmpLtU32Vop3::VCmpLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u32_e64_dpp"
+          : "v_cmp_lt_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -14868,7 +17411,15 @@ VCmpEqU32Vop3::VCmpEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u32_e64_dpp"
+          : "v_cmp_eq_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -14915,7 +17466,15 @@ VCmpLeU32Vop3::VCmpLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u32_e64_dpp"
+          : "v_cmp_le_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -14962,7 +17521,15 @@ VCmpGtU32Vop3::VCmpGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u32_e64_dpp"
+          : "v_cmp_gt_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -15009,7 +17576,15 @@ VCmpNeU32Vop3::VCmpNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u32_e64_dpp"
+          : "v_cmp_ne_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -15056,7 +17631,15 @@ VCmpGeU32Vop3::VCmpGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u32_e64_dpp"
+          : "v_cmp_ge_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -15103,7 +17686,15 @@ VCmpTU32Vop3::VCmpTU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_u32_e64_dpp"
+          : "v_cmp_t_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU32Vop3>(opcode);
 }
 } // namespace detail
@@ -15132,13 +17723,21 @@ VCmpFI64Vop3::VCmpFI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_i64_e64_dpp"
+          : "v_cmp_f_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I64 does not support DPP";
   return std::make_unique<VCmpFI64Vop3>(opcode);
 }
 } // namespace detail
@@ -15167,13 +17766,21 @@ VCmpLtI64Vop3::VCmpLtI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i64_e64_dpp"
+          : "v_cmp_lt_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support DPP";
   return std::make_unique<VCmpLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -15202,13 +17809,21 @@ VCmpEqI64Vop3::VCmpEqI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i64_e64_dpp"
+          : "v_cmp_eq_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support DPP";
   return std::make_unique<VCmpEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -15237,13 +17852,21 @@ VCmpLeI64Vop3::VCmpLeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i64_e64_dpp"
+          : "v_cmp_le_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support DPP";
   return std::make_unique<VCmpLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -15272,13 +17895,21 @@ VCmpGtI64Vop3::VCmpGtI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i64_e64_dpp"
+          : "v_cmp_gt_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support DPP";
   return std::make_unique<VCmpGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -15307,13 +17938,21 @@ VCmpNeI64Vop3::VCmpNeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i64_e64_dpp"
+          : "v_cmp_ne_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support DPP";
   return std::make_unique<VCmpNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -15342,13 +17981,21 @@ VCmpGeI64Vop3::VCmpGeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i64_e64_dpp"
+          : "v_cmp_ge_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support DPP";
   return std::make_unique<VCmpGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -15377,13 +18024,21 @@ VCmpTI64Vop3::VCmpTI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_i64_e64_dpp"
+          : "v_cmp_t_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I64 does not support DPP";
   return std::make_unique<VCmpTI64Vop3>(opcode);
 }
 } // namespace detail
@@ -15412,13 +18067,21 @@ VCmpFU64Vop3::VCmpFU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_u64_e64_dpp"
+          : "v_cmp_f_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U64 does not support DPP";
   return std::make_unique<VCmpFU64Vop3>(opcode);
 }
 } // namespace detail
@@ -15447,13 +18110,21 @@ VCmpLtU64Vop3::VCmpLtU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u64_e64_dpp"
+          : "v_cmp_lt_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support DPP";
   return std::make_unique<VCmpLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -15482,13 +18153,21 @@ VCmpEqU64Vop3::VCmpEqU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u64_e64_dpp"
+          : "v_cmp_eq_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support DPP";
   return std::make_unique<VCmpEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -15517,13 +18196,21 @@ VCmpLeU64Vop3::VCmpLeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u64_e64_dpp"
+          : "v_cmp_le_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support DPP";
   return std::make_unique<VCmpLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -15552,13 +18239,21 @@ VCmpGtU64Vop3::VCmpGtU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u64_e64_dpp"
+          : "v_cmp_gt_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support DPP";
   return std::make_unique<VCmpGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -15587,13 +18282,21 @@ VCmpNeU64Vop3::VCmpNeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u64_e64_dpp"
+          : "v_cmp_ne_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support DPP";
   return std::make_unique<VCmpNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -15622,13 +18325,21 @@ VCmpGeU64Vop3::VCmpGeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u64_e64_dpp"
+          : "v_cmp_ge_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support DPP";
   return std::make_unique<VCmpGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -15657,13 +18368,21 @@ VCmpTU64Vop3::VCmpTU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_u64_e64_dpp"
+          : "v_cmp_t_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U64 does not support DPP";
   return std::make_unique<VCmpTU64Vop3>(opcode);
 }
 } // namespace detail
@@ -15718,7 +18437,16 @@ VCmpClassF16Vop3::VCmpClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f16_e64_dpp"
+          : "v_cmp_class_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -15765,7 +18493,16 @@ VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f32_e64_dpp"
+          : "v_cmp_class_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -15793,13 +18530,22 @@ VCmpClassF64Vop3::VCmpClassF64Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f64_e64_dpp"
+          : "v_cmp_class_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support DPP";
   return std::make_unique<VCmpClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -15858,7 +18604,15 @@ VCmpxFF16Vop3::VCmpxFF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_f16_e64_dpp"
+          : "v_cmpx_f_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF16Vop3>(opcode);
 }
 } // namespace detail
@@ -15917,7 +18671,15 @@ VCmpxLtF16Vop3::VCmpxLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f16_e64_dpp"
+          : "v_cmpx_lt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -15976,7 +18738,15 @@ VCmpxEqF16Vop3::VCmpxEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f16_e64_dpp"
+          : "v_cmpx_eq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16035,7 +18805,15 @@ VCmpxLeF16Vop3::VCmpxLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f16_e64_dpp"
+          : "v_cmpx_le_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16094,7 +18872,15 @@ VCmpxGtF16Vop3::VCmpxGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f16_e64_dpp"
+          : "v_cmpx_gt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16153,7 +18939,15 @@ VCmpxLgF16Vop3::VCmpxLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f16_e64_dpp"
+          : "v_cmpx_lg_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16212,7 +19006,15 @@ VCmpxGeF16Vop3::VCmpxGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f16_e64_dpp"
+          : "v_cmpx_ge_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16271,7 +19073,15 @@ VCmpxOF16Vop3::VCmpxOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f16_e64_dpp"
+          : "v_cmpx_o_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16330,7 +19140,15 @@ VCmpxUF16Vop3::VCmpxUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f16_e64_dpp"
+          : "v_cmpx_u_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16389,7 +19207,16 @@ VCmpxNgeF16Vop3::VCmpxNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f16_e64_dpp"
+          : "v_cmpx_nge_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16448,7 +19275,16 @@ VCmpxNlgF16Vop3::VCmpxNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f16_e64_dpp"
+          : "v_cmpx_nlg_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16507,7 +19343,16 @@ VCmpxNgtF16Vop3::VCmpxNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f16_e64_dpp"
+          : "v_cmpx_ngt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16566,7 +19411,16 @@ VCmpxNleF16Vop3::VCmpxNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f16_e64_dpp"
+          : "v_cmpx_nle_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16625,7 +19479,16 @@ VCmpxNeqF16Vop3::VCmpxNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f16_e64_dpp"
+          : "v_cmpx_neq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16684,7 +19547,16 @@ VCmpxNltF16Vop3::VCmpxNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f16_e64_dpp"
+          : "v_cmpx_nlt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16743,7 +19615,15 @@ VCmpxTF16Vop3::VCmpxTF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_f16_e64_dpp"
+          : "v_cmpx_t_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16794,7 +19674,15 @@ VCmpxFF32Vop3::VCmpxFF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_f32_e64_dpp"
+          : "v_cmpx_f_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF32Vop3>(opcode);
 }
 } // namespace detail
@@ -16845,7 +19733,15 @@ VCmpxLtF32Vop3::VCmpxLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f32_e64_dpp"
+          : "v_cmpx_lt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -16896,7 +19792,15 @@ VCmpxEqF32Vop3::VCmpxEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f32_e64_dpp"
+          : "v_cmpx_eq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -16947,7 +19851,15 @@ VCmpxLeF32Vop3::VCmpxLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f32_e64_dpp"
+          : "v_cmpx_le_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -16998,7 +19910,15 @@ VCmpxGtF32Vop3::VCmpxGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f32_e64_dpp"
+          : "v_cmpx_gt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17049,7 +19969,15 @@ VCmpxLgF32Vop3::VCmpxLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f32_e64_dpp"
+          : "v_cmpx_lg_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17100,7 +20028,15 @@ VCmpxGeF32Vop3::VCmpxGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f32_e64_dpp"
+          : "v_cmpx_ge_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17151,7 +20087,15 @@ VCmpxOF32Vop3::VCmpxOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f32_e64_dpp"
+          : "v_cmpx_o_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17202,7 +20146,15 @@ VCmpxUF32Vop3::VCmpxUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f32_e64_dpp"
+          : "v_cmpx_u_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17253,7 +20205,16 @@ VCmpxNgeF32Vop3::VCmpxNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f32_e64_dpp"
+          : "v_cmpx_nge_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17304,7 +20265,16 @@ VCmpxNlgF32Vop3::VCmpxNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f32_e64_dpp"
+          : "v_cmpx_nlg_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17355,7 +20325,16 @@ VCmpxNgtF32Vop3::VCmpxNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f32_e64_dpp"
+          : "v_cmpx_ngt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17406,7 +20385,16 @@ VCmpxNleF32Vop3::VCmpxNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f32_e64_dpp"
+          : "v_cmpx_nle_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17457,7 +20445,16 @@ VCmpxNeqF32Vop3::VCmpxNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f32_e64_dpp"
+          : "v_cmpx_neq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17508,7 +20505,16 @@ VCmpxNltF32Vop3::VCmpxNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f32_e64_dpp"
+          : "v_cmpx_nlt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17559,7 +20565,15 @@ VCmpxTF32Vop3::VCmpxTF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_f32_e64_dpp"
+          : "v_cmpx_t_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17590,15 +20604,23 @@ VCmpxFF64Vop3::VCmpxFF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_f64_e64_dpp"
+          : "v_cmpx_f_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F64 does not support DPP";
   return std::make_unique<VCmpxFF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17629,15 +20651,23 @@ VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f64_e64_dpp"
+          : "v_cmpx_lt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support DPP";
   return std::make_unique<VCmpxLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17668,15 +20698,23 @@ VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f64_e64_dpp"
+          : "v_cmpx_eq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support DPP";
   return std::make_unique<VCmpxEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17707,15 +20745,23 @@ VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f64_e64_dpp"
+          : "v_cmpx_le_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support DPP";
   return std::make_unique<VCmpxLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17746,15 +20792,23 @@ VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f64_e64_dpp"
+          : "v_cmpx_gt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support DPP";
   return std::make_unique<VCmpxGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17785,15 +20839,23 @@ VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f64_e64_dpp"
+          : "v_cmpx_lg_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support DPP";
   return std::make_unique<VCmpxLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17824,15 +20886,23 @@ VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f64_e64_dpp"
+          : "v_cmpx_ge_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support DPP";
   return std::make_unique<VCmpxGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17863,15 +20933,23 @@ VCmpxOF64Vop3::VCmpxOF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_O_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f64_e64_dpp"
+          : "v_cmpx_o_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support DPP";
   return std::make_unique<VCmpxOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17902,15 +20980,23 @@ VCmpxUF64Vop3::VCmpxUF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_U_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f64_e64_dpp"
+          : "v_cmpx_u_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support DPP";
   return std::make_unique<VCmpxUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17941,15 +21027,24 @@ VCmpxNgeF64Vop3::VCmpxNgeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f64_e64_dpp"
+          : "v_cmpx_nge_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support DPP";
   return std::make_unique<VCmpxNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -17980,15 +21075,24 @@ VCmpxNlgF64Vop3::VCmpxNlgF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f64_e64_dpp"
+          : "v_cmpx_nlg_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support DPP";
   return std::make_unique<VCmpxNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18019,15 +21123,24 @@ VCmpxNgtF64Vop3::VCmpxNgtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f64_e64_dpp"
+          : "v_cmpx_ngt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support DPP";
   return std::make_unique<VCmpxNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18058,15 +21171,24 @@ VCmpxNleF64Vop3::VCmpxNleF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f64_e64_dpp"
+          : "v_cmpx_nle_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support DPP";
   return std::make_unique<VCmpxNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18097,15 +21219,24 @@ VCmpxNeqF64Vop3::VCmpxNeqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f64_e64_dpp"
+          : "v_cmpx_neq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support DPP";
   return std::make_unique<VCmpxNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18136,15 +21267,24 @@ VCmpxNltF64Vop3::VCmpxNltF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f64_e64_dpp"
+          : "v_cmpx_nlt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support DPP";
   return std::make_unique<VCmpxNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18175,15 +21315,23 @@ VCmpxTF64Vop3::VCmpxTF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_f64_e64_dpp"
+          : "v_cmpx_t_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_F64 does not support DPP";
   return std::make_unique<VCmpxTF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18242,7 +21390,15 @@ VCmpxLtI16Vop3::VCmpxLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i16_e64_dpp"
+          : "v_cmpx_lt_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -18301,7 +21457,15 @@ VCmpxEqI16Vop3::VCmpxEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i16_e64_dpp"
+          : "v_cmpx_eq_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -18360,7 +21524,15 @@ VCmpxLeI16Vop3::VCmpxLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i16_e64_dpp"
+          : "v_cmpx_le_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -18419,7 +21591,15 @@ VCmpxGtI16Vop3::VCmpxGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i16_e64_dpp"
+          : "v_cmpx_gt_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -18478,7 +21658,15 @@ VCmpxNeI16Vop3::VCmpxNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i16_e64_dpp"
+          : "v_cmpx_ne_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -18537,7 +21725,15 @@ VCmpxGeI16Vop3::VCmpxGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i16_e64_dpp"
+          : "v_cmpx_ge_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -18596,7 +21792,15 @@ VCmpxLtU16Vop3::VCmpxLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u16_e64_dpp"
+          : "v_cmpx_lt_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -18655,7 +21859,15 @@ VCmpxEqU16Vop3::VCmpxEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u16_e64_dpp"
+          : "v_cmpx_eq_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -18714,7 +21926,15 @@ VCmpxLeU16Vop3::VCmpxLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u16_e64_dpp"
+          : "v_cmpx_le_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -18773,7 +21993,15 @@ VCmpxGtU16Vop3::VCmpxGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u16_e64_dpp"
+          : "v_cmpx_gt_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -18832,7 +22060,15 @@ VCmpxNeU16Vop3::VCmpxNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u16_e64_dpp"
+          : "v_cmpx_ne_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -18891,7 +22127,15 @@ VCmpxGeU16Vop3::VCmpxGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u16_e64_dpp"
+          : "v_cmpx_ge_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -18942,7 +22186,15 @@ VCmpxFI32Vop3::VCmpxFI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_i32_e64_dpp"
+          : "v_cmpx_f_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI32Vop3>(opcode);
 }
 } // namespace detail
@@ -18993,7 +22245,15 @@ VCmpxLtI32Vop3::VCmpxLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i32_e64_dpp"
+          : "v_cmpx_lt_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19044,7 +22304,15 @@ VCmpxEqI32Vop3::VCmpxEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i32_e64_dpp"
+          : "v_cmpx_eq_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19095,7 +22363,15 @@ VCmpxLeI32Vop3::VCmpxLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i32_e64_dpp"
+          : "v_cmpx_le_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19146,7 +22422,15 @@ VCmpxGtI32Vop3::VCmpxGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i32_e64_dpp"
+          : "v_cmpx_gt_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19197,7 +22481,15 @@ VCmpxNeI32Vop3::VCmpxNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i32_e64_dpp"
+          : "v_cmpx_ne_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19248,7 +22540,15 @@ VCmpxGeI32Vop3::VCmpxGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i32_e64_dpp"
+          : "v_cmpx_ge_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19299,7 +22599,15 @@ VCmpxTI32Vop3::VCmpxTI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_i32_e64_dpp"
+          : "v_cmpx_t_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19350,7 +22658,15 @@ VCmpxFU32Vop3::VCmpxFU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_u32_e64_dpp"
+          : "v_cmpx_f_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19401,7 +22717,15 @@ VCmpxLtU32Vop3::VCmpxLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u32_e64_dpp"
+          : "v_cmpx_lt_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19452,7 +22776,15 @@ VCmpxEqU32Vop3::VCmpxEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u32_e64_dpp"
+          : "v_cmpx_eq_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19503,7 +22835,15 @@ VCmpxLeU32Vop3::VCmpxLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u32_e64_dpp"
+          : "v_cmpx_le_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19554,7 +22894,15 @@ VCmpxGtU32Vop3::VCmpxGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u32_e64_dpp"
+          : "v_cmpx_gt_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19605,7 +22953,15 @@ VCmpxNeU32Vop3::VCmpxNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u32_e64_dpp"
+          : "v_cmpx_ne_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19656,7 +23012,15 @@ VCmpxGeU32Vop3::VCmpxGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u32_e64_dpp"
+          : "v_cmpx_ge_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19707,7 +23071,15 @@ VCmpxTU32Vop3::VCmpxTU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_u32_e64_dpp"
+          : "v_cmpx_t_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19738,15 +23110,23 @@ VCmpxFI64Vop3::VCmpxFI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_i64_e64_dpp"
+          : "v_cmpx_f_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I64 does not support DPP";
   return std::make_unique<VCmpxFI64Vop3>(opcode);
 }
 } // namespace detail
@@ -19777,15 +23157,23 @@ VCmpxLtI64Vop3::VCmpxLtI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i64_e64_dpp"
+          : "v_cmpx_lt_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support DPP";
   return std::make_unique<VCmpxLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -19816,15 +23204,23 @@ VCmpxEqI64Vop3::VCmpxEqI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i64_e64_dpp"
+          : "v_cmpx_eq_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support DPP";
   return std::make_unique<VCmpxEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -19855,15 +23251,23 @@ VCmpxLeI64Vop3::VCmpxLeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i64_e64_dpp"
+          : "v_cmpx_le_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support DPP";
   return std::make_unique<VCmpxLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -19894,15 +23298,23 @@ VCmpxGtI64Vop3::VCmpxGtI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i64_e64_dpp"
+          : "v_cmpx_gt_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support DPP";
   return std::make_unique<VCmpxGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -19933,15 +23345,23 @@ VCmpxNeI64Vop3::VCmpxNeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i64_e64_dpp"
+          : "v_cmpx_ne_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support DPP";
   return std::make_unique<VCmpxNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -19972,15 +23392,23 @@ VCmpxGeI64Vop3::VCmpxGeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i64_e64_dpp"
+          : "v_cmpx_ge_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support DPP";
   return std::make_unique<VCmpxGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -20011,15 +23439,23 @@ VCmpxTI64Vop3::VCmpxTI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_i64_e64_dpp"
+          : "v_cmpx_t_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I64 does not support DPP";
   return std::make_unique<VCmpxTI64Vop3>(opcode);
 }
 } // namespace detail
@@ -20050,15 +23486,23 @@ VCmpxFU64Vop3::VCmpxFU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_u64_e64_dpp"
+          : "v_cmpx_f_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U64 does not support DPP";
   return std::make_unique<VCmpxFU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20089,15 +23533,23 @@ VCmpxLtU64Vop3::VCmpxLtU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u64_e64_dpp"
+          : "v_cmpx_lt_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support DPP";
   return std::make_unique<VCmpxLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20128,15 +23580,23 @@ VCmpxEqU64Vop3::VCmpxEqU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u64_e64_dpp"
+          : "v_cmpx_eq_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support DPP";
   return std::make_unique<VCmpxEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20167,15 +23627,23 @@ VCmpxLeU64Vop3::VCmpxLeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u64_e64_dpp"
+          : "v_cmpx_le_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support DPP";
   return std::make_unique<VCmpxLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20206,15 +23674,23 @@ VCmpxGtU64Vop3::VCmpxGtU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u64_e64_dpp"
+          : "v_cmpx_gt_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support DPP";
   return std::make_unique<VCmpxGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20245,15 +23721,23 @@ VCmpxNeU64Vop3::VCmpxNeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u64_e64_dpp"
+          : "v_cmpx_ne_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support DPP";
   return std::make_unique<VCmpxNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20284,15 +23768,23 @@ VCmpxGeU64Vop3::VCmpxGeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u64_e64_dpp"
+          : "v_cmpx_ge_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support DPP";
   return std::make_unique<VCmpxGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20323,15 +23815,23 @@ VCmpxTU64Vop3::VCmpxTU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_u64_e64_dpp"
+          : "v_cmpx_t_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U64 does not support DPP";
   return std::make_unique<VCmpxTU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20390,7 +23890,16 @@ VCmpxClassF16Vop3::VCmpxClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f16_e64_dpp"
+          : "v_cmpx_class_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -20441,7 +23950,16 @@ VCmpxClassF32Vop3::VCmpxClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f32_e64_dpp"
+          : "v_cmpx_class_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -20471,15 +23989,24 @@ VCmpxClassF64Vop3::VCmpxClassF64Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f64_e64_dpp"
+          : "v_cmpx_class_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support DPP";
   return std::make_unique<VCmpxClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -20530,7 +24057,16 @@ VAddCoCiU32Vop3SdstEnc::VAddCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_add_co_ci_u32_e64_dpp"
+          : "v_add_co_ci_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoCiU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20581,7 +24117,16 @@ VSubCoCiU32Vop3SdstEnc::VSubCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_sub_co_ci_u32_e64_dpp"
+          : "v_sub_co_ci_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoCiU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20632,7 +24177,16 @@ VSubrevCoCiU32Vop3SdstEnc::VSubrevCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_subrev_co_ci_u32_e64_dpp"
+          : "v_subrev_co_ci_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoCiU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20667,13 +24221,23 @@ VDivScaleF32Vop3SdstEnc::VDivScaleF32Vop3SdstEnc(const MachineInst *inst)
     src2 = Operand(32, OperandType::OPR_SIMM32,
                    static_cast<int>(
                        reinterpret_cast<const Vop3SdstEncInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_SCALE_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_div_scale_f32_e64_dpp"
+          : "v_div_scale_f32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DIV_SCALE_F32 does not support DPP";
   return std::make_unique<VDivScaleF32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20714,13 +24278,23 @@ VDivScaleF64Vop3SdstEnc::VDivScaleF64Vop3SdstEnc(const MachineInst *inst)
         static_cast<uint32_t>(
             reinterpret_cast<const Vop3SdstEncInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_SCALE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_div_scale_f64_e64_dpp"
+          : "v_div_scale_f64",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DIV_SCALE_F64 does not support DPP";
   return std::make_unique<VDivScaleF64Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20757,13 +24331,23 @@ VMadU64U32Vop3SdstEnc::VMadU64U32Vop3SdstEnc(const MachineInst *inst)
         static_cast<uint32_t>(
             reinterpret_cast<const Vop3SdstEncInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAD_U64_U32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_mad_u64_u32_e64_dpp"
+          : "v_mad_u64_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_MAD_U64_U32 does not support DPP";
   return std::make_unique<VMadU64U32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20800,13 +24384,23 @@ VMadI64I32Vop3SdstEnc::VMadI64I32Vop3SdstEnc(const MachineInst *inst)
         static_cast<uint32_t>(
             reinterpret_cast<const Vop3SdstEncInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAD_I64_I32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_mad_i64_i32_e64_dpp"
+          : "v_mad_i64_i32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_MAD_I64_I32 does not support DPP";
   return std::make_unique<VMadI64I32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20855,7 +24449,16 @@ VAddCoU32Vop3SdstEnc::VAddCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_add_co_u32_e64_dpp"
+          : "v_add_co_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20904,7 +24507,16 @@ VSubCoU32Vop3SdstEnc::VSubCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_sub_co_u32_e64_dpp"
+          : "v_sub_co_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20953,7 +24565,16 @@ VSubrevCoU32Vop3SdstEnc::VSubrevCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_subrev_co_u32_e64_dpp"
+          : "v_subrev_co_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop3p.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -41,13 +40,22 @@ VPkMadI16Vop3p::VPkMadI16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAD_I16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_mad_i16_e64_dpp"
+          : "v_pk_mad_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAD_I16 does not support DPP";
   return std::make_unique<VPkMadI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -74,13 +82,23 @@ VPkMulLoU16Vop3p::VPkMulLoU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MUL_LO_U16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_mul_lo_u16_e64_dpp"
+          : "v_pk_mul_lo_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MUL_LO_U16 does not support DPP";
   return std::make_unique<VPkMulLoU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -107,13 +125,22 @@ VPkAddI16Vop3p::VPkAddI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ADD_I16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_add_i16_e64_dpp"
+          : "v_pk_add_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ADD_I16 does not support DPP";
   return std::make_unique<VPkAddI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -140,13 +167,22 @@ VPkSubI16Vop3p::VPkSubI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_SUB_I16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_sub_i16_e64_dpp"
+          : "v_pk_sub_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_SUB_I16 does not support DPP";
   return std::make_unique<VPkSubI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -173,13 +209,23 @@ VPkLshlrevB16Vop3p::VPkLshlrevB16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_LSHLREV_B16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_lshlrev_b16_e64_dpp"
+          : "v_pk_lshlrev_b16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_LSHLREV_B16 does not support DPP";
   return std::make_unique<VPkLshlrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -206,13 +252,23 @@ VPkLshrrevB16Vop3p::VPkLshrrevB16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_LSHRREV_B16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_lshrrev_b16_e64_dpp"
+          : "v_pk_lshrrev_b16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_LSHRREV_B16 does not support DPP";
   return std::make_unique<VPkLshrrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -239,13 +295,23 @@ VPkAshrrevI16Vop3p::VPkAshrrevI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ASHRREV_I16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_ashrrev_i16_e64_dpp"
+          : "v_pk_ashrrev_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ASHRREV_I16 does not support DPP";
   return std::make_unique<VPkAshrrevI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -272,13 +338,22 @@ VPkMaxI16Vop3p::VPkMaxI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAX_I16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_max_i16_e64_dpp"
+          : "v_pk_max_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAX_I16 does not support DPP";
   return std::make_unique<VPkMaxI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -305,13 +380,22 @@ VPkMinI16Vop3p::VPkMinI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MIN_I16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_min_i16_e64_dpp"
+          : "v_pk_min_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MIN_I16 does not support DPP";
   return std::make_unique<VPkMinI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -344,13 +428,22 @@ VPkMadU16Vop3p::VPkMadU16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAD_U16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_mad_u16_e64_dpp"
+          : "v_pk_mad_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAD_U16 does not support DPP";
   return std::make_unique<VPkMadU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -377,13 +470,22 @@ VPkAddU16Vop3p::VPkAddU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ADD_U16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_add_u16_e64_dpp"
+          : "v_pk_add_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ADD_U16 does not support DPP";
   return std::make_unique<VPkAddU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -410,13 +512,22 @@ VPkSubU16Vop3p::VPkSubU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_SUB_U16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_sub_u16_e64_dpp"
+          : "v_pk_sub_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_SUB_U16 does not support DPP";
   return std::make_unique<VPkSubU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -443,13 +554,22 @@ VPkMaxU16Vop3p::VPkMaxU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAX_U16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_max_u16_e64_dpp"
+          : "v_pk_max_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAX_U16 does not support DPP";
   return std::make_unique<VPkMaxU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -476,13 +596,22 @@ VPkMinU16Vop3p::VPkMinU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MIN_U16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_min_u16_e64_dpp"
+          : "v_pk_min_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MIN_U16 does not support DPP";
   return std::make_unique<VPkMinU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -515,13 +644,22 @@ VPkFmaF16Vop3p::VPkFmaF16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_FMA_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_fma_f16_e64_dpp"
+          : "v_pk_fma_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_FMA_F16 does not support DPP";
   return std::make_unique<VPkFmaF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -548,13 +686,22 @@ VPkAddF16Vop3p::VPkAddF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ADD_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_add_f16_e64_dpp"
+          : "v_pk_add_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ADD_F16 does not support DPP";
   return std::make_unique<VPkAddF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -581,13 +728,22 @@ VPkMulF16Vop3p::VPkMulF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MUL_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_mul_f16_e64_dpp"
+          : "v_pk_mul_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MUL_F16 does not support DPP";
   return std::make_unique<VPkMulF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -614,13 +770,22 @@ VPkMinF16Vop3p::VPkMinF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MIN_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_min_f16_e64_dpp"
+          : "v_pk_min_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MIN_F16 does not support DPP";
   return std::make_unique<VPkMinF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -647,13 +812,22 @@ VPkMaxF16Vop3p::VPkMaxF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAX_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_max_f16_e64_dpp"
+          : "v_pk_max_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAX_F16 does not support DPP";
   return std::make_unique<VPkMaxF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -706,7 +880,16 @@ VDot2F32F16Vop3p::VDot2F32F16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2F32F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2F32F16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot2_f32_f16_e64_dpp"
+          : "v_dot2_f32_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2F32F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -739,13 +922,23 @@ VDot4I32Iu8Vop3p::VDot4I32Iu8Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT4_I32_IU8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4I32Iu8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4I32Iu8Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot4_i32_iu8_e64_dpp"
+          : "v_dot4_i32_iu8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT4_I32_IU8 does not support DPP";
   return std::make_unique<VDot4I32Iu8Vop3p>(opcode);
 }
 } // namespace detail
@@ -778,13 +971,23 @@ VDot4U32U8Vop3p::VDot4U32U8Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT4_U32_U8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot4_u32_u8_e64_dpp"
+          : "v_dot4_u32_u8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT4_U32_U8 does not support DPP";
   return std::make_unique<VDot4U32U8Vop3p>(opcode);
 }
 } // namespace detail
@@ -817,13 +1020,23 @@ VDot8I32Iu4Vop3p::VDot8I32Iu4Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT8_I32_IU4 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8I32Iu4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8I32Iu4Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot8_i32_iu4_e64_dpp"
+          : "v_dot8_i32_iu4",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT8_I32_IU4 does not support DPP";
   return std::make_unique<VDot8I32Iu4Vop3p>(opcode);
 }
 } // namespace detail
@@ -856,13 +1069,23 @@ VDot8U32U4Vop3p::VDot8U32U4Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT8_U32_U4 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot8_u32_u4_e64_dpp"
+          : "v_dot8_u32_u4",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT8_U32_U4 does not support DPP";
   return std::make_unique<VDot8U32U4Vop3p>(opcode);
 }
 } // namespace detail
@@ -915,7 +1138,16 @@ VDot2F32Bf16Vop3p::VDot2F32Bf16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2F32Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2F32Bf16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot2_f32_bf16_e64_dpp"
+          : "v_dot2_f32_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2F32Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -968,7 +1200,16 @@ VFmaMixF32Vop3p::VFmaMixF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixF32Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_fma_mix_f32_e64_dpp"
+          : "v_fma_mix_f32",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -1022,7 +1263,16 @@ VFmaMixloF16Vop3p::VFmaMixloF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixloF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_fma_mixlo_f16_e64_dpp"
+          : "v_fma_mixlo_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixloF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1082,7 +1332,16 @@ VFmaMixhiF16Vop3p::VFmaMixhiF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixhiF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_fma_mixhi_f16_e64_dpp"
+          : "v_fma_mixhi_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixhiF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1110,13 +1369,23 @@ VWmmaF3216x16x16F16Vop3p::VWmmaF3216x16x16F16Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X16_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x16F16Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x16_f16_e64_dpp"
+          : "v_wmma_f32_16x16x16_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X16_F16 does not support DPP";
   return std::make_unique<VWmmaF3216x16x16F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1138,13 +1407,23 @@ VWmmaF3216x16x16Bf16Vop3p::VWmmaF3216x16x16Bf16Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X16_BF16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x16Bf16Vop3p(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x16_bf16_e64_dpp"
+          : "v_wmma_f32_16x16x16_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X16_BF16 does not support DPP";
   return std::make_unique<VWmmaF3216x16x16Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1166,13 +1445,23 @@ VWmmaF1616x16x16F16Vop3p::VWmmaF1616x16x16F16Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F16_16X16X16_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x16F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF1616x16x16F16Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f16_16x16x16_f16_e64_dpp"
+          : "v_wmma_f16_16x16x16_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F16_16X16X16_F16 does not support DPP";
   return std::make_unique<VWmmaF1616x16x16F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1194,13 +1483,23 @@ VWmmaBf1616x16x16Bf16Vop3p::VWmmaBf1616x16x16Bf16Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_BF16_16X16X16_BF16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaBf1616x16x16Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaBf1616x16x16Bf16Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_bf16_16x16x16_bf16_e64_dpp"
+          : "v_wmma_bf16_16x16x16_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_BF16_16X16X16_BF16 does not support DPP";
   return std::make_unique<VWmmaBf1616x16x16Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1222,13 +1521,23 @@ VWmmaI3216x16x16Iu8Vop3p::VWmmaI3216x16x16Iu8Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_I32_16X16X16_IU8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaI3216x16x16Iu8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaI3216x16x16Iu8Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_i32_16x16x16_iu8_e64_dpp"
+          : "v_wmma_i32_16x16x16_iu8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_I32_16X16X16_IU8 does not support DPP";
   return std::make_unique<VWmmaI3216x16x16Iu8Vop3p>(opcode);
 }
 } // namespace detail
@@ -1250,13 +1559,23 @@ VWmmaI3216x16x16Iu4Vop3p::VWmmaI3216x16x16Iu4Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_I32_16X16X16_IU4 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaI3216x16x16Iu4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaI3216x16x16Iu4Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_i32_16x16x16_iu4_e64_dpp"
+          : "v_wmma_i32_16x16x16_iu4",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_I32_16X16X16_IU4 does not support DPP";
   return std::make_unique<VWmmaI3216x16x16Iu4Vop3p>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vopc.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -55,7 +54,15 @@ VCmpFF16Vopc::VCmpFF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_f16_dpp"
+          : "v_cmp_f_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF16Vopc>(opcode);
 }
 } // namespace detail
@@ -102,7 +109,15 @@ VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f16_dpp"
+          : "v_cmp_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -149,7 +164,15 @@ VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f16_dpp"
+          : "v_cmp_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -196,7 +219,15 @@ VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f16_dpp"
+          : "v_cmp_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -243,7 +274,15 @@ VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f16_dpp"
+          : "v_cmp_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -290,7 +329,15 @@ VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f16_dpp"
+          : "v_cmp_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -337,7 +384,15 @@ VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f16_dpp"
+          : "v_cmp_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -384,7 +439,15 @@ VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f16_dpp"
+          : "v_cmp_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -431,7 +494,15 @@ VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f16_dpp"
+          : "v_cmp_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -478,7 +549,15 @@ VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f16_dpp"
+          : "v_cmp_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -525,7 +604,15 @@ VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f16_dpp"
+          : "v_cmp_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -572,7 +659,15 @@ VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f16_dpp"
+          : "v_cmp_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -619,7 +714,15 @@ VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f16_dpp"
+          : "v_cmp_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -666,7 +769,15 @@ VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f16_dpp"
+          : "v_cmp_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -713,7 +824,15 @@ VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f16_dpp"
+          : "v_cmp_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -760,7 +879,15 @@ VCmpTF16Vopc::VCmpTF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_f16_dpp"
+          : "v_cmp_t_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTF16Vopc>(opcode);
 }
 } // namespace detail
@@ -804,7 +931,15 @@ VCmpFF32Vopc::VCmpFF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_f32_dpp"
+          : "v_cmp_f_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFF32Vopc>(opcode);
 }
 } // namespace detail
@@ -848,7 +983,15 @@ VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f32_dpp"
+          : "v_cmp_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -892,7 +1035,15 @@ VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f32_dpp"
+          : "v_cmp_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -936,7 +1087,15 @@ VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f32_dpp"
+          : "v_cmp_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -980,7 +1139,15 @@ VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f32_dpp"
+          : "v_cmp_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1024,7 +1191,15 @@ VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f32_dpp"
+          : "v_cmp_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1068,7 +1243,15 @@ VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f32_dpp"
+          : "v_cmp_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1112,7 +1295,15 @@ VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f32_dpp"
+          : "v_cmp_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1156,7 +1347,15 @@ VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f32_dpp"
+          : "v_cmp_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1200,7 +1399,15 @@ VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f32_dpp"
+          : "v_cmp_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1244,7 +1451,15 @@ VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f32_dpp"
+          : "v_cmp_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1288,7 +1503,15 @@ VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f32_dpp"
+          : "v_cmp_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1332,7 +1555,15 @@ VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f32_dpp"
+          : "v_cmp_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1376,7 +1607,15 @@ VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f32_dpp"
+          : "v_cmp_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1420,7 +1659,15 @@ VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f32_dpp"
+          : "v_cmp_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1464,7 +1711,15 @@ VCmpTF32Vopc::VCmpTF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_f32_dpp"
+          : "v_cmp_t_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1488,14 +1743,22 @@ VCmpFF64Vopc::VCmpFF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_f64_dpp"
+          : "v_cmp_f_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_F64 does not support DPP";
   return std::make_unique<VCmpFF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1519,14 +1782,22 @@ VCmpLtF64Vopc::VCmpLtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f64_dpp"
+          : "v_cmp_lt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support DPP";
   return std::make_unique<VCmpLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1550,14 +1821,22 @@ VCmpEqF64Vopc::VCmpEqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f64_dpp"
+          : "v_cmp_eq_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support DPP";
   return std::make_unique<VCmpEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1581,14 +1860,22 @@ VCmpLeF64Vopc::VCmpLeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f64_dpp"
+          : "v_cmp_le_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support DPP";
   return std::make_unique<VCmpLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1612,14 +1899,22 @@ VCmpGtF64Vopc::VCmpGtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f64_dpp"
+          : "v_cmp_gt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support DPP";
   return std::make_unique<VCmpGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1643,14 +1938,22 @@ VCmpLgF64Vopc::VCmpLgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LG_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f64_dpp"
+          : "v_cmp_lg_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support DPP";
   return std::make_unique<VCmpLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1674,14 +1977,22 @@ VCmpGeF64Vopc::VCmpGeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f64_dpp"
+          : "v_cmp_ge_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support DPP";
   return std::make_unique<VCmpGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1705,14 +2016,22 @@ VCmpOF64Vopc::VCmpOF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_O_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f64_dpp"
+          : "v_cmp_o_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support DPP";
   return std::make_unique<VCmpOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1736,14 +2055,22 @@ VCmpUF64Vopc::VCmpUF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_U_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f64_dpp"
+          : "v_cmp_u_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support DPP";
   return std::make_unique<VCmpUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1767,14 +2094,22 @@ VCmpNgeF64Vopc::VCmpNgeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f64_dpp"
+          : "v_cmp_nge_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support DPP";
   return std::make_unique<VCmpNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1798,14 +2133,22 @@ VCmpNlgF64Vopc::VCmpNlgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f64_dpp"
+          : "v_cmp_nlg_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support DPP";
   return std::make_unique<VCmpNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1829,14 +2172,22 @@ VCmpNgtF64Vopc::VCmpNgtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f64_dpp"
+          : "v_cmp_ngt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support DPP";
   return std::make_unique<VCmpNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1860,14 +2211,22 @@ VCmpNleF64Vopc::VCmpNleF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f64_dpp"
+          : "v_cmp_nle_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support DPP";
   return std::make_unique<VCmpNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1891,14 +2250,22 @@ VCmpNeqF64Vopc::VCmpNeqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f64_dpp"
+          : "v_cmp_neq_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support DPP";
   return std::make_unique<VCmpNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1922,14 +2289,22 @@ VCmpNltF64Vopc::VCmpNltF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f64_dpp"
+          : "v_cmp_nlt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support DPP";
   return std::make_unique<VCmpNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1953,14 +2328,22 @@ VCmpTF64Vopc::VCmpTF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_f64_dpp"
+          : "v_cmp_t_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_F64 does not support DPP";
   return std::make_unique<VCmpTF64Vopc>(opcode);
 }
 } // namespace detail
@@ -2007,7 +2390,15 @@ VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i16_dpp"
+          : "v_cmp_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2054,7 +2445,15 @@ VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i16_dpp"
+          : "v_cmp_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2101,7 +2500,15 @@ VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i16_dpp"
+          : "v_cmp_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2148,7 +2555,15 @@ VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i16_dpp"
+          : "v_cmp_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2195,7 +2610,15 @@ VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i16_dpp"
+          : "v_cmp_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2242,7 +2665,15 @@ VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i16_dpp"
+          : "v_cmp_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2289,7 +2720,15 @@ VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u16_dpp"
+          : "v_cmp_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2336,7 +2775,15 @@ VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u16_dpp"
+          : "v_cmp_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2383,7 +2830,15 @@ VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u16_dpp"
+          : "v_cmp_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2430,7 +2885,15 @@ VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u16_dpp"
+          : "v_cmp_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2477,7 +2940,15 @@ VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u16_dpp"
+          : "v_cmp_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2524,7 +2995,15 @@ VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u16_dpp"
+          : "v_cmp_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2568,7 +3047,15 @@ VCmpFI32Vopc::VCmpFI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_i32_dpp"
+          : "v_cmp_f_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2612,7 +3099,15 @@ VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i32_dpp"
+          : "v_cmp_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2656,7 +3151,15 @@ VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i32_dpp"
+          : "v_cmp_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2700,7 +3203,15 @@ VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i32_dpp"
+          : "v_cmp_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2744,7 +3255,15 @@ VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i32_dpp"
+          : "v_cmp_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2788,7 +3307,15 @@ VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i32_dpp"
+          : "v_cmp_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2832,7 +3359,15 @@ VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i32_dpp"
+          : "v_cmp_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2876,7 +3411,15 @@ VCmpTI32Vopc::VCmpTI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_i32_dpp"
+          : "v_cmp_t_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2920,7 +3463,15 @@ VCmpFU32Vopc::VCmpFU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_u32_dpp"
+          : "v_cmp_f_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpFU32Vopc>(opcode);
 }
 } // namespace detail
@@ -2964,7 +3515,15 @@ VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u32_dpp"
+          : "v_cmp_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3008,7 +3567,15 @@ VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u32_dpp"
+          : "v_cmp_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3052,7 +3619,15 @@ VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u32_dpp"
+          : "v_cmp_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3096,7 +3671,15 @@ VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u32_dpp"
+          : "v_cmp_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3140,7 +3723,15 @@ VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u32_dpp"
+          : "v_cmp_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3184,7 +3775,15 @@ VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u32_dpp"
+          : "v_cmp_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3228,7 +3827,15 @@ VCmpTU32Vopc::VCmpTU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_u32_dpp"
+          : "v_cmp_t_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpTU32Vopc>(opcode);
 }
 } // namespace detail
@@ -3252,14 +3859,22 @@ VCmpFI64Vopc::VCmpFI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_i64_dpp"
+          : "v_cmp_f_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_I64 does not support DPP";
   return std::make_unique<VCmpFI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3283,14 +3898,22 @@ VCmpLtI64Vopc::VCmpLtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i64_dpp"
+          : "v_cmp_lt_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support DPP";
   return std::make_unique<VCmpLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3314,14 +3937,22 @@ VCmpEqI64Vopc::VCmpEqI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i64_dpp"
+          : "v_cmp_eq_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support DPP";
   return std::make_unique<VCmpEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3345,14 +3976,22 @@ VCmpLeI64Vopc::VCmpLeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i64_dpp"
+          : "v_cmp_le_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support DPP";
   return std::make_unique<VCmpLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3376,14 +4015,22 @@ VCmpGtI64Vopc::VCmpGtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i64_dpp"
+          : "v_cmp_gt_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support DPP";
   return std::make_unique<VCmpGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3407,14 +4054,22 @@ VCmpNeI64Vopc::VCmpNeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i64_dpp"
+          : "v_cmp_ne_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support DPP";
   return std::make_unique<VCmpNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3438,14 +4093,22 @@ VCmpGeI64Vopc::VCmpGeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i64_dpp"
+          : "v_cmp_ge_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support DPP";
   return std::make_unique<VCmpGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3469,14 +4132,22 @@ VCmpTI64Vopc::VCmpTI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_i64_dpp"
+          : "v_cmp_t_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_I64 does not support DPP";
   return std::make_unique<VCmpTI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3500,14 +4171,22 @@ VCmpFU64Vopc::VCmpFU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_F_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpFU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_f_u64_dpp"
+          : "v_cmp_f_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_F_U64 does not support DPP";
   return std::make_unique<VCmpFU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3531,14 +4210,22 @@ VCmpLtU64Vopc::VCmpLtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u64_dpp"
+          : "v_cmp_lt_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support DPP";
   return std::make_unique<VCmpLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3562,14 +4249,22 @@ VCmpEqU64Vopc::VCmpEqU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u64_dpp"
+          : "v_cmp_eq_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support DPP";
   return std::make_unique<VCmpEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3593,14 +4288,22 @@ VCmpLeU64Vopc::VCmpLeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u64_dpp"
+          : "v_cmp_le_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support DPP";
   return std::make_unique<VCmpLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3624,14 +4327,22 @@ VCmpGtU64Vopc::VCmpGtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u64_dpp"
+          : "v_cmp_gt_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support DPP";
   return std::make_unique<VCmpGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3655,14 +4366,22 @@ VCmpNeU64Vopc::VCmpNeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u64_dpp"
+          : "v_cmp_ne_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support DPP";
   return std::make_unique<VCmpNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3686,14 +4405,22 @@ VCmpGeU64Vopc::VCmpGeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u64_dpp"
+          : "v_cmp_ge_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support DPP";
   return std::make_unique<VCmpGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3717,14 +4444,22 @@ VCmpTU64Vopc::VCmpTU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_T_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpTU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_t_u64_dpp"
+          : "v_cmp_t_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_T_U64 does not support DPP";
   return std::make_unique<VCmpTU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3771,7 +4506,16 @@ VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f16_dpp"
+          : "v_cmp_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3815,7 +4559,16 @@ VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f32_dpp"
+          : "v_cmp_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3839,14 +4592,23 @@ VCmpClassF64Vopc::VCmpClassF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f64_dpp"
+          : "v_cmp_class_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support DPP";
   return std::make_unique<VCmpClassF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3897,7 +4659,15 @@ VCmpxFF16Vopc::VCmpxFF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_f16_dpp"
+          : "v_cmpx_f_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3948,7 +4718,15 @@ VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f16_dpp"
+          : "v_cmpx_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3999,7 +4777,15 @@ VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f16_dpp"
+          : "v_cmpx_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4050,7 +4836,15 @@ VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f16_dpp"
+          : "v_cmpx_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4101,7 +4895,15 @@ VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f16_dpp"
+          : "v_cmpx_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4152,7 +4954,15 @@ VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f16_dpp"
+          : "v_cmpx_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4203,7 +5013,15 @@ VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f16_dpp"
+          : "v_cmpx_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4254,7 +5072,15 @@ VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f16_dpp"
+          : "v_cmpx_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4305,7 +5131,15 @@ VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f16_dpp"
+          : "v_cmpx_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4356,7 +5190,16 @@ VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f16_dpp"
+          : "v_cmpx_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4407,7 +5250,16 @@ VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f16_dpp"
+          : "v_cmpx_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4458,7 +5310,16 @@ VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f16_dpp"
+          : "v_cmpx_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4509,7 +5370,16 @@ VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f16_dpp"
+          : "v_cmpx_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4560,7 +5430,16 @@ VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f16_dpp"
+          : "v_cmpx_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4611,7 +5490,16 @@ VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f16_dpp"
+          : "v_cmpx_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4662,7 +5550,15 @@ VCmpxTF16Vopc::VCmpxTF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_f16_dpp"
+          : "v_cmpx_t_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4710,7 +5606,15 @@ VCmpxFF32Vopc::VCmpxFF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_f32_dpp"
+          : "v_cmpx_f_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4758,7 +5662,15 @@ VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f32_dpp"
+          : "v_cmpx_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4806,7 +5718,15 @@ VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f32_dpp"
+          : "v_cmpx_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4854,7 +5774,15 @@ VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f32_dpp"
+          : "v_cmpx_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4902,7 +5830,15 @@ VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f32_dpp"
+          : "v_cmpx_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4950,7 +5886,15 @@ VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f32_dpp"
+          : "v_cmpx_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4998,7 +5942,15 @@ VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f32_dpp"
+          : "v_cmpx_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5046,7 +5998,15 @@ VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f32_dpp"
+          : "v_cmpx_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5094,7 +6054,15 @@ VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f32_dpp"
+          : "v_cmpx_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5142,7 +6110,16 @@ VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f32_dpp"
+          : "v_cmpx_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5190,7 +6167,16 @@ VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f32_dpp"
+          : "v_cmpx_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5238,7 +6224,16 @@ VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f32_dpp"
+          : "v_cmpx_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5286,7 +6281,16 @@ VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f32_dpp"
+          : "v_cmpx_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5334,7 +6338,16 @@ VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f32_dpp"
+          : "v_cmpx_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5382,7 +6395,16 @@ VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f32_dpp"
+          : "v_cmpx_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5430,7 +6452,15 @@ VCmpxTF32Vopc::VCmpxTF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_f32_dpp"
+          : "v_cmpx_t_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTF32Vopc>(opcode);
 }
 } // namespace detail
@@ -5456,16 +6486,24 @@ VCmpxFF64Vopc::VCmpxFF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_f64_dpp"
+          : "v_cmpx_f_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_F64 does not support DPP";
   return std::make_unique<VCmpxFF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5491,16 +6529,24 @@ VCmpxLtF64Vopc::VCmpxLtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f64_dpp"
+          : "v_cmpx_lt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support DPP";
   return std::make_unique<VCmpxLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5526,16 +6572,24 @@ VCmpxEqF64Vopc::VCmpxEqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f64_dpp"
+          : "v_cmpx_eq_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support DPP";
   return std::make_unique<VCmpxEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5561,16 +6615,24 @@ VCmpxLeF64Vopc::VCmpxLeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f64_dpp"
+          : "v_cmpx_le_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support DPP";
   return std::make_unique<VCmpxLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5596,16 +6658,24 @@ VCmpxGtF64Vopc::VCmpxGtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f64_dpp"
+          : "v_cmpx_gt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support DPP";
   return std::make_unique<VCmpxGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5631,16 +6701,24 @@ VCmpxLgF64Vopc::VCmpxLgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f64_dpp"
+          : "v_cmpx_lg_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support DPP";
   return std::make_unique<VCmpxLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5666,16 +6744,24 @@ VCmpxGeF64Vopc::VCmpxGeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f64_dpp"
+          : "v_cmpx_ge_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support DPP";
   return std::make_unique<VCmpxGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5701,16 +6787,24 @@ VCmpxOF64Vopc::VCmpxOF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_O_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f64_dpp"
+          : "v_cmpx_o_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support DPP";
   return std::make_unique<VCmpxOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5736,16 +6830,24 @@ VCmpxUF64Vopc::VCmpxUF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_U_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f64_dpp"
+          : "v_cmpx_u_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support DPP";
   return std::make_unique<VCmpxUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5771,16 +6873,25 @@ VCmpxNgeF64Vopc::VCmpxNgeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f64_dpp"
+          : "v_cmpx_nge_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support DPP";
   return std::make_unique<VCmpxNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5806,16 +6917,25 @@ VCmpxNlgF64Vopc::VCmpxNlgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f64_dpp"
+          : "v_cmpx_nlg_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support DPP";
   return std::make_unique<VCmpxNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5841,16 +6961,25 @@ VCmpxNgtF64Vopc::VCmpxNgtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f64_dpp"
+          : "v_cmpx_ngt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support DPP";
   return std::make_unique<VCmpxNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5876,16 +7005,25 @@ VCmpxNleF64Vopc::VCmpxNleF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f64_dpp"
+          : "v_cmpx_nle_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support DPP";
   return std::make_unique<VCmpxNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5911,16 +7049,25 @@ VCmpxNeqF64Vopc::VCmpxNeqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f64_dpp"
+          : "v_cmpx_neq_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support DPP";
   return std::make_unique<VCmpxNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5946,16 +7093,25 @@ VCmpxNltF64Vopc::VCmpxNltF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f64_dpp"
+          : "v_cmpx_nlt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support DPP";
   return std::make_unique<VCmpxNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5981,16 +7137,24 @@ VCmpxTF64Vopc::VCmpxTF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_f64_dpp"
+          : "v_cmpx_t_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_F64 does not support DPP";
   return std::make_unique<VCmpxTF64Vopc>(opcode);
 }
 } // namespace detail
@@ -6041,7 +7205,15 @@ VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i16_dpp"
+          : "v_cmpx_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6092,7 +7264,15 @@ VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i16_dpp"
+          : "v_cmpx_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6143,7 +7323,15 @@ VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i16_dpp"
+          : "v_cmpx_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6194,7 +7382,15 @@ VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i16_dpp"
+          : "v_cmpx_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6245,7 +7441,15 @@ VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i16_dpp"
+          : "v_cmpx_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6296,7 +7500,15 @@ VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i16_dpp"
+          : "v_cmpx_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -6347,7 +7559,15 @@ VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u16_dpp"
+          : "v_cmpx_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6398,7 +7618,15 @@ VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u16_dpp"
+          : "v_cmpx_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6449,7 +7677,15 @@ VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u16_dpp"
+          : "v_cmpx_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6500,7 +7736,15 @@ VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u16_dpp"
+          : "v_cmpx_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6551,7 +7795,15 @@ VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u16_dpp"
+          : "v_cmpx_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6602,7 +7854,15 @@ VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u16_dpp"
+          : "v_cmpx_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -6650,7 +7910,15 @@ VCmpxFI32Vopc::VCmpxFI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_i32_dpp"
+          : "v_cmpx_f_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6698,7 +7966,15 @@ VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i32_dpp"
+          : "v_cmpx_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6746,7 +8022,15 @@ VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i32_dpp"
+          : "v_cmpx_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6794,7 +8078,15 @@ VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i32_dpp"
+          : "v_cmpx_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6842,7 +8134,15 @@ VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i32_dpp"
+          : "v_cmpx_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6890,7 +8190,15 @@ VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i32_dpp"
+          : "v_cmpx_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6938,7 +8246,15 @@ VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i32_dpp"
+          : "v_cmpx_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6986,7 +8302,15 @@ VCmpxTI32Vopc::VCmpxTI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_i32_dpp"
+          : "v_cmpx_t_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTI32Vopc>(opcode);
 }
 } // namespace detail
@@ -7034,7 +8358,15 @@ VCmpxFU32Vopc::VCmpxFU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_u32_dpp"
+          : "v_cmpx_f_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxFU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7082,7 +8414,15 @@ VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u32_dpp"
+          : "v_cmpx_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7130,7 +8470,15 @@ VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u32_dpp"
+          : "v_cmpx_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7178,7 +8526,15 @@ VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u32_dpp"
+          : "v_cmpx_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7226,7 +8582,15 @@ VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u32_dpp"
+          : "v_cmpx_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7274,7 +8638,15 @@ VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u32_dpp"
+          : "v_cmpx_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7322,7 +8694,15 @@ VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u32_dpp"
+          : "v_cmpx_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7370,7 +8750,15 @@ VCmpxTU32Vopc::VCmpxTU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_u32_dpp"
+          : "v_cmpx_t_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxTU32Vopc>(opcode);
 }
 } // namespace detail
@@ -7396,16 +8784,24 @@ VCmpxFI64Vopc::VCmpxFI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_i64_dpp"
+          : "v_cmpx_f_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_I64 does not support DPP";
   return std::make_unique<VCmpxFI64Vopc>(opcode);
 }
 } // namespace detail
@@ -7431,16 +8827,24 @@ VCmpxLtI64Vopc::VCmpxLtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i64_dpp"
+          : "v_cmpx_lt_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support DPP";
   return std::make_unique<VCmpxLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -7466,16 +8870,24 @@ VCmpxEqI64Vopc::VCmpxEqI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i64_dpp"
+          : "v_cmpx_eq_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support DPP";
   return std::make_unique<VCmpxEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -7501,16 +8913,24 @@ VCmpxLeI64Vopc::VCmpxLeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i64_dpp"
+          : "v_cmpx_le_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support DPP";
   return std::make_unique<VCmpxLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -7536,16 +8956,24 @@ VCmpxGtI64Vopc::VCmpxGtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i64_dpp"
+          : "v_cmpx_gt_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support DPP";
   return std::make_unique<VCmpxGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -7571,16 +8999,24 @@ VCmpxNeI64Vopc::VCmpxNeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i64_dpp"
+          : "v_cmpx_ne_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support DPP";
   return std::make_unique<VCmpxNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -7606,16 +9042,24 @@ VCmpxGeI64Vopc::VCmpxGeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i64_dpp"
+          : "v_cmpx_ge_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support DPP";
   return std::make_unique<VCmpxGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -7641,16 +9085,24 @@ VCmpxTI64Vopc::VCmpxTI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_i64_dpp"
+          : "v_cmpx_t_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_I64 does not support DPP";
   return std::make_unique<VCmpxTI64Vopc>(opcode);
 }
 } // namespace detail
@@ -7676,16 +9128,24 @@ VCmpxFU64Vopc::VCmpxFU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_F_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxFU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxFU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_f_u64_dpp"
+          : "v_cmpx_f_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_F_U64 does not support DPP";
   return std::make_unique<VCmpxFU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7711,16 +9171,24 @@ VCmpxLtU64Vopc::VCmpxLtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u64_dpp"
+          : "v_cmpx_lt_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support DPP";
   return std::make_unique<VCmpxLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7746,16 +9214,24 @@ VCmpxEqU64Vopc::VCmpxEqU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u64_dpp"
+          : "v_cmpx_eq_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support DPP";
   return std::make_unique<VCmpxEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7781,16 +9257,24 @@ VCmpxLeU64Vopc::VCmpxLeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u64_dpp"
+          : "v_cmpx_le_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support DPP";
   return std::make_unique<VCmpxLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7816,16 +9300,24 @@ VCmpxGtU64Vopc::VCmpxGtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u64_dpp"
+          : "v_cmpx_gt_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support DPP";
   return std::make_unique<VCmpxGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7851,16 +9343,24 @@ VCmpxNeU64Vopc::VCmpxNeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u64_dpp"
+          : "v_cmpx_ne_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support DPP";
   return std::make_unique<VCmpxNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7886,16 +9386,24 @@ VCmpxGeU64Vopc::VCmpxGeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u64_dpp"
+          : "v_cmpx_ge_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support DPP";
   return std::make_unique<VCmpxGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7921,16 +9429,24 @@ VCmpxTU64Vopc::VCmpxTU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_T_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxTU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxTU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_t_u64_dpp"
+          : "v_cmpx_t_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_T_U64 does not support DPP";
   return std::make_unique<VCmpxTU64Vopc>(opcode);
 }
 } // namespace detail
@@ -7981,7 +9497,16 @@ VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f16_dpp"
+          : "v_cmpx_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -8029,7 +9554,16 @@ VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f32_dpp"
+          : "v_cmpx_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -8055,16 +9589,25 @@ VCmpxClassF64Vopc::VCmpxClassF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f64_dpp"
+          : "v_cmpx_class_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support DPP";
   return std::make_unique<VCmpxClassF64Vopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vopd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vopd.cpp
@@ -95,6 +95,24 @@ const char *Vopd::op_name(uint16_t op) {
   }
 }
 
+Result Vopd::validate_encoding(const MachineInst *inst, const util::DiagnosticEmitter &emit_error) {
+  const auto *words = reinterpret_cast<const uint32_t *>(inst);
+  const uint32_t word0 = words[0];
+  const uint32_t word1 = words[1];
+
+  const uint16_t opx = static_cast<uint16_t>((word0 >> 22) & 0xF);
+  const uint16_t opy = static_cast<uint16_t>((word0 >> 17) & 0x1F);
+  if (!is_valid_opcode(opx, kVopdXOpcodeMask)) [[unlikely]]
+    return emit_error.emit() << "invalid VOPD X opcode";
+  if (!is_valid_opcode(opy, kVopdYOpcodeMask)) [[unlikely]]
+    return emit_error.emit() << "invalid VOPD Y opcode";
+  const uint16_t srcx0 = static_cast<uint16_t>(word0 & 0x1FF);
+  const uint16_t srcy0 = static_cast<uint16_t>(word1 & 0x1FF);
+  if (srcx0 == 254 || srcy0 == 254) [[unlikely]]
+    return emit_error.emit() << "VOPD does not support 64-bit literals";
+  return Result::success();
+}
+
 Vopd::Vopd(const MachineInst *inst)
     : IsaInstruction<Isa>("vopd", selected_exec_fn(InstructionExecutionId::Vopd)),
       dstx_(32, OperandType::OPR_VGPR, 0), dsty_(32, OperandType::OPR_VGPR, 0),
@@ -110,16 +128,10 @@ Vopd::Vopd(const MachineInst *inst)
   encoding_id_ = 0x32;
   opx_ = static_cast<uint16_t>((word0_ >> 22) & 0xF);
   opy_ = static_cast<uint16_t>((word0_ >> 17) & 0x1F);
-  if (!is_valid_opcode(opx_, kVopdXOpcodeMask))
-    throw util::InvalidInst("invalid VOPD X opcode", "");
-  if (!is_valid_opcode(opy_, kVopdYOpcodeMask))
-    throw util::InvalidInst("invalid VOPD Y opcode", "");
   uint16_t srcx0 = static_cast<uint16_t>(word0_ & 0x1FF);
   uint16_t vsrcx1 = static_cast<uint16_t>((word0_ >> 9) & 0xFF);
   uint16_t srcy0 = static_cast<uint16_t>(word1_ & 0x1FF);
   uint16_t vsrcy1 = static_cast<uint16_t>((word1_ >> 9) & 0xFF);
-  if (srcx0 == 254 || srcy0 == 254)
-    throw util::InvalidInst("VOPD does not support 64-bit literals", "");
   uint16_t vdstx = static_cast<uint16_t>((word1_ >> 24) & 0xFF);
   uint16_t vdsty_hi = static_cast<uint16_t>((word1_ >> 17) & 0x7F);
   uint16_t vdsty = static_cast<uint16_t>((vdsty_hi << 1) | ((~vdstx) & 1u));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vopd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vopd.h
@@ -9,6 +9,7 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/encodings.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/operand.h"
+#include "rocjitsu/isa/decode_result.h"
 #include <cstdint>
 #include <string>
 
@@ -18,6 +19,8 @@ namespace rdna3_5 {
 class Vopd : public IsaInstruction<Isa> {
 public:
   explicit Vopd(const MachineInst *inst);
+  static Result validate_encoding(const MachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error);
   void execute_impl(amdgpu::Wavefront &wf);
 
 private:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/decoder.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/decoder.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vopd.h"
-#include "util/except.h"
 #include <array>
 #include <bit>
 #include <format>
@@ -16,1573 +15,2198 @@ namespace rocjitsu {
 namespace rdna4 {
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddU32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAddU64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndB32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicAndB64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapB32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapB64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicCondSubU32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecU32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicDecU64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncU32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicIncU64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxI32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxI64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxNumF32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxU32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMaxU64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinI32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinI64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinNumF32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinU32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicMinU64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrB32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicOrB64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicPkAddBf16Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicPkAddF16Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubClampU32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubU32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSubU64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapB32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicSwapB64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorB32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferAtomicXorB64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadB128Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadB32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadB64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadB96Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16B16Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXyVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXyzVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXyzwVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16HiB16Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16HiFormatXVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16HiI8Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16HiU8Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16I8Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadD16U8Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzwVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadI16Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadI8Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadU16Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferLoadU8Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB128Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB16Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB32Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB64Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB8Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreB96Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXyVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXyzVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXyzwVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16HiB16Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16HiB8Vbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreD16HiFormatXVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzwVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddF32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnF32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddRtnU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAddU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAndRtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsAppendVds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsBpermuteB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsBpermuteFiB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsBvhStackPush4Pop1RtnB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsBvhStackPush8Pop1RtnB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsBvhStackPush8Pop2RtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCondSubRtnU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCondSubU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsConsumeVds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecRtnU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDecU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsDirectLoadVdsdir(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncRtnU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsIncU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoad2addrB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoad2addrB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoad2addrStride64B32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoad2addrStride64B64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadAddtidB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadB128Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadB96Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadI16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadI8D16HiVds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadI8D16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadI8Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU16D16HiVds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU16D16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU8D16HiVds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU8D16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsLoadU8Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxI64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxNumF32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxNumF64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxNumRtnF32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxNumRtnF64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMaxU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinI64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinNumF32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinNumF64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinNumRtnF32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinNumRtnF64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnI64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinRtnU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMinU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsNopVds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsOrRtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsParamLoadVdsdir(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPermuteB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPkAddBf16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPkAddF16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPkAddRtnBf16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsPkAddRtnF16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsRsubU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStore2addrB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStore2addrB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStore2addrStride64B32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStore2addrStride64B64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreAddtidB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB128Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB16D16HiVds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB16Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB8D16HiVds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB8Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStoreB96Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchg2addrRtnB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchg2addrRtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchg2addrStride64RtnB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchg2addrStride64RtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchgRtnB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsStorexchgRtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubClampRtnU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubClampU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubRtnU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSubU64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsSwizzleB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB32Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeDsXorRtnB64Vds(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeExportVexport(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddF32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddU32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAddU64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndB32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicAndB64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapB32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapB64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicCondSubU32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecU32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicDecU64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncU32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicIncU64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxI32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxI64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxNumF32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxU32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMaxU64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinI32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinI64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinNumF32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinU32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicMinU64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrB32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicOrB64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicPkAddBf16Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicPkAddF16Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubClampU32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubU32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSubU64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapB32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicSwapB64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorB32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatAtomicXorB64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadB128Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadB32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadB64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadB96Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16B16Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16HiB16Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16HiI8Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16HiU8Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16I8Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadD16U8Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadI16Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadI8Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadU16Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatLoadU8Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB128Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB16Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB32Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB64Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB8Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreB96Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreD16HiB16Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeFlatStoreD16HiB8Vflat(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicAddF32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicAddU32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicAddU64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicAndB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicAndB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicCmpswapB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicCmpswapB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicCondSubU32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicDecU32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicDecU64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicIncU32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicIncU64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxI32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxI64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxNumF32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxU32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxU64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMinI32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMinI64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMinNumF32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMinU32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicMinU64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicOrB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicOrB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicOrderedAddB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicPkAddBf16Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicPkAddF16Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicSubClampU32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicSubU32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicSubU64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicSwapB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicSwapB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicXorB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalAtomicXorB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalInvVglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadAddtidB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadB128Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadB96Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadBlockVglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadD16B16Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadD16HiB16Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadD16HiI8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadD16HiU8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadD16I8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadD16U8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadI16Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadI8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadTrB128Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadTrB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadU16Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalLoadU8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreAddtidB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreB128Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreB16Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreB32Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreB64Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreB8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreB96Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreBlockVglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreD16HiB16Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalStoreD16HiB8Vglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalWbVglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeGlobalWbinvVglobal(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicAddFltVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicAddUintVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicAndVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicCmpswapVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicDecUintVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicIncUintVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicMaxFltVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicMaxIntVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicMaxUintVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicMinFltVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicMinIntVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicMinUintVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicOrVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicPkAddBf16Vimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicPkAddF16Vimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSubUintVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicSwapVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageAtomicXorVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageBvh64IntersectRayVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageBvh8IntersectRayVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageBvhDualIntersectRayVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageBvhIntersectRayVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4BClVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4BVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CBClVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CBVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CClVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLzOVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CLzVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4CVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4ClVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LzOVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4LzVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4OVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4Vsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGather4hVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGetLodVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageGetResinfoVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipPckSgnVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipPckVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadMipVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadPckSgnVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadPckVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageLoadVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageMsaaLoadVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBClOVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBClVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBOVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleBVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBClOVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBClVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBOVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCBVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCClOVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCClVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClG16Vsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClOG16Vsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClOVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDClVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDG16Vsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDOG16Vsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDOVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCDVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLOVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLzOVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCLzVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCOVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleCVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleClOVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleClVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClG16Vsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClOG16Vsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClOVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDClVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDG16Vsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDOG16Vsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDOVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleDVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLOVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLzOVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleLzVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleOVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageSampleVsample(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipPckVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreMipVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStorePckVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeImageStoreVimage(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddCoCiU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddCoI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddCoU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddNcU64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAddkCoI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAllocVgprSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot0SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot0SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot0WrexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot0WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1WrexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndNot1WrexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtcProbeBufferSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSAtcProbeSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBarrierSignalIsfirstSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBarrierSignalSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBarrierWaitSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB128Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB256Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB32Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB512Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB64Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadB96Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadI16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadI8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadU16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferLoadU8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSBufferPrefetchDataSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCallB64Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCeilF16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCeilF32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClauseSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClsI32I64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClsI32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClzI32U32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSClzI32U64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNeqF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNeqF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNgeF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNgeF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNgtF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNgtF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNleF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNleF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNlgF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNlgF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNltF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpNltF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpOF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpOF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpUF16Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCmpUF32Sopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCodeEndSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCtzI32B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCtzI32B64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtF16F32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtF32F16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtF32I32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtF32U32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtHiF32F16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtI32F32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtPkRtzF16F32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSCvtU32F32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDelayAluSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSDenormModeSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFloorF16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFloorF32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFmaakF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFmacF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFmacF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSFmamkF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetpcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB128Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB256Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB32Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB512Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB64Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadB96Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadI16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadI8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadU16Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLoadU8Smem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxNumF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxNumF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaximumF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMaximumF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinNumF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinNumF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinimumF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMinimumF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMovrelsd2B32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulU64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot0SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot0SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot1B32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot1B64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot1SaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrNot1SaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackHlB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPrefetchDataPcRelSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPrefetchDataSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPrefetchInstPcRelSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSPrefetchInstSmem(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRfeB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRndneF16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRndneF32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSRoundModeSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsgRtnB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsgRtnB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetkillSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetpcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSleepVarSop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubCoCiU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubCoI32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubCoU32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubF16Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubF32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSubNcU64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSSwappcB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTruncF16Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTruncF32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTtracedataImmSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSVersionSopk(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitAluSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitBvhcntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitDscntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitEventSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitExpcntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitIdleSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitKmcntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitLoadcntDscntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitLoadcntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitSamplecntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitStorecntDscntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitStorecntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWaitcntSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorSaveexecB32Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadB128Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadB32Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadB64Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadB96Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadBlockVscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadD16B16Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadD16HiB16Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadD16HiI8Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadD16HiU8Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadD16I8Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadD16U8Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadI16Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadI8Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadU16Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchLoadU8Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchStoreB128Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchStoreB16Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchStoreB32Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchStoreB64Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchStoreB8Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchStoreB96Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchStoreBlockVscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchStoreD16HiB16Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeScratchStoreD16HiB8Vscratch(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXyVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXyzVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXyzwVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzwVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXyVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXyzVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXyzwVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzwVbuffer(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAddNcU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClsI32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClsI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClzI32U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVClzI32U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCtzI32B32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCtzI32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Bf8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Bf8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Fp8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Fp8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFloorI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtFloorI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtI32I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNearestI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNearestI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkBf8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF32Bf8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF32Bf8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF32Fp8Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkF32Fp8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkFp8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkI16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkNormI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkNormI16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkNormU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkNormU16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkRtzF16F32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkRtzF16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU16F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtSrBf8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtSrFp8F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32U16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVCvtU32U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2Bf16Bf16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2F16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2F32Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot2F32F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4F32Bf8Bf8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4F32Bf8Fp8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4F32Fp8Bf8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4F32Fp8Fp8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4I32Iu8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8I32Iu4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaDx9ZeroF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixF32Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixhiF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaMixloF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaakF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmaakF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmamkF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFmamkF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP10F16F32Vinterp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP10F32Vinterp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP10RtzF16F32Vinterp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2F16F32Vinterp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2F32Vinterp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVInterpP2RtzF16F32Vinterp(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadCoI64I32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadCoU64U32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3NumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3NumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxNumF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxNumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxNumF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxNumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxNumF64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxNumF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaximum3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaximum3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaximumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaximumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaximumF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaximumminimumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaximumminimumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxminI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxminNumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxminNumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMaxminU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3NumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3NumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3NumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3NumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinNumF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinNumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinNumF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinNumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinNumF64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinNumF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinimum3F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinimum3F32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinimumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinimumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinimumF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinimummaximumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinimummaximumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinmaxI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinmaxNumF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinmaxNumF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMinmaxU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovreldB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovreldB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulDx9ZeroF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulDx9ZeroF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF64Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVMullitF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlane16B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlane16VarB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlane64B32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlanex16B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPermlanex16VarB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPipeflushVop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPipeflushVop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxNumF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMaximumF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinNumF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMinimumF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSExpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSExpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSLogF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSLogF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSRcpF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSRcpF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSRsqF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSRsqF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSSqrtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSSqrtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcI16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcI32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubNcU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwapB16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwaprelB32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacBf1616x16x32Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacF1616x16x32F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x32Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x32Bf8Bf8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x32Bf8Fp8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x32F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x32Fp8Bf8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x32Fp8Fp8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacI3216x16x32Iu4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacI3216x16x32Iu8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVSwmmacI3216x16x64Iu4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaBf1616x16x16Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x16F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16Bf16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16Bf8Bf8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16Bf8Fp8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16F16Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16Fp8Bf8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16Fp8Fp8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaI3216x16x16Iu4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaI3216x16x16Iu8Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWmmaI3216x16x32Iu4Vop3p(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXor3B32Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB16Vop3(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode);
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode);
+DecodeResult decodeBufferAtomicAddF32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAddU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndB32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicAndB64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapB32Vbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCmpswapB64Vbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicCondSubU32Vbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicDecU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicIncU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxI32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxI64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxNumF32Vbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMaxU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinI32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinI64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinNumF32Vbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicMinU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrB32Vbuffer(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicOrB64Vbuffer(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicPkAddBf16Vbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicPkAddF16Vbuffer(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubClampU32Vbuffer(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSubU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapB32Vbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicSwapB64Vbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorB32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferAtomicXorB64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadB128Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadB32Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadB64Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadB96Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16B16Vbuffer(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16FormatXVbuffer(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16FormatXyVbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16FormatXyzVbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16FormatXyzwVbuffer(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16HiB16Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16HiFormatXVbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16HiI8Vbuffer(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16HiU8Vbuffer(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16I8Vbuffer(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadD16U8Vbuffer(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXVbuffer(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyVbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyzVbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadFormatXyzwVbuffer(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadI16Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadI8Vbuffer(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadU16Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferLoadU8Vbuffer(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB128Vbuffer(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB16Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB32Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB64Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB8Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreB96Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16FormatXVbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16FormatXyVbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16FormatXyzVbuffer(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16FormatXyzwVbuffer(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16HiB16Vbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16HiB8Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreD16HiFormatXVbuffer(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXVbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyVbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyzVbuffer(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeBufferStoreFormatXyzwVbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddF32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnF32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAddU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAndRtnB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsAppendVds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsBpermuteB32Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsBpermuteFiB32Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsBvhStackPush4Pop1RtnB32Vds(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsBvhStackPush8Pop1RtnB32Vds(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsBvhStackPush8Pop2RtnB64Vds(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreB32Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreB64Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreRtnB32Vds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCmpstoreRtnB64Vds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCondSubRtnU32Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCondSubU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsCondxchg32RtnB64Vds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsConsumeVds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDecU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsDirectLoadVdsdir(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsIncU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoad2addrB32Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoad2addrB64Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoad2addrStride64B32Vds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoad2addrStride64B64Vds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadAddtidB32Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadB128Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadB96Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadI16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadI8D16HiVds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadI8D16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadI8Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU16D16HiVds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU16D16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU8D16HiVds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU8D16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsLoadU8Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxI64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxNumF32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxNumF64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxNumRtnF32Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxNumRtnF64Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnI64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMaxU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinI64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinNumF32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinNumF64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinNumRtnF32Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinNumRtnF64Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnI64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMinU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB32Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsMskorRtnB64Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsNopVds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsOrRtnB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsParamLoadVdsdir(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPermuteB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPkAddBf16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPkAddF16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPkAddRtnBf16Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsPkAddRtnF16Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsRsubU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStore2addrB32Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStore2addrB64Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStore2addrStride64B32Vds(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStore2addrStride64B64Vds(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreAddtidB32Vds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB128Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB16D16HiVds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB8D16HiVds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB8Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStoreB96Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchg2addrRtnB32Vds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchg2addrRtnB64Vds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchg2addrStride64RtnB32Vds(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchg2addrStride64RtnB64Vds(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchgRtnB32Vds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsStorexchgRtnB64Vds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubClampRtnU32Vds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubClampU32Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSubU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsSwizzleB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeDsXorRtnB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeExportVexport(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddF32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAddU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndB32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicAndB64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapB32Vflat(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCmpswapB64Vflat(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicCondSubU32Vflat(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicDecU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicIncU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxI32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxI64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxNumF32Vflat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMaxU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinI32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinI64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinNumF32Vflat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicMinU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrB32Vflat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicOrB64Vflat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicPkAddBf16Vflat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicPkAddF16Vflat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubClampU32Vflat(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSubU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapB32Vflat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicSwapB64Vflat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorB32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatAtomicXorB64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadB128Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadB32Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadB64Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadB96Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16B16Vflat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16HiB16Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16HiI8Vflat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16HiU8Vflat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16I8Vflat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadD16U8Vflat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadI16Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadI8Vflat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadU16Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatLoadU8Vflat(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB128Vflat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB16Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB32Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB64Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB8Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreB96Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreD16HiB16Vflat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeFlatStoreD16HiB8Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicAddF32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicAddU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicAddU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicAndB32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicAndB64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicCmpswapB32Vglobal(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicCmpswapB64Vglobal(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicCondSubU32Vglobal(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicDecU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicDecU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicIncU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicIncU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMaxI32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMaxI64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMaxNumF32Vglobal(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMaxU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMaxU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMinI32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMinI64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMinNumF32Vglobal(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMinU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicMinU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicOrB32Vglobal(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicOrB64Vglobal(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicOrderedAddB64Vglobal(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicPkAddBf16Vglobal(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicPkAddF16Vglobal(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicSubClampU32Vglobal(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicSubU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicSubU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicSwapB32Vglobal(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicSwapB64Vglobal(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicXorB32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalAtomicXorB64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalInvVglobal(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadAddtidB32Vglobal(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadB128Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadB32Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadB64Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadB96Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadBlockVglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadD16B16Vglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadD16HiB16Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadD16HiI8Vglobal(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadD16HiU8Vglobal(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadD16I8Vglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadD16U8Vglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadI16Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadI8Vglobal(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadTrB128Vglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadTrB64Vglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadU16Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalLoadU8Vglobal(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreAddtidB32Vglobal(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreB128Vglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreB16Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreB32Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreB64Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreB8Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreB96Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreBlockVglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreD16HiB16Vglobal(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalStoreD16HiB8Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalWbVglobal(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeGlobalWbinvVglobal(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicAddFltVimage(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicAddUintVimage(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicAndVimage(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicCmpswapVimage(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicDecUintVimage(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicIncUintVimage(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicMaxFltVimage(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicMaxIntVimage(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicMaxUintVimage(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicMinFltVimage(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicMinIntVimage(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicMinUintVimage(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicOrVimage(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicPkAddBf16Vimage(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicPkAddF16Vimage(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSubUintVimage(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicSwapVimage(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageAtomicXorVimage(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageBvh64IntersectRayVimage(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageBvh8IntersectRayVimage(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageBvhDualIntersectRayVimage(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageBvhIntersectRayVimage(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4BClVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4BVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CBClVsample(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CBVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CClVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLzOVsample(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CLzVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4CVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4ClVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LzOVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4LzVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4OVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4Vsample(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGather4hVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGetLodVsample(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageGetResinfoVimage(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipPckSgnVimage(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipPckVimage(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadMipVimage(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadPckSgnVimage(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadPckVimage(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageLoadVimage(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageMsaaLoadVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBClOVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBClVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBOVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleBVsample(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBClOVsample(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBClVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBOVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCBVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCClOVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCClVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClG16Vsample(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClOG16Vsample(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClOVsample(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDClVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDG16Vsample(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDOG16Vsample(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDOVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCDVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLOVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLzOVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCLzVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCOVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleCVsample(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleClOVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleClVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClG16Vsample(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClOG16Vsample(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClOVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDClVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDG16Vsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDOG16Vsample(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDOVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleDVsample(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLOVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLVsample(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLzOVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleLzVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleOVsample(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageSampleVsample(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipPckVimage(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreMipVimage(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStorePckVimage(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeImageStoreVimage(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddCoCiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddCoI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddCoU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddNcU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAddkCoI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAllocVgprSop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot0SaveexecB32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot0SaveexecB64Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot0WrexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot0WrexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1SaveexecB32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1SaveexecB64Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1WrexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndNot1WrexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtcProbeBufferSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSAtcProbeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBarrierSignalIsfirstSop1(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBarrierSignalSop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBarrierWaitSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB128Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB256Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB32Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB512Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB64Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadB96Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadI16Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadI8Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadU16Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferLoadU8Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSBufferPrefetchDataSmem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCallB64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCeilF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCeilF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClauseSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClsI32I64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClzI32U32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSClzI32U64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNeqF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNeqF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNgeF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNgeF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNgtF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNgtF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNleF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNleF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNlgF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNlgF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNltF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpNltF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpOF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpOF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpUF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCmpUF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCodeEndSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCtzI32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCtzI32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtF16F32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtF32F16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtF32I32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtF32U32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtHiF32F16Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtI32F32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtPkRtzF16F32Sop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSCvtU32F32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDelayAluSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSDenormModeSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFloorF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFloorF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFmaakF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFmacF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFmacF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSFmamkF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB128Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB256Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB32Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB512Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB64Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadB96Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadI16Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadI8Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadU16Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLoadU8Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxNumF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxNumF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaximumF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMaximumF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinNumF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinNumF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinimumF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMinimumF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMovrelsd2B32Sop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot0SaveexecB32Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot0SaveexecB64Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot1B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot1B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot1SaveexecB32Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrNot1SaveexecB64Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrSaveexecB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackHlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPrefetchDataPcRelSmem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPrefetchDataSmem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPrefetchInstPcRelSmem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSPrefetchInstSmem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRfeB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRndneF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRndneF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSRoundModeSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsgRtnB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsgRtnB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetkillSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSleepVarSop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubCoCiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubCoI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubCoU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSubNcU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSSwappcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTruncF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTruncF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTtracedataImmSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSVersionSopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitAluSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitBvhcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitDscntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitEventSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitExpcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitIdleSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitKmcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitLoadcntDscntSopp(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitLoadcntSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitSamplecntSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitStorecntDscntSopp(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitStorecntSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWaitcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadB128Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadB32Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadB64Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadB96Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadBlockVscratch(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadD16B16Vscratch(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadD16HiB16Vscratch(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadD16HiI8Vscratch(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadD16HiU8Vscratch(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadD16I8Vscratch(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadD16U8Vscratch(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadI16Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadI8Vscratch(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadU16Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchLoadU8Vscratch(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchStoreB128Vscratch(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchStoreB16Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchStoreB32Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchStoreB64Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchStoreB8Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchStoreB96Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchStoreBlockVscratch(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchStoreD16HiB16Vscratch(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeScratchStoreD16HiB8Vscratch(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadD16FormatXVbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadD16FormatXyVbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadD16FormatXyzVbuffer(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadD16FormatXyzwVbuffer(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXVbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyVbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyzVbuffer(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferLoadFormatXyzwVbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreD16FormatXVbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreD16FormatXyVbuffer(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreD16FormatXyzVbuffer(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreD16FormatXyzwVbuffer(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXVbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyVbuffer(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyzVbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeTbufferStoreFormatXyzwVbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoCiU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAddNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClsI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClsI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClzI32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVClzI32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCtzI32B32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCtzI32B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Bf8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Bf8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Fp8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Fp8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFloorI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtFloorI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNearestI32F32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNearestI32F32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkBf8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF32Bf8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF32Bf8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF32Fp8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkF32Fp8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkFp8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkI16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkNormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkNormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkNormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkNormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkRtzF16F32Vop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkRtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtSrBf8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtSrFp8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVCvtU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2Bf16Bf16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2F16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2F32Bf16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot2F32F16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4F32Bf8Bf8Vop3p(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4F32Bf8Fp8Vop3p(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4F32Fp8Bf8Vop3p(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4F32Fp8Fp8Vop3p(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4I32Iu8Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8I32Iu4Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaDx9ZeroF32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixF32Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmaakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmamkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFmamkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP10F16F32Vinterp(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP10F32Vinterp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP10RtzF16F32Vinterp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2F16F32Vinterp(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2F32Vinterp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVInterpP2RtzF16F32Vinterp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadCoI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadCoU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3NumF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3NumF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxNumF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxNumF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxNumF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxNumF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxNumF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxNumF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaximum3F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaximum3F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaximumF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaximumF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaximumF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaximumminimumF16Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaximumminimumF32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxminI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxminNumF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxminNumF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMaxminU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3NumF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3NumF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3NumF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3NumF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinNumF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinNumF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinNumF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinNumF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinNumF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinNumF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinimum3F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinimum3F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinimumF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinimumF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinimumF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinimummaximumF16Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinimummaximumF32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinmaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinmaxNumF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinmaxNumF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMinmaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovreldB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovreldB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsd2B32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsd2B32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsdB32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMovrelsdB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulDx9ZeroF32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulDx9ZeroF32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVMullitF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlane16B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlane16VarB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlane64B32Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlanex16B32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPermlanex16VarB32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPipeflushVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPipeflushVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxNumF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMaximumF16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinNumF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMinimumF16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoCiU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoCiU32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevNcU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSubrevNcU32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwapB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwaprelB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacBf1616x16x32Bf16Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacF1616x16x32F16Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacF3216x16x32Bf16Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacF3216x16x32Bf8Bf8Vop3p(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacF3216x16x32Bf8Fp8Vop3p(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacF3216x16x32F16Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacF3216x16x32Fp8Bf8Vop3p(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacF3216x16x32Fp8Fp8Vop3p(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacI3216x16x32Iu4Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacI3216x16x32Iu8Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVSwmmacI3216x16x64Iu4Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaBf1616x16x16Bf16Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF1616x16x16F16Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x16Bf16Vop3p(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x16Bf8Bf8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x16Bf8Fp8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x16F16Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x16Fp8Bf8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaF3216x16x16Fp8Fp8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaI3216x16x16Iu4Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaI3216x16x16Iu8Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWmmaI3216x16x32Iu4Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXor3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 } // namespace detail
 
 struct DecoderImpl {
 public:
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 
 private:
-  using DecodeFunc = std::unique_ptr<Instruction> (*)(const MachineInst *);
-  static std::unique_ptr<Instruction> decodeInvalid(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> decodeVopd(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSop1(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopc(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSopp(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVbuffer(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3p(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVinterp(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVdsdir(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVimage(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVop3(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVds(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVsample(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVflat(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVscratch(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeVglobal(const MachineInst *opcode);
-  static std::unique_ptr<Instruction> subDecodeSmem(const MachineInst *opcode);
+  using DecodeFunc = DecodeResult (*)(const MachineInst *, const DecodeErrorEmitter &);
+  static DecodeResult decodeInvalid(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult decodeVopd(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVbuffer(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVinterp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVdsdir(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVimage(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVsample(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVscratch(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeVglobal(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error);
+  static DecodeResult subDecodeSmem(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error);
   static const std::array<DecodeFunc, 512> primary_decode_table;
   static const std::array<DecodeFunc, 256> sub_decode_vopc;
   static const std::array<DecodeFunc, 128> sub_decode_vop1;
@@ -1603,107 +2227,128 @@ private:
   static const std::array<DecodeFunc, 64> sub_decode_smem;
 };
 
-std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
-  return DecoderImpl::decode(opcode);
+DecodeResult Decoder::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  return DecoderImpl::decode(opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decode(const MachineInst *opcode) {
+DecodeResult DecoderImpl::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
   Sop1MachineInst op = std::bit_cast<decltype(op)>(*opcode);
-  return primary_decode_table[op.encoding](opcode);
+  return primary_decode_table[op.encoding](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decodeInvalid(const MachineInst *opcode) {
-  throw util::InvalidInst(std::format("{:X}", *opcode));
-  return nullptr;
+DecodeResult DecoderImpl::decodeInvalid(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  return emit_error.emit() << "Invalid instruction opcode: " << std::format("{:X}", *opcode);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::decodeVopd(const MachineInst *opcode) {
+DecodeResult DecoderImpl::decodeVopd(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vopd::validate_encoding(opcode, emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<Vopd>(opcode);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vopc[op.op](opcode);
+  return sub_decode_vopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop1[op.op](opcode);
+  return sub_decode_vop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSop1(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sop1::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sop1[op.op](opcode);
+  return sub_decode_sop1[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopc(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopc::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopc[op.op](opcode);
+  return sub_decode_sopc[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSopp(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSopp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Sopp::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_sopp[op.op](opcode);
+  return sub_decode_sopp[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVbuffer(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVbuffer(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
   Vbuffer::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vbuffer[op.op](opcode);
+  return sub_decode_vbuffer[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3p(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3p(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Vop3p::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3p[op.op](opcode);
+  return sub_decode_vop3p[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVinterp(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVinterp(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
   Vinterp::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vinterp[op.op](opcode);
+  return sub_decode_vinterp[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVdsdir(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVdsdir(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
   Vdsdir::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vdsdir[op.op](opcode);
+  return sub_decode_vdsdir[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVimage(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVimage(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
   Vimage::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vimage[op.op](opcode);
+  return sub_decode_vimage[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVop3(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Vop3::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vop3[op.op](opcode);
+  return sub_decode_vop3[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVds(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
   Vds::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vds[op.op](opcode);
+  return sub_decode_vds[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVsample(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVsample(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
   Vsample::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vsample[op.op](opcode);
+  return sub_decode_vsample[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVflat(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
   Vflat::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vflat[op.op](opcode);
+  return sub_decode_vflat[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVscratch(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVscratch(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
   Vscratch::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vscratch[op.op](opcode);
+  return sub_decode_vscratch[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeVglobal(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeVglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
   Vglobal::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_vglobal[op.op](opcode);
+  return sub_decode_vglobal[op.op](opcode, emit_error);
 }
 
-std::unique_ptr<Instruction> DecoderImpl::subDecodeSmem(const MachineInst *opcode) {
+DecodeResult DecoderImpl::subDecodeSmem(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
   Smem::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode);
-  return sub_decode_smem[op.op](opcode);
+  return sub_decode_smem[op.op](opcode, emit_error);
 }
 
 const std::array<DecoderImpl::DecodeFunc, 512> DecoderImpl::primary_decode_table = {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/decoder.h
@@ -8,6 +8,7 @@
 #define ROCJITSU_ISA_ARCH_AMDGPU_RDNA4_DECODER_H_
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/machine_insts.h"
+#include "rocjitsu/isa/decode_result.h"
 #include <array>
 #include <cstddef>
 #include <memory>
@@ -21,7 +22,7 @@ namespace rdna4 {
 class Decoder {
 public:
   static constexpr std::size_t kMaxInstructionWords = 3;
-  static std::unique_ptr<Instruction> decode(const MachineInst *opcode);
+  static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 };
 
 } // namespace rdna4

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/encodings.cpp
@@ -5,7 +5,6 @@
 // See lib/python/amdisa/README.md for regeneration instructions.
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/encodings.h"
-#include "util/except.h"
 #include <cstring>
 #include <string>
 
@@ -1197,9 +1196,6 @@ Vop3::Vop3(std::string_view mnemonic, const Vop3MachineInst *inst, ExecuteFn exe
   raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
-  if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
-      (has_encoded_literal32()))
-    throw util::InvalidInst("DPP and literal operands cannot be combined", "");
   if (has_encoded_literal32())
     size_ += sizeof(MachineInst);
   if (inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0))
@@ -1303,9 +1299,6 @@ Vop3p::Vop3p(std::string_view mnemonic, const Vop3pMachineInst *inst, ExecuteFn 
   raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
-  if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
-      (has_encoded_literal32()))
-    throw util::InvalidInst("DPP and literal operands cannot be combined", "");
   if (has_encoded_literal32())
     size_ += sizeof(MachineInst);
   if (inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0))
@@ -1503,9 +1496,6 @@ Vop3SdstEnc::Vop3SdstEnc(std::string_view mnemonic, const Vop3SdstEncMachineInst
   raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
-  if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
-      (has_encoded_literal32()))
-    throw util::InvalidInst("DPP and literal operands cannot be combined", "");
   if (has_encoded_literal32())
     size_ += sizeof(MachineInst);
   if (inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/encodings.h
@@ -10,6 +10,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna4/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
+#include "rocjitsu/isa/decode_result.h"
 #include "rocjitsu/isa/instruction.h"
 #include <array>
 #include <cstdint>
@@ -535,6 +536,15 @@ class Vop3 : public IsaInstruction<Isa> {
 public:
   Vop3(std::string_view mnemonic, const Vop3MachineInst *inst, ExecuteFn exec_fn);
   bool has_encoded_literal32() const;
+  static Result validate_encoding([[maybe_unused]] std::string_view mnemonic,
+                                  const Vop3MachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error) {
+    const auto &inst_ = *inst;
+    if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
+        (inst_.src0 == 255 || inst_.src1 == 255 || inst_.src2 == 255)) [[unlikely]]
+      return emit_error.emit() << "DPP and literal operands cannot be combined";
+    return Result::success();
+  }
   void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool has_lit_0();
@@ -561,6 +571,15 @@ class Vop3p : public IsaInstruction<Isa> {
 public:
   Vop3p(std::string_view mnemonic, const Vop3pMachineInst *inst, ExecuteFn exec_fn);
   bool has_encoded_literal32() const;
+  static Result validate_encoding([[maybe_unused]] std::string_view mnemonic,
+                                  const Vop3pMachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error) {
+    const auto &inst_ = *inst;
+    if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
+        (inst_.src0 == 255 || inst_.src1 == 255 || inst_.src2 == 255)) [[unlikely]]
+      return emit_error.emit() << "DPP and literal operands cannot be combined";
+    return Result::success();
+  }
   void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool has_lit_0();
@@ -662,6 +681,15 @@ class Vop3SdstEnc : public IsaInstruction<Isa> {
 public:
   Vop3SdstEnc(std::string_view mnemonic, const Vop3SdstEncMachineInst *inst, ExecuteFn exec_fn);
   bool has_encoded_literal32() const;
+  static Result validate_encoding([[maybe_unused]] std::string_view mnemonic,
+                                  const Vop3SdstEncMachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error) {
+    const auto &inst_ = *inst;
+    if ((inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) &&
+        (inst_.src0 == 255 || inst_.src1 == 255 || inst_.src2 == 255)) [[unlikely]]
+      return emit_error.emit() << "DPP and literal operands cannot be combined";
+    return Result::success();
+  }
   void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool has_lit_0();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/operand.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/operand.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/scalar_static_resolve.h"
-#include "util/except.h"
 #include <format>
 #include <optional>
 #include <stdexcept>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/smem.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/smem.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/smem.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -37,7 +36,11 @@ SLoadB32Smem::SLoadB32Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB32Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB32Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b32", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB32Smem>(opcode);
 }
 } // namespace detail
@@ -60,7 +63,11 @@ SLoadB64Smem::SLoadB64Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB64Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB64Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b64", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB64Smem>(opcode);
 }
 } // namespace detail
@@ -83,7 +90,11 @@ SLoadB128Smem::SLoadB128Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB128Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB128Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b128", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB128Smem>(opcode);
 }
 } // namespace detail
@@ -106,7 +117,11 @@ SLoadB256Smem::SLoadB256Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB256Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB256Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b256", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB256Smem>(opcode);
 }
 } // namespace detail
@@ -129,7 +144,11 @@ SLoadB512Smem::SLoadB512Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB512Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB512Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b512", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB512Smem>(opcode);
 }
 } // namespace detail
@@ -152,7 +171,11 @@ SLoadB96Smem::SLoadB96Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadB96Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadB96Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_b96", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadB96Smem>(opcode);
 }
 } // namespace detail
@@ -175,7 +198,11 @@ SLoadI8Smem::SLoadI8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadI8Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadI8Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_i8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadI8Smem>(opcode);
 }
 } // namespace detail
@@ -198,7 +225,11 @@ SLoadU8Smem::SLoadU8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadU8Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadU8Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_u8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadU8Smem>(opcode);
 }
 } // namespace detail
@@ -221,7 +252,11 @@ SLoadI16Smem::SLoadI16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadI16Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadI16Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_i16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadI16Smem>(opcode);
 }
 } // namespace detail
@@ -244,7 +279,11 @@ SLoadU16Smem::SLoadU16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLoadU16Smem(const MachineInst *opcode) {
+DecodeResult decodeSLoadU16Smem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_load_u16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLoadU16Smem>(opcode);
 }
 } // namespace detail
@@ -267,7 +306,12 @@ SBufferLoadB32Smem::SBufferLoadB32Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB32Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB32Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b32", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB32Smem>(opcode);
 }
 } // namespace detail
@@ -290,7 +334,12 @@ SBufferLoadB64Smem::SBufferLoadB64Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB64Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB64Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b64", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB64Smem>(opcode);
 }
 } // namespace detail
@@ -313,7 +362,12 @@ SBufferLoadB128Smem::SBufferLoadB128Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB128Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB128Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b128", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB128Smem>(opcode);
 }
 } // namespace detail
@@ -336,7 +390,12 @@ SBufferLoadB256Smem::SBufferLoadB256Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB256Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB256Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b256", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB256Smem>(opcode);
 }
 } // namespace detail
@@ -359,7 +418,12 @@ SBufferLoadB512Smem::SBufferLoadB512Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB512Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB512Smem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b512", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB512Smem>(opcode);
 }
 } // namespace detail
@@ -382,7 +446,12 @@ SBufferLoadB96Smem::SBufferLoadB96Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadB96Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadB96Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_b96", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadB96Smem>(opcode);
 }
 } // namespace detail
@@ -405,7 +474,12 @@ SBufferLoadI8Smem::SBufferLoadI8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadI8Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadI8Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_i8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadI8Smem>(opcode);
 }
 } // namespace detail
@@ -428,7 +502,12 @@ SBufferLoadU8Smem::SBufferLoadU8Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadU8Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadU8Smem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_u8", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadU8Smem>(opcode);
 }
 } // namespace detail
@@ -451,7 +530,12 @@ SBufferLoadI16Smem::SBufferLoadI16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadI16Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadI16Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_i16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadI16Smem>(opcode);
 }
 } // namespace detail
@@ -474,7 +558,12 @@ SBufferLoadU16Smem::SBufferLoadU16Smem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferLoadU16Smem(const MachineInst *opcode) {
+DecodeResult decodeSBufferLoadU16Smem(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_load_u16", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferLoadU16Smem>(opcode);
 }
 } // namespace detail
@@ -487,7 +576,11 @@ SDcacheInvSmem::SDcacheInvSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDcacheInvSmem(const MachineInst *opcode) {
+DecodeResult decodeSDcacheInvSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_dcache_inv", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDcacheInvSmem>(opcode);
 }
 } // namespace detail
@@ -506,7 +599,11 @@ SAtcProbeSmem::SAtcProbeSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtcProbeSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtcProbeSmem(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atc_probe", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtcProbeSmem>(opcode);
 }
 } // namespace detail
@@ -525,7 +622,12 @@ SAtcProbeBufferSmem::SAtcProbeBufferSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAtcProbeBufferSmem(const MachineInst *opcode) {
+DecodeResult decodeSAtcProbeBufferSmem(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_atc_probe_buffer", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAtcProbeBufferSmem>(opcode);
 }
 } // namespace detail
@@ -546,7 +648,12 @@ SPrefetchInstSmem::SPrefetchInstSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPrefetchInstSmem(const MachineInst *opcode) {
+DecodeResult decodeSPrefetchInstSmem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_prefetch_inst", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPrefetchInstSmem>(opcode);
 }
 } // namespace detail
@@ -565,7 +672,12 @@ SPrefetchInstPcRelSmem::SPrefetchInstPcRelSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPrefetchInstPcRelSmem(const MachineInst *opcode) {
+DecodeResult decodeSPrefetchInstPcRelSmem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_prefetch_inst_pc_rel", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPrefetchInstPcRelSmem>(opcode);
 }
 } // namespace detail
@@ -586,7 +698,12 @@ SPrefetchDataSmem::SPrefetchDataSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPrefetchDataSmem(const MachineInst *opcode) {
+DecodeResult decodeSPrefetchDataSmem(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_prefetch_data", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPrefetchDataSmem>(opcode);
 }
 } // namespace detail
@@ -607,7 +724,12 @@ SBufferPrefetchDataSmem::SBufferPrefetchDataSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBufferPrefetchDataSmem(const MachineInst *opcode) {
+DecodeResult decodeSBufferPrefetchDataSmem(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_buffer_prefetch_data", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBufferPrefetchDataSmem>(opcode);
 }
 } // namespace detail
@@ -626,7 +748,12 @@ SPrefetchDataPcRelSmem::SPrefetchDataPcRelSmem(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPrefetchDataPcRelSmem(const MachineInst *opcode) {
+DecodeResult decodeSPrefetchDataPcRelSmem(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Smem::validate_encoding(
+      "s_prefetch_data_pc_rel", reinterpret_cast<const Smem::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPrefetchDataPcRelSmem>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/sop1.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/sop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -29,7 +28,11 @@ SMovB32Sop1::SMovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -52,7 +55,11 @@ SMovB64Sop1::SMovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_mov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -78,7 +85,11 @@ SCmovB32Sop1::SCmovB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB32Sop1>(opcode);
 }
 } // namespace detail
@@ -105,7 +116,11 @@ SCmovB64Sop1::SCmovB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCmovB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cmov_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovB64Sop1>(opcode);
 }
 } // namespace detail
@@ -126,7 +141,11 @@ SBrevB32Sop1::SBrevB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB32Sop1>(opcode);
 }
 } // namespace detail
@@ -148,7 +167,11 @@ SBrevB64Sop1::SBrevB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBrevB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBrevB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_brev_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBrevB64Sop1>(opcode);
 }
 } // namespace detail
@@ -169,7 +192,11 @@ SCtzI32B32Sop1::SCtzI32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCtzI32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCtzI32B32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ctz_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCtzI32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -191,7 +218,11 @@ SCtzI32B64Sop1::SCtzI32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCtzI32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCtzI32B64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ctz_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCtzI32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -212,7 +243,11 @@ SClzI32U32Sop1::SClzI32U32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClzI32U32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSClzI32U32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_clz_i32_u32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClzI32U32Sop1>(opcode);
 }
 } // namespace detail
@@ -234,7 +269,11 @@ SClzI32U64Sop1::SClzI32U64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClzI32U64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSClzI32U64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_clz_i32_u64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClzI32U64Sop1>(opcode);
 }
 } // namespace detail
@@ -255,7 +294,11 @@ SClsI32Sop1::SClsI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClsI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSClsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cls_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClsI32Sop1>(opcode);
 }
 } // namespace detail
@@ -277,7 +320,11 @@ SClsI32I64Sop1::SClsI32I64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClsI32I64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSClsI32I64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cls_i32_i64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClsI32I64Sop1>(opcode);
 }
 } // namespace detail
@@ -299,7 +346,11 @@ SSextI32I8Sop1::SSextI32I8Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I8Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I8Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i8", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I8Sop1>(opcode);
 }
 } // namespace detail
@@ -321,7 +372,12 @@ SSextI32I16Sop1::SSextI32I16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSextI32I16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSextI32I16Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sext_i32_i16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSextI32I16Sop1>(opcode);
 }
 } // namespace detail
@@ -343,7 +399,12 @@ SBitset0B32Sop1::SBitset0B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B32Sop1>(opcode);
 }
 } // namespace detail
@@ -365,7 +426,12 @@ SBitset0B64Sop1::SBitset0B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset0B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset0B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset0_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset0B64Sop1>(opcode);
 }
 } // namespace detail
@@ -387,7 +453,12 @@ SBitset1B32Sop1::SBitset1B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B32Sop1>(opcode);
 }
 } // namespace detail
@@ -409,7 +480,12 @@ SBitset1B64Sop1::SBitset1B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitset1B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitset1B64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitset1_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitset1B64Sop1>(opcode);
 }
 } // namespace detail
@@ -430,7 +506,12 @@ SBitreplicateB64B32Sop1::SBitreplicateB64B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitreplicateB64B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBitreplicateB64B32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bitreplicate_b64_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitreplicateB64B32Sop1>(opcode);
 }
 } // namespace detail
@@ -454,7 +535,11 @@ SAbsI32Sop1::SAbsI32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsI32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAbsI32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_abs_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsI32Sop1>(opcode);
 }
 } // namespace detail
@@ -478,7 +563,12 @@ SBcnt0I32B32Sop1::SBcnt0I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -503,7 +593,12 @@ SBcnt0I32B64Sop1::SBcnt0I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt0I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt0I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt0_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt0I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -527,7 +622,12 @@ SBcnt1I32B32Sop1::SBcnt1I32B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B32Sop1>(opcode);
 }
 } // namespace detail
@@ -552,7 +652,12 @@ SBcnt1I32B64Sop1::SBcnt1I32B64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBcnt1I32B64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSBcnt1I32B64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_bcnt1_i32_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBcnt1I32B64Sop1>(opcode);
 }
 } // namespace detail
@@ -576,7 +681,12 @@ SQuadmaskB32Sop1::SQuadmaskB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB32Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB32Sop1>(opcode);
 }
 } // namespace detail
@@ -601,7 +711,12 @@ SQuadmaskB64Sop1::SQuadmaskB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSQuadmaskB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSQuadmaskB64Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_quadmask_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SQuadmaskB64Sop1>(opcode);
 }
 } // namespace detail
@@ -625,7 +740,11 @@ SWqmB32Sop1::SWqmB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB32Sop1>(opcode);
 }
 } // namespace detail
@@ -650,7 +769,11 @@ SWqmB64Sop1::SWqmB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWqmB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSWqmB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_wqm_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWqmB64Sop1>(opcode);
 }
 } // namespace detail
@@ -674,7 +797,11 @@ SNotB32Sop1::SNotB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB32Sop1>(opcode);
 }
 } // namespace detail
@@ -699,7 +826,11 @@ SNotB64Sop1::SNotB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNotB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNotB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_not_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNotB64Sop1>(opcode);
 }
 } // namespace detail
@@ -730,7 +861,12 @@ SAndSaveexecB32Sop1::SAndSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -762,7 +898,12 @@ SAndSaveexecB64Sop1::SAndSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -794,7 +935,12 @@ SOrSaveexecB32Sop1::SOrSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrSaveexecB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -827,7 +973,12 @@ SOrSaveexecB64Sop1::SOrSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrSaveexecB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -858,7 +1009,12 @@ SXorSaveexecB32Sop1::SXorSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xor_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -890,7 +1046,12 @@ SXorSaveexecB64Sop1::SXorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -921,7 +1082,12 @@ SNandSaveexecB32Sop1::SNandSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNandSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nand_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -953,7 +1119,12 @@ SNandSaveexecB64Sop1::SNandSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNandSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nand_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -984,7 +1155,12 @@ SNorSaveexecB32Sop1::SNorSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNorSaveexecB32Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nor_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1016,7 +1192,12 @@ SNorSaveexecB64Sop1::SNorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSNorSaveexecB64Sop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_nor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1047,7 +1228,12 @@ SXnorSaveexecB32Sop1::SXnorSaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorSaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXnorSaveexecB32Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xnor_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorSaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1079,7 +1265,12 @@ SXnorSaveexecB64Sop1::SXnorSaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorSaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSXnorSaveexecB64Sop1(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_xnor_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorSaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1110,7 +1301,12 @@ SAndNot0SaveexecB32Sop1::SAndNot0SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot0SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot0SaveexecB32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not0_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot0SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1142,7 +1338,12 @@ SAndNot0SaveexecB64Sop1::SAndNot0SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot0SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot0SaveexecB64Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not0_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot0SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1173,7 +1374,12 @@ SOrNot0SaveexecB32Sop1::SOrNot0SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot0SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrNot0SaveexecB32Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_not0_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot0SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1205,7 +1411,12 @@ SOrNot0SaveexecB64Sop1::SOrNot0SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot0SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrNot0SaveexecB64Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_not0_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot0SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1236,7 +1447,12 @@ SAndNot1SaveexecB32Sop1::SAndNot1SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1SaveexecB32Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not1_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1268,7 +1484,12 @@ SAndNot1SaveexecB64Sop1::SAndNot1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1SaveexecB64Sop1(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1299,7 +1520,12 @@ SOrNot1SaveexecB32Sop1::SOrNot1SaveexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot1SaveexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrNot1SaveexecB32Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_not1_saveexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot1SaveexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1331,7 +1557,12 @@ SOrNot1SaveexecB64Sop1::SOrNot1SaveexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot1SaveexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSOrNot1SaveexecB64Sop1(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_or_not1_saveexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot1SaveexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1362,7 +1593,12 @@ SAndNot0WrexecB32Sop1::SAndNot0WrexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot0WrexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot0WrexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not0_wrexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot0WrexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1394,7 +1630,12 @@ SAndNot0WrexecB64Sop1::SAndNot0WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot0WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot0WrexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not0_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot0WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1425,7 +1666,12 @@ SAndNot1WrexecB32Sop1::SAndNot1WrexecB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1WrexecB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1WrexecB32Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not1_wrexec_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1WrexecB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1457,7 +1703,12 @@ SAndNot1WrexecB64Sop1::SAndNot1WrexecB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1WrexecB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1WrexecB64Sop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_and_not1_wrexec_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1WrexecB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1477,7 +1728,12 @@ SMovrelsB32Sop1::SMovrelsB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrels_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1497,7 +1753,12 @@ SMovrelsB64Sop1::SMovrelsB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrels_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1521,7 +1782,12 @@ SMovreldB32Sop1::SMovreldB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB32Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1546,7 +1812,12 @@ SMovreldB64Sop1::SMovreldB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovreldB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovreldB64Sop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movreld_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovreldB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1566,7 +1837,12 @@ SMovrelsd2B32Sop1::SMovrelsd2B32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovrelsd2B32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSMovrelsd2B32Sop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_movrelsd_2_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovrelsd2B32Sop1>(opcode);
 }
 } // namespace detail
@@ -1584,7 +1860,11 @@ SGetpcB64Sop1::SGetpcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetpcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSGetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_getpc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetpcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1603,7 +1883,11 @@ SSetpcB64Sop1::SSetpcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetpcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSetpcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_setpc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetpcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1626,7 +1910,11 @@ SSwappcB64Sop1::SSwappcB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSwappcB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSwappcB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_swappc_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSwappcB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1644,7 +1932,11 @@ SRfeB64Sop1::SRfeB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRfeB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSRfeB64Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_rfe_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRfeB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1661,7 +1953,12 @@ SSendmsgRtnB32Sop1::SSendmsgRtnB32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsgRtnB32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSendmsgRtnB32Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sendmsg_rtn_b32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsgRtnB32Sop1>(opcode);
 }
 } // namespace detail
@@ -1678,7 +1975,12 @@ SSendmsgRtnB64Sop1::SSendmsgRtnB64Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsgRtnB64Sop1(const MachineInst *opcode) {
+DecodeResult decodeSSendmsgRtnB64Sop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sendmsg_rtn_b64", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsgRtnB64Sop1>(opcode);
 }
 } // namespace detail
@@ -1695,7 +1997,12 @@ SBarrierSignalSop1::SBarrierSignalSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBarrierSignalSop1(const MachineInst *opcode) {
+DecodeResult decodeSBarrierSignalSop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_barrier_signal", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBarrierSignalSop1>(opcode);
 }
 } // namespace detail
@@ -1714,7 +2021,12 @@ SBarrierSignalIsfirstSop1::SBarrierSignalIsfirstSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBarrierSignalIsfirstSop1(const MachineInst *opcode) {
+DecodeResult decodeSBarrierSignalIsfirstSop1(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_barrier_signal_isfirst", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBarrierSignalIsfirstSop1>(opcode);
 }
 } // namespace detail
@@ -1736,7 +2048,11 @@ SAllocVgprSop1::SAllocVgprSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAllocVgprSop1(const MachineInst *opcode) {
+DecodeResult decodeSAllocVgprSop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_alloc_vgpr", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAllocVgprSop1>(opcode);
 }
 } // namespace detail
@@ -1755,7 +2071,11 @@ SSleepVarSop1::SSleepVarSop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSleepVarSop1(const MachineInst *opcode) {
+DecodeResult decodeSSleepVarSop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_sleep_var", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSleepVarSop1>(opcode);
 }
 } // namespace detail
@@ -1776,7 +2096,11 @@ SCeilF32Sop1::SCeilF32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCeilF32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCeilF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ceil_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCeilF32Sop1>(opcode);
 }
 } // namespace detail
@@ -1797,7 +2121,11 @@ SFloorF32Sop1::SFloorF32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFloorF32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFloorF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_floor_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFloorF32Sop1>(opcode);
 }
 } // namespace detail
@@ -1818,7 +2146,11 @@ STruncF32Sop1::STruncF32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTruncF32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSTruncF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_trunc_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STruncF32Sop1>(opcode);
 }
 } // namespace detail
@@ -1839,7 +2171,11 @@ SRndneF32Sop1::SRndneF32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRndneF32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSRndneF32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_rndne_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRndneF32Sop1>(opcode);
 }
 } // namespace detail
@@ -1860,7 +2196,11 @@ SCvtF32I32Sop1::SCvtF32I32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtF32I32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtF32I32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_f32_i32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtF32I32Sop1>(opcode);
 }
 } // namespace detail
@@ -1881,7 +2221,11 @@ SCvtF32U32Sop1::SCvtF32U32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtF32U32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtF32U32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_f32_u32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtF32U32Sop1>(opcode);
 }
 } // namespace detail
@@ -1902,7 +2246,11 @@ SCvtI32F32Sop1::SCvtI32F32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtI32F32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtI32F32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_i32_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtI32F32Sop1>(opcode);
 }
 } // namespace detail
@@ -1923,7 +2271,11 @@ SCvtU32F32Sop1::SCvtU32F32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtU32F32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtU32F32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_u32_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtU32F32Sop1>(opcode);
 }
 } // namespace detail
@@ -1944,7 +2296,11 @@ SCvtF16F32Sop1::SCvtF16F32Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtF16F32Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtF16F32Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_f16_f32", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtF16F32Sop1>(opcode);
 }
 } // namespace detail
@@ -1972,7 +2328,11 @@ SCvtF32F16Sop1::SCvtF32F16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtF32F16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtF32F16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_f32_f16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtF32F16Sop1>(opcode);
 }
 } // namespace detail
@@ -1994,7 +2354,12 @@ SCvtHiF32F16Sop1::SCvtHiF32F16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtHiF32F16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCvtHiF32F16Sop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_cvt_hi_f32_f16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtHiF32F16Sop1>(opcode);
 }
 } // namespace detail
@@ -2016,7 +2381,11 @@ SCeilF16Sop1::SCeilF16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCeilF16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSCeilF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_ceil_f16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCeilF16Sop1>(opcode);
 }
 } // namespace detail
@@ -2044,7 +2413,11 @@ SFloorF16Sop1::SFloorF16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFloorF16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSFloorF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_floor_f16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFloorF16Sop1>(opcode);
 }
 } // namespace detail
@@ -2072,7 +2445,11 @@ STruncF16Sop1::STruncF16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTruncF16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSTruncF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_trunc_f16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STruncF16Sop1>(opcode);
 }
 } // namespace detail
@@ -2100,7 +2477,11 @@ SRndneF16Sop1::SRndneF16Sop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRndneF16Sop1(const MachineInst *opcode) {
+DecodeResult decodeSRndneF16Sop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop1::validate_encoding(
+      "s_rndne_f16", reinterpret_cast<const Sop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRndneF16Sop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/sop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/sop2.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/sop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -37,7 +36,11 @@ SAddCoU32Sop2::SAddCoU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddCoU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddCoU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_co_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddCoU32Sop2>(opcode);
 }
 } // namespace detail
@@ -67,7 +70,11 @@ SSubCoU32Sop2::SSubCoU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubCoU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubCoU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_co_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubCoU32Sop2>(opcode);
 }
 } // namespace detail
@@ -97,7 +104,11 @@ SAddCoI32Sop2::SAddCoI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddCoI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddCoI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_co_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddCoI32Sop2>(opcode);
 }
 } // namespace detail
@@ -127,7 +138,11 @@ SSubCoI32Sop2::SSubCoI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubCoI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubCoI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_co_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubCoI32Sop2>(opcode);
 }
 } // namespace detail
@@ -160,7 +175,12 @@ SAddCoCiU32Sop2::SAddCoCiU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddCoCiU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddCoCiU32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_co_ci_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddCoCiU32Sop2>(opcode);
 }
 } // namespace detail
@@ -193,7 +213,12 @@ SSubCoCiU32Sop2::SSubCoCiU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubCoCiU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubCoCiU32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_co_ci_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubCoCiU32Sop2>(opcode);
 }
 } // namespace detail
@@ -223,7 +248,12 @@ SAbsdiffI32Sop2::SAbsdiffI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAbsdiffI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAbsdiffI32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_absdiff_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAbsdiffI32Sop2>(opcode);
 }
 } // namespace detail
@@ -253,7 +283,11 @@ SLshlB32Sop2::SLshlB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshlB32Sop2>(opcode);
 }
 } // namespace detail
@@ -284,7 +318,11 @@ SLshlB64Sop2::SLshlB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshlB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshlB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshlB64Sop2>(opcode);
 }
 } // namespace detail
@@ -314,7 +352,11 @@ SLshrB32Sop2::SLshrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -345,7 +387,11 @@ SLshrB64Sop2::SLshrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshr_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -375,7 +421,11 @@ SAshrI32Sop2::SAshrI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAshrI32Sop2>(opcode);
 }
 } // namespace detail
@@ -406,7 +456,11 @@ SAshrI64Sop2::SAshrI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAshrI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAshrI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_ashr_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAshrI64Sop2>(opcode);
 }
 } // namespace detail
@@ -436,7 +490,12 @@ SLshl1AddU32Sop2::SLshl1AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl1AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl1AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl1_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl1AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -466,7 +525,12 @@ SLshl2AddU32Sop2::SLshl2AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl2AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl2AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl2_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl2AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -496,7 +560,12 @@ SLshl3AddU32Sop2::SLshl3AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl3AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl3AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl3_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl3AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -526,7 +595,12 @@ SLshl4AddU32Sop2::SLshl4AddU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSLshl4AddU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSLshl4AddU32Sop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_lshl4_add_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SLshl4AddU32Sop2>(opcode);
 }
 } // namespace detail
@@ -556,7 +630,11 @@ SMinI32Sop2::SMinI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinI32Sop2>(opcode);
 }
 } // namespace detail
@@ -586,7 +664,11 @@ SMinU32Sop2::SMinU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinU32Sop2>(opcode);
 }
 } // namespace detail
@@ -616,7 +698,11 @@ SMaxI32Sop2::SMaxI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxI32Sop2>(opcode);
 }
 } // namespace detail
@@ -646,7 +732,11 @@ SMaxU32Sop2::SMaxU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxU32Sop2>(opcode);
 }
 } // namespace detail
@@ -676,7 +766,11 @@ SAndB32Sop2::SAndB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndB32Sop2>(opcode);
 }
 } // namespace detail
@@ -708,7 +802,11 @@ SAndB64Sop2::SAndB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndB64Sop2>(opcode);
 }
 } // namespace detail
@@ -739,7 +837,11 @@ SOrB32Sop2::SOrB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrB32Sop2>(opcode);
 }
 } // namespace detail
@@ -772,7 +874,11 @@ SOrB64Sop2::SOrB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrB64Sop2>(opcode);
 }
 } // namespace detail
@@ -802,7 +908,11 @@ SXorB32Sop2::SXorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -834,7 +944,11 @@ SXorB64Sop2::SXorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -864,7 +978,11 @@ SNandB32Sop2::SNandB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandB32Sop2>(opcode);
 }
 } // namespace detail
@@ -896,7 +1014,11 @@ SNandB64Sop2::SNandB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNandB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNandB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nand_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNandB64Sop2>(opcode);
 }
 } // namespace detail
@@ -926,7 +1048,11 @@ SNorB32Sop2::SNorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -958,7 +1084,11 @@ SNorB64Sop2::SNorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSNorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_nor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -988,7 +1118,11 @@ SXnorB32Sop2::SXnorB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1020,7 +1154,11 @@ SXnorB64Sop2::SXnorB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSXnorB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSXnorB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_xnor_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SXnorB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1050,7 +1188,12 @@ SAndNot1B32Sop2::SAndNot1B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1B32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_not1_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1B32Sop2>(opcode);
 }
 } // namespace detail
@@ -1082,7 +1225,12 @@ SAndNot1B64Sop2::SAndNot1B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAndNot1B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAndNot1B64Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_and_not1_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAndNot1B64Sop2>(opcode);
 }
 } // namespace detail
@@ -1112,7 +1260,11 @@ SOrNot1B32Sop2::SOrNot1B32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot1B32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrNot1B32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_not1_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot1B32Sop2>(opcode);
 }
 } // namespace detail
@@ -1144,7 +1296,11 @@ SOrNot1B64Sop2::SOrNot1B64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSOrNot1B64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSOrNot1B64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_or_not1_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SOrNot1B64Sop2>(opcode);
 }
 } // namespace detail
@@ -1174,7 +1330,11 @@ SBfeU32Sop2::SBfeU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1204,7 +1364,11 @@ SBfeI32Sop2::SBfeI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1235,7 +1399,11 @@ SBfeU64Sop2::SBfeU64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeU64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_u64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeU64Sop2>(opcode);
 }
 } // namespace detail
@@ -1266,7 +1434,11 @@ SBfeI64Sop2::SBfeI64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfeI64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfeI64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfe_i64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfeI64Sop2>(opcode);
 }
 } // namespace detail
@@ -1293,7 +1465,11 @@ SBfmB32Sop2::SBfmB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfmB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1320,7 +1496,11 @@ SBfmB64Sop2::SBfmB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBfmB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSBfmB64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_bfm_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBfmB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1347,7 +1527,11 @@ SMulI32Sop2::SMulI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1374,7 +1558,11 @@ SMulHiU32Sop2::SMulHiU32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiU32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiU32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_u32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulHiU32Sop2>(opcode);
 }
 } // namespace detail
@@ -1401,7 +1589,11 @@ SMulHiI32Sop2::SMulHiI32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulHiI32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulHiI32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_hi_i32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulHiI32Sop2>(opcode);
 }
 } // namespace detail
@@ -1431,7 +1623,12 @@ SCselectB32Sop2::SCselectB32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCselectB32Sop2>(opcode);
 }
 } // namespace detail
@@ -1463,7 +1660,12 @@ SCselectB64Sop2::SCselectB64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCselectB64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCselectB64Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cselect_b64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCselectB64Sop2>(opcode);
 }
 } // namespace detail
@@ -1492,7 +1694,12 @@ SPackLlB32B16Sop2::SPackLlB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLlB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_ll_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackLlB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1520,7 +1727,12 @@ SPackLhB32B16Sop2::SPackLhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackLhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackLhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_lh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackLhB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1547,7 +1759,12 @@ SPackHhB32B16Sop2::SPackHhB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackHhB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackHhB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_hh_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackHhB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1575,7 +1792,12 @@ SPackHlB32B16Sop2::SPackHlB32B16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSPackHlB32B16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSPackHlB32B16Sop2(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_pack_hl_b32_b16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SPackHlB32B16Sop2>(opcode);
 }
 } // namespace detail
@@ -1602,7 +1824,11 @@ SAddF32Sop2::SAddF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddF32Sop2>(opcode);
 }
 } // namespace detail
@@ -1629,7 +1855,11 @@ SSubF32Sop2::SSubF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubF32Sop2>(opcode);
 }
 } // namespace detail
@@ -1656,7 +1886,11 @@ SMinNumF32Sop2::SMinNumF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinNumF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinNumF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_num_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinNumF32Sop2>(opcode);
 }
 } // namespace detail
@@ -1683,7 +1917,11 @@ SMaxNumF32Sop2::SMaxNumF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxNumF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxNumF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_num_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxNumF32Sop2>(opcode);
 }
 } // namespace detail
@@ -1710,7 +1948,11 @@ SMulF32Sop2::SMulF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulF32Sop2>(opcode);
 }
 } // namespace detail
@@ -1743,7 +1985,11 @@ SFmaakF32Sop2::SFmaakF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFmaakF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSFmaakF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_fmaak_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFmaakF32Sop2>(opcode);
 }
 } // namespace detail
@@ -1776,7 +2022,11 @@ SFmamkF32Sop2::SFmamkF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFmamkF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSFmamkF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_fmamk_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFmamkF32Sop2>(opcode);
 }
 } // namespace detail
@@ -1804,7 +2054,11 @@ SFmacF32Sop2::SFmacF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFmacF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSFmacF32Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_fmac_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFmacF32Sop2>(opcode);
 }
 } // namespace detail
@@ -1831,7 +2085,12 @@ SCvtPkRtzF16F32Sop2::SCvtPkRtzF16F32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCvtPkRtzF16F32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSCvtPkRtzF16F32Sop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_cvt_pk_rtz_f16_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCvtPkRtzF16F32Sop2>(opcode);
 }
 } // namespace detail
@@ -1866,7 +2125,11 @@ SAddF16Sop2::SAddF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddF16Sop2>(opcode);
 }
 } // namespace detail
@@ -1901,7 +2164,11 @@ SSubF16Sop2::SSubF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubF16Sop2>(opcode);
 }
 } // namespace detail
@@ -1936,7 +2203,11 @@ SMinNumF16Sop2::SMinNumF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinNumF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinNumF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_min_num_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinNumF16Sop2>(opcode);
 }
 } // namespace detail
@@ -1971,7 +2242,11 @@ SMaxNumF16Sop2::SMaxNumF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaxNumF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaxNumF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_max_num_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaxNumF16Sop2>(opcode);
 }
 } // namespace detail
@@ -2006,7 +2281,11 @@ SMulF16Sop2::SMulF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulF16Sop2>(opcode);
 }
 } // namespace detail
@@ -2042,7 +2321,11 @@ SFmacF16Sop2::SFmacF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSFmacF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSFmacF16Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_fmac_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SFmacF16Sop2>(opcode);
 }
 } // namespace detail
@@ -2075,7 +2358,12 @@ SMinimumF32Sop2::SMinimumF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinimumF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinimumF32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_minimum_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinimumF32Sop2>(opcode);
 }
 } // namespace detail
@@ -2102,7 +2390,12 @@ SMaximumF32Sop2::SMaximumF32Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaximumF32Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaximumF32Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_maximum_f32", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaximumF32Sop2>(opcode);
 }
 } // namespace detail
@@ -2131,7 +2424,12 @@ SMinimumF16Sop2::SMinimumF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMinimumF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMinimumF16Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_minimum_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMinimumF16Sop2>(opcode);
 }
 } // namespace detail
@@ -2166,7 +2464,12 @@ SMaximumF16Sop2::SMaximumF16Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMaximumF16Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMaximumF16Sop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_maximum_f16", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMaximumF16Sop2>(opcode);
 }
 } // namespace detail
@@ -2201,7 +2504,11 @@ SAddNcU64Sop2::SAddNcU64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddNcU64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSAddNcU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_add_nc_u64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddNcU64Sop2>(opcode);
 }
 } // namespace detail
@@ -2230,7 +2537,11 @@ SSubNcU64Sop2::SSubNcU64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSubNcU64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSSubNcU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_sub_nc_u64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSubNcU64Sop2>(opcode);
 }
 } // namespace detail
@@ -2259,7 +2570,11 @@ SMulU64Sop2::SMulU64Sop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulU64Sop2(const MachineInst *opcode) {
+DecodeResult decodeSMulU64Sop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sop2::validate_encoding(
+      "s_mul_u64", reinterpret_cast<const Sop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulU64Sop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/sopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/sopc.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/sopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -35,7 +34,11 @@ SCmpEqI32Sopc::SCmpEqI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqI32Sopc>(opcode);
 }
 } // namespace detail
@@ -63,7 +66,11 @@ SCmpLgI32Sopc::SCmpLgI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgI32Sopc>(opcode);
 }
 } // namespace detail
@@ -91,7 +98,11 @@ SCmpGtI32Sopc::SCmpGtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -119,7 +130,11 @@ SCmpGeI32Sopc::SCmpGeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -147,7 +162,11 @@ SCmpLtI32Sopc::SCmpLtI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtI32Sopc>(opcode);
 }
 } // namespace detail
@@ -175,7 +194,11 @@ SCmpLeI32Sopc::SCmpLeI32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeI32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeI32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_i32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeI32Sopc>(opcode);
 }
 } // namespace detail
@@ -203,7 +226,11 @@ SCmpEqU32Sopc::SCmpEqU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqU32Sopc>(opcode);
 }
 } // namespace detail
@@ -231,7 +258,11 @@ SCmpLgU32Sopc::SCmpLgU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgU32Sopc>(opcode);
 }
 } // namespace detail
@@ -259,7 +290,11 @@ SCmpGtU32Sopc::SCmpGtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -287,7 +322,11 @@ SCmpGeU32Sopc::SCmpGeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -315,7 +354,11 @@ SCmpLtU32Sopc::SCmpLtU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtU32Sopc>(opcode);
 }
 } // namespace detail
@@ -343,7 +386,11 @@ SCmpLeU32Sopc::SCmpLeU32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeU32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeU32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_u32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeU32Sopc>(opcode);
 }
 } // namespace detail
@@ -371,7 +418,12 @@ SBitcmp0B32Sopc::SBitcmp0B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp0B32Sopc>(opcode);
 }
 } // namespace detail
@@ -399,7 +451,12 @@ SBitcmp1B32Sopc::SBitcmp1B32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B32Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp1B32Sopc>(opcode);
 }
 } // namespace detail
@@ -428,7 +485,12 @@ SBitcmp0B64Sopc::SBitcmp0B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp0B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp0B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp0_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp0B64Sopc>(opcode);
 }
 } // namespace detail
@@ -457,7 +519,12 @@ SBitcmp1B64Sopc::SBitcmp1B64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBitcmp1B64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSBitcmp1B64Sopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_bitcmp1_b64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBitcmp1B64Sopc>(opcode);
 }
 } // namespace detail
@@ -487,7 +554,11 @@ SCmpEqU64Sopc::SCmpEqU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqU64Sopc>(opcode);
 }
 } // namespace detail
@@ -517,7 +588,11 @@ SCmpLgU64Sopc::SCmpLgU64Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgU64Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgU64Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_u64", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgU64Sopc>(opcode);
 }
 } // namespace detail
@@ -545,7 +620,11 @@ SCmpLtF32Sopc::SCmpLtF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtF32Sopc>(opcode);
 }
 } // namespace detail
@@ -575,7 +654,11 @@ SCmpLtF16Sopc::SCmpLtF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLtF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLtF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lt_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLtF16Sopc>(opcode);
 }
 } // namespace detail
@@ -603,7 +686,11 @@ SCmpEqF32Sopc::SCmpEqF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqF32Sopc>(opcode);
 }
 } // namespace detail
@@ -633,7 +720,11 @@ SCmpEqF16Sopc::SCmpEqF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpEqF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpEqF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_eq_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpEqF16Sopc>(opcode);
 }
 } // namespace detail
@@ -661,7 +752,11 @@ SCmpLeF32Sopc::SCmpLeF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeF32Sopc>(opcode);
 }
 } // namespace detail
@@ -691,7 +786,11 @@ SCmpLeF16Sopc::SCmpLeF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLeF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLeF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_le_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLeF16Sopc>(opcode);
 }
 } // namespace detail
@@ -719,7 +818,11 @@ SCmpGtF32Sopc::SCmpGtF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtF32Sopc>(opcode);
 }
 } // namespace detail
@@ -749,7 +852,11 @@ SCmpGtF16Sopc::SCmpGtF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGtF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGtF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_gt_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGtF16Sopc>(opcode);
 }
 } // namespace detail
@@ -777,7 +884,11 @@ SCmpLgF32Sopc::SCmpLgF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgF32Sopc>(opcode);
 }
 } // namespace detail
@@ -807,7 +918,11 @@ SCmpLgF16Sopc::SCmpLgF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpLgF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpLgF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_lg_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpLgF16Sopc>(opcode);
 }
 } // namespace detail
@@ -835,7 +950,11 @@ SCmpGeF32Sopc::SCmpGeF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeF32Sopc>(opcode);
 }
 } // namespace detail
@@ -865,7 +984,11 @@ SCmpGeF16Sopc::SCmpGeF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpGeF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpGeF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ge_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpGeF16Sopc>(opcode);
 }
 } // namespace detail
@@ -893,7 +1016,11 @@ SCmpOF32Sopc::SCmpOF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpOF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpOF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_o_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpOF32Sopc>(opcode);
 }
 } // namespace detail
@@ -923,7 +1050,11 @@ SCmpOF16Sopc::SCmpOF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpOF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpOF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_o_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpOF16Sopc>(opcode);
 }
 } // namespace detail
@@ -951,7 +1082,11 @@ SCmpUF32Sopc::SCmpUF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpUF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpUF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_u_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpUF32Sopc>(opcode);
 }
 } // namespace detail
@@ -981,7 +1116,11 @@ SCmpUF16Sopc::SCmpUF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpUF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpUF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_u_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpUF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1009,7 +1148,11 @@ SCmpNgeF32Sopc::SCmpNgeF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNgeF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNgeF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nge_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNgeF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1039,7 +1182,11 @@ SCmpNgeF16Sopc::SCmpNgeF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNgeF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNgeF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nge_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNgeF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1067,7 +1214,11 @@ SCmpNlgF32Sopc::SCmpNlgF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNlgF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNlgF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nlg_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNlgF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1097,7 +1248,11 @@ SCmpNlgF16Sopc::SCmpNlgF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNlgF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNlgF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nlg_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNlgF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1125,7 +1280,11 @@ SCmpNgtF32Sopc::SCmpNgtF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNgtF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNgtF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ngt_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNgtF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1155,7 +1314,11 @@ SCmpNgtF16Sopc::SCmpNgtF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNgtF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNgtF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_ngt_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNgtF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1183,7 +1346,11 @@ SCmpNleF32Sopc::SCmpNleF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNleF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNleF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nle_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNleF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1213,7 +1380,11 @@ SCmpNleF16Sopc::SCmpNleF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNleF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNleF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nle_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNleF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1241,7 +1412,11 @@ SCmpNeqF32Sopc::SCmpNeqF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNeqF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNeqF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_neq_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNeqF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1271,7 +1446,11 @@ SCmpNeqF16Sopc::SCmpNeqF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNeqF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNeqF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_neq_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNeqF16Sopc>(opcode);
 }
 } // namespace detail
@@ -1299,7 +1478,11 @@ SCmpNltF32Sopc::SCmpNltF32Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNltF32Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNltF32Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nlt_f32", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNltF32Sopc>(opcode);
 }
 } // namespace detail
@@ -1329,7 +1512,11 @@ SCmpNltF16Sopc::SCmpNltF16Sopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmpNltF16Sopc(const MachineInst *opcode) {
+DecodeResult decodeSCmpNltF16Sopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopc::validate_encoding(
+      "s_cmp_nlt_f16", reinterpret_cast<const Sopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmpNltF16Sopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/sopk.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -24,7 +23,11 @@ SMovkI32Sopk::SMovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_movk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -39,7 +42,11 @@ SVersionSopk::SVersionSopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSVersionSopk(const MachineInst *opcode) {
+DecodeResult decodeSVersionSopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_version", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SVersionSopk>(opcode);
 }
 } // namespace detail
@@ -61,7 +68,11 @@ SCmovkI32Sopk::SCmovkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCmovkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCmovkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_cmovk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCmovkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -82,7 +93,11 @@ SAddkCoI32Sopk::SAddkCoI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSAddkCoI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSAddkCoI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_addk_co_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SAddkCoI32Sopk>(opcode);
 }
 } // namespace detail
@@ -100,7 +115,11 @@ SMulkI32Sopk::SMulkI32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSMulkI32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSMulkI32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_mulk_i32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SMulkI32Sopk>(opcode);
 }
 } // namespace detail
@@ -117,7 +136,11 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSGetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSGetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_getreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SGetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -134,7 +157,11 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregB32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregB32Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregB32Sopk>(opcode);
 }
 } // namespace detail
@@ -159,7 +186,12 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetregImm32B32Sopk(const MachineInst *opcode) {
+DecodeResult decodeSSetregImm32B32Sopk(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_setreg_imm32_b32", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetregImm32B32Sopk>(opcode);
 }
 } // namespace detail
@@ -188,7 +220,11 @@ SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCallB64Sopk(const MachineInst *opcode) {
+DecodeResult decodeSCallB64Sopk(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopk::validate_encoding(
+      "s_call_b64", reinterpret_cast<const Sopk::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCallB64Sopk>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/sopp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/sopp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/sopp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -22,7 +21,11 @@ SNopSopp::SNopSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSNopSopp(const MachineInst *opcode) {
+DecodeResult decodeSNopSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_nop", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SNopSopp>(opcode);
 }
 } // namespace detail
@@ -37,7 +40,11 @@ SSetkillSopp::SSetkillSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetkillSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetkillSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setkill", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetkillSopp>(opcode);
 }
 } // namespace detail
@@ -52,7 +59,11 @@ SSethaltSopp::SSethaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSethaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSethaltSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sethalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSethaltSopp>(opcode);
 }
 } // namespace detail
@@ -67,7 +78,11 @@ SSleepSopp::SSleepSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSleepSopp(const MachineInst *opcode) {
+DecodeResult decodeSSleepSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sleep", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSleepSopp>(opcode);
 }
 } // namespace detail
@@ -82,7 +97,11 @@ SClauseSopp::SClauseSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSClauseSopp(const MachineInst *opcode) {
+DecodeResult decodeSClauseSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_clause", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SClauseSopp>(opcode);
 }
 } // namespace detail
@@ -97,7 +116,11 @@ SDelayAluSopp::SDelayAluSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDelayAluSopp(const MachineInst *opcode) {
+DecodeResult decodeSDelayAluSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_delay_alu", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDelayAluSopp>(opcode);
 }
 } // namespace detail
@@ -113,7 +136,11 @@ SWaitAluSopp::SWaitAluSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitAluSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitAluSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_alu", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitAluSopp>(opcode);
 }
 } // namespace detail
@@ -129,7 +156,11 @@ SWaitcntSopp::SWaitcntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitcntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_waitcnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitcntSopp>(opcode);
 }
 } // namespace detail
@@ -143,7 +174,11 @@ SWaitIdleSopp::SWaitIdleSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitIdleSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitIdleSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_idle", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitIdleSopp>(opcode);
 }
 } // namespace detail
@@ -159,7 +194,11 @@ SWaitEventSopp::SWaitEventSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitEventSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitEventSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_event", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitEventSopp>(opcode);
 }
 } // namespace detail
@@ -174,7 +213,11 @@ STrapSopp::STrapSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTrapSopp(const MachineInst *opcode) {
+DecodeResult decodeSTrapSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_trap", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STrapSopp>(opcode);
 }
 } // namespace detail
@@ -189,7 +232,11 @@ SRoundModeSopp::SRoundModeSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSRoundModeSopp(const MachineInst *opcode) {
+DecodeResult decodeSRoundModeSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_round_mode", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SRoundModeSopp>(opcode);
 }
 } // namespace detail
@@ -204,7 +251,12 @@ SDenormModeSopp::SDenormModeSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDenormModeSopp(const MachineInst *opcode) {
+DecodeResult decodeSDenormModeSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_denorm_mode", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDenormModeSopp>(opcode);
 }
 } // namespace detail
@@ -220,7 +272,12 @@ SBarrierWaitSopp::SBarrierWaitSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBarrierWaitSopp(const MachineInst *opcode) {
+DecodeResult decodeSBarrierWaitSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_barrier_wait", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBarrierWaitSopp>(opcode);
 }
 } // namespace detail
@@ -233,7 +290,11 @@ SCodeEndSopp::SCodeEndSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCodeEndSopp(const MachineInst *opcode) {
+DecodeResult decodeSCodeEndSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_code_end", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCodeEndSopp>(opcode);
 }
 } // namespace detail
@@ -250,7 +311,11 @@ SBranchSopp::SBranchSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSBranchSopp(const MachineInst *opcode) {
+DecodeResult decodeSBranchSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_branch", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SBranchSopp>(opcode);
 }
 } // namespace detail
@@ -275,7 +340,12 @@ SCbranchScc0Sopp::SCbranchScc0Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc0Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc0Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc0", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc0Sopp>(opcode);
 }
 } // namespace detail
@@ -300,7 +370,12 @@ SCbranchScc1Sopp::SCbranchScc1Sopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchScc1Sopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchScc1Sopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_scc1", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchScc1Sopp>(opcode);
 }
 } // namespace detail
@@ -325,7 +400,12 @@ SCbranchVcczSopp::SCbranchVcczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVcczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVcczSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVcczSopp>(opcode);
 }
 } // namespace detail
@@ -350,7 +430,12 @@ SCbranchVccnzSopp::SCbranchVccnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchVccnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchVccnzSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_vccnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchVccnzSopp>(opcode);
 }
 } // namespace detail
@@ -375,7 +460,12 @@ SCbranchExeczSopp::SCbranchExeczSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExeczSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExeczSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExeczSopp>(opcode);
 }
 } // namespace detail
@@ -400,7 +490,12 @@ SCbranchExecnzSopp::SCbranchExecnzSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSCbranchExecnzSopp(const MachineInst *opcode) {
+DecodeResult decodeSCbranchExecnzSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_cbranch_execnz", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SCbranchExecnzSopp>(opcode);
 }
 } // namespace detail
@@ -419,7 +514,11 @@ SEndpgmSopp::SEndpgmSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSopp>(opcode);
 }
 } // namespace detail
@@ -433,7 +532,12 @@ SEndpgmSavedSopp::SEndpgmSavedSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSEndpgmSavedSopp(const MachineInst *opcode) {
+DecodeResult decodeSEndpgmSavedSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_endpgm_saved", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SEndpgmSavedSopp>(opcode);
 }
 } // namespace detail
@@ -446,7 +550,11 @@ SWakeupSopp::SWakeupSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWakeupSopp(const MachineInst *opcode) {
+DecodeResult decodeSWakeupSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wakeup", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWakeupSopp>(opcode);
 }
 } // namespace detail
@@ -461,7 +569,11 @@ SSetprioSopp::SSetprioSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSetprioSopp(const MachineInst *opcode) {
+DecodeResult decodeSSetprioSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_setprio", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSetprioSopp>(opcode);
 }
 } // namespace detail
@@ -479,7 +591,11 @@ SSendmsgSopp::SSendmsgSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsgSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsgSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsg", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsgSopp>(opcode);
 }
 } // namespace detail
@@ -497,7 +613,12 @@ SSendmsghaltSopp::SSendmsghaltSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSSendmsghaltSopp(const MachineInst *opcode) {
+DecodeResult decodeSSendmsghaltSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_sendmsghalt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SSendmsghaltSopp>(opcode);
 }
 } // namespace detail
@@ -512,7 +633,12 @@ SIncperflevelSopp::SIncperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIncperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSIncperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_incperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIncperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -527,7 +653,12 @@ SDecperflevelSopp::SDecperflevelSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSDecperflevelSopp(const MachineInst *opcode) {
+DecodeResult decodeSDecperflevelSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_decperflevel", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SDecperflevelSopp>(opcode);
 }
 } // namespace detail
@@ -543,7 +674,12 @@ STtracedataSopp::STtracedataSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTtracedataSopp(const MachineInst *opcode) {
+DecodeResult decodeSTtracedataSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_ttracedata", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STtracedataSopp>(opcode);
 }
 } // namespace detail
@@ -561,7 +697,12 @@ STtracedataImmSopp::STtracedataImmSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSTtracedataImmSopp(const MachineInst *opcode) {
+DecodeResult decodeSTtracedataImmSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_ttracedata_imm", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<STtracedataImmSopp>(opcode);
 }
 } // namespace detail
@@ -574,7 +715,11 @@ SIcacheInvSopp::SIcacheInvSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSIcacheInvSopp(const MachineInst *opcode) {
+DecodeResult decodeSIcacheInvSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_icache_inv", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SIcacheInvSopp>(opcode);
 }
 } // namespace detail
@@ -590,7 +735,12 @@ SWaitLoadcntSopp::SWaitLoadcntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitLoadcntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitLoadcntSopp(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_loadcnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitLoadcntSopp>(opcode);
 }
 } // namespace detail
@@ -606,7 +756,12 @@ SWaitStorecntSopp::SWaitStorecntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitStorecntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitStorecntSopp(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_storecnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitStorecntSopp>(opcode);
 }
 } // namespace detail
@@ -622,7 +777,12 @@ SWaitSamplecntSopp::SWaitSamplecntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitSamplecntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitSamplecntSopp(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_samplecnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitSamplecntSopp>(opcode);
 }
 } // namespace detail
@@ -638,7 +798,12 @@ SWaitBvhcntSopp::SWaitBvhcntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitBvhcntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitBvhcntSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_bvhcnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitBvhcntSopp>(opcode);
 }
 } // namespace detail
@@ -654,7 +819,12 @@ SWaitExpcntSopp::SWaitExpcntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitExpcntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitExpcntSopp(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_expcnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitExpcntSopp>(opcode);
 }
 } // namespace detail
@@ -670,7 +840,11 @@ SWaitDscntSopp::SWaitDscntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitDscntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitDscntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_dscnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitDscntSopp>(opcode);
 }
 } // namespace detail
@@ -686,7 +860,11 @@ SWaitKmcntSopp::SWaitKmcntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitKmcntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitKmcntSopp(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_kmcnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitKmcntSopp>(opcode);
 }
 } // namespace detail
@@ -702,7 +880,12 @@ SWaitLoadcntDscntSopp::SWaitLoadcntDscntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitLoadcntDscntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitLoadcntDscntSopp(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_loadcnt_dscnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitLoadcntDscntSopp>(opcode);
 }
 } // namespace detail
@@ -718,7 +901,12 @@ SWaitStorecntDscntSopp::SWaitStorecntDscntSopp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeSWaitStorecntDscntSopp(const MachineInst *opcode) {
+DecodeResult decodeSWaitStorecntDscntSopp(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Sopp::validate_encoding(
+      "s_wait_storecnt_dscnt", reinterpret_cast<const Sopp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<SWaitStorecntDscntSopp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vbuffer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vbuffer.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vbuffer.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -44,7 +43,12 @@ BufferLoadFormatXVbuffer::BufferLoadFormatXVbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXVbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXVbuffer(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_format_x", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXVbuffer>(opcode);
 }
 } // namespace detail
@@ -70,7 +74,12 @@ BufferLoadFormatXyVbuffer::BufferLoadFormatXyVbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyVbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyVbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_format_xy", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyVbuffer>(opcode);
 }
 } // namespace detail
@@ -96,7 +105,12 @@ BufferLoadFormatXyzVbuffer::BufferLoadFormatXyzVbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzVbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyzVbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_format_xyz", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyzVbuffer>(opcode);
 }
 } // namespace detail
@@ -122,7 +136,12 @@ BufferLoadFormatXyzwVbuffer::BufferLoadFormatXyzwVbuffer(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadFormatXyzwVbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadFormatXyzwVbuffer(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_format_xyzw", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadFormatXyzwVbuffer>(opcode);
 }
 } // namespace detail
@@ -148,7 +167,12 @@ BufferStoreFormatXVbuffer::BufferStoreFormatXVbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXVbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXVbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_format_x", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXVbuffer>(opcode);
 }
 } // namespace detail
@@ -174,7 +198,12 @@ BufferStoreFormatXyVbuffer::BufferStoreFormatXyVbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyVbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyVbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_format_xy", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyVbuffer>(opcode);
 }
 } // namespace detail
@@ -200,7 +229,12 @@ BufferStoreFormatXyzVbuffer::BufferStoreFormatXyzVbuffer(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzVbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyzVbuffer(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_format_xyz", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyzVbuffer>(opcode);
 }
 } // namespace detail
@@ -226,7 +260,13 @@ BufferStoreFormatXyzwVbuffer::BufferStoreFormatXyzwVbuffer(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreFormatXyzwVbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreFormatXyzwVbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_store_format_xyzw",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreFormatXyzwVbuffer>(opcode);
 }
 } // namespace detail
@@ -252,7 +292,13 @@ BufferLoadD16FormatXVbuffer::BufferLoadD16FormatXVbuffer(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXVbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16FormatXVbuffer(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_load_d16_format_x",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16FormatXVbuffer>(opcode);
 }
 } // namespace detail
@@ -284,7 +330,13 @@ BufferLoadD16FormatXyVbuffer::BufferLoadD16FormatXyVbuffer(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXyVbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16FormatXyVbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_load_d16_format_xy",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16FormatXyVbuffer>(opcode);
 }
 } // namespace detail
@@ -310,7 +362,13 @@ BufferLoadD16FormatXyzVbuffer::BufferLoadD16FormatXyzVbuffer(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXyzVbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16FormatXyzVbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_load_d16_format_xyz",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16FormatXyzVbuffer>(opcode);
 }
 } // namespace detail
@@ -342,7 +400,13 @@ BufferLoadD16FormatXyzwVbuffer::BufferLoadD16FormatXyzwVbuffer(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16FormatXyzwVbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16FormatXyzwVbuffer(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_load_d16_format_xyzw",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16FormatXyzwVbuffer>(opcode);
 }
 } // namespace detail
@@ -368,7 +432,13 @@ BufferStoreD16FormatXVbuffer::BufferStoreD16FormatXVbuffer(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXVbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16FormatXVbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_store_d16_format_x",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16FormatXVbuffer>(opcode);
 }
 } // namespace detail
@@ -394,7 +464,13 @@ BufferStoreD16FormatXyVbuffer::BufferStoreD16FormatXyVbuffer(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXyVbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16FormatXyVbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_store_d16_format_xy",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16FormatXyVbuffer>(opcode);
 }
 } // namespace detail
@@ -420,7 +496,13 @@ BufferStoreD16FormatXyzVbuffer::BufferStoreD16FormatXyzVbuffer(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXyzVbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16FormatXyzVbuffer(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_store_d16_format_xyz",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16FormatXyzVbuffer>(opcode);
 }
 } // namespace detail
@@ -446,7 +528,13 @@ BufferStoreD16FormatXyzwVbuffer::BufferStoreD16FormatXyzwVbuffer(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16FormatXyzwVbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16FormatXyzwVbuffer(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_store_d16_format_xyzw",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16FormatXyzwVbuffer>(opcode);
 }
 } // namespace detail
@@ -472,7 +560,12 @@ BufferLoadU8Vbuffer::BufferLoadU8Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadU8Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadU8Vbuffer(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_u8", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadU8Vbuffer>(opcode);
 }
 } // namespace detail
@@ -498,7 +591,12 @@ BufferLoadI8Vbuffer::BufferLoadI8Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadI8Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadI8Vbuffer(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_i8", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadI8Vbuffer>(opcode);
 }
 } // namespace detail
@@ -524,7 +622,12 @@ BufferLoadU16Vbuffer::BufferLoadU16Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadU16Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadU16Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_u16", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadU16Vbuffer>(opcode);
 }
 } // namespace detail
@@ -550,7 +653,12 @@ BufferLoadI16Vbuffer::BufferLoadI16Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadI16Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadI16Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_i16", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadI16Vbuffer>(opcode);
 }
 } // namespace detail
@@ -576,7 +684,12 @@ BufferLoadB32Vbuffer::BufferLoadB32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadB32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadB32Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_b32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadB32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -602,7 +715,12 @@ BufferLoadB64Vbuffer::BufferLoadB64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadB64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadB64Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_b64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadB64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -628,7 +746,12 @@ BufferLoadB96Vbuffer::BufferLoadB96Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadB96Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadB96Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_b96", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadB96Vbuffer>(opcode);
 }
 } // namespace detail
@@ -654,7 +777,12 @@ BufferLoadB128Vbuffer::BufferLoadB128Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadB128Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadB128Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_b128", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadB128Vbuffer>(opcode);
 }
 } // namespace detail
@@ -680,7 +808,12 @@ BufferStoreB8Vbuffer::BufferStoreB8Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB8Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB8Vbuffer(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_b8", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB8Vbuffer>(opcode);
 }
 } // namespace detail
@@ -706,7 +839,12 @@ BufferStoreB16Vbuffer::BufferStoreB16Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB16Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB16Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_b16", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB16Vbuffer>(opcode);
 }
 } // namespace detail
@@ -732,7 +870,12 @@ BufferStoreB32Vbuffer::BufferStoreB32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB32Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_b32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -758,7 +901,12 @@ BufferStoreB64Vbuffer::BufferStoreB64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB64Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_b64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -784,7 +932,12 @@ BufferStoreB96Vbuffer::BufferStoreB96Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB96Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB96Vbuffer(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_b96", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB96Vbuffer>(opcode);
 }
 } // namespace detail
@@ -810,7 +963,12 @@ BufferStoreB128Vbuffer::BufferStoreB128Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreB128Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreB128Vbuffer(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_b128", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreB128Vbuffer>(opcode);
 }
 } // namespace detail
@@ -836,7 +994,12 @@ BufferLoadD16U8Vbuffer::BufferLoadD16U8Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16U8Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16U8Vbuffer(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_d16_u8", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16U8Vbuffer>(opcode);
 }
 } // namespace detail
@@ -868,7 +1031,12 @@ BufferLoadD16I8Vbuffer::BufferLoadD16I8Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16I8Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16I8Vbuffer(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_d16_i8", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16I8Vbuffer>(opcode);
 }
 } // namespace detail
@@ -900,7 +1068,12 @@ BufferLoadD16B16Vbuffer::BufferLoadD16B16Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16B16Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16B16Vbuffer(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_d16_b16", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16B16Vbuffer>(opcode);
 }
 } // namespace detail
@@ -932,7 +1105,12 @@ BufferLoadD16HiU8Vbuffer::BufferLoadD16HiU8Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16HiU8Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16HiU8Vbuffer(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_d16_hi_u8", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16HiU8Vbuffer>(opcode);
 }
 } // namespace detail
@@ -964,7 +1142,12 @@ BufferLoadD16HiI8Vbuffer::BufferLoadD16HiI8Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16HiI8Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16HiI8Vbuffer(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_d16_hi_i8", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16HiI8Vbuffer>(opcode);
 }
 } // namespace detail
@@ -996,7 +1179,12 @@ BufferLoadD16HiB16Vbuffer::BufferLoadD16HiB16Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16HiB16Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16HiB16Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_load_d16_hi_b16", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16HiB16Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1028,7 +1216,12 @@ BufferStoreD16HiB8Vbuffer::BufferStoreD16HiB8Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16HiB8Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16HiB8Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_d16_hi_b8", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16HiB8Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1054,7 +1247,12 @@ BufferStoreD16HiB16Vbuffer::BufferStoreD16HiB16Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16HiB16Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16HiB16Vbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_store_d16_hi_b16", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16HiB16Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1080,7 +1278,13 @@ BufferLoadD16HiFormatXVbuffer::BufferLoadD16HiFormatXVbuffer(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferLoadD16HiFormatXVbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferLoadD16HiFormatXVbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_load_d16_hi_format_x",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferLoadD16HiFormatXVbuffer>(opcode);
 }
 } // namespace detail
@@ -1112,7 +1316,13 @@ BufferStoreD16HiFormatXVbuffer::BufferStoreD16HiFormatXVbuffer(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferStoreD16HiFormatXVbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferStoreD16HiFormatXVbuffer(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_store_d16_hi_format_x",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferStoreD16HiFormatXVbuffer>(opcode);
 }
 } // namespace detail
@@ -1142,7 +1352,12 @@ BufferAtomicSwapB32Vbuffer::BufferAtomicSwapB32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapB32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapB32Vbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_swap_b32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapB32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1173,7 +1388,13 @@ BufferAtomicCmpswapB32Vbuffer::BufferAtomicCmpswapB32Vbuffer(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapB32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapB32Vbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_atomic_cmpswap_b32",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapB32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1203,7 +1424,12 @@ BufferAtomicAddU32Vbuffer::BufferAtomicAddU32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddU32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_add_u32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddU32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1233,7 +1459,12 @@ BufferAtomicSubU32Vbuffer::BufferAtomicSubU32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubU32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_sub_u32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubU32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1263,7 +1494,13 @@ BufferAtomicSubClampU32Vbuffer::BufferAtomicSubClampU32Vbuffer(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubClampU32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubClampU32Vbuffer(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_atomic_sub_clamp_u32",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubClampU32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1293,7 +1530,12 @@ BufferAtomicMinI32Vbuffer::BufferAtomicMinI32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinI32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinI32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_min_i32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinI32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1323,7 +1565,12 @@ BufferAtomicMinU32Vbuffer::BufferAtomicMinU32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinU32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_min_u32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinU32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1353,7 +1600,12 @@ BufferAtomicMaxI32Vbuffer::BufferAtomicMaxI32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxI32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxI32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_max_i32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxI32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1383,7 +1635,12 @@ BufferAtomicMaxU32Vbuffer::BufferAtomicMaxU32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxU32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_max_u32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxU32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1413,7 +1670,12 @@ BufferAtomicAndB32Vbuffer::BufferAtomicAndB32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndB32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndB32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_and_b32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndB32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1443,7 +1705,12 @@ BufferAtomicOrB32Vbuffer::BufferAtomicOrB32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrB32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrB32Vbuffer(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_or_b32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrB32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1473,7 +1740,12 @@ BufferAtomicXorB32Vbuffer::BufferAtomicXorB32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorB32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorB32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_xor_b32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorB32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1503,7 +1775,12 @@ BufferAtomicIncU32Vbuffer::BufferAtomicIncU32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncU32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_inc_u32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncU32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1533,7 +1810,12 @@ BufferAtomicDecU32Vbuffer::BufferAtomicDecU32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecU32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecU32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_dec_u32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecU32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1563,7 +1845,12 @@ BufferAtomicSwapB64Vbuffer::BufferAtomicSwapB64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSwapB64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSwapB64Vbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_swap_b64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSwapB64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1594,7 +1881,13 @@ BufferAtomicCmpswapB64Vbuffer::BufferAtomicCmpswapB64Vbuffer(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCmpswapB64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCmpswapB64Vbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_atomic_cmpswap_b64",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCmpswapB64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1624,7 +1917,12 @@ BufferAtomicAddU64Vbuffer::BufferAtomicAddU64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddU64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_add_u64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddU64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1654,7 +1952,12 @@ BufferAtomicSubU64Vbuffer::BufferAtomicSubU64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicSubU64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicSubU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_sub_u64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicSubU64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1684,7 +1987,12 @@ BufferAtomicMinI64Vbuffer::BufferAtomicMinI64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinI64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinI64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_min_i64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinI64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1714,7 +2022,12 @@ BufferAtomicMinU64Vbuffer::BufferAtomicMinU64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinU64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_min_u64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinU64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1744,7 +2057,12 @@ BufferAtomicMaxI64Vbuffer::BufferAtomicMaxI64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxI64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxI64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_max_i64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxI64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1774,7 +2092,12 @@ BufferAtomicMaxU64Vbuffer::BufferAtomicMaxU64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxU64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_max_u64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxU64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1804,7 +2127,12 @@ BufferAtomicAndB64Vbuffer::BufferAtomicAndB64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAndB64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAndB64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_and_b64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAndB64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1834,7 +2162,12 @@ BufferAtomicOrB64Vbuffer::BufferAtomicOrB64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicOrB64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicOrB64Vbuffer(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_or_b64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicOrB64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1864,7 +2197,12 @@ BufferAtomicXorB64Vbuffer::BufferAtomicXorB64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicXorB64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicXorB64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_xor_b64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicXorB64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1894,7 +2232,12 @@ BufferAtomicIncU64Vbuffer::BufferAtomicIncU64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicIncU64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicIncU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_inc_u64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicIncU64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1924,7 +2267,12 @@ BufferAtomicDecU64Vbuffer::BufferAtomicDecU64Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicDecU64Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicDecU64Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_dec_u64", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicDecU64Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1954,7 +2302,13 @@ BufferAtomicCondSubU32Vbuffer::BufferAtomicCondSubU32Vbuffer(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicCondSubU32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicCondSubU32Vbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_atomic_cond_sub_u32",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicCondSubU32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -1984,7 +2338,13 @@ BufferAtomicMinNumF32Vbuffer::BufferAtomicMinNumF32Vbuffer(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMinNumF32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMinNumF32Vbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_atomic_min_num_f32",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMinNumF32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -2014,7 +2374,13 @@ BufferAtomicMaxNumF32Vbuffer::BufferAtomicMaxNumF32Vbuffer(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicMaxNumF32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicMaxNumF32Vbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_atomic_max_num_f32",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicMaxNumF32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -2044,7 +2410,12 @@ BufferAtomicAddF32Vbuffer::BufferAtomicAddF32Vbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicAddF32Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicAddF32Vbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "buffer_atomic_add_f32", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicAddF32Vbuffer>(opcode);
 }
 } // namespace detail
@@ -2074,7 +2445,13 @@ BufferAtomicPkAddF16Vbuffer::BufferAtomicPkAddF16Vbuffer(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicPkAddF16Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicPkAddF16Vbuffer(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_atomic_pk_add_f16",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicPkAddF16Vbuffer>(opcode);
 }
 } // namespace detail
@@ -2104,7 +2481,13 @@ BufferAtomicPkAddBf16Vbuffer::BufferAtomicPkAddBf16Vbuffer(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeBufferAtomicPkAddBf16Vbuffer(const MachineInst *opcode) {
+DecodeResult decodeBufferAtomicPkAddBf16Vbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("buffer_atomic_pk_add_bf16",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<BufferAtomicPkAddBf16Vbuffer>(opcode);
 }
 } // namespace detail
@@ -2129,7 +2512,12 @@ TbufferLoadFormatXVbuffer::TbufferLoadFormatXVbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXVbuffer(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXVbuffer(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "tbuffer_load_format_x", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXVbuffer>(opcode);
 }
 } // namespace detail
@@ -2154,7 +2542,12 @@ TbufferLoadFormatXyVbuffer::TbufferLoadFormatXyVbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyVbuffer(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyVbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "tbuffer_load_format_xy", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyVbuffer>(opcode);
 }
 } // namespace detail
@@ -2179,7 +2572,12 @@ TbufferLoadFormatXyzVbuffer::TbufferLoadFormatXyzVbuffer(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzVbuffer(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyzVbuffer(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "tbuffer_load_format_xyz", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyzVbuffer>(opcode);
 }
 } // namespace detail
@@ -2204,7 +2602,13 @@ TbufferLoadFormatXyzwVbuffer::TbufferLoadFormatXyzwVbuffer(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadFormatXyzwVbuffer(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadFormatXyzwVbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("tbuffer_load_format_xyzw",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadFormatXyzwVbuffer>(opcode);
 }
 } // namespace detail
@@ -2229,7 +2633,12 @@ TbufferStoreFormatXVbuffer::TbufferStoreFormatXVbuffer(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXVbuffer(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXVbuffer(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "tbuffer_store_format_x", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXVbuffer>(opcode);
 }
 } // namespace detail
@@ -2254,7 +2663,12 @@ TbufferStoreFormatXyVbuffer::TbufferStoreFormatXyVbuffer(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyVbuffer(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyVbuffer(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vbuffer::validate_encoding(
+      "tbuffer_store_format_xy", reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyVbuffer>(opcode);
 }
 } // namespace detail
@@ -2279,7 +2693,13 @@ TbufferStoreFormatXyzVbuffer::TbufferStoreFormatXyzVbuffer(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzVbuffer(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyzVbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("tbuffer_store_format_xyz",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyzVbuffer>(opcode);
 }
 } // namespace detail
@@ -2304,7 +2724,13 @@ TbufferStoreFormatXyzwVbuffer::TbufferStoreFormatXyzwVbuffer(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreFormatXyzwVbuffer(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreFormatXyzwVbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("tbuffer_store_format_xyzw",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreFormatXyzwVbuffer>(opcode);
 }
 } // namespace detail
@@ -2330,7 +2756,13 @@ TbufferLoadD16FormatXVbuffer::TbufferLoadD16FormatXVbuffer(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXVbuffer(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadD16FormatXVbuffer(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("tbuffer_load_d16_format_x",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadD16FormatXVbuffer>(opcode);
 }
 } // namespace detail
@@ -2362,7 +2794,13 @@ TbufferLoadD16FormatXyVbuffer::TbufferLoadD16FormatXyVbuffer(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXyVbuffer(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadD16FormatXyVbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("tbuffer_load_d16_format_xy",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadD16FormatXyVbuffer>(opcode);
 }
 } // namespace detail
@@ -2388,7 +2826,13 @@ TbufferLoadD16FormatXyzVbuffer::TbufferLoadD16FormatXyzVbuffer(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXyzVbuffer(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadD16FormatXyzVbuffer(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("tbuffer_load_d16_format_xyz",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadD16FormatXyzVbuffer>(opcode);
 }
 } // namespace detail
@@ -2420,7 +2864,13 @@ TbufferLoadD16FormatXyzwVbuffer::TbufferLoadD16FormatXyzwVbuffer(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferLoadD16FormatXyzwVbuffer(const MachineInst *opcode) {
+DecodeResult decodeTbufferLoadD16FormatXyzwVbuffer(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("tbuffer_load_d16_format_xyzw",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferLoadD16FormatXyzwVbuffer>(opcode);
 }
 } // namespace detail
@@ -2446,7 +2896,13 @@ TbufferStoreD16FormatXVbuffer::TbufferStoreD16FormatXVbuffer(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXVbuffer(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreD16FormatXVbuffer(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("tbuffer_store_d16_format_x",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreD16FormatXVbuffer>(opcode);
 }
 } // namespace detail
@@ -2472,7 +2928,13 @@ TbufferStoreD16FormatXyVbuffer::TbufferStoreD16FormatXyVbuffer(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXyVbuffer(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreD16FormatXyVbuffer(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("tbuffer_store_d16_format_xy",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreD16FormatXyVbuffer>(opcode);
 }
 } // namespace detail
@@ -2498,7 +2960,13 @@ TbufferStoreD16FormatXyzVbuffer::TbufferStoreD16FormatXyzVbuffer(const MachineIn
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXyzVbuffer(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreD16FormatXyzVbuffer(const MachineInst *opcode,
+                                                   const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("tbuffer_store_d16_format_xyz",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreD16FormatXyzVbuffer>(opcode);
 }
 } // namespace detail
@@ -2524,7 +2992,13 @@ TbufferStoreD16FormatXyzwVbuffer::TbufferStoreD16FormatXyzwVbuffer(const Machine
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeTbufferStoreD16FormatXyzwVbuffer(const MachineInst *opcode) {
+DecodeResult decodeTbufferStoreD16FormatXyzwVbuffer(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vbuffer::validate_encoding("tbuffer_store_d16_format_xyzw",
+                                 reinterpret_cast<const Vbuffer::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<TbufferStoreD16FormatXyzwVbuffer>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vds.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vds.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vds.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -31,7 +30,11 @@ DsAddU32Vds::DsAddU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_add_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU32Vds>(opcode);
 }
 } // namespace detail
@@ -54,7 +57,11 @@ DsSubU32Vds::DsSubU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_sub_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU32Vds>(opcode);
 }
 } // namespace detail
@@ -77,7 +84,11 @@ DsRsubU32Vds::DsRsubU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_rsub_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU32Vds>(opcode);
 }
 } // namespace detail
@@ -100,7 +111,11 @@ DsIncU32Vds::DsIncU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_inc_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU32Vds>(opcode);
 }
 } // namespace detail
@@ -123,7 +138,11 @@ DsDecU32Vds::DsDecU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_dec_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU32Vds>(opcode);
 }
 } // namespace detail
@@ -146,7 +165,11 @@ DsMinI32Vds::DsMinI32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_i32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI32Vds>(opcode);
 }
 } // namespace detail
@@ -169,7 +192,11 @@ DsMaxI32Vds::DsMaxI32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_i32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI32Vds>(opcode);
 }
 } // namespace detail
@@ -192,7 +219,11 @@ DsMinU32Vds::DsMinU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU32Vds>(opcode);
 }
 } // namespace detail
@@ -215,7 +246,11 @@ DsMaxU32Vds::DsMaxU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU32Vds>(opcode);
 }
 } // namespace detail
@@ -238,7 +273,11 @@ DsAndB32Vds::DsAndB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_and_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB32Vds>(opcode);
 }
 } // namespace detail
@@ -261,7 +300,11 @@ DsOrB32Vds::DsOrB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_or_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB32Vds>(opcode);
 }
 } // namespace detail
@@ -284,7 +327,11 @@ DsXorB32Vds::DsXorB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_xor_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB32Vds>(opcode);
 }
 } // namespace detail
@@ -309,7 +356,11 @@ DsMskorB32Vds::DsMskorB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_mskor_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB32Vds>(opcode);
 }
 } // namespace detail
@@ -330,7 +381,11 @@ DsStoreB32Vds::DsStoreB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB32Vds>(opcode);
 }
 } // namespace detail
@@ -353,7 +408,12 @@ DsStore2addrB32Vds::DsStore2addrB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStore2addrB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStore2addrB32Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_2addr_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStore2addrB32Vds>(opcode);
 }
 } // namespace detail
@@ -376,7 +436,12 @@ DsStore2addrStride64B32Vds::DsStore2addrStride64B32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStore2addrStride64B32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStore2addrStride64B32Vds(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_2addr_stride64_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStore2addrStride64B32Vds>(opcode);
 }
 } // namespace detail
@@ -401,7 +466,12 @@ DsCmpstoreB32Vds::DsCmpstoreB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreB32Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_cmpstore_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreB32Vds>(opcode);
 }
 } // namespace detail
@@ -424,7 +494,11 @@ DsMinNumF32Vds::DsMinNumF32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinNumF32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinNumF32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_num_f32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinNumF32Vds>(opcode);
 }
 } // namespace detail
@@ -447,7 +521,11 @@ DsMaxNumF32Vds::DsMaxNumF32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxNumF32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxNumF32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_num_f32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxNumF32Vds>(opcode);
 }
 } // namespace detail
@@ -460,7 +538,11 @@ DsNopVds::DsNopVds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsNopVds(const MachineInst *opcode) {
+DecodeResult decodeDsNopVds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_nop", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsNopVds>(opcode);
 }
 } // namespace detail
@@ -483,7 +565,11 @@ DsAddF32Vds::DsAddF32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddF32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAddF32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_add_f32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddF32Vds>(opcode);
 }
 } // namespace detail
@@ -504,7 +590,11 @@ DsStoreB8Vds::DsStoreB8Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB8Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB8Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_b8", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB8Vds>(opcode);
 }
 } // namespace detail
@@ -525,7 +615,11 @@ DsStoreB16Vds::DsStoreB16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_b16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB16Vds>(opcode);
 }
 } // namespace detail
@@ -550,7 +644,11 @@ DsAddRtnU32Vds::DsAddRtnU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_add_rtn_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU32Vds>(opcode);
 }
 } // namespace detail
@@ -575,7 +673,11 @@ DsSubRtnU32Vds::DsSubRtnU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_sub_rtn_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU32Vds>(opcode);
 }
 } // namespace detail
@@ -600,7 +702,12 @@ DsRsubRtnU32Vds::DsRsubRtnU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU32Vds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_rsub_rtn_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU32Vds>(opcode);
 }
 } // namespace detail
@@ -625,7 +732,11 @@ DsIncRtnU32Vds::DsIncRtnU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_inc_rtn_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU32Vds>(opcode);
 }
 } // namespace detail
@@ -650,7 +761,11 @@ DsDecRtnU32Vds::DsDecRtnU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_dec_rtn_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU32Vds>(opcode);
 }
 } // namespace detail
@@ -675,7 +790,11 @@ DsMinRtnI32Vds::DsMinRtnI32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_rtn_i32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI32Vds>(opcode);
 }
 } // namespace detail
@@ -700,7 +819,11 @@ DsMaxRtnI32Vds::DsMaxRtnI32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_rtn_i32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI32Vds>(opcode);
 }
 } // namespace detail
@@ -725,7 +848,11 @@ DsMinRtnU32Vds::DsMinRtnU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_rtn_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU32Vds>(opcode);
 }
 } // namespace detail
@@ -750,7 +877,11 @@ DsMaxRtnU32Vds::DsMaxRtnU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_rtn_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU32Vds>(opcode);
 }
 } // namespace detail
@@ -775,7 +906,11 @@ DsAndRtnB32Vds::DsAndRtnB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_and_rtn_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB32Vds>(opcode);
 }
 } // namespace detail
@@ -800,7 +935,11 @@ DsOrRtnB32Vds::DsOrRtnB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_or_rtn_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB32Vds>(opcode);
 }
 } // namespace detail
@@ -825,7 +964,11 @@ DsXorRtnB32Vds::DsXorRtnB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_xor_rtn_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB32Vds>(opcode);
 }
 } // namespace detail
@@ -852,7 +995,12 @@ DsMskorRtnB32Vds::DsMskorRtnB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB32Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_mskor_rtn_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB32Vds>(opcode);
 }
 } // namespace detail
@@ -877,7 +1025,12 @@ DsStorexchgRtnB32Vds::DsStorexchgRtnB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchgRtnB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchgRtnB32Vds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_storexchg_rtn_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchgRtnB32Vds>(opcode);
 }
 } // namespace detail
@@ -904,7 +1057,12 @@ DsStorexchg2addrRtnB32Vds::DsStorexchg2addrRtnB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchg2addrRtnB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchg2addrRtnB32Vds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_storexchg_2addr_rtn_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchg2addrRtnB32Vds>(opcode);
 }
 } // namespace detail
@@ -931,7 +1089,13 @@ DsStorexchg2addrStride64RtnB32Vds::DsStorexchg2addrStride64RtnB32Vds(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchg2addrStride64RtnB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchg2addrStride64RtnB32Vds(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vds::validate_encoding("ds_storexchg_2addr_stride64_rtn_b32",
+                             reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchg2addrStride64RtnB32Vds>(opcode);
 }
 } // namespace detail
@@ -958,7 +1122,12 @@ DsCmpstoreRtnB32Vds::DsCmpstoreRtnB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreRtnB32Vds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_cmpstore_rtn_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreRtnB32Vds>(opcode);
 }
 } // namespace detail
@@ -983,7 +1152,12 @@ DsMinNumRtnF32Vds::DsMinNumRtnF32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinNumRtnF32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinNumRtnF32Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_num_rtn_f32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinNumRtnF32Vds>(opcode);
 }
 } // namespace detail
@@ -1008,7 +1182,12 @@ DsMaxNumRtnF32Vds::DsMaxNumRtnF32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxNumRtnF32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxNumRtnF32Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_num_rtn_f32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxNumRtnF32Vds>(opcode);
 }
 } // namespace detail
@@ -1025,7 +1204,12 @@ DsSwizzleB32Vds::DsSwizzleB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSwizzleB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsSwizzleB32Vds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_swizzle_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSwizzleB32Vds>(opcode);
 }
 } // namespace detail
@@ -1046,7 +1230,11 @@ DsLoadB32Vds::DsLoadB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadB32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadB32Vds>(opcode);
 }
 } // namespace detail
@@ -1067,7 +1255,12 @@ DsLoad2addrB32Vds::DsLoad2addrB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoad2addrB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoad2addrB32Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_2addr_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoad2addrB32Vds>(opcode);
 }
 } // namespace detail
@@ -1088,7 +1281,12 @@ DsLoad2addrStride64B32Vds::DsLoad2addrStride64B32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoad2addrStride64B32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoad2addrStride64B32Vds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_2addr_stride64_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoad2addrStride64B32Vds>(opcode);
 }
 } // namespace detail
@@ -1109,7 +1307,11 @@ DsLoadI8Vds::DsLoadI8Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadI8Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadI8Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_i8", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadI8Vds>(opcode);
 }
 } // namespace detail
@@ -1130,7 +1332,11 @@ DsLoadU8Vds::DsLoadU8Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU8Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU8Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_u8", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU8Vds>(opcode);
 }
 } // namespace detail
@@ -1151,7 +1357,11 @@ DsLoadI16Vds::DsLoadI16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadI16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadI16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_i16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadI16Vds>(opcode);
 }
 } // namespace detail
@@ -1172,7 +1382,11 @@ DsLoadU16Vds::DsLoadU16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_u16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU16Vds>(opcode);
 }
 } // namespace detail
@@ -1193,7 +1407,11 @@ DsConsumeVds::DsConsumeVds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsConsumeVds(const MachineInst *opcode) {
+DecodeResult decodeDsConsumeVds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_consume", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsConsumeVds>(opcode);
 }
 } // namespace detail
@@ -1214,7 +1432,11 @@ DsAppendVds::DsAppendVds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAppendVds(const MachineInst *opcode) {
+DecodeResult decodeDsAppendVds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_append", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAppendVds>(opcode);
 }
 } // namespace detail
@@ -1237,7 +1459,11 @@ DsAddU64Vds::DsAddU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAddU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_add_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddU64Vds>(opcode);
 }
 } // namespace detail
@@ -1260,7 +1486,11 @@ DsSubU64Vds::DsSubU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsSubU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_sub_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubU64Vds>(opcode);
 }
 } // namespace detail
@@ -1283,7 +1513,11 @@ DsRsubU64Vds::DsRsubU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_rsub_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubU64Vds>(opcode);
 }
 } // namespace detail
@@ -1306,7 +1540,11 @@ DsIncU64Vds::DsIncU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsIncU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_inc_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncU64Vds>(opcode);
 }
 } // namespace detail
@@ -1329,7 +1567,11 @@ DsDecU64Vds::DsDecU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsDecU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_dec_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecU64Vds>(opcode);
 }
 } // namespace detail
@@ -1352,7 +1594,11 @@ DsMinI64Vds::DsMinI64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinI64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinI64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_i64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinI64Vds>(opcode);
 }
 } // namespace detail
@@ -1375,7 +1621,11 @@ DsMaxI64Vds::DsMaxI64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxI64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxI64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_i64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxI64Vds>(opcode);
 }
 } // namespace detail
@@ -1398,7 +1648,11 @@ DsMinU64Vds::DsMinU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinU64Vds>(opcode);
 }
 } // namespace detail
@@ -1421,7 +1675,11 @@ DsMaxU64Vds::DsMaxU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxU64Vds>(opcode);
 }
 } // namespace detail
@@ -1444,7 +1702,11 @@ DsAndB64Vds::DsAndB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAndB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_and_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndB64Vds>(opcode);
 }
 } // namespace detail
@@ -1467,7 +1729,11 @@ DsOrB64Vds::DsOrB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsOrB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_or_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrB64Vds>(opcode);
 }
 } // namespace detail
@@ -1490,7 +1756,11 @@ DsXorB64Vds::DsXorB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsXorB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_xor_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorB64Vds>(opcode);
 }
 } // namespace detail
@@ -1515,7 +1785,11 @@ DsMskorB64Vds::DsMskorB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_mskor_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorB64Vds>(opcode);
 }
 } // namespace detail
@@ -1536,7 +1810,11 @@ DsStoreB64Vds::DsStoreB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB64Vds>(opcode);
 }
 } // namespace detail
@@ -1559,7 +1837,12 @@ DsStore2addrB64Vds::DsStore2addrB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStore2addrB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStore2addrB64Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_2addr_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStore2addrB64Vds>(opcode);
 }
 } // namespace detail
@@ -1582,7 +1865,12 @@ DsStore2addrStride64B64Vds::DsStore2addrStride64B64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStore2addrStride64B64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStore2addrStride64B64Vds(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_2addr_stride64_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStore2addrStride64B64Vds>(opcode);
 }
 } // namespace detail
@@ -1607,7 +1895,12 @@ DsCmpstoreB64Vds::DsCmpstoreB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreB64Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_cmpstore_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreB64Vds>(opcode);
 }
 } // namespace detail
@@ -1630,7 +1923,11 @@ DsMinNumF64Vds::DsMinNumF64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinNumF64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinNumF64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_num_f64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinNumF64Vds>(opcode);
 }
 } // namespace detail
@@ -1653,7 +1950,11 @@ DsMaxNumF64Vds::DsMaxNumF64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxNumF64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxNumF64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_num_f64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxNumF64Vds>(opcode);
 }
 } // namespace detail
@@ -1678,7 +1979,11 @@ DsAddRtnU64Vds::DsAddRtnU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_add_rtn_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnU64Vds>(opcode);
 }
 } // namespace detail
@@ -1703,7 +2008,11 @@ DsSubRtnU64Vds::DsSubRtnU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubRtnU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsSubRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_sub_rtn_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubRtnU64Vds>(opcode);
 }
 } // namespace detail
@@ -1728,7 +2037,12 @@ DsRsubRtnU64Vds::DsRsubRtnU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsRsubRtnU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsRsubRtnU64Vds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_rsub_rtn_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsRsubRtnU64Vds>(opcode);
 }
 } // namespace detail
@@ -1753,7 +2067,11 @@ DsIncRtnU64Vds::DsIncRtnU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsIncRtnU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsIncRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_inc_rtn_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsIncRtnU64Vds>(opcode);
 }
 } // namespace detail
@@ -1778,7 +2096,11 @@ DsDecRtnU64Vds::DsDecRtnU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDecRtnU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsDecRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_dec_rtn_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDecRtnU64Vds>(opcode);
 }
 } // namespace detail
@@ -1803,7 +2125,11 @@ DsMinRtnI64Vds::DsMinRtnI64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnI64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnI64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_rtn_i64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnI64Vds>(opcode);
 }
 } // namespace detail
@@ -1828,7 +2154,11 @@ DsMaxRtnI64Vds::DsMaxRtnI64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnI64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnI64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_rtn_i64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnI64Vds>(opcode);
 }
 } // namespace detail
@@ -1853,7 +2183,11 @@ DsMinRtnU64Vds::DsMinRtnU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinRtnU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_rtn_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinRtnU64Vds>(opcode);
 }
 } // namespace detail
@@ -1878,7 +2212,11 @@ DsMaxRtnU64Vds::DsMaxRtnU64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxRtnU64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxRtnU64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_rtn_u64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxRtnU64Vds>(opcode);
 }
 } // namespace detail
@@ -1903,7 +2241,11 @@ DsAndRtnB64Vds::DsAndRtnB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAndRtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAndRtnB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_and_rtn_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAndRtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -1928,7 +2270,11 @@ DsOrRtnB64Vds::DsOrRtnB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsOrRtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsOrRtnB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_or_rtn_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsOrRtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -1953,7 +2299,11 @@ DsXorRtnB64Vds::DsXorRtnB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsXorRtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsXorRtnB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_xor_rtn_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsXorRtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -1980,7 +2330,12 @@ DsMskorRtnB64Vds::DsMskorRtnB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMskorRtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMskorRtnB64Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_mskor_rtn_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMskorRtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -2005,7 +2360,12 @@ DsStorexchgRtnB64Vds::DsStorexchgRtnB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchgRtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchgRtnB64Vds(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_storexchg_rtn_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchgRtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -2032,7 +2392,12 @@ DsStorexchg2addrRtnB64Vds::DsStorexchg2addrRtnB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchg2addrRtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchg2addrRtnB64Vds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_storexchg_2addr_rtn_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchg2addrRtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -2059,7 +2424,13 @@ DsStorexchg2addrStride64RtnB64Vds::DsStorexchg2addrStride64RtnB64Vds(const Machi
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStorexchg2addrStride64RtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStorexchg2addrStride64RtnB64Vds(const MachineInst *opcode,
+                                                     const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vds::validate_encoding("ds_storexchg_2addr_stride64_rtn_b64",
+                             reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStorexchg2addrStride64RtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -2086,7 +2457,12 @@ DsCmpstoreRtnB64Vds::DsCmpstoreRtnB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCmpstoreRtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsCmpstoreRtnB64Vds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_cmpstore_rtn_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCmpstoreRtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -2111,7 +2487,12 @@ DsMinNumRtnF64Vds::DsMinNumRtnF64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMinNumRtnF64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMinNumRtnF64Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_min_num_rtn_f64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMinNumRtnF64Vds>(opcode);
 }
 } // namespace detail
@@ -2136,7 +2517,12 @@ DsMaxNumRtnF64Vds::DsMaxNumRtnF64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsMaxNumRtnF64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsMaxNumRtnF64Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_max_num_rtn_f64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsMaxNumRtnF64Vds>(opcode);
 }
 } // namespace detail
@@ -2157,7 +2543,11 @@ DsLoadB64Vds::DsLoadB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadB64Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadB64Vds>(opcode);
 }
 } // namespace detail
@@ -2178,7 +2568,12 @@ DsLoad2addrB64Vds::DsLoad2addrB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoad2addrB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoad2addrB64Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_2addr_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoad2addrB64Vds>(opcode);
 }
 } // namespace detail
@@ -2199,7 +2594,12 @@ DsLoad2addrStride64B64Vds::DsLoad2addrStride64B64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoad2addrStride64B64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoad2addrStride64B64Vds(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_2addr_stride64_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoad2addrStride64B64Vds>(opcode);
 }
 } // namespace detail
@@ -2224,7 +2624,11 @@ DsAddRtnF32Vds::DsAddRtnF32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsAddRtnF32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsAddRtnF32Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_add_rtn_f32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsAddRtnF32Vds>(opcode);
 }
 } // namespace detail
@@ -2249,7 +2653,12 @@ DsCondxchg32RtnB64Vds::DsCondxchg32RtnB64Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCondxchg32RtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsCondxchg32RtnB64Vds(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_condxchg32_rtn_b64", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCondxchg32RtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -2272,7 +2681,12 @@ DsCondSubU32Vds::DsCondSubU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCondSubU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsCondSubU32Vds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_cond_sub_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCondSubU32Vds>(opcode);
 }
 } // namespace detail
@@ -2295,7 +2709,12 @@ DsSubClampU32Vds::DsSubClampU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubClampU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsSubClampU32Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_sub_clamp_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubClampU32Vds>(opcode);
 }
 } // namespace detail
@@ -2318,7 +2737,11 @@ DsPkAddF16Vds::DsPkAddF16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPkAddF16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsPkAddF16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_pk_add_f16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPkAddF16Vds>(opcode);
 }
 } // namespace detail
@@ -2341,7 +2764,11 @@ DsPkAddBf16Vds::DsPkAddBf16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPkAddBf16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsPkAddBf16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_pk_add_bf16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPkAddBf16Vds>(opcode);
 }
 } // namespace detail
@@ -2362,7 +2789,12 @@ DsStoreB8D16HiVds::DsStoreB8D16HiVds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB8D16HiVds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB8D16HiVds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_b8_d16_hi", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB8D16HiVds>(opcode);
 }
 } // namespace detail
@@ -2383,7 +2815,12 @@ DsStoreB16D16HiVds::DsStoreB16D16HiVds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB16D16HiVds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB16D16HiVds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_b16_d16_hi", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB16D16HiVds>(opcode);
 }
 } // namespace detail
@@ -2404,7 +2841,11 @@ DsLoadU8D16Vds::DsLoadU8D16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU8D16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU8D16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_u8_d16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU8D16Vds>(opcode);
 }
 } // namespace detail
@@ -2431,7 +2872,12 @@ DsLoadU8D16HiVds::DsLoadU8D16HiVds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU8D16HiVds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU8D16HiVds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_u8_d16_hi", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU8D16HiVds>(opcode);
 }
 } // namespace detail
@@ -2458,7 +2904,11 @@ DsLoadI8D16Vds::DsLoadI8D16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadI8D16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadI8D16Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_i8_d16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadI8D16Vds>(opcode);
 }
 } // namespace detail
@@ -2485,7 +2935,12 @@ DsLoadI8D16HiVds::DsLoadI8D16HiVds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadI8D16HiVds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadI8D16HiVds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_i8_d16_hi", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadI8D16HiVds>(opcode);
 }
 } // namespace detail
@@ -2512,7 +2967,12 @@ DsLoadU16D16Vds::DsLoadU16D16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU16D16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU16D16Vds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_u16_d16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU16D16Vds>(opcode);
 }
 } // namespace detail
@@ -2539,7 +2999,12 @@ DsLoadU16D16HiVds::DsLoadU16D16HiVds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadU16D16HiVds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadU16D16HiVds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_u16_d16_hi", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadU16D16HiVds>(opcode);
 }
 } // namespace detail
@@ -2570,7 +3035,12 @@ DsCondSubRtnU32Vds::DsCondSubRtnU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsCondSubRtnU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsCondSubRtnU32Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_cond_sub_rtn_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsCondSubRtnU32Vds>(opcode);
 }
 } // namespace detail
@@ -2595,7 +3065,12 @@ DsSubClampRtnU32Vds::DsSubClampRtnU32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsSubClampRtnU32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsSubClampRtnU32Vds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_sub_clamp_rtn_u32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsSubClampRtnU32Vds>(opcode);
 }
 } // namespace detail
@@ -2620,7 +3095,12 @@ DsPkAddRtnF16Vds::DsPkAddRtnF16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPkAddRtnF16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsPkAddRtnF16Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_pk_add_rtn_f16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPkAddRtnF16Vds>(opcode);
 }
 } // namespace detail
@@ -2645,7 +3125,12 @@ DsPkAddRtnBf16Vds::DsPkAddRtnBf16Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPkAddRtnBf16Vds(const MachineInst *opcode) {
+DecodeResult decodeDsPkAddRtnBf16Vds(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_pk_add_rtn_bf16", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPkAddRtnBf16Vds>(opcode);
 }
 } // namespace detail
@@ -2666,7 +3151,12 @@ DsStoreAddtidB32Vds::DsStoreAddtidB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreAddtidB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreAddtidB32Vds(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_addtid_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreAddtidB32Vds>(opcode);
 }
 } // namespace detail
@@ -2687,7 +3177,12 @@ DsLoadAddtidB32Vds::DsLoadAddtidB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadAddtidB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadAddtidB32Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_addtid_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadAddtidB32Vds>(opcode);
 }
 } // namespace detail
@@ -2706,7 +3201,12 @@ DsPermuteB32Vds::DsPermuteB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsPermuteB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsPermuteB32Vds(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_permute_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsPermuteB32Vds>(opcode);
 }
 } // namespace detail
@@ -2725,7 +3225,12 @@ DsBpermuteB32Vds::DsBpermuteB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsBpermuteB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsBpermuteB32Vds(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_bpermute_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsBpermuteB32Vds>(opcode);
 }
 } // namespace detail
@@ -2744,7 +3249,12 @@ DsBpermuteFiB32Vds::DsBpermuteFiB32Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsBpermuteFiB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsBpermuteFiB32Vds(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_bpermute_fi_b32", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsBpermuteFiB32Vds>(opcode);
 }
 } // namespace detail
@@ -2765,7 +3275,11 @@ DsStoreB96Vds::DsStoreB96Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB96Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB96Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_b96", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB96Vds>(opcode);
 }
 } // namespace detail
@@ -2786,7 +3300,11 @@ DsStoreB128Vds::DsStoreB128Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsStoreB128Vds(const MachineInst *opcode) {
+DecodeResult decodeDsStoreB128Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_store_b128", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsStoreB128Vds>(opcode);
 }
 } // namespace detail
@@ -2808,7 +3326,13 @@ DsBvhStackPush4Pop1RtnB32Vds::DsBvhStackPush4Pop1RtnB32Vds(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsBvhStackPush4Pop1RtnB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsBvhStackPush4Pop1RtnB32Vds(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vds::validate_encoding("ds_bvh_stack_push4_pop1_rtn_b32",
+                             reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsBvhStackPush4Pop1RtnB32Vds>(opcode);
 }
 } // namespace detail
@@ -2830,7 +3354,13 @@ DsBvhStackPush8Pop1RtnB32Vds::DsBvhStackPush8Pop1RtnB32Vds(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsBvhStackPush8Pop1RtnB32Vds(const MachineInst *opcode) {
+DecodeResult decodeDsBvhStackPush8Pop1RtnB32Vds(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vds::validate_encoding("ds_bvh_stack_push8_pop1_rtn_b32",
+                             reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsBvhStackPush8Pop1RtnB32Vds>(opcode);
 }
 } // namespace detail
@@ -2852,7 +3382,13 @@ DsBvhStackPush8Pop2RtnB64Vds::DsBvhStackPush8Pop2RtnB64Vds(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsBvhStackPush8Pop2RtnB64Vds(const MachineInst *opcode) {
+DecodeResult decodeDsBvhStackPush8Pop2RtnB64Vds(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vds::validate_encoding("ds_bvh_stack_push8_pop2_rtn_b64",
+                             reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsBvhStackPush8Pop2RtnB64Vds>(opcode);
 }
 } // namespace detail
@@ -2873,7 +3409,11 @@ DsLoadB96Vds::DsLoadB96Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadB96Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadB96Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_b96", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadB96Vds>(opcode);
 }
 } // namespace detail
@@ -2894,7 +3434,11 @@ DsLoadB128Vds::DsLoadB128Vds(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsLoadB128Vds(const MachineInst *opcode) {
+DecodeResult decodeDsLoadB128Vds(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vds::validate_encoding(
+      "ds_load_b128", reinterpret_cast<const Vds::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsLoadB128Vds>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vdsdir.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vdsdir.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vdsdir.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -29,7 +28,12 @@ DsParamLoadVdsdir::DsParamLoadVdsdir(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsParamLoadVdsdir(const MachineInst *opcode) {
+DecodeResult decodeDsParamLoadVdsdir(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vdsdir::validate_encoding(
+      "ds_param_load", reinterpret_cast<const Vdsdir::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsParamLoadVdsdir>(opcode);
 }
 } // namespace detail
@@ -49,7 +53,12 @@ DsDirectLoadVdsdir::DsDirectLoadVdsdir(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeDsDirectLoadVdsdir(const MachineInst *opcode) {
+DecodeResult decodeDsDirectLoadVdsdir(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vdsdir::validate_encoding(
+      "ds_direct_load", reinterpret_cast<const Vdsdir::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<DsDirectLoadVdsdir>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vexport.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vexport.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vexport.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -35,7 +34,11 @@ ExportVexport::ExportVexport(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeExportVexport(const MachineInst *opcode) {
+DecodeResult decodeExportVexport(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  Result validation = Vexport::validate_encoding(
+      "export", reinterpret_cast<const Vexport::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ExportVexport>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vflat.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vflat.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vflat.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -37,7 +36,12 @@ FlatLoadU8Vflat::FlatLoadU8Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadU8Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadU8Vflat(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_u8", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadU8Vflat>(opcode);
 }
 } // namespace detail
@@ -59,7 +63,12 @@ FlatLoadI8Vflat::FlatLoadI8Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadI8Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadI8Vflat(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_i8", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadI8Vflat>(opcode);
 }
 } // namespace detail
@@ -81,7 +90,12 @@ FlatLoadU16Vflat::FlatLoadU16Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadU16Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadU16Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_u16", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadU16Vflat>(opcode);
 }
 } // namespace detail
@@ -103,7 +117,12 @@ FlatLoadI16Vflat::FlatLoadI16Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadI16Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadI16Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_i16", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadI16Vflat>(opcode);
 }
 } // namespace detail
@@ -125,7 +144,12 @@ FlatLoadB32Vflat::FlatLoadB32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadB32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadB32Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_b32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadB32Vflat>(opcode);
 }
 } // namespace detail
@@ -147,7 +171,12 @@ FlatLoadB64Vflat::FlatLoadB64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadB64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadB64Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_b64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadB64Vflat>(opcode);
 }
 } // namespace detail
@@ -169,7 +198,12 @@ FlatLoadB96Vflat::FlatLoadB96Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadB96Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadB96Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_b96", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadB96Vflat>(opcode);
 }
 } // namespace detail
@@ -191,7 +225,12 @@ FlatLoadB128Vflat::FlatLoadB128Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadB128Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadB128Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_b128", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadB128Vflat>(opcode);
 }
 } // namespace detail
@@ -213,7 +252,12 @@ FlatStoreB8Vflat::FlatStoreB8Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB8Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB8Vflat(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_store_b8", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB8Vflat>(opcode);
 }
 } // namespace detail
@@ -235,7 +279,12 @@ FlatStoreB16Vflat::FlatStoreB16Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB16Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB16Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_store_b16", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB16Vflat>(opcode);
 }
 } // namespace detail
@@ -257,7 +306,12 @@ FlatStoreB32Vflat::FlatStoreB32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB32Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_store_b32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB32Vflat>(opcode);
 }
 } // namespace detail
@@ -279,7 +333,12 @@ FlatStoreB64Vflat::FlatStoreB64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB64Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_store_b64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB64Vflat>(opcode);
 }
 } // namespace detail
@@ -301,7 +360,12 @@ FlatStoreB96Vflat::FlatStoreB96Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB96Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB96Vflat(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_store_b96", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB96Vflat>(opcode);
 }
 } // namespace detail
@@ -323,7 +387,12 @@ FlatStoreB128Vflat::FlatStoreB128Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreB128Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreB128Vflat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_store_b128", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreB128Vflat>(opcode);
 }
 } // namespace detail
@@ -345,7 +414,12 @@ FlatLoadD16U8Vflat::FlatLoadD16U8Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16U8Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16U8Vflat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_d16_u8", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16U8Vflat>(opcode);
 }
 } // namespace detail
@@ -373,7 +447,12 @@ FlatLoadD16I8Vflat::FlatLoadD16I8Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16I8Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16I8Vflat(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_d16_i8", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16I8Vflat>(opcode);
 }
 } // namespace detail
@@ -401,7 +480,12 @@ FlatLoadD16B16Vflat::FlatLoadD16B16Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16B16Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16B16Vflat(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_d16_b16", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16B16Vflat>(opcode);
 }
 } // namespace detail
@@ -429,7 +513,12 @@ FlatLoadD16HiU8Vflat::FlatLoadD16HiU8Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16HiU8Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16HiU8Vflat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_d16_hi_u8", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16HiU8Vflat>(opcode);
 }
 } // namespace detail
@@ -457,7 +546,12 @@ FlatLoadD16HiI8Vflat::FlatLoadD16HiI8Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16HiI8Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16HiI8Vflat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_d16_hi_i8", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16HiI8Vflat>(opcode);
 }
 } // namespace detail
@@ -485,7 +579,12 @@ FlatLoadD16HiB16Vflat::FlatLoadD16HiB16Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatLoadD16HiB16Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatLoadD16HiB16Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_load_d16_hi_b16", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatLoadD16HiB16Vflat>(opcode);
 }
 } // namespace detail
@@ -513,7 +612,12 @@ FlatStoreD16HiB8Vflat::FlatStoreD16HiB8Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreD16HiB8Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreD16HiB8Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_store_d16_hi_b8", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreD16HiB8Vflat>(opcode);
 }
 } // namespace detail
@@ -535,7 +639,12 @@ FlatStoreD16HiB16Vflat::FlatStoreD16HiB16Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatStoreD16HiB16Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatStoreD16HiB16Vflat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_store_d16_hi_b16", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatStoreD16HiB16Vflat>(opcode);
 }
 } // namespace detail
@@ -562,7 +671,12 @@ FlatAtomicSwapB32Vflat::FlatAtomicSwapB32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapB32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapB32Vflat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_swap_b32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapB32Vflat>(opcode);
 }
 } // namespace detail
@@ -589,7 +703,12 @@ FlatAtomicCmpswapB32Vflat::FlatAtomicCmpswapB32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapB32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapB32Vflat(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_cmpswap_b32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapB32Vflat>(opcode);
 }
 } // namespace detail
@@ -616,7 +735,12 @@ FlatAtomicAddU32Vflat::FlatAtomicAddU32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddU32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_add_u32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddU32Vflat>(opcode);
 }
 } // namespace detail
@@ -643,7 +767,12 @@ FlatAtomicSubU32Vflat::FlatAtomicSubU32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubU32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_sub_u32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubU32Vflat>(opcode);
 }
 } // namespace detail
@@ -670,7 +799,12 @@ FlatAtomicSubClampU32Vflat::FlatAtomicSubClampU32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubClampU32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubClampU32Vflat(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_sub_clamp_u32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubClampU32Vflat>(opcode);
 }
 } // namespace detail
@@ -697,7 +831,12 @@ FlatAtomicMinI32Vflat::FlatAtomicMinI32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinI32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinI32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_min_i32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinI32Vflat>(opcode);
 }
 } // namespace detail
@@ -724,7 +863,12 @@ FlatAtomicMinU32Vflat::FlatAtomicMinU32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinU32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_min_u32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinU32Vflat>(opcode);
 }
 } // namespace detail
@@ -751,7 +895,12 @@ FlatAtomicMaxI32Vflat::FlatAtomicMaxI32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxI32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxI32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_max_i32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxI32Vflat>(opcode);
 }
 } // namespace detail
@@ -778,7 +927,12 @@ FlatAtomicMaxU32Vflat::FlatAtomicMaxU32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxU32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_max_u32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxU32Vflat>(opcode);
 }
 } // namespace detail
@@ -805,7 +959,12 @@ FlatAtomicAndB32Vflat::FlatAtomicAndB32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndB32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndB32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_and_b32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndB32Vflat>(opcode);
 }
 } // namespace detail
@@ -832,7 +991,12 @@ FlatAtomicOrB32Vflat::FlatAtomicOrB32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrB32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrB32Vflat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_or_b32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrB32Vflat>(opcode);
 }
 } // namespace detail
@@ -859,7 +1023,12 @@ FlatAtomicXorB32Vflat::FlatAtomicXorB32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorB32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorB32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_xor_b32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorB32Vflat>(opcode);
 }
 } // namespace detail
@@ -886,7 +1055,12 @@ FlatAtomicIncU32Vflat::FlatAtomicIncU32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncU32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_inc_u32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncU32Vflat>(opcode);
 }
 } // namespace detail
@@ -913,7 +1087,12 @@ FlatAtomicDecU32Vflat::FlatAtomicDecU32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecU32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecU32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_dec_u32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecU32Vflat>(opcode);
 }
 } // namespace detail
@@ -940,7 +1119,12 @@ FlatAtomicSwapB64Vflat::FlatAtomicSwapB64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSwapB64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSwapB64Vflat(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_swap_b64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSwapB64Vflat>(opcode);
 }
 } // namespace detail
@@ -967,7 +1151,12 @@ FlatAtomicCmpswapB64Vflat::FlatAtomicCmpswapB64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCmpswapB64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCmpswapB64Vflat(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_cmpswap_b64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCmpswapB64Vflat>(opcode);
 }
 } // namespace detail
@@ -994,7 +1183,12 @@ FlatAtomicAddU64Vflat::FlatAtomicAddU64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddU64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_add_u64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddU64Vflat>(opcode);
 }
 } // namespace detail
@@ -1021,7 +1215,12 @@ FlatAtomicSubU64Vflat::FlatAtomicSubU64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicSubU64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicSubU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_sub_u64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicSubU64Vflat>(opcode);
 }
 } // namespace detail
@@ -1048,7 +1247,12 @@ FlatAtomicMinI64Vflat::FlatAtomicMinI64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinI64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinI64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_min_i64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinI64Vflat>(opcode);
 }
 } // namespace detail
@@ -1075,7 +1279,12 @@ FlatAtomicMinU64Vflat::FlatAtomicMinU64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinU64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_min_u64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinU64Vflat>(opcode);
 }
 } // namespace detail
@@ -1102,7 +1311,12 @@ FlatAtomicMaxI64Vflat::FlatAtomicMaxI64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxI64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxI64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_max_i64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxI64Vflat>(opcode);
 }
 } // namespace detail
@@ -1129,7 +1343,12 @@ FlatAtomicMaxU64Vflat::FlatAtomicMaxU64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxU64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_max_u64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxU64Vflat>(opcode);
 }
 } // namespace detail
@@ -1156,7 +1375,12 @@ FlatAtomicAndB64Vflat::FlatAtomicAndB64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAndB64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAndB64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_and_b64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAndB64Vflat>(opcode);
 }
 } // namespace detail
@@ -1183,7 +1407,12 @@ FlatAtomicOrB64Vflat::FlatAtomicOrB64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicOrB64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicOrB64Vflat(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_or_b64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicOrB64Vflat>(opcode);
 }
 } // namespace detail
@@ -1210,7 +1439,12 @@ FlatAtomicXorB64Vflat::FlatAtomicXorB64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicXorB64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicXorB64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_xor_b64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicXorB64Vflat>(opcode);
 }
 } // namespace detail
@@ -1237,7 +1471,12 @@ FlatAtomicIncU64Vflat::FlatAtomicIncU64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicIncU64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicIncU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_inc_u64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicIncU64Vflat>(opcode);
 }
 } // namespace detail
@@ -1264,7 +1503,12 @@ FlatAtomicDecU64Vflat::FlatAtomicDecU64Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicDecU64Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicDecU64Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_dec_u64", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicDecU64Vflat>(opcode);
 }
 } // namespace detail
@@ -1291,7 +1535,12 @@ FlatAtomicCondSubU32Vflat::FlatAtomicCondSubU32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicCondSubU32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicCondSubU32Vflat(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_cond_sub_u32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicCondSubU32Vflat>(opcode);
 }
 } // namespace detail
@@ -1318,7 +1567,12 @@ FlatAtomicMinNumF32Vflat::FlatAtomicMinNumF32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMinNumF32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMinNumF32Vflat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_min_num_f32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMinNumF32Vflat>(opcode);
 }
 } // namespace detail
@@ -1345,7 +1599,12 @@ FlatAtomicMaxNumF32Vflat::FlatAtomicMaxNumF32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicMaxNumF32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicMaxNumF32Vflat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_max_num_f32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicMaxNumF32Vflat>(opcode);
 }
 } // namespace detail
@@ -1372,7 +1631,12 @@ FlatAtomicAddF32Vflat::FlatAtomicAddF32Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicAddF32Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicAddF32Vflat(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_add_f32", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicAddF32Vflat>(opcode);
 }
 } // namespace detail
@@ -1399,7 +1663,12 @@ FlatAtomicPkAddF16Vflat::FlatAtomicPkAddF16Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicPkAddF16Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicPkAddF16Vflat(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_pk_add_f16", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicPkAddF16Vflat>(opcode);
 }
 } // namespace detail
@@ -1426,7 +1695,12 @@ FlatAtomicPkAddBf16Vflat::FlatAtomicPkAddBf16Vflat(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeFlatAtomicPkAddBf16Vflat(const MachineInst *opcode) {
+DecodeResult decodeFlatAtomicPkAddBf16Vflat(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vflat::validate_encoding(
+      "flat_atomic_pk_add_bf16", reinterpret_cast<const Vflat::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<FlatAtomicPkAddBf16Vflat>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vglobal.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vglobal.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vglobal.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -40,7 +39,12 @@ GlobalLoadU8Vglobal::GlobalLoadU8Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadU8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadU8Vglobal(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_u8", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadU8Vglobal>(opcode);
 }
 } // namespace detail
@@ -65,7 +69,12 @@ GlobalLoadI8Vglobal::GlobalLoadI8Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadI8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadI8Vglobal(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_i8", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadI8Vglobal>(opcode);
 }
 } // namespace detail
@@ -90,7 +99,12 @@ GlobalLoadU16Vglobal::GlobalLoadU16Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadU16Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadU16Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_u16", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadU16Vglobal>(opcode);
 }
 } // namespace detail
@@ -115,7 +129,12 @@ GlobalLoadI16Vglobal::GlobalLoadI16Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadI16Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadI16Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_i16", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadI16Vglobal>(opcode);
 }
 } // namespace detail
@@ -140,7 +159,12 @@ GlobalLoadB32Vglobal::GlobalLoadB32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadB32Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_b32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -165,7 +189,12 @@ GlobalLoadB64Vglobal::GlobalLoadB64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadB64Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_b64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -190,7 +219,12 @@ GlobalLoadB96Vglobal::GlobalLoadB96Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadB96Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadB96Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_b96", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadB96Vglobal>(opcode);
 }
 } // namespace detail
@@ -215,7 +249,12 @@ GlobalLoadB128Vglobal::GlobalLoadB128Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadB128Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadB128Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_b128", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadB128Vglobal>(opcode);
 }
 } // namespace detail
@@ -240,7 +279,12 @@ GlobalStoreB8Vglobal::GlobalStoreB8Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreB8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreB8Vglobal(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_b8", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreB8Vglobal>(opcode);
 }
 } // namespace detail
@@ -265,7 +309,12 @@ GlobalStoreB16Vglobal::GlobalStoreB16Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreB16Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreB16Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_b16", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreB16Vglobal>(opcode);
 }
 } // namespace detail
@@ -290,7 +339,12 @@ GlobalStoreB32Vglobal::GlobalStoreB32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreB32Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_b32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -315,7 +369,12 @@ GlobalStoreB64Vglobal::GlobalStoreB64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreB64Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_b64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -340,7 +399,12 @@ GlobalStoreB96Vglobal::GlobalStoreB96Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreB96Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreB96Vglobal(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_b96", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreB96Vglobal>(opcode);
 }
 } // namespace detail
@@ -365,7 +429,12 @@ GlobalStoreB128Vglobal::GlobalStoreB128Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreB128Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreB128Vglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_b128", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreB128Vglobal>(opcode);
 }
 } // namespace detail
@@ -390,7 +459,12 @@ GlobalLoadD16U8Vglobal::GlobalLoadD16U8Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadD16U8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadD16U8Vglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_d16_u8", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadD16U8Vglobal>(opcode);
 }
 } // namespace detail
@@ -421,7 +495,12 @@ GlobalLoadD16I8Vglobal::GlobalLoadD16I8Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadD16I8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadD16I8Vglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_d16_i8", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadD16I8Vglobal>(opcode);
 }
 } // namespace detail
@@ -452,7 +531,12 @@ GlobalLoadD16B16Vglobal::GlobalLoadD16B16Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadD16B16Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadD16B16Vglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_d16_b16", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadD16B16Vglobal>(opcode);
 }
 } // namespace detail
@@ -483,7 +567,12 @@ GlobalLoadD16HiU8Vglobal::GlobalLoadD16HiU8Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadD16HiU8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadD16HiU8Vglobal(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_d16_hi_u8", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadD16HiU8Vglobal>(opcode);
 }
 } // namespace detail
@@ -514,7 +603,12 @@ GlobalLoadD16HiI8Vglobal::GlobalLoadD16HiI8Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadD16HiI8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadD16HiI8Vglobal(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_d16_hi_i8", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadD16HiI8Vglobal>(opcode);
 }
 } // namespace detail
@@ -545,7 +639,12 @@ GlobalLoadD16HiB16Vglobal::GlobalLoadD16HiB16Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadD16HiB16Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadD16HiB16Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_d16_hi_b16", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadD16HiB16Vglobal>(opcode);
 }
 } // namespace detail
@@ -576,7 +675,12 @@ GlobalStoreD16HiB8Vglobal::GlobalStoreD16HiB8Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreD16HiB8Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreD16HiB8Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_d16_hi_b8", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreD16HiB8Vglobal>(opcode);
 }
 } // namespace detail
@@ -601,7 +705,12 @@ GlobalStoreD16HiB16Vglobal::GlobalStoreD16HiB16Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreD16HiB16Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreD16HiB16Vglobal(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_d16_hi_b16", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreD16HiB16Vglobal>(opcode);
 }
 } // namespace detail
@@ -623,7 +732,12 @@ GlobalLoadAddtidB32Vglobal::GlobalLoadAddtidB32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadAddtidB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadAddtidB32Vglobal(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_addtid_b32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadAddtidB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -645,7 +759,12 @@ GlobalStoreAddtidB32Vglobal::GlobalStoreAddtidB32Vglobal(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreAddtidB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreAddtidB32Vglobal(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_addtid_b32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreAddtidB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -658,7 +777,12 @@ GlobalInvVglobal::GlobalInvVglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalInvVglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalInvVglobal(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_inv", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalInvVglobal>(opcode);
 }
 } // namespace detail
@@ -671,7 +795,12 @@ GlobalWbVglobal::GlobalWbVglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalWbVglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalWbVglobal(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_wb", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalWbVglobal>(opcode);
 }
 } // namespace detail
@@ -701,7 +830,12 @@ GlobalAtomicSwapB32Vglobal::GlobalAtomicSwapB32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicSwapB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicSwapB32Vglobal(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_swap_b32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicSwapB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -731,7 +865,13 @@ GlobalAtomicCmpswapB32Vglobal::GlobalAtomicCmpswapB32Vglobal(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicCmpswapB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicCmpswapB32Vglobal(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_cmpswap_b32",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicCmpswapB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -761,7 +901,12 @@ GlobalAtomicAddU32Vglobal::GlobalAtomicAddU32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicAddU32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicAddU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_add_u32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicAddU32Vglobal>(opcode);
 }
 } // namespace detail
@@ -791,7 +936,12 @@ GlobalAtomicSubU32Vglobal::GlobalAtomicSubU32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicSubU32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicSubU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_sub_u32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicSubU32Vglobal>(opcode);
 }
 } // namespace detail
@@ -821,7 +971,13 @@ GlobalAtomicSubClampU32Vglobal::GlobalAtomicSubClampU32Vglobal(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicSubClampU32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicSubClampU32Vglobal(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_sub_clamp_u32",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicSubClampU32Vglobal>(opcode);
 }
 } // namespace detail
@@ -851,7 +1007,12 @@ GlobalAtomicMinI32Vglobal::GlobalAtomicMinI32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMinI32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMinI32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_min_i32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMinI32Vglobal>(opcode);
 }
 } // namespace detail
@@ -881,7 +1042,12 @@ GlobalAtomicMinU32Vglobal::GlobalAtomicMinU32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMinU32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMinU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_min_u32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMinU32Vglobal>(opcode);
 }
 } // namespace detail
@@ -911,7 +1077,12 @@ GlobalAtomicMaxI32Vglobal::GlobalAtomicMaxI32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxI32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMaxI32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_max_i32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMaxI32Vglobal>(opcode);
 }
 } // namespace detail
@@ -941,7 +1112,12 @@ GlobalAtomicMaxU32Vglobal::GlobalAtomicMaxU32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxU32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMaxU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_max_u32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMaxU32Vglobal>(opcode);
 }
 } // namespace detail
@@ -971,7 +1147,12 @@ GlobalAtomicAndB32Vglobal::GlobalAtomicAndB32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicAndB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicAndB32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_and_b32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicAndB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1001,7 +1182,12 @@ GlobalAtomicOrB32Vglobal::GlobalAtomicOrB32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicOrB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicOrB32Vglobal(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_or_b32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicOrB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1031,7 +1217,12 @@ GlobalAtomicXorB32Vglobal::GlobalAtomicXorB32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicXorB32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicXorB32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_xor_b32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicXorB32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1061,7 +1252,12 @@ GlobalAtomicIncU32Vglobal::GlobalAtomicIncU32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicIncU32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicIncU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_inc_u32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicIncU32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1091,7 +1287,12 @@ GlobalAtomicDecU32Vglobal::GlobalAtomicDecU32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicDecU32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicDecU32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_dec_u32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicDecU32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1121,7 +1322,12 @@ GlobalAtomicSwapB64Vglobal::GlobalAtomicSwapB64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicSwapB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicSwapB64Vglobal(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_swap_b64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicSwapB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1151,7 +1357,13 @@ GlobalAtomicCmpswapB64Vglobal::GlobalAtomicCmpswapB64Vglobal(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicCmpswapB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicCmpswapB64Vglobal(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_cmpswap_b64",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicCmpswapB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1181,7 +1393,12 @@ GlobalAtomicAddU64Vglobal::GlobalAtomicAddU64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicAddU64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicAddU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_add_u64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicAddU64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1211,7 +1428,12 @@ GlobalAtomicSubU64Vglobal::GlobalAtomicSubU64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicSubU64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicSubU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_sub_u64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicSubU64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1241,7 +1463,12 @@ GlobalAtomicMinI64Vglobal::GlobalAtomicMinI64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMinI64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMinI64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_min_i64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMinI64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1271,7 +1498,12 @@ GlobalAtomicMinU64Vglobal::GlobalAtomicMinU64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMinU64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMinU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_min_u64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMinU64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1301,7 +1533,12 @@ GlobalAtomicMaxI64Vglobal::GlobalAtomicMaxI64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxI64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMaxI64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_max_i64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMaxI64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1331,7 +1568,12 @@ GlobalAtomicMaxU64Vglobal::GlobalAtomicMaxU64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxU64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMaxU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_max_u64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMaxU64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1361,7 +1603,12 @@ GlobalAtomicAndB64Vglobal::GlobalAtomicAndB64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicAndB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicAndB64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_and_b64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicAndB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1391,7 +1638,12 @@ GlobalAtomicOrB64Vglobal::GlobalAtomicOrB64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicOrB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicOrB64Vglobal(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_or_b64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicOrB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1421,7 +1673,12 @@ GlobalAtomicXorB64Vglobal::GlobalAtomicXorB64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicXorB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicXorB64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_xor_b64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicXorB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1451,7 +1708,12 @@ GlobalAtomicIncU64Vglobal::GlobalAtomicIncU64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicIncU64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicIncU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_inc_u64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicIncU64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1481,7 +1743,12 @@ GlobalAtomicDecU64Vglobal::GlobalAtomicDecU64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicDecU64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicDecU64Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_dec_u64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicDecU64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1494,7 +1761,12 @@ GlobalWbinvVglobal::GlobalWbinvVglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalWbinvVglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalWbinvVglobal(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_wbinv", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalWbinvVglobal>(opcode);
 }
 } // namespace detail
@@ -1524,7 +1796,13 @@ GlobalAtomicCondSubU32Vglobal::GlobalAtomicCondSubU32Vglobal(const MachineInst *
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicCondSubU32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicCondSubU32Vglobal(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_cond_sub_u32",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicCondSubU32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1554,7 +1832,13 @@ GlobalAtomicMinNumF32Vglobal::GlobalAtomicMinNumF32Vglobal(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMinNumF32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMinNumF32Vglobal(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_min_num_f32",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMinNumF32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1584,7 +1868,13 @@ GlobalAtomicMaxNumF32Vglobal::GlobalAtomicMaxNumF32Vglobal(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicMaxNumF32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicMaxNumF32Vglobal(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_max_num_f32",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicMaxNumF32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1611,7 +1901,12 @@ GlobalLoadBlockVglobal::GlobalLoadBlockVglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadBlockVglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadBlockVglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_block", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadBlockVglobal>(opcode);
 }
 } // namespace detail
@@ -1638,7 +1933,12 @@ GlobalStoreBlockVglobal::GlobalStoreBlockVglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalStoreBlockVglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalStoreBlockVglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_store_block", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalStoreBlockVglobal>(opcode);
 }
 } // namespace detail
@@ -1668,7 +1968,12 @@ GlobalAtomicAddF32Vglobal::GlobalAtomicAddF32Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicAddF32Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicAddF32Vglobal(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_atomic_add_f32", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicAddF32Vglobal>(opcode);
 }
 } // namespace detail
@@ -1693,7 +1998,12 @@ GlobalLoadTrB128Vglobal::GlobalLoadTrB128Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadTrB128Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadTrB128Vglobal(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_tr_b128", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadTrB128Vglobal>(opcode);
 }
 } // namespace detail
@@ -1718,7 +2028,12 @@ GlobalLoadTrB64Vglobal::GlobalLoadTrB64Vglobal(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalLoadTrB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalLoadTrB64Vglobal(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vglobal::validate_encoding(
+      "global_load_tr_b64", reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalLoadTrB64Vglobal>(opcode);
 }
 } // namespace detail
@@ -1748,7 +2063,13 @@ GlobalAtomicPkAddF16Vglobal::GlobalAtomicPkAddF16Vglobal(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicPkAddF16Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicPkAddF16Vglobal(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_pk_add_f16",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicPkAddF16Vglobal>(opcode);
 }
 } // namespace detail
@@ -1778,7 +2099,13 @@ GlobalAtomicPkAddBf16Vglobal::GlobalAtomicPkAddBf16Vglobal(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicPkAddBf16Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicPkAddBf16Vglobal(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_pk_add_bf16",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicPkAddBf16Vglobal>(opcode);
 }
 } // namespace detail
@@ -1808,7 +2135,13 @@ GlobalAtomicOrderedAddB64Vglobal::GlobalAtomicOrderedAddB64Vglobal(const Machine
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeGlobalAtomicOrderedAddB64Vglobal(const MachineInst *opcode) {
+DecodeResult decodeGlobalAtomicOrderedAddB64Vglobal(const MachineInst *opcode,
+                                                    const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vglobal::validate_encoding("global_atomic_ordered_add_b64",
+                                 reinterpret_cast<const Vglobal::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<GlobalAtomicOrderedAddB64Vglobal>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vimage.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vimage.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vimage.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -27,7 +26,12 @@ ImageLoadVimage::ImageLoadVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadVimage(const MachineInst *opcode) {
+DecodeResult decodeImageLoadVimage(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_load", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadVimage>(opcode);
 }
 } // namespace detail
@@ -47,7 +51,12 @@ ImageLoadMipVimage::ImageLoadMipVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipVimage(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipVimage(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_load_mip", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipVimage>(opcode);
 }
 } // namespace detail
@@ -67,7 +76,12 @@ ImageLoadPckVimage::ImageLoadPckVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadPckVimage(const MachineInst *opcode) {
+DecodeResult decodeImageLoadPckVimage(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_load_pck", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadPckVimage>(opcode);
 }
 } // namespace detail
@@ -87,7 +101,12 @@ ImageLoadPckSgnVimage::ImageLoadPckSgnVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadPckSgnVimage(const MachineInst *opcode) {
+DecodeResult decodeImageLoadPckSgnVimage(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_load_pck_sgn", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadPckSgnVimage>(opcode);
 }
 } // namespace detail
@@ -107,7 +126,12 @@ ImageLoadMipPckVimage::ImageLoadMipPckVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipPckVimage(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipPckVimage(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_load_mip_pck", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipPckVimage>(opcode);
 }
 } // namespace detail
@@ -127,7 +151,12 @@ ImageLoadMipPckSgnVimage::ImageLoadMipPckSgnVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageLoadMipPckSgnVimage(const MachineInst *opcode) {
+DecodeResult decodeImageLoadMipPckSgnVimage(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_load_mip_pck_sgn", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageLoadMipPckSgnVimage>(opcode);
 }
 } // namespace detail
@@ -147,7 +176,12 @@ ImageStoreVimage::ImageStoreVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreVimage(const MachineInst *opcode) {
+DecodeResult decodeImageStoreVimage(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_store", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreVimage>(opcode);
 }
 } // namespace detail
@@ -167,7 +201,12 @@ ImageStoreMipVimage::ImageStoreMipVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipVimage(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipVimage(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_store_mip", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipVimage>(opcode);
 }
 } // namespace detail
@@ -187,7 +226,12 @@ ImageStorePckVimage::ImageStorePckVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStorePckVimage(const MachineInst *opcode) {
+DecodeResult decodeImageStorePckVimage(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_store_pck", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStorePckVimage>(opcode);
 }
 } // namespace detail
@@ -207,7 +251,12 @@ ImageStoreMipPckVimage::ImageStoreMipPckVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageStoreMipPckVimage(const MachineInst *opcode) {
+DecodeResult decodeImageStoreMipPckVimage(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_store_mip_pck", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageStoreMipPckVimage>(opcode);
 }
 } // namespace detail
@@ -233,7 +282,12 @@ ImageAtomicSwapVimage::ImageAtomicSwapVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSwapVimage(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSwapVimage(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_atomic_swap", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSwapVimage>(opcode);
 }
 } // namespace detail
@@ -259,7 +313,12 @@ ImageAtomicCmpswapVimage::ImageAtomicCmpswapVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicCmpswapVimage(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicCmpswapVimage(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_atomic_cmpswap", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicCmpswapVimage>(opcode);
 }
 } // namespace detail
@@ -285,7 +344,12 @@ ImageAtomicAddUintVimage::ImageAtomicAddUintVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicAddUintVimage(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicAddUintVimage(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_atomic_add_uint", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicAddUintVimage>(opcode);
 }
 } // namespace detail
@@ -311,7 +375,12 @@ ImageAtomicSubUintVimage::ImageAtomicSubUintVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicSubUintVimage(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicSubUintVimage(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_atomic_sub_uint", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicSubUintVimage>(opcode);
 }
 } // namespace detail
@@ -337,7 +406,12 @@ ImageAtomicMinIntVimage::ImageAtomicMinIntVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicMinIntVimage(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicMinIntVimage(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_atomic_min_int", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicMinIntVimage>(opcode);
 }
 } // namespace detail
@@ -363,7 +437,12 @@ ImageAtomicMinUintVimage::ImageAtomicMinUintVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicMinUintVimage(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicMinUintVimage(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_atomic_min_uint", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicMinUintVimage>(opcode);
 }
 } // namespace detail
@@ -389,7 +468,12 @@ ImageAtomicMaxIntVimage::ImageAtomicMaxIntVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicMaxIntVimage(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicMaxIntVimage(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_atomic_max_int", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicMaxIntVimage>(opcode);
 }
 } // namespace detail
@@ -415,7 +499,12 @@ ImageAtomicMaxUintVimage::ImageAtomicMaxUintVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicMaxUintVimage(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicMaxUintVimage(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_atomic_max_uint", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicMaxUintVimage>(opcode);
 }
 } // namespace detail
@@ -441,7 +530,12 @@ ImageAtomicAndVimage::ImageAtomicAndVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicAndVimage(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicAndVimage(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_atomic_and", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicAndVimage>(opcode);
 }
 } // namespace detail
@@ -467,7 +561,12 @@ ImageAtomicOrVimage::ImageAtomicOrVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicOrVimage(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicOrVimage(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_atomic_or", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicOrVimage>(opcode);
 }
 } // namespace detail
@@ -493,7 +592,12 @@ ImageAtomicXorVimage::ImageAtomicXorVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicXorVimage(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicXorVimage(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_atomic_xor", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicXorVimage>(opcode);
 }
 } // namespace detail
@@ -519,7 +623,12 @@ ImageAtomicIncUintVimage::ImageAtomicIncUintVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicIncUintVimage(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicIncUintVimage(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_atomic_inc_uint", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicIncUintVimage>(opcode);
 }
 } // namespace detail
@@ -545,7 +654,12 @@ ImageAtomicDecUintVimage::ImageAtomicDecUintVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicDecUintVimage(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicDecUintVimage(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_atomic_dec_uint", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicDecUintVimage>(opcode);
 }
 } // namespace detail
@@ -565,7 +679,12 @@ ImageGetResinfoVimage::ImageGetResinfoVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGetResinfoVimage(const MachineInst *opcode) {
+DecodeResult decodeImageGetResinfoVimage(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_get_resinfo", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGetResinfoVimage>(opcode);
 }
 } // namespace detail
@@ -585,7 +704,12 @@ ImageBvhIntersectRayVimage::ImageBvhIntersectRayVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageBvhIntersectRayVimage(const MachineInst *opcode) {
+DecodeResult decodeImageBvhIntersectRayVimage(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_bvh_intersect_ray", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageBvhIntersectRayVimage>(opcode);
 }
 } // namespace detail
@@ -605,7 +729,13 @@ ImageBvh64IntersectRayVimage::ImageBvh64IntersectRayVimage(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageBvh64IntersectRayVimage(const MachineInst *opcode) {
+DecodeResult decodeImageBvh64IntersectRayVimage(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vimage::validate_encoding("image_bvh64_intersect_ray",
+                                reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageBvh64IntersectRayVimage>(opcode);
 }
 } // namespace detail
@@ -626,7 +756,13 @@ ImageBvhDualIntersectRayVimage::ImageBvhDualIntersectRayVimage(const MachineInst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageBvhDualIntersectRayVimage(const MachineInst *opcode) {
+DecodeResult decodeImageBvhDualIntersectRayVimage(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vimage::validate_encoding("image_bvh_dual_intersect_ray",
+                                reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageBvhDualIntersectRayVimage>(opcode);
 }
 } // namespace detail
@@ -647,7 +783,12 @@ ImageBvh8IntersectRayVimage::ImageBvh8IntersectRayVimage(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageBvh8IntersectRayVimage(const MachineInst *opcode) {
+DecodeResult decodeImageBvh8IntersectRayVimage(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_bvh8_intersect_ray", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageBvh8IntersectRayVimage>(opcode);
 }
 } // namespace detail
@@ -673,7 +814,12 @@ ImageAtomicAddFltVimage::ImageAtomicAddFltVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicAddFltVimage(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicAddFltVimage(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_atomic_add_flt", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicAddFltVimage>(opcode);
 }
 } // namespace detail
@@ -699,7 +845,12 @@ ImageAtomicMinFltVimage::ImageAtomicMinFltVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicMinFltVimage(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicMinFltVimage(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_atomic_min_flt", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicMinFltVimage>(opcode);
 }
 } // namespace detail
@@ -725,7 +876,12 @@ ImageAtomicMaxFltVimage::ImageAtomicMaxFltVimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicMaxFltVimage(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicMaxFltVimage(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_atomic_max_flt", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicMaxFltVimage>(opcode);
 }
 } // namespace detail
@@ -751,7 +907,12 @@ ImageAtomicPkAddF16Vimage::ImageAtomicPkAddF16Vimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicPkAddF16Vimage(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicPkAddF16Vimage(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_atomic_pk_add_f16", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicPkAddF16Vimage>(opcode);
 }
 } // namespace detail
@@ -777,7 +938,12 @@ ImageAtomicPkAddBf16Vimage::ImageAtomicPkAddBf16Vimage(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageAtomicPkAddBf16Vimage(const MachineInst *opcode) {
+DecodeResult decodeImageAtomicPkAddBf16Vimage(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vimage::validate_encoding(
+      "image_atomic_pk_add_bf16", reinterpret_cast<const Vimage::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageAtomicPkAddBf16Vimage>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vinterp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vinterp.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vinterp.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -28,7 +27,12 @@ VInterpP10F32Vinterp::VInterpP10F32Vinterp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP10F32Vinterp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP10F32Vinterp(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vinterp::validate_encoding(
+      "v_interp_p10_f32", reinterpret_cast<const Vinterp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP10F32Vinterp>(opcode);
 }
 } // namespace detail
@@ -49,7 +53,12 @@ VInterpP2F32Vinterp::VInterpP2F32Vinterp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2F32Vinterp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2F32Vinterp(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vinterp::validate_encoding(
+      "v_interp_p2_f32", reinterpret_cast<const Vinterp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2F32Vinterp>(opcode);
 }
 } // namespace detail
@@ -70,7 +79,12 @@ VInterpP10F16F32Vinterp::VInterpP10F16F32Vinterp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP10F16F32Vinterp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP10F16F32Vinterp(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vinterp::validate_encoding(
+      "v_interp_p10_f16_f32", reinterpret_cast<const Vinterp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP10F16F32Vinterp>(opcode);
 }
 } // namespace detail
@@ -91,7 +105,12 @@ VInterpP2F16F32Vinterp::VInterpP2F16F32Vinterp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2F16F32Vinterp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2F16F32Vinterp(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vinterp::validate_encoding(
+      "v_interp_p2_f16_f32", reinterpret_cast<const Vinterp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2F16F32Vinterp>(opcode);
 }
 } // namespace detail
@@ -118,7 +137,13 @@ VInterpP10RtzF16F32Vinterp::VInterpP10RtzF16F32Vinterp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP10RtzF16F32Vinterp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP10RtzF16F32Vinterp(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vinterp::validate_encoding("v_interp_p10_rtz_f16_f32",
+                                 reinterpret_cast<const Vinterp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP10RtzF16F32Vinterp>(opcode);
 }
 } // namespace detail
@@ -139,7 +164,12 @@ VInterpP2RtzF16F32Vinterp::VInterpP2RtzF16F32Vinterp(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVInterpP2RtzF16F32Vinterp(const MachineInst *opcode) {
+DecodeResult decodeVInterpP2RtzF16F32Vinterp(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vinterp::validate_encoding(
+      "v_interp_p2_rtz_f16_f32", reinterpret_cast<const Vinterp::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VInterpP2RtzF16F32Vinterp>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop1.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -23,7 +22,15 @@ VNopVop1::VNopVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop1(const MachineInst *opcode) {
+DecodeResult decodeVNopVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_nop_dpp"
+          : "v_nop_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop1>(opcode);
 }
 } // namespace detail
@@ -64,7 +71,15 @@ VMovB32Vop1::VMovB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_mov_b32_dpp"
+          : "v_mov_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop1>(opcode);
 }
 } // namespace detail
@@ -81,13 +96,22 @@ VReadfirstlaneB32Vop1::VReadfirstlaneB32Vop1(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_readfirstlane_b32_dpp"
+          : "v_readfirstlane_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support DPP";
   return std::make_unique<VReadfirstlaneB32Vop1>(opcode);
 }
 } // namespace detail
@@ -109,13 +133,21 @@ VCvtI32F64Vop1::VCvtI32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_I32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f64_dpp"
+          : "v_cvt_i32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_I32_F64 does not support DPP";
   return std::make_unique<VCvtI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -136,13 +168,21 @@ VCvtF64I32Vop1::VCvtF64I32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_I32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_i32_dpp"
+          : "v_cvt_f64_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_I32 does not support DPP";
   return std::make_unique<VCvtF64I32Vop1>(opcode);
 }
 } // namespace detail
@@ -183,7 +223,15 @@ VCvtF32I32Vop1::VCvtF32I32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_i32_dpp"
+          : "v_cvt_f32_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop1>(opcode);
 }
 } // namespace detail
@@ -224,7 +272,15 @@ VCvtF32U32Vop1::VCvtF32U32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_u32_dpp"
+          : "v_cvt_f32_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop1>(opcode);
 }
 } // namespace detail
@@ -265,7 +321,15 @@ VCvtU32F32Vop1::VCvtU32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f32_dpp"
+          : "v_cvt_u32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -306,7 +370,15 @@ VCvtI32F32Vop1::VCvtI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f32_dpp"
+          : "v_cvt_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -349,7 +421,15 @@ VCvtF16F32Vop1::VCvtF16F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_f32_dpp"
+          : "v_cvt_f16_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop1>(opcode);
 }
 } // namespace detail
@@ -398,7 +478,15 @@ VCvtF32F16Vop1::VCvtF32F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f16_dpp"
+          : "v_cvt_f32_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop1>(opcode);
 }
 } // namespace detail
@@ -439,7 +527,16 @@ VCvtNearestI32F32Vop1::VCvtNearestI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNearestI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNearestI32F32Vop1(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_nearest_i32_f32_dpp"
+          : "v_cvt_nearest_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNearestI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -480,7 +577,16 @@ VCvtFloorI32F32Vop1::VCvtFloorI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFloorI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtFloorI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_floor_i32_f32_dpp"
+          : "v_cvt_floor_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFloorI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -521,7 +627,16 @@ VCvtOffF32I4Vop1::VCvtOffF32I4Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_off_f32_i4_dpp"
+          : "v_cvt_off_f32_i4_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop1>(opcode);
 }
 } // namespace detail
@@ -543,13 +658,21 @@ VCvtF32F64Vop1::VCvtF32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f64_dpp"
+          : "v_cvt_f32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F32_F64 does not support DPP";
   return std::make_unique<VCvtF32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -570,13 +693,21 @@ VCvtF64F32Vop1::VCvtF64F32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_f32_dpp"
+          : "v_cvt_f64_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support DPP";
   return std::make_unique<VCvtF64F32Vop1>(opcode);
 }
 } // namespace detail
@@ -617,7 +748,16 @@ VCvtF32Ubyte0Vop1::VCvtF32Ubyte0Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte0_dpp"
+          : "v_cvt_f32_ubyte0_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop1>(opcode);
 }
 } // namespace detail
@@ -658,7 +798,16 @@ VCvtF32Ubyte1Vop1::VCvtF32Ubyte1Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte1_dpp"
+          : "v_cvt_f32_ubyte1_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop1>(opcode);
 }
 } // namespace detail
@@ -699,7 +848,16 @@ VCvtF32Ubyte2Vop1::VCvtF32Ubyte2Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte2_dpp"
+          : "v_cvt_f32_ubyte2_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop1>(opcode);
 }
 } // namespace detail
@@ -740,7 +898,16 @@ VCvtF32Ubyte3Vop1::VCvtF32Ubyte3Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte3_dpp"
+          : "v_cvt_f32_ubyte3_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop1>(opcode);
 }
 } // namespace detail
@@ -762,13 +929,21 @@ VCvtU32F64Vop1::VCvtU32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_U32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f64_dpp"
+          : "v_cvt_u32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_U32_F64 does not support DPP";
   return std::make_unique<VCvtU32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -789,13 +964,21 @@ VCvtF64U32Vop1::VCvtF64U32Vop1(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_U32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_u32_dpp"
+          : "v_cvt_f64_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_U32 does not support DPP";
   return std::make_unique<VCvtF64U32Vop1>(opcode);
 }
 } // namespace detail
@@ -817,13 +1000,21 @@ VTruncF64Vop1::VTruncF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_TRUNC_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f64_dpp"
+          : "v_trunc_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_TRUNC_F64 does not support DPP";
   return std::make_unique<VTruncF64Vop1>(opcode);
 }
 } // namespace detail
@@ -845,13 +1036,21 @@ VCeilF64Vop1::VCeilF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CEIL_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f64_dpp"
+          : "v_ceil_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CEIL_F64 does not support DPP";
   return std::make_unique<VCeilF64Vop1>(opcode);
 }
 } // namespace detail
@@ -873,13 +1072,21 @@ VRndneF64Vop1::VRndneF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RNDNE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f64_dpp"
+          : "v_rndne_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support DPP";
   return std::make_unique<VRndneF64Vop1>(opcode);
 }
 } // namespace detail
@@ -901,13 +1108,21 @@ VFloorF64Vop1::VFloorF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FLOOR_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_floor_f64_dpp"
+          : "v_floor_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FLOOR_F64 does not support DPP";
   return std::make_unique<VFloorF64Vop1>(opcode);
 }
 } // namespace detail
@@ -923,7 +1138,15 @@ VPipeflushVop1::VPipeflushVop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPipeflushVop1(const MachineInst *opcode) {
+DecodeResult decodeVPipeflushVop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_pipeflush_dpp"
+          : "v_pipeflush_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPipeflushVop1>(opcode);
 }
 } // namespace detail
@@ -968,7 +1191,15 @@ VMovB16Vop1::VMovB16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_mov_b16_dpp"
+          : "v_mov_b16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB16Vop1>(opcode);
 }
 } // namespace detail
@@ -1015,7 +1246,15 @@ VFractF32Vop1::VFractF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_fract_f32_dpp"
+          : "v_fract_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1056,7 +1295,15 @@ VTruncF32Vop1::VTruncF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f32_dpp"
+          : "v_trunc_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1097,7 +1344,15 @@ VCeilF32Vop1::VCeilF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f32_dpp"
+          : "v_ceil_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1138,7 +1393,15 @@ VRndneF32Vop1::VRndneF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f32_dpp"
+          : "v_rndne_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1179,7 +1442,15 @@ VFloorF32Vop1::VFloorF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_floor_f32_dpp"
+          : "v_floor_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1220,7 +1491,15 @@ VExpF32Vop1::VExpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_exp_f32_dpp"
+          : "v_exp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1261,7 +1540,15 @@ VLogF32Vop1::VLogF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_log_f32_dpp"
+          : "v_log_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1302,7 +1589,15 @@ VRcpF32Vop1::VRcpF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f32_dpp"
+          : "v_rcp_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1343,7 +1638,16 @@ VRcpIflagF32Vop1::VRcpIflagF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_iflag_f32_dpp"
+          : "v_rcp_iflag_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1384,7 +1688,15 @@ VRsqF32Vop1::VRsqF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f32_dpp"
+          : "v_rsq_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1406,13 +1718,21 @@ VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RCP_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f64_dpp"
+          : "v_rcp_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support DPP";
   return std::make_unique<VRcpF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1434,13 +1754,21 @@ VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RSQ_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f64_dpp"
+          : "v_rsq_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support DPP";
   return std::make_unique<VRsqF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1481,7 +1809,15 @@ VSqrtF32Vop1::VSqrtF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f32_dpp"
+          : "v_sqrt_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1503,13 +1839,21 @@ VSqrtF64Vop1::VSqrtF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SQRT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f64_dpp"
+          : "v_sqrt_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support DPP";
   return std::make_unique<VSqrtF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1550,7 +1894,15 @@ VSinF32Vop1::VSinF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sin_f32_dpp"
+          : "v_sin_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1591,7 +1943,15 @@ VCosF32Vop1::VCosF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cos_f32_dpp"
+          : "v_cos_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop1>(opcode);
 }
 } // namespace detail
@@ -1632,7 +1992,15 @@ VNotB32Vop1::VNotB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_not_b32_dpp"
+          : "v_not_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop1>(opcode);
 }
 } // namespace detail
@@ -1673,7 +2041,15 @@ VBfrevB32Vop1::VBfrevB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_bfrev_b32_dpp"
+          : "v_bfrev_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop1>(opcode);
 }
 } // namespace detail
@@ -1714,7 +2090,15 @@ VClzI32U32Vop1::VClzI32U32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClzI32U32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVClzI32U32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_clz_i32_u32_dpp"
+          : "v_clz_i32_u32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClzI32U32Vop1>(opcode);
 }
 } // namespace detail
@@ -1755,7 +2139,15 @@ VCtzI32B32Vop1::VCtzI32B32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCtzI32B32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCtzI32B32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ctz_i32_b32_dpp"
+          : "v_ctz_i32_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCtzI32B32Vop1>(opcode);
 }
 } // namespace detail
@@ -1796,7 +2188,15 @@ VClsI32Vop1::VClsI32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClsI32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVClsI32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cls_i32_dpp"
+          : "v_cls_i32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClsI32Vop1>(opcode);
 }
 } // namespace detail
@@ -1818,13 +2218,22 @@ VFrexpExpI32F64Vop1::VFrexpExpI32F64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_EXP_I32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f64_dpp"
+          : "v_frexp_exp_i32_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_EXP_I32_F64 does not support DPP";
   return std::make_unique<VFrexpExpI32F64Vop1>(opcode);
 }
 } // namespace detail
@@ -1846,13 +2255,22 @@ VFrexpMantF64Vop1::VFrexpMantF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_MANT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f64_dpp"
+          : "v_frexp_mant_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_MANT_F64 does not support DPP";
   return std::make_unique<VFrexpMantF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1874,13 +2292,21 @@ VFractF64Vop1::VFractF64Vop1(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FRACT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_fract_f64_dpp"
+          : "v_fract_f64_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FRACT_F64 does not support DPP";
   return std::make_unique<VFractF64Vop1>(opcode);
 }
 } // namespace detail
@@ -1921,7 +2347,16 @@ VFrexpExpI32F32Vop1::VFrexpExpI32F32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f32_dpp"
+          : "v_frexp_exp_i32_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop1>(opcode);
 }
 } // namespace detail
@@ -1962,7 +2397,16 @@ VFrexpMantF32Vop1::VFrexpMantF32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f32_dpp"
+          : "v_frexp_mant_f32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop1>(opcode);
 }
 } // namespace detail
@@ -2006,7 +2450,16 @@ VMovreldB32Vop1::VMovreldB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovreldB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovreldB32Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movreld_b32_dpp"
+          : "v_movreld_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovreldB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2046,7 +2499,16 @@ VMovrelsB32Vop1::VMovrelsB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsB32Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movrels_b32_dpp"
+          : "v_movrels_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2086,7 +2548,16 @@ VMovrelsdB32Vop1::VMovrelsdB32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsdB32Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_b32_dpp"
+          : "v_movrelsd_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsdB32Vop1>(opcode);
 }
 } // namespace detail
@@ -2126,7 +2597,16 @@ VMovrelsd2B32Vop1::VMovrelsd2B32Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsd2B32Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_2_b32_dpp"
+          : "v_movrelsd_2_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsd2B32Vop1>(opcode);
 }
 } // namespace detail
@@ -2171,7 +2651,15 @@ VCvtF16U16Vop1::VCvtF16U16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_u16_dpp"
+          : "v_cvt_f16_u16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop1>(opcode);
 }
 } // namespace detail
@@ -2222,7 +2710,15 @@ VCvtF16I16Vop1::VCvtF16I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_i16_dpp"
+          : "v_cvt_f16_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop1>(opcode);
 }
 } // namespace detail
@@ -2273,7 +2769,15 @@ VCvtU16F16Vop1::VCvtU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u16_f16_dpp"
+          : "v_cvt_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2324,7 +2828,15 @@ VCvtI16F16Vop1::VCvtI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i16_f16_dpp"
+          : "v_cvt_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2375,7 +2887,15 @@ VRcpF16Vop1::VRcpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f16_dpp"
+          : "v_rcp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2426,7 +2946,15 @@ VSqrtF16Vop1::VSqrtF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f16_dpp"
+          : "v_sqrt_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2477,7 +3005,15 @@ VRsqF16Vop1::VRsqF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f16_dpp"
+          : "v_rsq_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2528,7 +3064,15 @@ VLogF16Vop1::VLogF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_log_f16_dpp"
+          : "v_log_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2579,7 +3123,15 @@ VExpF16Vop1::VExpF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_exp_f16_dpp"
+          : "v_exp_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2630,7 +3182,16 @@ VFrexpMantF16Vop1::VFrexpMantF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop1(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f16_dpp"
+          : "v_frexp_mant_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2681,7 +3242,16 @@ VFrexpExpI16F16Vop1::VFrexpExpI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop1(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i16_f16_dpp"
+          : "v_frexp_exp_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -2732,7 +3302,15 @@ VFloorF16Vop1::VFloorF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_floor_f16_dpp"
+          : "v_floor_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2783,7 +3361,15 @@ VCeilF16Vop1::VCeilF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f16_dpp"
+          : "v_ceil_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2834,7 +3420,15 @@ VTruncF16Vop1::VTruncF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f16_dpp"
+          : "v_trunc_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2885,7 +3479,15 @@ VRndneF16Vop1::VRndneF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f16_dpp"
+          : "v_rndne_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2936,7 +3538,15 @@ VFractF16Vop1::VFractF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_fract_f16_dpp"
+          : "v_fract_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop1>(opcode);
 }
 } // namespace detail
@@ -2987,7 +3597,15 @@ VSinF16Vop1::VSinF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sin_f16_dpp"
+          : "v_sin_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3038,7 +3656,15 @@ VCosF16Vop1::VCosF16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cos_f16_dpp"
+          : "v_cos_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop1>(opcode);
 }
 } // namespace detail
@@ -3087,7 +3713,16 @@ VSatPkU8I16Vop1::VSatPkU8I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_sat_pk_u8_i16_dpp"
+          : "v_sat_pk_u8_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop1>(opcode);
 }
 } // namespace detail
@@ -3138,7 +3773,16 @@ VCvtNormI16F16Vop1::VCvtNormI16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_i16_f16_dpp"
+          : "v_cvt_norm_i16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3189,7 +3833,16 @@ VCvtNormU16F16Vop1::VCvtNormU16F16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_u16_f16_dpp"
+          : "v_cvt_norm_u16_f16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop1>(opcode);
 }
 } // namespace detail
@@ -3214,13 +3867,21 @@ VSwapB32Vop1::VSwapB32Vop1(const MachineInst *inst)
   dst_operands_[1] = &src0;
   num_src_ = 2;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWAP_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwapB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swap_b32_dpp"
+          : "v_swap_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B32 does not support DPP";
   return std::make_unique<VSwapB32Vop1>(opcode);
 }
 } // namespace detail
@@ -3242,13 +3903,21 @@ VSwapB16Vop1::VSwapB16Vop1(const MachineInst *inst)
   dst_operands_[1] = &src0;
   num_src_ = 2;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWAP_B16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwapB16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwapB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swap_b16_dpp"
+          : "v_swap_b16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SWAP_B16 does not support DPP";
   return std::make_unique<VSwapB16Vop1>(opcode);
 }
 } // namespace detail
@@ -3273,13 +3942,22 @@ VPermlane64B32Vop1::VPermlane64B32Vop1(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANE64_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlane64B32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVPermlane64B32Vop1(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_permlane64_b32_dpp"
+          : "v_permlane64_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE64_B32 does not support DPP";
   return std::make_unique<VPermlane64B32Vop1>(opcode);
 }
 } // namespace detail
@@ -3300,14 +3978,23 @@ VSwaprelB32Vop1::VSwaprelB32Vop1(const MachineInst *inst)
   src_operands_[2] = &m0;
   num_src_ = 3;
   num_dst_ = 2;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWAPREL_B32 does not support DPP", "");
   m0.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwaprelB32Vop1(const MachineInst *opcode) {
+DecodeResult decodeVSwaprelB32Vop1(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swaprel_b32_dpp"
+          : "v_swaprel_b32_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SWAPREL_B32 does not support DPP";
   return std::make_unique<VSwaprelB32Vop1>(opcode);
 }
 } // namespace detail
@@ -3352,7 +4039,15 @@ VNotB16Vop1::VNotB16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVNotB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_not_b16_dpp"
+          : "v_not_b16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB16Vop1>(opcode);
 }
 } // namespace detail
@@ -3401,7 +4096,15 @@ VCvtI32I16Vop1::VCvtI32I16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32I16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32I16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_i16_dpp"
+          : "v_cvt_i32_i16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32I16Vop1>(opcode);
 }
 } // namespace detail
@@ -3444,7 +4147,15 @@ VCvtU32U16Vop1::VCvtU32U16Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32U16Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32U16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_u16_dpp"
+          : "v_cvt_u32_u16_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32U16Vop1>(opcode);
 }
 } // namespace detail
@@ -3485,7 +4196,15 @@ VCvtF32Fp8Vop1::VCvtF32Fp8Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Fp8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Fp8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_fp8_dpp"
+          : "v_cvt_f32_fp8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Fp8Vop1>(opcode);
 }
 } // namespace detail
@@ -3526,7 +4245,15 @@ VCvtF32Bf8Vop1::VCvtF32Bf8Vop1(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Bf8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Bf8Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_bf8_dpp"
+          : "v_cvt_f32_bf8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Bf8Vop1>(opcode);
 }
 } // namespace detail
@@ -3549,13 +4276,22 @@ VCvtPkF32Fp8Vop1::VCvtPkF32Fp8Vop1(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_PK_F32_FP8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF32Fp8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF32Fp8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_f32_fp8_dpp"
+          : "v_cvt_pk_f32_fp8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_PK_F32_FP8 does not support DPP";
   return std::make_unique<VCvtPkF32Fp8Vop1>(opcode);
 }
 } // namespace detail
@@ -3578,13 +4314,22 @@ VCvtPkF32Bf8Vop1::VCvtPkF32Bf8Vop1(const MachineInst *inst)
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const Vop1InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_PK_F32_BF8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF32Bf8Vop1(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF32Bf8Vop1(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_f32_bf8_dpp"
+          : "v_cvt_pk_f32_bf8_e32",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_PK_F32_BF8 does not support DPP";
   return std::make_unique<VCvtPkF32Bf8Vop1>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop2.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -54,7 +53,16 @@ VCndmaskB32Vop2::VCndmaskB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_cndmask_b32_dpp"
+          : "v_cndmask_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop2>(opcode);
 }
 } // namespace detail
@@ -78,13 +86,21 @@ VAddF64Vop2::VAddF64Vop2(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_ADD_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_f64_dpp"
+          : "v_add_f64_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_ADD_F64 does not support DPP";
   return std::make_unique<VAddF64Vop2>(opcode);
 }
 } // namespace detail
@@ -127,7 +143,15 @@ VAddF32Vop2::VAddF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_f32_dpp"
+          : "v_add_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop2>(opcode);
 }
 } // namespace detail
@@ -170,7 +194,15 @@ VSubF32Vop2::VSubF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_f32_dpp"
+          : "v_sub_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop2>(opcode);
 }
 } // namespace detail
@@ -213,7 +245,15 @@ VSubrevF32Vop2::VSubrevF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f32_dpp"
+          : "v_subrev_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop2>(opcode);
 }
 } // namespace detail
@@ -237,13 +277,21 @@ VMulF64Vop2::VMulF64Vop2(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_f64_dpp"
+          : "v_mul_f64_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_F64 does not support DPP";
   return std::make_unique<VMulF64Vop2>(opcode);
 }
 } // namespace detail
@@ -286,7 +334,16 @@ VMulDx9ZeroF32Vop2::VMulDx9ZeroF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulDx9ZeroF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulDx9ZeroF32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_dx9_zero_f32_dpp"
+          : "v_mul_dx9_zero_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulDx9ZeroF32Vop2>(opcode);
 }
 } // namespace detail
@@ -329,7 +386,15 @@ VMulF32Vop2::VMulF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_f32_dpp"
+          : "v_mul_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop2>(opcode);
 }
 } // namespace detail
@@ -372,7 +437,15 @@ VMulI32I24Vop2::VMulI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_i32_i24_dpp"
+          : "v_mul_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -415,7 +488,16 @@ VMulHiI32I24Vop2::VMulHiI32I24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_i32_i24_dpp"
+          : "v_mul_hi_i32_i24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop2>(opcode);
 }
 } // namespace detail
@@ -458,7 +540,15 @@ VMulU32U24Vop2::VMulU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_u32_u24_dpp"
+          : "v_mul_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -501,7 +591,16 @@ VMulHiU32U24Vop2::VMulHiU32U24Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_u32_u24_dpp"
+          : "v_mul_hi_u32_u24_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop2>(opcode);
 }
 } // namespace detail
@@ -525,13 +624,21 @@ VMinNumF64Vop2::VMinNumF64Vop2(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MIN_NUM_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinNumF64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinNumF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_num_f64_dpp"
+          : "v_min_num_f64_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MIN_NUM_F64 does not support DPP";
   return std::make_unique<VMinNumF64Vop2>(opcode);
 }
 } // namespace detail
@@ -555,13 +662,21 @@ VMaxNumF64Vop2::VMaxNumF64Vop2(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAX_NUM_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxNumF64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxNumF64Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_num_f64_dpp"
+          : "v_max_num_f64_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MAX_NUM_F64 does not support DPP";
   return std::make_unique<VMaxNumF64Vop2>(opcode);
 }
 } // namespace detail
@@ -604,7 +719,15 @@ VMinI32Vop2::VMinI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_i32_dpp"
+          : "v_min_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop2>(opcode);
 }
 } // namespace detail
@@ -647,7 +770,15 @@ VMaxI32Vop2::VMaxI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_i32_dpp"
+          : "v_max_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop2>(opcode);
 }
 } // namespace detail
@@ -690,7 +821,15 @@ VMinU32Vop2::VMinU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_u32_dpp"
+          : "v_min_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop2>(opcode);
 }
 } // namespace detail
@@ -733,7 +872,15 @@ VMaxU32Vop2::VMaxU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_u32_dpp"
+          : "v_max_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop2>(opcode);
 }
 } // namespace detail
@@ -776,7 +923,15 @@ VMinNumF32Vop2::VMinNumF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinNumF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinNumF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_num_f32_dpp"
+          : "v_min_num_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinNumF32Vop2>(opcode);
 }
 } // namespace detail
@@ -819,7 +974,15 @@ VMaxNumF32Vop2::VMaxNumF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxNumF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxNumF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_num_f32_dpp"
+          : "v_max_num_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxNumF32Vop2>(opcode);
 }
 } // namespace detail
@@ -862,7 +1025,16 @@ VLshlrevB32Vop2::VLshlrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b32_dpp"
+          : "v_lshlrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -905,7 +1077,16 @@ VLshrrevB32Vop2::VLshrrevB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_lshrrev_b32_dpp"
+          : "v_lshrrev_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop2>(opcode);
 }
 } // namespace detail
@@ -948,7 +1129,16 @@ VAshrrevI32Vop2::VAshrrevI32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_ashrrev_i32_dpp"
+          : "v_ashrrev_i32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop2>(opcode);
 }
 } // namespace detail
@@ -991,7 +1181,15 @@ VAndB32Vop2::VAndB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_and_b32_dpp"
+          : "v_and_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1034,7 +1232,15 @@ VOrB32Vop2::VOrB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_or_b32_dpp"
+          : "v_or_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1077,7 +1283,15 @@ VXorB32Vop2::VXorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_xor_b32_dpp"
+          : "v_xor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1120,7 +1334,15 @@ VXnorB32Vop2::VXnorB32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_xnor_b32_dpp"
+          : "v_xnor_b32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop2>(opcode);
 }
 } // namespace detail
@@ -1143,13 +1365,22 @@ VLshlrevB64Vop2::VLshlrevB64Vop2(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_LSHLREV_B64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB64Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b64_dpp"
+          : "v_lshlrev_b64_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_LSHLREV_B64 does not support DPP";
   return std::make_unique<VLshlrevB64Vop2>(opcode);
 }
 } // namespace detail
@@ -1198,7 +1429,16 @@ VAddCoCiU32Vop2::VAddCoCiU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddCoCiU32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_co_ci_u32_dpp"
+          : "v_add_co_ci_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoCiU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1247,7 +1487,16 @@ VSubCoCiU32Vop2::VSubCoCiU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubCoCiU32Vop2(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_co_ci_u32_dpp"
+          : "v_sub_co_ci_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoCiU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1296,7 +1545,16 @@ VSubrevCoCiU32Vop2::VSubrevCoCiU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoCiU32Vop2(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_co_ci_u32_dpp"
+          : "v_subrev_co_ci_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoCiU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1339,7 +1597,15 @@ VAddNcU32Vop2::VAddNcU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_u32_dpp"
+          : "v_add_nc_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1382,7 +1648,15 @@ VSubNcU32Vop2::VSubNcU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_u32_dpp"
+          : "v_sub_nc_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1425,7 +1699,16 @@ VSubrevNcU32Vop2::VSubrevNcU32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevNcU32Vop2(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_nc_u32_dpp"
+          : "v_subrev_nc_u32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevNcU32Vop2>(opcode);
 }
 } // namespace detail
@@ -1469,7 +1752,15 @@ VFmacF32Vop2::VFmacF32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f32_dpp"
+          : "v_fmac_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1497,14 +1788,22 @@ VFmamkF32Vop2::VFmamkF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAMK_F32 does not support DPP", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmamkF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmamkF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmamk_f32_dpp"
+          : "v_fmamk_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F32 does not support DPP";
   return std::make_unique<VFmamkF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1532,14 +1831,22 @@ VFmaakF32Vop2::VFmaakF32Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAAK_F32 does not support DPP", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaakF32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmaakF32Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmaak_f32_dpp"
+          : "v_fmaak_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F32 does not support DPP";
   return std::make_unique<VFmaakF32Vop2>(opcode);
 }
 } // namespace detail
@@ -1582,7 +1889,16 @@ VCvtPkRtzF16F32Vop2::VCvtPkRtzF16F32Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkRtzF16F32Vop2(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkRtzF16F32Vop2(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_rtz_f16_f32_dpp"
+          : "v_cvt_pk_rtz_f16_f32_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkRtzF16F32Vop2>(opcode);
 }
 } // namespace detail
@@ -1630,7 +1946,15 @@ VMinNumF16Vop2::VMinNumF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinNumF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMinNumF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_min_num_f16_dpp"
+          : "v_min_num_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinNumF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1684,7 +2008,15 @@ VMaxNumF16Vop2::VMaxNumF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxNumF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMaxNumF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_max_num_f16_dpp"
+          : "v_max_num_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxNumF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1738,7 +2070,15 @@ VAddF16Vop2::VAddF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_add_f16_dpp"
+          : "v_add_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1792,7 +2132,15 @@ VSubF16Vop2::VSubF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_sub_f16_dpp"
+          : "v_sub_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1846,7 +2194,15 @@ VSubrevF16Vop2::VSubrevF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f16_dpp"
+          : "v_subrev_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1900,7 +2256,15 @@ VMulF16Vop2::VMulF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_mul_f16_dpp"
+          : "v_mul_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1955,7 +2319,15 @@ VFmacF16Vop2::VFmacF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f16_dpp"
+          : "v_fmac_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF16Vop2>(opcode);
 }
 } // namespace detail
@@ -1995,14 +2367,22 @@ VFmamkF16Vop2::VFmamkF16Vop2(const MachineInst *inst)
       Operand(16, OperandType::OPR_SIMM32,
               static_cast<int>(
                   (reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAMK_F16 does not support DPP", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmamkF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmamkF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmamk_f16_dpp"
+          : "v_fmamk_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAMK_F16 does not support DPP";
   return std::make_unique<VFmamkF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2041,14 +2421,22 @@ VFmaakF16Vop2::VFmaakF16Vop2(const MachineInst *inst)
   simm32 =
       Operand(32, OperandType::OPR_SIMM32,
               static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMAAK_F16 does not support DPP", "");
   simm32.apply_fieldless_caps(true, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaakF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVFmaakF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_fmaak_f16_dpp"
+          : "v_fmaak_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMAAK_F16 does not support DPP";
   return std::make_unique<VFmaakF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2102,7 +2490,15 @@ VLdexpF16Vop2::VLdexpF16Vop2(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_ldexp_f16_dpp"
+          : "v_ldexp_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop2>(opcode);
 }
 } // namespace detail
@@ -2132,13 +2528,21 @@ VPkFmacF16Vop2::VPkFmacF16Vop2(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop2InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_FMAC_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmacF16Vop2(const MachineInst *opcode) {
+DecodeResult decodeVPkFmacF16Vop2(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop2::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)
+          ? "v_pk_fmac_f16_dpp"
+          : "v_pk_fmac_f16_e32",
+      reinterpret_cast<const Vop2::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop2::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PK_FMAC_F16 does not support DPP";
   return std::make_unique<VPkFmacF16Vop2>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop3.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vop3.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -24,7 +23,15 @@ VNopVop3::VNopVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNopVop3(const MachineInst *opcode) {
+DecodeResult decodeVNopVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_nop_e64_dpp"
+          : "v_nop",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNopVop3>(opcode);
 }
 } // namespace detail
@@ -65,7 +72,15 @@ VMovB32Vop3::VMovB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mov_b32_e64_dpp"
+          : "v_mov_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB32Vop3>(opcode);
 }
 } // namespace detail
@@ -82,13 +97,22 @@ VReadfirstlaneB32Vop3::VReadfirstlaneB32Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_READFIRSTLANE_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadfirstlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadfirstlaneB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_readfirstlane_b32_e64_dpp"
+          : "v_readfirstlane_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_READFIRSTLANE_B32 does not support DPP";
   return std::make_unique<VReadfirstlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -110,13 +134,21 @@ VCvtI32F64Vop3::VCvtI32F64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_I32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f64_e64_dpp"
+          : "v_cvt_i32_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_I32_F64 does not support DPP";
   return std::make_unique<VCvtI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -137,13 +169,21 @@ VCvtF64I32Vop3::VCvtF64I32Vop3(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_I32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_i32_e64_dpp"
+          : "v_cvt_f64_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_I32 does not support DPP";
   return std::make_unique<VCvtF64I32Vop3>(opcode);
 }
 } // namespace detail
@@ -184,7 +224,15 @@ VCvtF32I32Vop3::VCvtF32I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_i32_e64_dpp"
+          : "v_cvt_f32_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32I32Vop3>(opcode);
 }
 } // namespace detail
@@ -225,7 +273,15 @@ VCvtF32U32Vop3::VCvtF32U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_u32_e64_dpp"
+          : "v_cvt_f32_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32U32Vop3>(opcode);
 }
 } // namespace detail
@@ -266,7 +322,15 @@ VCvtU32F32Vop3::VCvtU32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f32_e64_dpp"
+          : "v_cvt_u32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -307,7 +371,15 @@ VCvtI32F32Vop3::VCvtI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_f32_e64_dpp"
+          : "v_cvt_i32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -348,7 +420,15 @@ VCvtF16F32Vop3::VCvtF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_f32_e64_dpp"
+          : "v_cvt_f16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -399,7 +479,15 @@ VCvtF32F16Vop3::VCvtF32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f16_e64_dpp"
+          : "v_cvt_f32_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -440,7 +528,16 @@ VCvtNearestI32F32Vop3::VCvtNearestI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNearestI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNearestI32F32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_nearest_i32_f32_e64_dpp"
+          : "v_cvt_nearest_i32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNearestI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -481,7 +578,16 @@ VCvtFloorI32F32Vop3::VCvtFloorI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtFloorI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtFloorI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_floor_i32_f32_e64_dpp"
+          : "v_cvt_floor_i32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtFloorI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -522,7 +628,16 @@ VCvtOffF32I4Vop3::VCvtOffF32I4Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtOffF32I4Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtOffF32I4Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_off_f32_i4_e64_dpp"
+          : "v_cvt_off_f32_i4",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtOffF32I4Vop3>(opcode);
 }
 } // namespace detail
@@ -544,13 +659,21 @@ VCvtF32F64Vop3::VCvtF32F64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_f64_e64_dpp"
+          : "v_cvt_f32_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F32_F64 does not support DPP";
   return std::make_unique<VCvtF32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -571,13 +694,21 @@ VCvtF64F32Vop3::VCvtF64F32Vop3(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64F32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_f32_e64_dpp"
+          : "v_cvt_f64_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_F32 does not support DPP";
   return std::make_unique<VCvtF64F32Vop3>(opcode);
 }
 } // namespace detail
@@ -618,7 +749,16 @@ VCvtF32Ubyte0Vop3::VCvtF32Ubyte0Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte0Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte0_e64_dpp"
+          : "v_cvt_f32_ubyte0",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte0Vop3>(opcode);
 }
 } // namespace detail
@@ -659,7 +799,16 @@ VCvtF32Ubyte1Vop3::VCvtF32Ubyte1Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte1Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte1_e64_dpp"
+          : "v_cvt_f32_ubyte1",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte1Vop3>(opcode);
 }
 } // namespace detail
@@ -700,7 +849,16 @@ VCvtF32Ubyte2Vop3::VCvtF32Ubyte2Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte2Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte2_e64_dpp"
+          : "v_cvt_f32_ubyte2",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte2Vop3>(opcode);
 }
 } // namespace detail
@@ -741,7 +899,16 @@ VCvtF32Ubyte3Vop3::VCvtF32Ubyte3Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Ubyte3Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_ubyte3_e64_dpp"
+          : "v_cvt_f32_ubyte3",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Ubyte3Vop3>(opcode);
 }
 } // namespace detail
@@ -763,13 +930,21 @@ VCvtU32F64Vop3::VCvtU32F64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_U32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32F64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_f64_e64_dpp"
+          : "v_cvt_u32_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_U32_F64 does not support DPP";
   return std::make_unique<VCvtU32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -790,13 +965,21 @@ VCvtF64U32Vop3::VCvtF64U32Vop3(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_F64_U32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF64U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF64U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f64_u32_e64_dpp"
+          : "v_cvt_f64_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_F64_U32 does not support DPP";
   return std::make_unique<VCvtF64U32Vop3>(opcode);
 }
 } // namespace detail
@@ -818,13 +1001,21 @@ VTruncF64Vop3::VTruncF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_TRUNC_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f64_e64_dpp"
+          : "v_trunc_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_TRUNC_F64 does not support DPP";
   return std::make_unique<VTruncF64Vop3>(opcode);
 }
 } // namespace detail
@@ -846,13 +1037,21 @@ VCeilF64Vop3::VCeilF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CEIL_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f64_e64_dpp"
+          : "v_ceil_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CEIL_F64 does not support DPP";
   return std::make_unique<VCeilF64Vop3>(opcode);
 }
 } // namespace detail
@@ -874,13 +1073,21 @@ VRndneF64Vop3::VRndneF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RNDNE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f64_e64_dpp"
+          : "v_rndne_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RNDNE_F64 does not support DPP";
   return std::make_unique<VRndneF64Vop3>(opcode);
 }
 } // namespace detail
@@ -902,13 +1109,21 @@ VFloorF64Vop3::VFloorF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FLOOR_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_floor_f64_e64_dpp"
+          : "v_floor_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FLOOR_F64 does not support DPP";
   return std::make_unique<VFloorF64Vop3>(opcode);
 }
 } // namespace detail
@@ -924,7 +1139,15 @@ VPipeflushVop3::VPipeflushVop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPipeflushVop3(const MachineInst *opcode) {
+DecodeResult decodeVPipeflushVop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_pipeflush_e64_dpp"
+          : "v_pipeflush",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPipeflushVop3>(opcode);
 }
 } // namespace detail
@@ -969,7 +1192,15 @@ VMovB16Vop3::VMovB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mov_b16_e64_dpp"
+          : "v_mov_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovB16Vop3>(opcode);
 }
 } // namespace detail
@@ -1016,7 +1247,15 @@ VFractF32Vop3::VFractF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fract_f32_e64_dpp"
+          : "v_fract_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1057,7 +1296,15 @@ VTruncF32Vop3::VTruncF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f32_e64_dpp"
+          : "v_trunc_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1098,7 +1345,15 @@ VCeilF32Vop3::VCeilF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f32_e64_dpp"
+          : "v_ceil_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1139,7 +1394,15 @@ VRndneF32Vop3::VRndneF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f32_e64_dpp"
+          : "v_rndne_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1180,7 +1443,15 @@ VFloorF32Vop3::VFloorF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_floor_f32_e64_dpp"
+          : "v_floor_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1221,7 +1492,15 @@ VExpF32Vop3::VExpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_exp_f32_e64_dpp"
+          : "v_exp_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1262,7 +1541,15 @@ VLogF32Vop3::VLogF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_log_f32_e64_dpp"
+          : "v_log_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1303,7 +1590,15 @@ VRcpF32Vop3::VRcpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f32_e64_dpp"
+          : "v_rcp_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1344,7 +1639,16 @@ VRcpIflagF32Vop3::VRcpIflagF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpIflagF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpIflagF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rcp_iflag_f32_e64_dpp"
+          : "v_rcp_iflag_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpIflagF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1385,7 +1689,15 @@ VRsqF32Vop3::VRsqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f32_e64_dpp"
+          : "v_rsq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1407,13 +1719,21 @@ VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RCP_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f64_e64_dpp"
+          : "v_rcp_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RCP_F64 does not support DPP";
   return std::make_unique<VRcpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1435,13 +1755,21 @@ VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_RSQ_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f64_e64_dpp"
+          : "v_rsq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_RSQ_F64 does not support DPP";
   return std::make_unique<VRsqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1482,7 +1810,15 @@ VSqrtF32Vop3::VSqrtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f32_e64_dpp"
+          : "v_sqrt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1504,13 +1840,21 @@ VSqrtF64Vop3::VSqrtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SQRT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f64_e64_dpp"
+          : "v_sqrt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_SQRT_F64 does not support DPP";
   return std::make_unique<VSqrtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1551,7 +1895,15 @@ VSinF32Vop3::VSinF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sin_f32_e64_dpp"
+          : "v_sin_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1592,7 +1944,15 @@ VCosF32Vop3::VCosF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cos_f32_e64_dpp"
+          : "v_cos_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF32Vop3>(opcode);
 }
 } // namespace detail
@@ -1633,7 +1993,15 @@ VNotB32Vop3::VNotB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVNotB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_not_b32_e64_dpp"
+          : "v_not_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1674,7 +2042,15 @@ VBfrevB32Vop3::VBfrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfrevB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfrev_b32_e64_dpp"
+          : "v_bfrev_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -1715,7 +2091,15 @@ VClzI32U32Vop3::VClzI32U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClzI32U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVClzI32U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_clz_i32_u32_e64_dpp"
+          : "v_clz_i32_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClzI32U32Vop3>(opcode);
 }
 } // namespace detail
@@ -1756,7 +2140,15 @@ VCtzI32B32Vop3::VCtzI32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCtzI32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCtzI32B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ctz_i32_b32_e64_dpp"
+          : "v_ctz_i32_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCtzI32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -1797,7 +2189,15 @@ VClsI32Vop3::VClsI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVClsI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVClsI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cls_i32_e64_dpp"
+          : "v_cls_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VClsI32Vop3>(opcode);
 }
 } // namespace detail
@@ -1819,13 +2219,22 @@ VFrexpExpI32F64Vop3::VFrexpExpI32F64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_EXP_I32_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F64Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f64_e64_dpp"
+          : "v_frexp_exp_i32_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_EXP_I32_F64 does not support DPP";
   return std::make_unique<VFrexpExpI32F64Vop3>(opcode);
 }
 } // namespace detail
@@ -1847,13 +2256,22 @@ VFrexpMantF64Vop3::VFrexpMantF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FREXP_MANT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f64_e64_dpp"
+          : "v_frexp_mant_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FREXP_MANT_F64 does not support DPP";
   return std::make_unique<VFrexpMantF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1875,13 +2293,21 @@ VFractF64Vop3::VFractF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FRACT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fract_f64_e64_dpp"
+          : "v_fract_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FRACT_F64 does not support DPP";
   return std::make_unique<VFractF64Vop3>(opcode);
 }
 } // namespace detail
@@ -1922,7 +2348,16 @@ VFrexpExpI32F32Vop3::VFrexpExpI32F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI32F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI32F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i32_f32_e64_dpp"
+          : "v_frexp_exp_i32_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI32F32Vop3>(opcode);
 }
 } // namespace detail
@@ -1963,7 +2398,16 @@ VFrexpMantF32Vop3::VFrexpMantF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f32_e64_dpp"
+          : "v_frexp_mant_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF32Vop3>(opcode);
 }
 } // namespace detail
@@ -2007,7 +2451,16 @@ VMovreldB32Vop3::VMovreldB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovreldB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovreldB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_movreld_b32_e64_dpp"
+          : "v_movreld_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovreldB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2047,7 +2500,16 @@ VMovrelsB32Vop3::VMovrelsB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_movrels_b32_e64_dpp"
+          : "v_movrels_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2087,7 +2549,16 @@ VMovrelsdB32Vop3::VMovrelsdB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsdB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsdB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_b32_e64_dpp"
+          : "v_movrelsd_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsdB32Vop3>(opcode);
 }
 } // namespace detail
@@ -2127,7 +2598,16 @@ VMovrelsd2B32Vop3::VMovrelsd2B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMovrelsd2B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMovrelsd2B32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_movrelsd_2_b32_e64_dpp"
+          : "v_movrelsd_2_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMovrelsd2B32Vop3>(opcode);
 }
 } // namespace detail
@@ -2172,7 +2652,15 @@ VCvtF16U16Vop3::VCvtF16U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_u16_e64_dpp"
+          : "v_cvt_f16_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16U16Vop3>(opcode);
 }
 } // namespace detail
@@ -2223,7 +2711,15 @@ VCvtF16I16Vop3::VCvtF16I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF16I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF16I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f16_i16_e64_dpp"
+          : "v_cvt_f16_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF16I16Vop3>(opcode);
 }
 } // namespace detail
@@ -2274,7 +2770,15 @@ VCvtU16F16Vop3::VCvtU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u16_f16_e64_dpp"
+          : "v_cvt_u16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -2325,7 +2829,15 @@ VCvtI16F16Vop3::VCvtI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI16F16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i16_f16_e64_dpp"
+          : "v_cvt_i16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -2376,7 +2888,15 @@ VRcpF16Vop3::VRcpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRcpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rcp_f16_e64_dpp"
+          : "v_rcp_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRcpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2427,7 +2947,15 @@ VSqrtF16Vop3::VSqrtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSqrtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sqrt_f16_e64_dpp"
+          : "v_sqrt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSqrtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2478,7 +3006,15 @@ VRsqF16Vop3::VRsqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRsqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rsq_f16_e64_dpp"
+          : "v_rsq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRsqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2529,7 +3065,15 @@ VLogF16Vop3::VLogF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLogF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_log_f16_e64_dpp"
+          : "v_log_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLogF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2580,7 +3124,15 @@ VExpF16Vop3::VExpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVExpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_exp_f16_e64_dpp"
+          : "v_exp_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VExpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2631,7 +3183,16 @@ VFrexpMantF16Vop3::VFrexpMantF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpMantF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpMantF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_mant_f16_e64_dpp"
+          : "v_frexp_mant_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpMantF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2682,7 +3243,16 @@ VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFrexpExpI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFrexpExpI16F16Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_frexp_exp_i16_f16_e64_dpp"
+          : "v_frexp_exp_i16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFrexpExpI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -2733,7 +3303,15 @@ VFloorF16Vop3::VFloorF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFloorF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFloorF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_floor_f16_e64_dpp"
+          : "v_floor_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFloorF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2784,7 +3362,15 @@ VCeilF16Vop3::VCeilF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCeilF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCeilF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ceil_f16_e64_dpp"
+          : "v_ceil_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCeilF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2835,7 +3421,15 @@ VTruncF16Vop3::VTruncF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTruncF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTruncF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_trunc_f16_e64_dpp"
+          : "v_trunc_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VTruncF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2886,7 +3480,15 @@ VRndneF16Vop3::VRndneF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVRndneF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVRndneF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_rndne_f16_e64_dpp"
+          : "v_rndne_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VRndneF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2937,7 +3539,15 @@ VFractF16Vop3::VFractF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFractF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFractF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fract_f16_e64_dpp"
+          : "v_fract_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFractF16Vop3>(opcode);
 }
 } // namespace detail
@@ -2988,7 +3598,15 @@ VSinF16Vop3::VSinF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSinF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSinF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sin_f16_e64_dpp"
+          : "v_sin_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSinF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3039,7 +3657,15 @@ VCosF16Vop3::VCosF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCosF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCosF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cos_f16_e64_dpp"
+          : "v_cos_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCosF16Vop3>(opcode);
 }
 } // namespace detail
@@ -3086,7 +3712,16 @@ VSatPkU8I16Vop3::VSatPkU8I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSatPkU8I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSatPkU8I16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sat_pk_u8_i16_e64_dpp"
+          : "v_sat_pk_u8_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSatPkU8I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3137,7 +3772,16 @@ VCvtNormI16F16Vop3::VCvtNormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormI16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_i16_f16_e64_dpp"
+          : "v_cvt_norm_i16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3188,7 +3832,16 @@ VCvtNormU16F16Vop3::VCvtNormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtNormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtNormU16F16Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_norm_u16_f16_e64_dpp"
+          : "v_cvt_norm_u16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtNormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -3239,7 +3892,15 @@ VNotB16Vop3::VNotB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVNotB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVNotB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_not_b16_e64_dpp"
+          : "v_not_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VNotB16Vop3>(opcode);
 }
 } // namespace detail
@@ -3290,7 +3951,15 @@ VCvtI32I16Vop3::VCvtI32I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtI32I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_i32_i16_e64_dpp"
+          : "v_cvt_i32_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtI32I16Vop3>(opcode);
 }
 } // namespace detail
@@ -3335,7 +4004,15 @@ VCvtU32U16Vop3::VCvtU32U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtU32U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_u32_u16_e64_dpp"
+          : "v_cvt_u32_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtU32U16Vop3>(opcode);
 }
 } // namespace detail
@@ -3376,7 +4053,15 @@ VCvtF32Fp8Vop3::VCvtF32Fp8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Fp8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Fp8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_fp8_e64_dpp"
+          : "v_cvt_f32_fp8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Fp8Vop3>(opcode);
 }
 } // namespace detail
@@ -3417,7 +4102,15 @@ VCvtF32Bf8Vop3::VCvtF32Bf8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtF32Bf8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtF32Bf8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_f32_bf8_e64_dpp"
+          : "v_cvt_f32_bf8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtF32Bf8Vop3>(opcode);
 }
 } // namespace detail
@@ -3442,13 +4135,22 @@ VCvtPkF32Fp8Vop3::VCvtPkF32Fp8Vop3(const MachineInst *inst)
                                (((amdgpu::vop3_opsel(inst_) >> 0) & 1u) * 16u)) &
                               0xFFFFu),
         true);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_PK_F32_FP8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF32Fp8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF32Fp8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_f32_fp8_e64_dpp"
+          : "v_cvt_pk_f32_fp8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_PK_F32_FP8 does not support DPP";
   return std::make_unique<VCvtPkF32Fp8Vop3>(opcode);
 }
 } // namespace detail
@@ -3473,13 +4175,22 @@ VCvtPkF32Bf8Vop3::VCvtPkF32Bf8Vop3(const MachineInst *inst)
                                (((amdgpu::vop3_opsel(inst_) >> 0) & 1u) * 16u)) &
                               0xFFFFu),
         true);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CVT_PK_F32_BF8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkF32Bf8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkF32Bf8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_f32_bf8_e64_dpp"
+          : "v_cvt_pk_f32_bf8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CVT_PK_F32_BF8 does not support DPP";
   return std::make_unique<VCvtPkF32Bf8Vop3>(opcode);
 }
 } // namespace detail
@@ -3528,7 +4239,16 @@ VCndmaskB32Vop3::VCndmaskB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cndmask_b32_e64_dpp"
+          : "v_cndmask_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB32Vop3>(opcode);
 }
 } // namespace detail
@@ -3557,13 +4277,21 @@ VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_ADD_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_f64_e64_dpp"
+          : "v_add_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_ADD_F64 does not support DPP";
   return std::make_unique<VAddF64Vop3>(opcode);
 }
 } // namespace detail
@@ -3610,7 +4338,15 @@ VAddF32Vop3::VAddF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_f32_e64_dpp"
+          : "v_add_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3657,7 +4393,15 @@ VSubF32Vop3::VSubF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_f32_e64_dpp"
+          : "v_sub_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3704,7 +4448,15 @@ VSubrevF32Vop3::VSubrevF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f32_e64_dpp"
+          : "v_subrev_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3733,13 +4485,21 @@ VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_f64_e64_dpp"
+          : "v_mul_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_F64 does not support DPP";
   return std::make_unique<VMulF64Vop3>(opcode);
 }
 } // namespace detail
@@ -3786,7 +4546,16 @@ VMulDx9ZeroF32Vop3::VMulDx9ZeroF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulDx9ZeroF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulDx9ZeroF32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_dx9_zero_f32_e64_dpp"
+          : "v_mul_dx9_zero_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulDx9ZeroF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3833,7 +4602,15 @@ VMulF32Vop3::VMulF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_f32_e64_dpp"
+          : "v_mul_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF32Vop3>(opcode);
 }
 } // namespace detail
@@ -3880,7 +4657,15 @@ VMulI32I24Vop3::VMulI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_i32_i24_e64_dpp"
+          : "v_mul_i32_i24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -3927,7 +4712,16 @@ VMulHiI32I24Vop3::VMulHiI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32I24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_i32_i24_e64_dpp"
+          : "v_mul_hi_i32_i24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -3974,7 +4768,15 @@ VMulU32U24Vop3::VMulU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_u32_u24_e64_dpp"
+          : "v_mul_u32_u24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -4021,7 +4823,16 @@ VMulHiU32U24Vop3::VMulHiU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32U24Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_u32_u24_e64_dpp"
+          : "v_mul_hi_u32_u24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulHiU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -4050,13 +4861,21 @@ VMinNumF64Vop3::VMinNumF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MIN_NUM_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinNumF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinNumF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_num_f64_e64_dpp"
+          : "v_min_num_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MIN_NUM_F64 does not support DPP";
   return std::make_unique<VMinNumF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4085,13 +4904,21 @@ VMaxNumF64Vop3::VMaxNumF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAX_NUM_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxNumF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxNumF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_num_f64_e64_dpp"
+          : "v_max_num_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MAX_NUM_F64 does not support DPP";
   return std::make_unique<VMaxNumF64Vop3>(opcode);
 }
 } // namespace detail
@@ -4138,7 +4965,15 @@ VMinI32Vop3::VMinI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_i32_e64_dpp"
+          : "v_min_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4185,7 +5020,15 @@ VMaxI32Vop3::VMaxI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_i32_e64_dpp"
+          : "v_max_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4232,7 +5075,15 @@ VMinU32Vop3::VMinU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_u32_e64_dpp"
+          : "v_min_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4279,7 +5130,15 @@ VMaxU32Vop3::VMaxU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_u32_e64_dpp"
+          : "v_max_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4326,7 +5185,15 @@ VMinNumF32Vop3::VMinNumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinNumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinNumF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_num_f32_e64_dpp"
+          : "v_min_num_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinNumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4373,7 +5240,15 @@ VMaxNumF32Vop3::VMaxNumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxNumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxNumF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_num_f32_e64_dpp"
+          : "v_max_num_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxNumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4420,7 +5295,16 @@ VLshlrevB32Vop3::VLshlrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b32_e64_dpp"
+          : "v_lshlrev_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4467,7 +5351,16 @@ VLshrrevB32Vop3::VLshrrevB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshrrev_b32_e64_dpp"
+          : "v_lshrrev_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4514,7 +5407,16 @@ VAshrrevI32Vop3::VAshrrevI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ashrrev_i32_e64_dpp"
+          : "v_ashrrev_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI32Vop3>(opcode);
 }
 } // namespace detail
@@ -4561,7 +5463,15 @@ VAndB32Vop3::VAndB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_and_b32_e64_dpp"
+          : "v_and_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4608,7 +5518,15 @@ VOrB32Vop3::VOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_or_b32_e64_dpp"
+          : "v_or_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4655,7 +5573,15 @@ VXorB32Vop3::VXorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xor_b32_e64_dpp"
+          : "v_xor_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4702,7 +5628,15 @@ VXnorB32Vop3::VXnorB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXnorB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXnorB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xnor_b32_e64_dpp"
+          : "v_xnor_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXnorB32Vop3>(opcode);
 }
 } // namespace detail
@@ -4730,13 +5664,22 @@ VLshlrevB64Vop3::VLshlrevB64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_LSHLREV_B64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b64_e64_dpp"
+          : "v_lshlrev_b64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_LSHLREV_B64 does not support DPP";
   return std::make_unique<VLshlrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -4783,7 +5726,15 @@ VAddNcU32Vop3::VAddNcU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_u32_e64_dpp"
+          : "v_add_nc_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4830,7 +5781,15 @@ VSubNcU32Vop3::VSubNcU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_u32_e64_dpp"
+          : "v_sub_nc_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4877,7 +5836,16 @@ VSubrevNcU32Vop3::VSubrevNcU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevNcU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevNcU32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_subrev_nc_u32_e64_dpp"
+          : "v_subrev_nc_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevNcU32Vop3>(opcode);
 }
 } // namespace detail
@@ -4925,7 +5893,15 @@ VFmacF32Vop3::VFmacF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f32_e64_dpp"
+          : "v_fmac_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF32Vop3>(opcode);
 }
 } // namespace detail
@@ -4972,7 +5948,16 @@ VCvtPkRtzF16F32Vop3::VCvtPkRtzF16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkRtzF16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkRtzF16F32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_rtz_f16_f32_e64_dpp"
+          : "v_cvt_pk_rtz_f16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkRtzF16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -5027,7 +6012,15 @@ VMinNumF16Vop3::VMinNumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinNumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinNumF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_num_f16_e64_dpp"
+          : "v_min_num_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinNumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5088,7 +6081,15 @@ VMaxNumF16Vop3::VMaxNumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxNumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxNumF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_num_f16_e64_dpp"
+          : "v_max_num_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxNumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5149,7 +6150,15 @@ VAddF16Vop3::VAddF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_f16_e64_dpp"
+          : "v_add_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5210,7 +6219,15 @@ VSubF16Vop3::VSubF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_f16_e64_dpp"
+          : "v_sub_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5271,7 +6288,15 @@ VSubrevF16Vop3::VSubrevF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubrevF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_subrev_f16_e64_dpp"
+          : "v_subrev_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5332,7 +6357,15 @@ VMulF16Vop3::VMulF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_f16_e64_dpp"
+          : "v_mul_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5394,7 +6427,15 @@ VFmacF16Vop3::VFmacF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmacF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmacF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fmac_f16_e64_dpp"
+          : "v_fmac_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmacF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5455,7 +6496,15 @@ VLdexpF16Vop3::VLdexpF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ldexp_f16_e64_dpp"
+          : "v_ldexp_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -5514,7 +6563,16 @@ VFmaDx9ZeroF32Vop3::VFmaDx9ZeroF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaDx9ZeroF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaDx9ZeroF32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fma_dx9_zero_f32_e64_dpp"
+          : "v_fma_dx9_zero_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaDx9ZeroF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5567,7 +6625,15 @@ VMadI32I24Vop3::VMadI32I24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_i32_i24_e64_dpp"
+          : "v_mad_i32_i24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I24Vop3>(opcode);
 }
 } // namespace detail
@@ -5620,7 +6686,15 @@ VMadU32U24Vop3::VMadU32U24Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U24Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U24Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_u32_u24_e64_dpp"
+          : "v_mad_u32_u24",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U24Vop3>(opcode);
 }
 } // namespace detail
@@ -5673,7 +6747,15 @@ VCubeidF32Vop3::VCubeidF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubeidF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubeidF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cubeid_f32_e64_dpp"
+          : "v_cubeid_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubeidF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5726,7 +6808,15 @@ VCubescF32Vop3::VCubescF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubescF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubescF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cubesc_f32_e64_dpp"
+          : "v_cubesc_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubescF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5779,7 +6869,15 @@ VCubetcF32Vop3::VCubetcF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubetcF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubetcF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cubetc_f32_e64_dpp"
+          : "v_cubetc_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubetcF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5832,7 +6930,15 @@ VCubemaF32Vop3::VCubemaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCubemaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCubemaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cubema_f32_e64_dpp"
+          : "v_cubema_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCubemaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -5885,7 +6991,15 @@ VBfeU32Vop3::VBfeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfe_u32_e64_dpp"
+          : "v_bfe_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -5938,7 +7052,15 @@ VBfeI32Vop3::VBfeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfe_i32_e64_dpp"
+          : "v_bfe_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -5991,7 +7113,15 @@ VBfiB32Vop3::VBfiB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfiB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfiB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfi_b32_e64_dpp"
+          : "v_bfi_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfiB32Vop3>(opcode);
 }
 } // namespace detail
@@ -6044,7 +7174,15 @@ VFmaF32Vop3::VFmaF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fma_f32_e64_dpp"
+          : "v_fma_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6080,13 +7218,21 @@ VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_FMA_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fma_f64_e64_dpp"
+          : "v_fma_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_FMA_F64 does not support DPP";
   return std::make_unique<VFmaF64Vop3>(opcode);
 }
 } // namespace detail
@@ -6139,7 +7285,15 @@ VLerpU8Vop3::VLerpU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLerpU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLerpU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lerp_u8_e64_dpp"
+          : "v_lerp_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLerpU8Vop3>(opcode);
 }
 } // namespace detail
@@ -6196,7 +7350,16 @@ VAlignbitB32Vop3::VAlignbitB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbitB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbitB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_alignbit_b32_e64_dpp"
+          : "v_alignbit_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbitB32Vop3>(opcode);
 }
 } // namespace detail
@@ -6253,7 +7416,16 @@ VAlignbyteB32Vop3::VAlignbyteB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAlignbyteB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAlignbyteB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_alignbyte_b32_e64_dpp"
+          : "v_alignbyte_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAlignbyteB32Vop3>(opcode);
 }
 } // namespace detail
@@ -6306,7 +7478,15 @@ VMullitF32Vop3::VMullitF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMullitF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMullitF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mullit_f32_e64_dpp"
+          : "v_mullit_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMullitF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6359,7 +7539,15 @@ VMin3I32Vop3::VMin3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_i32_e64_dpp"
+          : "v_min3_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -6412,7 +7600,15 @@ VMin3U32Vop3::VMin3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_u32_e64_dpp"
+          : "v_min3_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -6465,7 +7661,15 @@ VMax3I32Vop3::VMax3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_i32_e64_dpp"
+          : "v_max3_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -6518,7 +7722,15 @@ VMax3U32Vop3::VMax3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_u32_e64_dpp"
+          : "v_max3_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -6571,7 +7783,15 @@ VMed3I32Vop3::VMed3I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_i32_e64_dpp"
+          : "v_med3_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I32Vop3>(opcode);
 }
 } // namespace detail
@@ -6624,7 +7844,15 @@ VMed3U32Vop3::VMed3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_u32_e64_dpp"
+          : "v_med3_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -6677,7 +7905,15 @@ VSadU8Vop3::VSadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sad_u8_e64_dpp"
+          : "v_sad_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -6730,7 +7966,15 @@ VSadHiU8Vop3::VSadHiU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadHiU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadHiU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sad_hi_u8_e64_dpp"
+          : "v_sad_hi_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadHiU8Vop3>(opcode);
 }
 } // namespace detail
@@ -6783,7 +8027,15 @@ VSadU16Vop3::VSadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sad_u16_e64_dpp"
+          : "v_sad_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -6836,7 +8088,15 @@ VSadU32Vop3::VSadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sad_u32_e64_dpp"
+          : "v_sad_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -6889,7 +8149,16 @@ VCvtPkU8F32Vop3::VCvtPkU8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU8F32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_u8_f32_e64_dpp"
+          : "v_cvt_pk_u8_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -6922,13 +8191,22 @@ VDivFixupF32Vop3::VDivFixupF32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_FIXUP_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fixup_f32_e64_dpp"
+          : "v_div_fixup_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_DIV_FIXUP_F32 does not support DPP";
   return std::make_unique<VDivFixupF32Vop3>(opcode);
 }
 } // namespace detail
@@ -6964,13 +8242,22 @@ VDivFixupF64Vop3::VDivFixupF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_FIXUP_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fixup_f64_e64_dpp"
+          : "v_div_fixup_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_DIV_FIXUP_F64 does not support DPP";
   return std::make_unique<VDivFixupF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7023,7 +8310,16 @@ VMin3NumF32Vop3::VMin3NumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3NumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3NumF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_num_f32_e64_dpp"
+          : "v_min3_num_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3NumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7076,7 +8372,16 @@ VMax3NumF32Vop3::VMax3NumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3NumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3NumF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_num_f32_e64_dpp"
+          : "v_max3_num_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3NumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7141,7 +8446,16 @@ VMin3NumF16Vop3::VMin3NumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3NumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3NumF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_num_f16_e64_dpp"
+          : "v_min3_num_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3NumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -7212,7 +8526,16 @@ VMax3NumF16Vop3::VMax3NumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3NumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3NumF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_num_f16_e64_dpp"
+          : "v_max3_num_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3NumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -7271,7 +8594,16 @@ VMinimum3F32Vop3::VMinimum3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinimum3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinimum3F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minimum3_f32_e64_dpp"
+          : "v_minimum3_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinimum3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -7324,7 +8656,16 @@ VMaximum3F32Vop3::VMaximum3F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaximum3F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaximum3F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maximum3_f32_e64_dpp"
+          : "v_maximum3_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaximum3F32Vop3>(opcode);
 }
 } // namespace detail
@@ -7389,7 +8730,16 @@ VMinimum3F16Vop3::VMinimum3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinimum3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinimum3F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minimum3_f16_e64_dpp"
+          : "v_minimum3_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinimum3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -7460,7 +8810,16 @@ VMaximum3F16Vop3::VMaximum3F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaximum3F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaximum3F16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maximum3_f16_e64_dpp"
+          : "v_maximum3_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaximum3F16Vop3>(opcode);
 }
 } // namespace detail
@@ -7519,7 +8878,16 @@ VMed3NumF32Vop3::VMed3NumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3NumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3NumF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_num_f32_e64_dpp"
+          : "v_med3_num_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3NumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7584,7 +8952,16 @@ VMed3NumF16Vop3::VMed3NumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3NumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3NumF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_num_f16_e64_dpp"
+          : "v_med3_num_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3NumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -7625,14 +9002,23 @@ VDivFmasF32Vop3::VDivFmasF32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_FMAS_F32 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fmas_f32_e64_dpp"
+          : "v_div_fmas_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_DIV_FMAS_F32 does not support DPP";
   return std::make_unique<VDivFmasF32Vop3>(opcode);
 }
 } // namespace detail
@@ -7670,14 +9056,23 @@ VDivFmasF64Vop3::VDivFmasF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_FMAS_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFmasF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFmasF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fmas_f64_e64_dpp"
+          : "v_div_fmas_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_DIV_FMAS_F64 does not support DPP";
   return std::make_unique<VDivFmasF64Vop3>(opcode);
 }
 } // namespace detail
@@ -7730,7 +9125,15 @@ VMsadU8Vop3::VMsadU8Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMsadU8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMsadU8Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_msad_u8_e64_dpp"
+          : "v_msad_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMsadU8Vop3>(opcode);
 }
 } // namespace detail
@@ -7765,13 +9168,22 @@ VQsadPkU16U8Vop3::VQsadPkU16U8Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_QSAD_PK_U16_U8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVQsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVQsadPkU16U8Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_qsad_pk_u16_u8_e64_dpp"
+          : "v_qsad_pk_u16_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_QSAD_PK_U16_U8 does not support DPP";
   return std::make_unique<VQsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -7806,13 +9218,22 @@ VMqsadPkU16U8Vop3::VMqsadPkU16U8Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MQSAD_PK_U16_U8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadPkU16U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadPkU16U8Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mqsad_pk_u16_u8_e64_dpp"
+          : "v_mqsad_pk_u16_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MQSAD_PK_U16_U8 does not support DPP";
   return std::make_unique<VMqsadPkU16U8Vop3>(opcode);
 }
 } // namespace detail
@@ -7842,13 +9263,22 @@ VMqsadU32U8Vop3::VMqsadU32U8Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MQSAD_U32_U8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMqsadU32U8Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMqsadU32U8Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mqsad_u32_u8_e64_dpp"
+          : "v_mqsad_u32_u8",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MQSAD_U32_U8 does not support DPP";
   return std::make_unique<VMqsadU32U8Vop3>(opcode);
 }
 } // namespace detail
@@ -7901,7 +9331,15 @@ VXor3B32Vop3::VXor3B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXor3B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXor3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xor3_b32_e64_dpp"
+          : "v_xor3_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXor3B32Vop3>(opcode);
 }
 } // namespace detail
@@ -7966,7 +9404,15 @@ VMadU16Vop3::VMadU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_u16_e64_dpp"
+          : "v_mad_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU16Vop3>(opcode);
 }
 } // namespace detail
@@ -8025,7 +9471,15 @@ VPermB32Vop3::VPermB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_perm_b32_e64_dpp"
+          : "v_perm_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPermB32Vop3>(opcode);
 }
 } // namespace detail
@@ -8078,7 +9532,15 @@ VXadU32Vop3::VXadU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXadU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXadU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xad_u32_e64_dpp"
+          : "v_xad_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXadU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8131,7 +9593,16 @@ VLshlAddU32Vop3::VLshlAddU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlAddU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlAddU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshl_add_u32_e64_dpp"
+          : "v_lshl_add_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlAddU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8184,7 +9655,16 @@ VAddLshlU32Vop3::VAddLshlU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddLshlU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddLshlU32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_lshl_u32_e64_dpp"
+          : "v_add_lshl_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddLshlU32Vop3>(opcode);
 }
 } // namespace detail
@@ -8249,7 +9729,15 @@ VFmaF16Vop3::VFmaF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVFmaF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_fma_f16_e64_dpp"
+          : "v_fma_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaF16Vop3>(opcode);
 }
 } // namespace detail
@@ -8320,7 +9808,15 @@ VMin3I16Vop3::VMin3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_i16_e64_dpp"
+          : "v_min3_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -8391,7 +9887,15 @@ VMin3U16Vop3::VMin3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMin3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMin3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min3_u16_e64_dpp"
+          : "v_min3_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMin3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -8462,7 +9966,15 @@ VMax3I16Vop3::VMax3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_i16_e64_dpp"
+          : "v_max3_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -8533,7 +10045,15 @@ VMax3U16Vop3::VMax3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMax3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMax3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max3_u16_e64_dpp"
+          : "v_max3_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMax3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -8604,7 +10124,15 @@ VMed3I16Vop3::VMed3I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_i16_e64_dpp"
+          : "v_med3_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3I16Vop3>(opcode);
 }
 } // namespace detail
@@ -8675,7 +10203,15 @@ VMed3U16Vop3::VMed3U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMed3U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_med3_u16_e64_dpp"
+          : "v_med3_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMed3U16Vop3>(opcode);
 }
 } // namespace detail
@@ -8746,7 +10282,15 @@ VMadI16Vop3::VMadI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_i16_e64_dpp"
+          : "v_mad_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI16Vop3>(opcode);
 }
 } // namespace detail
@@ -8817,7 +10361,16 @@ VDivFixupF16Vop3::VDivFixupF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivFixupF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDivFixupF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_div_fixup_f16_e64_dpp"
+          : "v_div_fixup_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDivFixupF16Vop3>(opcode);
 }
 } // namespace detail
@@ -8876,7 +10429,15 @@ VAdd3U32Vop3::VAdd3U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAdd3U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAdd3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add3_u32_e64_dpp"
+          : "v_add3_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAdd3U32Vop3>(opcode);
 }
 } // namespace detail
@@ -8929,7 +10490,15 @@ VLshlOrB32Vop3::VLshlOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshl_or_b32_e64_dpp"
+          : "v_lshl_or_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -8982,7 +10551,15 @@ VAndOrB32Vop3::VAndOrB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndOrB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndOrB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_and_or_b32_e64_dpp"
+          : "v_and_or_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndOrB32Vop3>(opcode);
 }
 } // namespace detail
@@ -9035,7 +10612,15 @@ VOr3B32Vop3::VOr3B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOr3B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOr3B32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_or3_b32_e64_dpp"
+          : "v_or3_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOr3B32Vop3>(opcode);
 }
 } // namespace detail
@@ -9096,7 +10681,15 @@ VMadU32U16Vop3::VMadU32U16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadU32U16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadU32U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_u32_u16_e64_dpp"
+          : "v_mad_u32_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadU32U16Vop3>(opcode);
 }
 } // namespace detail
@@ -9157,7 +10750,15 @@ VMadI32I16Vop3::VMadI32I16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadI32I16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMadI32I16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mad_i32_i16_e64_dpp"
+          : "v_mad_i32_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMadI32I16Vop3>(opcode);
 }
 } // namespace detail
@@ -9186,13 +10787,22 @@ VPermlane16B32Vop3::VPermlane16B32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANE16_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlane16B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlane16B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_permlane16_b32_e64_dpp"
+          : "v_permlane16_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE16_B32 does not support DPP";
   return std::make_unique<VPermlane16B32Vop3>(opcode);
 }
 } // namespace detail
@@ -9221,13 +10831,22 @@ VPermlanex16B32Vop3::VPermlanex16B32Vop3(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANEX16_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlanex16B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlanex16B32Vop3(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_permlanex16_b32_e64_dpp"
+          : "v_permlanex16_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANEX16_B32 does not support DPP";
   return std::make_unique<VPermlanex16B32Vop3>(opcode);
 }
 } // namespace detail
@@ -9284,7 +10903,16 @@ VCndmaskB16Vop3::VCndmaskB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCndmaskB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCndmaskB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cndmask_b16_e64_dpp"
+          : "v_cndmask_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCndmaskB16Vop3>(opcode);
 }
 } // namespace detail
@@ -9343,7 +10971,15 @@ VMaxminU32Vop3::VMaxminU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxminU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxminU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maxmin_u32_e64_dpp"
+          : "v_maxmin_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxminU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9396,7 +11032,15 @@ VMinmaxU32Vop3::VMinmaxU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinmaxU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinmaxU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minmax_u32_e64_dpp"
+          : "v_minmax_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinmaxU32Vop3>(opcode);
 }
 } // namespace detail
@@ -9449,7 +11093,15 @@ VMaxminI32Vop3::VMaxminI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxminI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxminI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maxmin_i32_e64_dpp"
+          : "v_maxmin_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxminI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9502,7 +11154,15 @@ VMinmaxI32Vop3::VMinmaxI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinmaxI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinmaxI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minmax_i32_e64_dpp"
+          : "v_minmax_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinmaxI32Vop3>(opcode);
 }
 } // namespace detail
@@ -9559,7 +11219,16 @@ VDot2F16F16Vop3::VDot2F16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2F16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot2F16F16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_dot2_f16_f16_e64_dpp"
+          : "v_dot2_f16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2F16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -9622,7 +11291,16 @@ VDot2Bf16Bf16Vop3::VDot2Bf16Bf16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2Bf16Bf16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVDot2Bf16Bf16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_dot2_bf16_bf16_e64_dpp"
+          : "v_dot2_bf16_bf16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2Bf16Bf16Vop3>(opcode);
 }
 } // namespace detail
@@ -9681,7 +11359,16 @@ VMinmaxNumF32Vop3::VMinmaxNumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinmaxNumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinmaxNumF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minmax_num_f32_e64_dpp"
+          : "v_minmax_num_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinmaxNumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -9734,7 +11421,16 @@ VMaxminNumF32Vop3::VMaxminNumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxminNumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxminNumF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maxmin_num_f32_e64_dpp"
+          : "v_maxmin_num_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxminNumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -9799,7 +11495,16 @@ VMinmaxNumF16Vop3::VMinmaxNumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinmaxNumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinmaxNumF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minmax_num_f16_e64_dpp"
+          : "v_minmax_num_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinmaxNumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -9870,7 +11575,16 @@ VMaxminNumF16Vop3::VMaxminNumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxminNumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxminNumF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maxmin_num_f16_e64_dpp"
+          : "v_maxmin_num_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxminNumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -9929,7 +11643,16 @@ VMinimummaximumF32Vop3::VMinimummaximumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinimummaximumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinimummaximumF32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minimummaximum_f32_e64_dpp"
+          : "v_minimummaximum_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinimummaximumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -9982,7 +11705,16 @@ VMaximumminimumF32Vop3::VMaximumminimumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaximumminimumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaximumminimumF32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maximumminimum_f32_e64_dpp"
+          : "v_maximumminimum_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaximumminimumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -10047,7 +11779,16 @@ VMinimummaximumF16Vop3::VMinimummaximumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinimummaximumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinimummaximumF16Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minimummaximum_f16_e64_dpp"
+          : "v_minimummaximum_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinimummaximumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10118,7 +11859,16 @@ VMaximumminimumF16Vop3::VMaximumminimumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaximumminimumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaximumminimumF16Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maximumminimum_f16_e64_dpp"
+          : "v_maximumminimum_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaximumminimumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10141,19 +11891,28 @@ VSExpF32Vop3::VSExpF32Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_EXP_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_EXP_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSExpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSExpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_exp_f32_e64_dpp"
+          : "v_s_exp_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_EXP_F32 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_EXP_F32 does not support DPP";
   return std::make_unique<VSExpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -10170,20 +11929,29 @@ VSExpF16Vop3::VSExpF16Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_EXP_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_EXP_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSExpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSExpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_exp_f16_e64_dpp"
+          : "v_s_exp_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_EXP_F16 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_EXP_F16 does not support DPP";
   return std::make_unique<VSExpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10200,19 +11968,28 @@ VSLogF32Vop3::VSLogF32Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_LOG_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_LOG_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSLogF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSLogF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_log_f32_e64_dpp"
+          : "v_s_log_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_LOG_F32 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_LOG_F32 does not support DPP";
   return std::make_unique<VSLogF32Vop3>(opcode);
 }
 } // namespace detail
@@ -10229,20 +12006,29 @@ VSLogF16Vop3::VSLogF16Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_LOG_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_LOG_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSLogF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSLogF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_log_f16_e64_dpp"
+          : "v_s_log_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_LOG_F16 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_LOG_F16 does not support DPP";
   return std::make_unique<VSLogF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10259,19 +12045,28 @@ VSRcpF32Vop3::VSRcpF32Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_RCP_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_RCP_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSRcpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSRcpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_rcp_f32_e64_dpp"
+          : "v_s_rcp_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_RCP_F32 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_RCP_F32 does not support DPP";
   return std::make_unique<VSRcpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -10288,20 +12083,29 @@ VSRcpF16Vop3::VSRcpF16Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_RCP_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_RCP_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSRcpF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSRcpF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_rcp_f16_e64_dpp"
+          : "v_s_rcp_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_RCP_F16 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_RCP_F16 does not support DPP";
   return std::make_unique<VSRcpF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10318,19 +12122,28 @@ VSRsqF32Vop3::VSRsqF32Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_RSQ_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_RSQ_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSRsqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSRsqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_rsq_f32_e64_dpp"
+          : "v_s_rsq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_RSQ_F32 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_RSQ_F32 does not support DPP";
   return std::make_unique<VSRsqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -10347,20 +12160,29 @@ VSRsqF16Vop3::VSRsqF16Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_RSQ_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_RSQ_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSRsqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSRsqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_rsq_f16_e64_dpp"
+          : "v_s_rsq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_RSQ_F16 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_RSQ_F16 does not support DPP";
   return std::make_unique<VSRsqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10377,19 +12199,28 @@ VSSqrtF32Vop3::VSSqrtF32Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_SQRT_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_SQRT_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSSqrtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSSqrtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_sqrt_f32_e64_dpp"
+          : "v_s_sqrt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_SQRT_F32 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_SQRT_F32 does not support DPP";
   return std::make_unique<VSSqrtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -10406,20 +12237,29 @@ VSSqrtF16Vop3::VSSqrtF16Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
-    throw util::InvalidInst("V_S_SQRT_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,
                 static_cast<int>((
                     reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32 & 0xFFFFu)));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_S_SQRT_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSSqrtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSSqrtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_s_sqrt_f16_e64_dpp"
+          : "v_s_sqrt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->vdst >=
+      OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) [[unlikely]]
+    return emit_error.emit() << "V_S_SQRT_F16 has an invalid SReg_32_XEXEC destination";
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_S_SQRT_F16 does not support DPP";
   return std::make_unique<VSSqrtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -10474,7 +12314,15 @@ VAddNcU16Vop3::VAddNcU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_u16_e64_dpp"
+          : "v_add_nc_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcU16Vop3>(opcode);
 }
 } // namespace detail
@@ -10535,7 +12383,15 @@ VSubNcU16Vop3::VSubNcU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_u16_e64_dpp"
+          : "v_sub_nc_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcU16Vop3>(opcode);
 }
 } // namespace detail
@@ -10596,7 +12452,15 @@ VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_lo_u16_e64_dpp"
+          : "v_mul_lo_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMulLoU16Vop3>(opcode);
 }
 } // namespace detail
@@ -10649,7 +12513,16 @@ VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkI16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkI16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_i16_f32_e64_dpp"
+          : "v_cvt_pk_i16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkI16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -10696,7 +12569,16 @@ VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU16F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_u16_f32_e64_dpp"
+          : "v_cvt_pk_u16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -10751,7 +12633,15 @@ VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_u16_e64_dpp"
+          : "v_max_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxU16Vop3>(opcode);
 }
 } // namespace detail
@@ -10812,7 +12702,15 @@ VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaxI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaxI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_max_i16_e64_dpp"
+          : "v_max_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaxI16Vop3>(opcode);
 }
 } // namespace detail
@@ -10873,7 +12771,15 @@ VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_u16_e64_dpp"
+          : "v_min_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinU16Vop3>(opcode);
 }
 } // namespace detail
@@ -10934,7 +12840,15 @@ VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_min_i16_e64_dpp"
+          : "v_min_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinI16Vop3>(opcode);
 }
 } // namespace detail
@@ -10995,7 +12909,15 @@ VAddNcI16Vop3::VAddNcI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_i16_e64_dpp"
+          : "v_add_nc_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcI16Vop3>(opcode);
 }
 } // namespace detail
@@ -11056,7 +12978,15 @@ VSubNcI16Vop3::VSubNcI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_i16_e64_dpp"
+          : "v_sub_nc_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcI16Vop3>(opcode);
 }
 } // namespace detail
@@ -11081,13 +13011,22 @@ VPermlane16VarB32Vop3::VPermlane16VarB32Vop3(const MachineInst *inst)
   src_operands_[1] = &src1;
   num_src_ = 2;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANE16_VAR_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlane16VarB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlane16VarB32Vop3(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_permlane16_var_b32_e64_dpp"
+          : "v_permlane16_var_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANE16_VAR_B32 does not support DPP";
   return std::make_unique<VPermlane16VarB32Vop3>(opcode);
 }
 } // namespace detail
@@ -11106,13 +13045,22 @@ VPermlanex16VarB32Vop3::VPermlanex16VarB32Vop3(const MachineInst *inst)
   src_operands_[1] = &src1;
   num_src_ = 2;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PERMLANEX16_VAR_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPermlanex16VarB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPermlanex16VarB32Vop3(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_permlanex16_var_b32_e64_dpp"
+          : "v_permlanex16_var_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_PERMLANEX16_VAR_B32 does not support DPP";
   return std::make_unique<VPermlanex16VarB32Vop3>(opcode);
 }
 } // namespace detail
@@ -11167,7 +13115,16 @@ VPackB32F16Vop3::VPackB32F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPackB32F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVPackB32F16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_pack_b32_f16_e64_dpp"
+          : "v_pack_b32_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VPackB32F16Vop3>(opcode);
 }
 } // namespace detail
@@ -11222,7 +13179,16 @@ VCvtPkNormI16F16Vop3::VCvtPkNormI16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkNormI16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkNormI16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_norm_i16_f16_e64_dpp"
+          : "v_cvt_pk_norm_i16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkNormI16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -11277,7 +13243,16 @@ VCvtPkNormU16F16Vop3::VCvtPkNormU16F16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkNormU16F16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkNormU16F16Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_norm_u16_f16_e64_dpp"
+          : "v_cvt_pk_norm_u16_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkNormU16F16Vop3>(opcode);
 }
 } // namespace detail
@@ -11324,7 +13299,15 @@ VLdexpF32Vop3::VLdexpF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ldexp_f32_e64_dpp"
+          : "v_ldexp_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLdexpF32Vop3>(opcode);
 }
 } // namespace detail
@@ -11371,7 +13354,15 @@ VBfmB32Vop3::VBfmB32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBfmB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBfmB32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bfm_b32_e64_dpp"
+          : "v_bfm_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBfmB32Vop3>(opcode);
 }
 } // namespace detail
@@ -11418,7 +13409,16 @@ VBcntU32B32Vop3::VBcntU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVBcntU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVBcntU32B32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_bcnt_u32_b32_e64_dpp"
+          : "v_bcnt_u32_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VBcntU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -11465,7 +13465,16 @@ VMbcntLoU32B32Vop3::VMbcntLoU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntLoU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntLoU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mbcnt_lo_u32_b32_e64_dpp"
+          : "v_mbcnt_lo_u32_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntLoU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -11512,7 +13521,16 @@ VMbcntHiU32B32Vop3::VMbcntHiU32B32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMbcntHiU32B32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMbcntHiU32B32Vop3(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mbcnt_hi_u32_b32_e64_dpp"
+          : "v_mbcnt_hi_u32_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMbcntHiU32B32Vop3>(opcode);
 }
 } // namespace detail
@@ -11559,7 +13577,16 @@ VCvtPkNormI16F32Vop3::VCvtPkNormI16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkNormI16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkNormI16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_norm_i16_f32_e64_dpp"
+          : "v_cvt_pk_norm_i16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkNormI16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -11606,7 +13633,16 @@ VCvtPkNormU16F32Vop3::VCvtPkNormU16F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkNormU16F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkNormU16F32Vop3(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_norm_u16_f32_e64_dpp"
+          : "v_cvt_pk_norm_u16_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkNormU16F32Vop3>(opcode);
 }
 } // namespace detail
@@ -11653,7 +13689,16 @@ VCvtPkU16U32Vop3::VCvtPkU16U32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkU16U32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkU16U32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_u16_u32_e64_dpp"
+          : "v_cvt_pk_u16_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkU16U32Vop3>(opcode);
 }
 } // namespace detail
@@ -11700,7 +13745,16 @@ VCvtPkI16I32Vop3::VCvtPkI16I32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkI16I32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkI16I32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_i16_i32_e64_dpp"
+          : "v_cvt_pk_i16_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkI16I32Vop3>(opcode);
 }
 } // namespace detail
@@ -11747,7 +13801,15 @@ VSubNcI32Vop3::VSubNcI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubNcI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVSubNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_sub_nc_i32_e64_dpp"
+          : "v_sub_nc_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubNcI32Vop3>(opcode);
 }
 } // namespace detail
@@ -11794,7 +13856,15 @@ VAddNcI32Vop3::VAddNcI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddNcI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAddNcI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_add_nc_i32_e64_dpp"
+          : "v_add_nc_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddNcI32Vop3>(opcode);
 }
 } // namespace detail
@@ -11822,13 +13892,21 @@ VLdexpF64Vop3::VLdexpF64Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_LDEXP_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLdexpF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLdexpF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ldexp_f64_e64_dpp"
+          : "v_ldexp_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_LDEXP_F64 does not support DPP";
   return std::make_unique<VLdexpF64Vop3>(opcode);
 }
 } // namespace detail
@@ -11855,13 +13933,21 @@ VMulLoU32Vop3::VMulLoU32Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_LO_U32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulLoU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulLoU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_lo_u32_e64_dpp"
+          : "v_mul_lo_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_LO_U32 does not support DPP";
   return std::make_unique<VMulLoU32Vop3>(opcode);
 }
 } // namespace detail
@@ -11888,13 +13974,21 @@ VMulHiU32Vop3::VMulHiU32Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_HI_U32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_u32_e64_dpp"
+          : "v_mul_hi_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_HI_U32 does not support DPP";
   return std::make_unique<VMulHiU32Vop3>(opcode);
 }
 } // namespace detail
@@ -11921,13 +14015,21 @@ VMulHiI32Vop3::VMulHiI32Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MUL_HI_I32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMulHiI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMulHiI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_mul_hi_i32_e64_dpp"
+          : "v_mul_hi_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MUL_HI_I32 does not support DPP";
   return std::make_unique<VMulHiI32Vop3>(opcode);
 }
 } // namespace detail
@@ -11955,13 +14057,22 @@ VTrigPreopF64Vop3::VTrigPreopF64Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_TRIG_PREOP_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVTrigPreopF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVTrigPreopF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_trig_preop_f64_e64_dpp"
+          : "v_trig_preop_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_TRIG_PREOP_F64 does not support DPP";
   return std::make_unique<VTrigPreopF64Vop3>(opcode);
 }
 } // namespace detail
@@ -12016,7 +14127,16 @@ VLshlrevB16Vop3::VLshlrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshlrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshlrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshlrev_b16_e64_dpp"
+          : "v_lshlrev_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshlrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -12077,7 +14197,16 @@ VLshrrevB16Vop3::VLshrrevB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshrrev_b16_e64_dpp"
+          : "v_lshrrev_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VLshrrevB16Vop3>(opcode);
 }
 } // namespace detail
@@ -12138,7 +14267,16 @@ VAshrrevI16Vop3::VAshrrevI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ashrrev_i16_e64_dpp"
+          : "v_ashrrev_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAshrrevI16Vop3>(opcode);
 }
 } // namespace detail
@@ -12172,13 +14310,22 @@ VLshrrevB64Vop3::VLshrrevB64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_LSHRREV_B64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVLshrrevB64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVLshrrevB64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_lshrrev_b64_e64_dpp"
+          : "v_lshrrev_b64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_LSHRREV_B64 does not support DPP";
   return std::make_unique<VLshrrevB64Vop3>(opcode);
 }
 } // namespace detail
@@ -12206,13 +14353,22 @@ VAshrrevI64Vop3::VAshrrevI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_ASHRREV_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAshrrevI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAshrrevI64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_ashrrev_i64_e64_dpp"
+          : "v_ashrrev_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_ASHRREV_I64 does not support DPP";
   return std::make_unique<VAshrrevI64Vop3>(opcode);
 }
 } // namespace detail
@@ -12241,13 +14397,22 @@ VMinimumF64Vop3::VMinimumF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MINIMUM_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinimumF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinimumF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minimum_f64_e64_dpp"
+          : "v_minimum_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MINIMUM_F64 does not support DPP";
   return std::make_unique<VMinimumF64Vop3>(opcode);
 }
 } // namespace detail
@@ -12276,13 +14441,22 @@ VMaximumF64Vop3::VMaximumF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAXIMUM_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaximumF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaximumF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maximum_f64_e64_dpp"
+          : "v_maximum_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_MAXIMUM_F64 does not support DPP";
   return std::make_unique<VMaximumF64Vop3>(opcode);
 }
 } // namespace detail
@@ -12301,13 +14475,22 @@ VReadlaneB32Vop3::VReadlaneB32Vop3(const MachineInst *inst)
   src_operands_[1] = &src1;
   num_src_ = 2;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_READLANE_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVReadlaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVReadlaneB32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_readlane_b32_e64_dpp"
+          : "v_readlane_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_READLANE_B32 does not support DPP";
   return std::make_unique<VReadlaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -12331,13 +14514,22 @@ VWritelaneB32Vop3::VWritelaneB32Vop3(const MachineInst *inst)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WRITELANE_B32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWritelaneB32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVWritelaneB32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_writelane_b32_e64_dpp"
+          : "v_writelane_b32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_WRITELANE_B32 does not support DPP";
   return std::make_unique<VWritelaneB32Vop3>(opcode);
 }
 } // namespace detail
@@ -12392,7 +14584,15 @@ VAndB16Vop3::VAndB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAndB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVAndB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_and_b16_e64_dpp"
+          : "v_and_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAndB16Vop3>(opcode);
 }
 } // namespace detail
@@ -12453,7 +14653,15 @@ VOrB16Vop3::VOrB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVOrB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVOrB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_or_b16_e64_dpp"
+          : "v_or_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VOrB16Vop3>(opcode);
 }
 } // namespace detail
@@ -12514,7 +14722,15 @@ VXorB16Vop3::VXorB16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVXorB16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVXorB16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_xor_b16_e64_dpp"
+          : "v_xor_b16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VXorB16Vop3>(opcode);
 }
 } // namespace detail
@@ -12567,7 +14783,16 @@ VMinimumF32Vop3::VMinimumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinimumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinimumF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minimum_f32_e64_dpp"
+          : "v_minimum_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinimumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12614,7 +14839,16 @@ VMaximumF32Vop3::VMaximumF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaximumF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaximumF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maximum_f32_e64_dpp"
+          : "v_maximum_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaximumF32Vop3>(opcode);
 }
 } // namespace detail
@@ -12669,7 +14903,16 @@ VMinimumF16Vop3::VMinimumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMinimumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMinimumF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_minimum_f16_e64_dpp"
+          : "v_minimum_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMinimumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12730,7 +14973,16 @@ VMaximumF16Vop3::VMaximumF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMaximumF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVMaximumF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_maximum_f16_e64_dpp"
+          : "v_maximum_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VMaximumF16Vop3>(opcode);
 }
 } // namespace detail
@@ -12783,7 +15035,16 @@ VCvtPkFp8F32Vop3::VCvtPkFp8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkFp8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkFp8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_fp8_f32_e64_dpp"
+          : "v_cvt_pk_fp8_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkFp8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -12836,7 +15097,16 @@ VCvtPkBf8F32Vop3::VCvtPkBf8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtPkBf8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtPkBf8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_pk_bf8_f32_e64_dpp"
+          : "v_cvt_pk_bf8_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtPkBf8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -12890,7 +15160,16 @@ VCvtSrFp8F32Vop3::VCvtSrFp8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtSrFp8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtSrFp8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_sr_fp8_f32_e64_dpp"
+          : "v_cvt_sr_fp8_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtSrFp8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -12944,7 +15223,16 @@ VCvtSrBf8F32Vop3::VCvtSrBf8F32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCvtSrBf8F32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCvtSrBf8F32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cvt_sr_bf8_f32_e64_dpp"
+          : "v_cvt_sr_bf8_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCvtSrBf8F32Vop3>(opcode);
 }
 } // namespace detail
@@ -13005,7 +15293,15 @@ VCmpLtF16Vop3::VCmpLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f16_e64_dpp"
+          : "v_cmp_lt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -13060,7 +15356,15 @@ VCmpEqF16Vop3::VCmpEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f16_e64_dpp"
+          : "v_cmp_eq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -13115,7 +15419,15 @@ VCmpLeF16Vop3::VCmpLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f16_e64_dpp"
+          : "v_cmp_le_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -13170,7 +15482,15 @@ VCmpGtF16Vop3::VCmpGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f16_e64_dpp"
+          : "v_cmp_gt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -13225,7 +15545,15 @@ VCmpLgF16Vop3::VCmpLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f16_e64_dpp"
+          : "v_cmp_lg_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -13280,7 +15608,15 @@ VCmpGeF16Vop3::VCmpGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f16_e64_dpp"
+          : "v_cmp_ge_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -13335,7 +15671,15 @@ VCmpOF16Vop3::VCmpOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f16_e64_dpp"
+          : "v_cmp_o_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -13390,7 +15734,15 @@ VCmpUF16Vop3::VCmpUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f16_e64_dpp"
+          : "v_cmp_u_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -13445,7 +15797,15 @@ VCmpNgeF16Vop3::VCmpNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f16_e64_dpp"
+          : "v_cmp_nge_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -13500,7 +15860,15 @@ VCmpNlgF16Vop3::VCmpNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f16_e64_dpp"
+          : "v_cmp_nlg_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -13555,7 +15923,15 @@ VCmpNgtF16Vop3::VCmpNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f16_e64_dpp"
+          : "v_cmp_ngt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -13610,7 +15986,15 @@ VCmpNleF16Vop3::VCmpNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f16_e64_dpp"
+          : "v_cmp_nle_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -13665,7 +16049,15 @@ VCmpNeqF16Vop3::VCmpNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f16_e64_dpp"
+          : "v_cmp_neq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -13720,7 +16112,15 @@ VCmpNltF16Vop3::VCmpNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f16_e64_dpp"
+          : "v_cmp_nlt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -13767,7 +16167,15 @@ VCmpLtF32Vop3::VCmpLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f32_e64_dpp"
+          : "v_cmp_lt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -13814,7 +16222,15 @@ VCmpEqF32Vop3::VCmpEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f32_e64_dpp"
+          : "v_cmp_eq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -13861,7 +16277,15 @@ VCmpLeF32Vop3::VCmpLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f32_e64_dpp"
+          : "v_cmp_le_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -13908,7 +16332,15 @@ VCmpGtF32Vop3::VCmpGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f32_e64_dpp"
+          : "v_cmp_gt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -13955,7 +16387,15 @@ VCmpLgF32Vop3::VCmpLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f32_e64_dpp"
+          : "v_cmp_lg_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -14002,7 +16442,15 @@ VCmpGeF32Vop3::VCmpGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f32_e64_dpp"
+          : "v_cmp_ge_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -14049,7 +16497,15 @@ VCmpOF32Vop3::VCmpOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f32_e64_dpp"
+          : "v_cmp_o_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -14096,7 +16552,15 @@ VCmpUF32Vop3::VCmpUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f32_e64_dpp"
+          : "v_cmp_u_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -14143,7 +16607,15 @@ VCmpNgeF32Vop3::VCmpNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f32_e64_dpp"
+          : "v_cmp_nge_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -14190,7 +16662,15 @@ VCmpNlgF32Vop3::VCmpNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f32_e64_dpp"
+          : "v_cmp_nlg_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -14237,7 +16717,15 @@ VCmpNgtF32Vop3::VCmpNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f32_e64_dpp"
+          : "v_cmp_ngt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -14284,7 +16772,15 @@ VCmpNleF32Vop3::VCmpNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f32_e64_dpp"
+          : "v_cmp_nle_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -14331,7 +16827,15 @@ VCmpNeqF32Vop3::VCmpNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f32_e64_dpp"
+          : "v_cmp_neq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -14378,7 +16882,15 @@ VCmpNltF32Vop3::VCmpNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f32_e64_dpp"
+          : "v_cmp_nlt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -14407,13 +16919,21 @@ VCmpLtF64Vop3::VCmpLtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f64_e64_dpp"
+          : "v_cmp_lt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support DPP";
   return std::make_unique<VCmpLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -14442,13 +16962,21 @@ VCmpEqF64Vop3::VCmpEqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f64_e64_dpp"
+          : "v_cmp_eq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support DPP";
   return std::make_unique<VCmpEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -14477,13 +17005,21 @@ VCmpLeF64Vop3::VCmpLeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f64_e64_dpp"
+          : "v_cmp_le_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support DPP";
   return std::make_unique<VCmpLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -14512,13 +17048,21 @@ VCmpGtF64Vop3::VCmpGtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f64_e64_dpp"
+          : "v_cmp_gt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support DPP";
   return std::make_unique<VCmpGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -14547,13 +17091,21 @@ VCmpLgF64Vop3::VCmpLgF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LG_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f64_e64_dpp"
+          : "v_cmp_lg_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support DPP";
   return std::make_unique<VCmpLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -14582,13 +17134,21 @@ VCmpGeF64Vop3::VCmpGeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f64_e64_dpp"
+          : "v_cmp_ge_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support DPP";
   return std::make_unique<VCmpGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -14617,13 +17177,21 @@ VCmpOF64Vop3::VCmpOF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_O_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f64_e64_dpp"
+          : "v_cmp_o_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support DPP";
   return std::make_unique<VCmpOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -14652,13 +17220,21 @@ VCmpUF64Vop3::VCmpUF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_U_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f64_e64_dpp"
+          : "v_cmp_u_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support DPP";
   return std::make_unique<VCmpUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -14687,13 +17263,21 @@ VCmpNgeF64Vop3::VCmpNgeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f64_e64_dpp"
+          : "v_cmp_nge_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support DPP";
   return std::make_unique<VCmpNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -14722,13 +17306,21 @@ VCmpNlgF64Vop3::VCmpNlgF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f64_e64_dpp"
+          : "v_cmp_nlg_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support DPP";
   return std::make_unique<VCmpNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -14757,13 +17349,21 @@ VCmpNgtF64Vop3::VCmpNgtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f64_e64_dpp"
+          : "v_cmp_ngt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support DPP";
   return std::make_unique<VCmpNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -14792,13 +17392,21 @@ VCmpNleF64Vop3::VCmpNleF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f64_e64_dpp"
+          : "v_cmp_nle_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support DPP";
   return std::make_unique<VCmpNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -14827,13 +17435,21 @@ VCmpNeqF64Vop3::VCmpNeqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f64_e64_dpp"
+          : "v_cmp_neq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support DPP";
   return std::make_unique<VCmpNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -14862,13 +17478,21 @@ VCmpNltF64Vop3::VCmpNltF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f64_e64_dpp"
+          : "v_cmp_nlt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support DPP";
   return std::make_unique<VCmpNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -14923,7 +17547,15 @@ VCmpLtI16Vop3::VCmpLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i16_e64_dpp"
+          : "v_cmp_lt_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -14978,7 +17610,15 @@ VCmpEqI16Vop3::VCmpEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i16_e64_dpp"
+          : "v_cmp_eq_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -15033,7 +17673,15 @@ VCmpLeI16Vop3::VCmpLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i16_e64_dpp"
+          : "v_cmp_le_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -15088,7 +17736,15 @@ VCmpGtI16Vop3::VCmpGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i16_e64_dpp"
+          : "v_cmp_gt_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -15143,7 +17799,15 @@ VCmpNeI16Vop3::VCmpNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i16_e64_dpp"
+          : "v_cmp_ne_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -15198,7 +17862,15 @@ VCmpGeI16Vop3::VCmpGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i16_e64_dpp"
+          : "v_cmp_ge_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -15253,7 +17925,15 @@ VCmpLtU16Vop3::VCmpLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u16_e64_dpp"
+          : "v_cmp_lt_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -15308,7 +17988,15 @@ VCmpEqU16Vop3::VCmpEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u16_e64_dpp"
+          : "v_cmp_eq_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -15363,7 +18051,15 @@ VCmpLeU16Vop3::VCmpLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u16_e64_dpp"
+          : "v_cmp_le_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -15418,7 +18114,15 @@ VCmpGtU16Vop3::VCmpGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u16_e64_dpp"
+          : "v_cmp_gt_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -15473,7 +18177,15 @@ VCmpNeU16Vop3::VCmpNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u16_e64_dpp"
+          : "v_cmp_ne_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -15528,7 +18240,15 @@ VCmpGeU16Vop3::VCmpGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u16_e64_dpp"
+          : "v_cmp_ge_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -15575,7 +18295,15 @@ VCmpLtI32Vop3::VCmpLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i32_e64_dpp"
+          : "v_cmp_lt_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -15622,7 +18350,15 @@ VCmpEqI32Vop3::VCmpEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i32_e64_dpp"
+          : "v_cmp_eq_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -15669,7 +18405,15 @@ VCmpLeI32Vop3::VCmpLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i32_e64_dpp"
+          : "v_cmp_le_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -15716,7 +18460,15 @@ VCmpGtI32Vop3::VCmpGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i32_e64_dpp"
+          : "v_cmp_gt_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -15763,7 +18515,15 @@ VCmpNeI32Vop3::VCmpNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i32_e64_dpp"
+          : "v_cmp_ne_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -15810,7 +18570,15 @@ VCmpGeI32Vop3::VCmpGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i32_e64_dpp"
+          : "v_cmp_ge_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -15857,7 +18625,15 @@ VCmpLtU32Vop3::VCmpLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u32_e64_dpp"
+          : "v_cmp_lt_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -15904,7 +18680,15 @@ VCmpEqU32Vop3::VCmpEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u32_e64_dpp"
+          : "v_cmp_eq_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -15951,7 +18735,15 @@ VCmpLeU32Vop3::VCmpLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u32_e64_dpp"
+          : "v_cmp_le_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -15998,7 +18790,15 @@ VCmpGtU32Vop3::VCmpGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u32_e64_dpp"
+          : "v_cmp_gt_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -16045,7 +18845,15 @@ VCmpNeU32Vop3::VCmpNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u32_e64_dpp"
+          : "v_cmp_ne_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -16092,7 +18900,15 @@ VCmpGeU32Vop3::VCmpGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u32_e64_dpp"
+          : "v_cmp_ge_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -16121,13 +18937,21 @@ VCmpLtI64Vop3::VCmpLtI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i64_e64_dpp"
+          : "v_cmp_lt_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support DPP";
   return std::make_unique<VCmpLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -16156,13 +18980,21 @@ VCmpEqI64Vop3::VCmpEqI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i64_e64_dpp"
+          : "v_cmp_eq_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support DPP";
   return std::make_unique<VCmpEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -16191,13 +19023,21 @@ VCmpLeI64Vop3::VCmpLeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i64_e64_dpp"
+          : "v_cmp_le_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support DPP";
   return std::make_unique<VCmpLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -16226,13 +19066,21 @@ VCmpGtI64Vop3::VCmpGtI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i64_e64_dpp"
+          : "v_cmp_gt_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support DPP";
   return std::make_unique<VCmpGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -16261,13 +19109,21 @@ VCmpNeI64Vop3::VCmpNeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i64_e64_dpp"
+          : "v_cmp_ne_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support DPP";
   return std::make_unique<VCmpNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -16296,13 +19152,21 @@ VCmpGeI64Vop3::VCmpGeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_I64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i64_e64_dpp"
+          : "v_cmp_ge_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support DPP";
   return std::make_unique<VCmpGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -16331,13 +19195,21 @@ VCmpLtU64Vop3::VCmpLtU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u64_e64_dpp"
+          : "v_cmp_lt_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support DPP";
   return std::make_unique<VCmpLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -16366,13 +19238,21 @@ VCmpEqU64Vop3::VCmpEqU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u64_e64_dpp"
+          : "v_cmp_eq_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support DPP";
   return std::make_unique<VCmpEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -16401,13 +19281,21 @@ VCmpLeU64Vop3::VCmpLeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u64_e64_dpp"
+          : "v_cmp_le_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support DPP";
   return std::make_unique<VCmpLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -16436,13 +19324,21 @@ VCmpGtU64Vop3::VCmpGtU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u64_e64_dpp"
+          : "v_cmp_gt_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support DPP";
   return std::make_unique<VCmpGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -16471,13 +19367,21 @@ VCmpNeU64Vop3::VCmpNeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u64_e64_dpp"
+          : "v_cmp_ne_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support DPP";
   return std::make_unique<VCmpNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -16506,13 +19410,21 @@ VCmpGeU64Vop3::VCmpGeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_U64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u64_e64_dpp"
+          : "v_cmp_ge_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support DPP";
   return std::make_unique<VCmpGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -16567,7 +19479,16 @@ VCmpClassF16Vop3::VCmpClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f16_e64_dpp"
+          : "v_cmp_class_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16614,7 +19535,16 @@ VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f32_e64_dpp"
+          : "v_cmp_class_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -16642,13 +19572,22 @@ VCmpClassF64Vop3::VCmpClassF64Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vop3(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f64_e64_dpp"
+          : "v_cmp_class_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support DPP";
   return std::make_unique<VCmpClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -16707,7 +19646,15 @@ VCmpxLtF16Vop3::VCmpxLtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f16_e64_dpp"
+          : "v_cmpx_lt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16766,7 +19713,15 @@ VCmpxEqF16Vop3::VCmpxEqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f16_e64_dpp"
+          : "v_cmpx_eq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16825,7 +19780,15 @@ VCmpxLeF16Vop3::VCmpxLeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f16_e64_dpp"
+          : "v_cmpx_le_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16884,7 +19847,15 @@ VCmpxGtF16Vop3::VCmpxGtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f16_e64_dpp"
+          : "v_cmpx_gt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -16943,7 +19914,15 @@ VCmpxLgF16Vop3::VCmpxLgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f16_e64_dpp"
+          : "v_cmpx_lg_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -17002,7 +19981,15 @@ VCmpxGeF16Vop3::VCmpxGeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f16_e64_dpp"
+          : "v_cmpx_ge_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -17061,7 +20048,15 @@ VCmpxOF16Vop3::VCmpxOF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f16_e64_dpp"
+          : "v_cmpx_o_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF16Vop3>(opcode);
 }
 } // namespace detail
@@ -17120,7 +20115,15 @@ VCmpxUF16Vop3::VCmpxUF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f16_e64_dpp"
+          : "v_cmpx_u_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF16Vop3>(opcode);
 }
 } // namespace detail
@@ -17179,7 +20182,16 @@ VCmpxNgeF16Vop3::VCmpxNgeF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f16_e64_dpp"
+          : "v_cmpx_nge_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF16Vop3>(opcode);
 }
 } // namespace detail
@@ -17238,7 +20250,16 @@ VCmpxNlgF16Vop3::VCmpxNlgF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f16_e64_dpp"
+          : "v_cmpx_nlg_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF16Vop3>(opcode);
 }
 } // namespace detail
@@ -17297,7 +20318,16 @@ VCmpxNgtF16Vop3::VCmpxNgtF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f16_e64_dpp"
+          : "v_cmpx_ngt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF16Vop3>(opcode);
 }
 } // namespace detail
@@ -17356,7 +20386,16 @@ VCmpxNleF16Vop3::VCmpxNleF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f16_e64_dpp"
+          : "v_cmpx_nle_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF16Vop3>(opcode);
 }
 } // namespace detail
@@ -17415,7 +20454,16 @@ VCmpxNeqF16Vop3::VCmpxNeqF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f16_e64_dpp"
+          : "v_cmpx_neq_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF16Vop3>(opcode);
 }
 } // namespace detail
@@ -17474,7 +20522,16 @@ VCmpxNltF16Vop3::VCmpxNltF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f16_e64_dpp"
+          : "v_cmpx_nlt_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF16Vop3>(opcode);
 }
 } // namespace detail
@@ -17525,7 +20582,15 @@ VCmpxLtF32Vop3::VCmpxLtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f32_e64_dpp"
+          : "v_cmpx_lt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17576,7 +20641,15 @@ VCmpxEqF32Vop3::VCmpxEqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f32_e64_dpp"
+          : "v_cmpx_eq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17627,7 +20700,15 @@ VCmpxLeF32Vop3::VCmpxLeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f32_e64_dpp"
+          : "v_cmpx_le_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17678,7 +20759,15 @@ VCmpxGtF32Vop3::VCmpxGtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f32_e64_dpp"
+          : "v_cmpx_gt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17729,7 +20818,15 @@ VCmpxLgF32Vop3::VCmpxLgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f32_e64_dpp"
+          : "v_cmpx_lg_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17780,7 +20877,15 @@ VCmpxGeF32Vop3::VCmpxGeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f32_e64_dpp"
+          : "v_cmpx_ge_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17831,7 +20936,15 @@ VCmpxOF32Vop3::VCmpxOF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f32_e64_dpp"
+          : "v_cmpx_o_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17882,7 +20995,15 @@ VCmpxUF32Vop3::VCmpxUF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f32_e64_dpp"
+          : "v_cmpx_u_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17933,7 +21054,16 @@ VCmpxNgeF32Vop3::VCmpxNgeF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f32_e64_dpp"
+          : "v_cmpx_nge_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF32Vop3>(opcode);
 }
 } // namespace detail
@@ -17984,7 +21114,16 @@ VCmpxNlgF32Vop3::VCmpxNlgF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f32_e64_dpp"
+          : "v_cmpx_nlg_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF32Vop3>(opcode);
 }
 } // namespace detail
@@ -18035,7 +21174,16 @@ VCmpxNgtF32Vop3::VCmpxNgtF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f32_e64_dpp"
+          : "v_cmpx_ngt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF32Vop3>(opcode);
 }
 } // namespace detail
@@ -18086,7 +21234,16 @@ VCmpxNleF32Vop3::VCmpxNleF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f32_e64_dpp"
+          : "v_cmpx_nle_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF32Vop3>(opcode);
 }
 } // namespace detail
@@ -18137,7 +21294,16 @@ VCmpxNeqF32Vop3::VCmpxNeqF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f32_e64_dpp"
+          : "v_cmpx_neq_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF32Vop3>(opcode);
 }
 } // namespace detail
@@ -18188,7 +21354,16 @@ VCmpxNltF32Vop3::VCmpxNltF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f32_e64_dpp"
+          : "v_cmpx_nlt_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF32Vop3>(opcode);
 }
 } // namespace detail
@@ -18219,15 +21394,23 @@ VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f64_e64_dpp"
+          : "v_cmpx_lt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support DPP";
   return std::make_unique<VCmpxLtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18258,15 +21441,23 @@ VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f64_e64_dpp"
+          : "v_cmpx_eq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support DPP";
   return std::make_unique<VCmpxEqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18297,15 +21488,23 @@ VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f64_e64_dpp"
+          : "v_cmpx_le_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support DPP";
   return std::make_unique<VCmpxLeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18336,15 +21535,23 @@ VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f64_e64_dpp"
+          : "v_cmpx_gt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support DPP";
   return std::make_unique<VCmpxGtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18375,15 +21582,23 @@ VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f64_e64_dpp"
+          : "v_cmpx_lg_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support DPP";
   return std::make_unique<VCmpxLgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18414,15 +21629,23 @@ VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f64_e64_dpp"
+          : "v_cmpx_ge_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support DPP";
   return std::make_unique<VCmpxGeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18453,15 +21676,23 @@ VCmpxOF64Vop3::VCmpxOF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_O_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f64_e64_dpp"
+          : "v_cmpx_o_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support DPP";
   return std::make_unique<VCmpxOF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18492,15 +21723,23 @@ VCmpxUF64Vop3::VCmpxUF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_U_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f64_e64_dpp"
+          : "v_cmpx_u_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support DPP";
   return std::make_unique<VCmpxUF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18531,15 +21770,24 @@ VCmpxNgeF64Vop3::VCmpxNgeF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f64_e64_dpp"
+          : "v_cmpx_nge_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support DPP";
   return std::make_unique<VCmpxNgeF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18570,15 +21818,24 @@ VCmpxNlgF64Vop3::VCmpxNlgF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f64_e64_dpp"
+          : "v_cmpx_nlg_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support DPP";
   return std::make_unique<VCmpxNlgF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18609,15 +21866,24 @@ VCmpxNgtF64Vop3::VCmpxNgtF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f64_e64_dpp"
+          : "v_cmpx_ngt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support DPP";
   return std::make_unique<VCmpxNgtF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18648,15 +21914,24 @@ VCmpxNleF64Vop3::VCmpxNleF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f64_e64_dpp"
+          : "v_cmpx_nle_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support DPP";
   return std::make_unique<VCmpxNleF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18687,15 +21962,24 @@ VCmpxNeqF64Vop3::VCmpxNeqF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f64_e64_dpp"
+          : "v_cmpx_neq_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support DPP";
   return std::make_unique<VCmpxNeqF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18726,15 +22010,24 @@ VCmpxNltF64Vop3::VCmpxNltF64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vop3(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f64_e64_dpp"
+          : "v_cmpx_nlt_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support DPP";
   return std::make_unique<VCmpxNltF64Vop3>(opcode);
 }
 } // namespace detail
@@ -18793,7 +22086,15 @@ VCmpxLtI16Vop3::VCmpxLtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i16_e64_dpp"
+          : "v_cmpx_lt_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -18852,7 +22153,15 @@ VCmpxEqI16Vop3::VCmpxEqI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i16_e64_dpp"
+          : "v_cmpx_eq_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI16Vop3>(opcode);
 }
 } // namespace detail
@@ -18911,7 +22220,15 @@ VCmpxLeI16Vop3::VCmpxLeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i16_e64_dpp"
+          : "v_cmpx_le_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -18970,7 +22287,15 @@ VCmpxGtI16Vop3::VCmpxGtI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i16_e64_dpp"
+          : "v_cmpx_gt_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI16Vop3>(opcode);
 }
 } // namespace detail
@@ -19029,7 +22354,15 @@ VCmpxNeI16Vop3::VCmpxNeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i16_e64_dpp"
+          : "v_cmpx_ne_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -19088,7 +22421,15 @@ VCmpxGeI16Vop3::VCmpxGeI16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i16_e64_dpp"
+          : "v_cmpx_ge_i16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI16Vop3>(opcode);
 }
 } // namespace detail
@@ -19147,7 +22488,15 @@ VCmpxLtU16Vop3::VCmpxLtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u16_e64_dpp"
+          : "v_cmpx_lt_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -19206,7 +22555,15 @@ VCmpxEqU16Vop3::VCmpxEqU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u16_e64_dpp"
+          : "v_cmpx_eq_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU16Vop3>(opcode);
 }
 } // namespace detail
@@ -19265,7 +22622,15 @@ VCmpxLeU16Vop3::VCmpxLeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u16_e64_dpp"
+          : "v_cmpx_le_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -19324,7 +22689,15 @@ VCmpxGtU16Vop3::VCmpxGtU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u16_e64_dpp"
+          : "v_cmpx_gt_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU16Vop3>(opcode);
 }
 } // namespace detail
@@ -19383,7 +22756,15 @@ VCmpxNeU16Vop3::VCmpxNeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u16_e64_dpp"
+          : "v_cmpx_ne_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -19442,7 +22823,15 @@ VCmpxGeU16Vop3::VCmpxGeU16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u16_e64_dpp"
+          : "v_cmpx_ge_u16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU16Vop3>(opcode);
 }
 } // namespace detail
@@ -19493,7 +22882,15 @@ VCmpxLtI32Vop3::VCmpxLtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i32_e64_dpp"
+          : "v_cmpx_lt_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19544,7 +22941,15 @@ VCmpxEqI32Vop3::VCmpxEqI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i32_e64_dpp"
+          : "v_cmpx_eq_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19595,7 +23000,15 @@ VCmpxLeI32Vop3::VCmpxLeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i32_e64_dpp"
+          : "v_cmpx_le_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19646,7 +23059,15 @@ VCmpxGtI32Vop3::VCmpxGtI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i32_e64_dpp"
+          : "v_cmpx_gt_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19697,7 +23118,15 @@ VCmpxNeI32Vop3::VCmpxNeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i32_e64_dpp"
+          : "v_cmpx_ne_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19748,7 +23177,15 @@ VCmpxGeI32Vop3::VCmpxGeI32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i32_e64_dpp"
+          : "v_cmpx_ge_i32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI32Vop3>(opcode);
 }
 } // namespace detail
@@ -19799,7 +23236,15 @@ VCmpxLtU32Vop3::VCmpxLtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u32_e64_dpp"
+          : "v_cmpx_lt_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19850,7 +23295,15 @@ VCmpxEqU32Vop3::VCmpxEqU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u32_e64_dpp"
+          : "v_cmpx_eq_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19901,7 +23354,15 @@ VCmpxLeU32Vop3::VCmpxLeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u32_e64_dpp"
+          : "v_cmpx_le_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -19952,7 +23413,15 @@ VCmpxGtU32Vop3::VCmpxGtU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u32_e64_dpp"
+          : "v_cmpx_gt_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU32Vop3>(opcode);
 }
 } // namespace detail
@@ -20003,7 +23472,15 @@ VCmpxNeU32Vop3::VCmpxNeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u32_e64_dpp"
+          : "v_cmpx_ne_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -20054,7 +23531,15 @@ VCmpxGeU32Vop3::VCmpxGeU32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u32_e64_dpp"
+          : "v_cmpx_ge_u32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU32Vop3>(opcode);
 }
 } // namespace detail
@@ -20085,15 +23570,23 @@ VCmpxLtI64Vop3::VCmpxLtI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i64_e64_dpp"
+          : "v_cmpx_lt_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support DPP";
   return std::make_unique<VCmpxLtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -20124,15 +23617,23 @@ VCmpxEqI64Vop3::VCmpxEqI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i64_e64_dpp"
+          : "v_cmpx_eq_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support DPP";
   return std::make_unique<VCmpxEqI64Vop3>(opcode);
 }
 } // namespace detail
@@ -20163,15 +23664,23 @@ VCmpxLeI64Vop3::VCmpxLeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i64_e64_dpp"
+          : "v_cmpx_le_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support DPP";
   return std::make_unique<VCmpxLeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -20202,15 +23711,23 @@ VCmpxGtI64Vop3::VCmpxGtI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i64_e64_dpp"
+          : "v_cmpx_gt_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support DPP";
   return std::make_unique<VCmpxGtI64Vop3>(opcode);
 }
 } // namespace detail
@@ -20241,15 +23758,23 @@ VCmpxNeI64Vop3::VCmpxNeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i64_e64_dpp"
+          : "v_cmpx_ne_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support DPP";
   return std::make_unique<VCmpxNeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -20280,15 +23805,23 @@ VCmpxGeI64Vop3::VCmpxGeI64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i64_e64_dpp"
+          : "v_cmpx_ge_i64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support DPP";
   return std::make_unique<VCmpxGeI64Vop3>(opcode);
 }
 } // namespace detail
@@ -20319,15 +23852,23 @@ VCmpxLtU64Vop3::VCmpxLtU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u64_e64_dpp"
+          : "v_cmpx_lt_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support DPP";
   return std::make_unique<VCmpxLtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20358,15 +23899,23 @@ VCmpxEqU64Vop3::VCmpxEqU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u64_e64_dpp"
+          : "v_cmpx_eq_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support DPP";
   return std::make_unique<VCmpxEqU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20397,15 +23946,23 @@ VCmpxLeU64Vop3::VCmpxLeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u64_e64_dpp"
+          : "v_cmpx_le_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support DPP";
   return std::make_unique<VCmpxLeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20436,15 +23993,23 @@ VCmpxGtU64Vop3::VCmpxGtU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u64_e64_dpp"
+          : "v_cmpx_gt_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support DPP";
   return std::make_unique<VCmpxGtU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20475,15 +24040,23 @@ VCmpxNeU64Vop3::VCmpxNeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u64_e64_dpp"
+          : "v_cmpx_ne_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support DPP";
   return std::make_unique<VCmpxNeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20514,15 +24087,23 @@ VCmpxGeU64Vop3::VCmpxGeU64Vop3(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u64_e64_dpp"
+          : "v_cmpx_ge_u64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support DPP";
   return std::make_unique<VCmpxGeU64Vop3>(opcode);
 }
 } // namespace detail
@@ -20581,7 +24162,16 @@ VCmpxClassF16Vop3::VCmpxClassF16Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f16_e64_dpp"
+          : "v_cmpx_class_f16",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF16Vop3>(opcode);
 }
 } // namespace detail
@@ -20632,7 +24222,16 @@ VCmpxClassF32Vop3::VCmpxClassF32Vop3(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f32_e64_dpp"
+          : "v_cmpx_class_f32",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF32Vop3>(opcode);
 }
 } // namespace detail
@@ -20662,15 +24261,24 @@ VCmpxClassF64Vop3::VCmpxClassF64Vop3(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support DPP", "");
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vop3(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vop3(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f64_e64_dpp"
+          : "v_cmpx_class_f64",
+      reinterpret_cast<const Vop3::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support DPP";
   return std::make_unique<VCmpxClassF64Vop3>(opcode);
 }
 } // namespace detail
@@ -20721,7 +24329,16 @@ VAddCoCiU32Vop3SdstEnc::VAddCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_add_co_ci_u32_e64_dpp"
+          : "v_add_co_ci_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoCiU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20772,7 +24389,16 @@ VSubCoCiU32Vop3SdstEnc::VSubCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_sub_co_ci_u32_e64_dpp"
+          : "v_sub_co_ci_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoCiU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20823,7 +24449,16 @@ VSubrevCoCiU32Vop3SdstEnc::VSubrevCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoCiU32Vop3SdstEnc(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_subrev_co_ci_u32_e64_dpp"
+          : "v_subrev_co_ci_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoCiU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20858,13 +24493,23 @@ VDivScaleF32Vop3SdstEnc::VDivScaleF32Vop3SdstEnc(const MachineInst *inst)
     src2 = Operand(32, OperandType::OPR_SIMM32,
                    static_cast<int>(
                        reinterpret_cast<const Vop3SdstEncInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_SCALE_F32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_div_scale_f32_e64_dpp"
+          : "v_div_scale_f32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DIV_SCALE_F32 does not support DPP";
   return std::make_unique<VDivScaleF32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20905,13 +24550,23 @@ VDivScaleF64Vop3SdstEnc::VDivScaleF64Vop3SdstEnc(const MachineInst *inst)
         static_cast<uint32_t>(
             reinterpret_cast<const Vop3SdstEncInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DIV_SCALE_F64 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVDivScaleF64Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_div_scale_f64_e64_dpp"
+          : "v_div_scale_f64",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DIV_SCALE_F64 does not support DPP";
   return std::make_unique<VDivScaleF64Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20948,13 +24603,23 @@ VMadCoU64U32Vop3SdstEnc::VMadCoU64U32Vop3SdstEnc(const MachineInst *inst)
         static_cast<uint32_t>(
             reinterpret_cast<const Vop3SdstEncInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAD_CO_U64_U32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadCoU64U32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadCoU64U32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_mad_co_u64_u32_e64_dpp"
+          : "v_mad_co_u64_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_MAD_CO_U64_U32 does not support DPP";
   return std::make_unique<VMadCoU64U32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -20991,13 +24656,23 @@ VMadCoI64I32Vop3SdstEnc::VMadCoI64I32Vop3SdstEnc(const MachineInst *inst)
         static_cast<uint32_t>(
             reinterpret_cast<const Vop3SdstEncInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_MAD_CO_I64_I32 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVMadCoI64I32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVMadCoI64I32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_mad_co_i64_i32_e64_dpp"
+          : "v_mad_co_i64_i32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_MAD_CO_I64_I32 does not support DPP";
   return std::make_unique<VMadCoI64I32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -21046,7 +24721,16 @@ VAddCoU32Vop3SdstEnc::VAddCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVAddCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_add_co_u32_e64_dpp"
+          : "v_add_co_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VAddCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -21095,7 +24779,16 @@ VSubCoU32Vop3SdstEnc::VSubCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_sub_co_u32_e64_dpp"
+          : "v_sub_co_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail
@@ -21144,7 +24837,16 @@ VSubrevCoU32Vop3SdstEnc::VSubrevCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode) {
+DecodeResult decodeVSubrevCoU32Vop3SdstEnc(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3SdstEnc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(inst)->src0)
+          ? "v_subrev_co_u32_e64_dpp"
+          : "v_subrev_co_u32",
+      reinterpret_cast<const Vop3SdstEnc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VSubrevCoU32Vop3SdstEnc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop3p.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -41,13 +40,22 @@ VPkMadI16Vop3p::VPkMadI16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAD_I16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_mad_i16_e64_dpp"
+          : "v_pk_mad_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAD_I16 does not support DPP";
   return std::make_unique<VPkMadI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -74,13 +82,23 @@ VPkMulLoU16Vop3p::VPkMulLoU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MUL_LO_U16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulLoU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulLoU16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_mul_lo_u16_e64_dpp"
+          : "v_pk_mul_lo_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MUL_LO_U16 does not support DPP";
   return std::make_unique<VPkMulLoU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -107,13 +125,22 @@ VPkAddI16Vop3p::VPkAddI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ADD_I16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_add_i16_e64_dpp"
+          : "v_pk_add_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ADD_I16 does not support DPP";
   return std::make_unique<VPkAddI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -140,13 +167,22 @@ VPkSubI16Vop3p::VPkSubI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_SUB_I16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_sub_i16_e64_dpp"
+          : "v_pk_sub_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_SUB_I16 does not support DPP";
   return std::make_unique<VPkSubI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -173,13 +209,23 @@ VPkLshlrevB16Vop3p::VPkLshlrevB16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_LSHLREV_B16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshlrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshlrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_lshlrev_b16_e64_dpp"
+          : "v_pk_lshlrev_b16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_LSHLREV_B16 does not support DPP";
   return std::make_unique<VPkLshlrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -206,13 +252,23 @@ VPkLshrrevB16Vop3p::VPkLshrrevB16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_LSHRREV_B16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkLshrrevB16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkLshrrevB16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_lshrrev_b16_e64_dpp"
+          : "v_pk_lshrrev_b16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_LSHRREV_B16 does not support DPP";
   return std::make_unique<VPkLshrrevB16Vop3p>(opcode);
 }
 } // namespace detail
@@ -239,13 +295,23 @@ VPkAshrrevI16Vop3p::VPkAshrrevI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ASHRREV_I16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAshrrevI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAshrrevI16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_ashrrev_i16_e64_dpp"
+          : "v_pk_ashrrev_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ASHRREV_I16 does not support DPP";
   return std::make_unique<VPkAshrrevI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -272,13 +338,22 @@ VPkMaxI16Vop3p::VPkMaxI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAX_I16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_max_i16_e64_dpp"
+          : "v_pk_max_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAX_I16 does not support DPP";
   return std::make_unique<VPkMaxI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -305,13 +380,22 @@ VPkMinI16Vop3p::VPkMinI16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MIN_I16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinI16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinI16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_min_i16_e64_dpp"
+          : "v_pk_min_i16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MIN_I16 does not support DPP";
   return std::make_unique<VPkMinI16Vop3p>(opcode);
 }
 } // namespace detail
@@ -344,13 +428,22 @@ VPkMadU16Vop3p::VPkMadU16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAD_U16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMadU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMadU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_mad_u16_e64_dpp"
+          : "v_pk_mad_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAD_U16 does not support DPP";
   return std::make_unique<VPkMadU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -377,13 +470,22 @@ VPkAddU16Vop3p::VPkAddU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ADD_U16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_add_u16_e64_dpp"
+          : "v_pk_add_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ADD_U16 does not support DPP";
   return std::make_unique<VPkAddU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -410,13 +512,22 @@ VPkSubU16Vop3p::VPkSubU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_SUB_U16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkSubU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkSubU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_sub_u16_e64_dpp"
+          : "v_pk_sub_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_SUB_U16 does not support DPP";
   return std::make_unique<VPkSubU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -443,13 +554,22 @@ VPkMaxU16Vop3p::VPkMaxU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAX_U16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_max_u16_e64_dpp"
+          : "v_pk_max_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAX_U16 does not support DPP";
   return std::make_unique<VPkMaxU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -476,13 +596,22 @@ VPkMinU16Vop3p::VPkMinU16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MIN_U16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinU16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinU16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_min_u16_e64_dpp"
+          : "v_pk_min_u16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MIN_U16 does not support DPP";
   return std::make_unique<VPkMinU16Vop3p>(opcode);
 }
 } // namespace detail
@@ -515,13 +644,22 @@ VPkFmaF16Vop3p::VPkFmaF16Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_FMA_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkFmaF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkFmaF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_fma_f16_e64_dpp"
+          : "v_pk_fma_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_FMA_F16 does not support DPP";
   return std::make_unique<VPkFmaF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -548,13 +686,22 @@ VPkAddF16Vop3p::VPkAddF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_ADD_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkAddF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkAddF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_add_f16_e64_dpp"
+          : "v_pk_add_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_ADD_F16 does not support DPP";
   return std::make_unique<VPkAddF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -581,13 +728,22 @@ VPkMulF16Vop3p::VPkMulF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MUL_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMulF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMulF16Vop3p(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_mul_f16_e64_dpp"
+          : "v_pk_mul_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MUL_F16 does not support DPP";
   return std::make_unique<VPkMulF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -640,7 +796,16 @@ VDot2F32F16Vop3p::VDot2F32F16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2F32F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2F32F16Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot2_f32_f16_e64_dpp"
+          : "v_dot2_f32_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2F32F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -673,13 +838,23 @@ VDot4I32Iu8Vop3p::VDot4I32Iu8Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT4_I32_IU8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4I32Iu8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4I32Iu8Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot4_i32_iu8_e64_dpp"
+          : "v_dot4_i32_iu8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT4_I32_IU8 does not support DPP";
   return std::make_unique<VDot4I32Iu8Vop3p>(opcode);
 }
 } // namespace detail
@@ -712,13 +887,23 @@ VDot4U32U8Vop3p::VDot4U32U8Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT4_U32_U8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4U32U8Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot4_u32_u8_e64_dpp"
+          : "v_dot4_u32_u8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT4_U32_U8 does not support DPP";
   return std::make_unique<VDot4U32U8Vop3p>(opcode);
 }
 } // namespace detail
@@ -751,13 +936,23 @@ VDot8I32Iu4Vop3p::VDot8I32Iu4Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT8_I32_IU4 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8I32Iu4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8I32Iu4Vop3p(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot8_i32_iu4_e64_dpp"
+          : "v_dot8_i32_iu4",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT8_I32_IU4 does not support DPP";
   return std::make_unique<VDot8I32Iu4Vop3p>(opcode);
 }
 } // namespace detail
@@ -790,13 +985,23 @@ VDot8U32U4Vop3p::VDot8U32U4Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT8_U32_U4 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot8U32U4Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot8_u32_u4_e64_dpp"
+          : "v_dot8_u32_u4",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT8_U32_U4 does not support DPP";
   return std::make_unique<VDot8U32U4Vop3p>(opcode);
 }
 } // namespace detail
@@ -849,7 +1054,16 @@ VDot2F32Bf16Vop3p::VDot2F32Bf16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot2F32Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot2F32Bf16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot2_f32_bf16_e64_dpp"
+          : "v_dot2_f32_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VDot2F32Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -876,13 +1090,23 @@ VPkMinNumF16Vop3p::VPkMinNumF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MIN_NUM_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinNumF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinNumF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_min_num_f16_e64_dpp"
+          : "v_pk_min_num_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MIN_NUM_F16 does not support DPP";
   return std::make_unique<VPkMinNumF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -909,13 +1133,23 @@ VPkMaxNumF16Vop3p::VPkMaxNumF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAX_NUM_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaxNumF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaxNumF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_max_num_f16_e64_dpp"
+          : "v_pk_max_num_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAX_NUM_F16 does not support DPP";
   return std::make_unique<VPkMaxNumF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -942,13 +1176,23 @@ VPkMinimumF16Vop3p::VPkMinimumF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MINIMUM_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMinimumF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMinimumF16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_minimum_f16_e64_dpp"
+          : "v_pk_minimum_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MINIMUM_F16 does not support DPP";
   return std::make_unique<VPkMinimumF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -975,13 +1219,23 @@ VPkMaximumF16Vop3p::VPkMaximumF16Vop3p(const MachineInst *inst)
     src1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_PK_MAXIMUM_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVPkMaximumF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVPkMaximumF16Vop3p(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_pk_maximum_f16_e64_dpp"
+          : "v_pk_maximum_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_PK_MAXIMUM_F16 does not support DPP";
   return std::make_unique<VPkMaximumF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1034,7 +1288,16 @@ VFmaMixF32Vop3p::VFmaMixF32Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixF32Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixF32Vop3p(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_fma_mix_f32_e64_dpp"
+          : "v_fma_mix_f32",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixF32Vop3p>(opcode);
 }
 } // namespace detail
@@ -1088,7 +1351,16 @@ VFmaMixloF16Vop3p::VFmaMixloF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixloF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixloF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_fma_mixlo_f16_e64_dpp"
+          : "v_fma_mixlo_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixloF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1148,7 +1420,16 @@ VFmaMixhiF16Vop3p::VFmaMixhiF16Vop3p(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVFmaMixhiF16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVFmaMixhiF16Vop3p(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_fma_mixhi_f16_e64_dpp"
+          : "v_fma_mixhi_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VFmaMixhiF16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1187,13 +1468,23 @@ VDot4F32Fp8Bf8Vop3p::VDot4F32Fp8Bf8Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT4_F32_FP8_BF8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4F32Fp8Bf8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4F32Fp8Bf8Vop3p(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot4_f32_fp8_bf8_e64_dpp"
+          : "v_dot4_f32_fp8_bf8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT4_F32_FP8_BF8 does not support DPP";
   return std::make_unique<VDot4F32Fp8Bf8Vop3p>(opcode);
 }
 } // namespace detail
@@ -1226,13 +1517,23 @@ VDot4F32Bf8Fp8Vop3p::VDot4F32Bf8Fp8Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT4_F32_BF8_FP8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4F32Bf8Fp8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4F32Bf8Fp8Vop3p(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot4_f32_bf8_fp8_e64_dpp"
+          : "v_dot4_f32_bf8_fp8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT4_F32_BF8_FP8 does not support DPP";
   return std::make_unique<VDot4F32Bf8Fp8Vop3p>(opcode);
 }
 } // namespace detail
@@ -1265,13 +1566,23 @@ VDot4F32Fp8Fp8Vop3p::VDot4F32Fp8Fp8Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT4_F32_FP8_FP8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4F32Fp8Fp8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4F32Fp8Fp8Vop3p(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot4_f32_fp8_fp8_e64_dpp"
+          : "v_dot4_f32_fp8_fp8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT4_F32_FP8_FP8 does not support DPP";
   return std::make_unique<VDot4F32Fp8Fp8Vop3p>(opcode);
 }
 } // namespace detail
@@ -1304,13 +1615,23 @@ VDot4F32Bf8Bf8Vop3p::VDot4F32Bf8Bf8Vop3p(const MachineInst *inst)
     src2 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Vop3pInstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_DOT4_F32_BF8_BF8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVDot4F32Bf8Bf8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVDot4F32Bf8Bf8Vop3p(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_dot4_f32_bf8_bf8_e64_dpp"
+          : "v_dot4_f32_bf8_bf8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_DOT4_F32_BF8_BF8 does not support DPP";
   return std::make_unique<VDot4F32Bf8Bf8Vop3p>(opcode);
 }
 } // namespace detail
@@ -1332,13 +1653,23 @@ VWmmaF3216x16x16F16Vop3p::VWmmaF3216x16x16F16Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X16_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x16F16Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x16_f16_e64_dpp"
+          : "v_wmma_f32_16x16x16_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X16_F16 does not support DPP";
   return std::make_unique<VWmmaF3216x16x16F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1360,13 +1691,23 @@ VWmmaF3216x16x16Bf16Vop3p::VWmmaF3216x16x16Bf16Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X16_BF16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x16Bf16Vop3p(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x16_bf16_e64_dpp"
+          : "v_wmma_f32_16x16x16_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X16_BF16 does not support DPP";
   return std::make_unique<VWmmaF3216x16x16Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1388,13 +1729,23 @@ VWmmaF1616x16x16F16Vop3p::VWmmaF1616x16x16F16Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F16_16X16X16_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF1616x16x16F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF1616x16x16F16Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f16_16x16x16_f16_e64_dpp"
+          : "v_wmma_f16_16x16x16_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F16_16X16X16_F16 does not support DPP";
   return std::make_unique<VWmmaF1616x16x16F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1416,13 +1767,23 @@ VWmmaBf1616x16x16Bf16Vop3p::VWmmaBf1616x16x16Bf16Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_BF16_16X16X16_BF16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaBf1616x16x16Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaBf1616x16x16Bf16Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_bf16_16x16x16_bf16_e64_dpp"
+          : "v_wmma_bf16_16x16x16_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_BF16_16X16X16_BF16 does not support DPP";
   return std::make_unique<VWmmaBf1616x16x16Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1444,13 +1805,23 @@ VWmmaI3216x16x16Iu8Vop3p::VWmmaI3216x16x16Iu8Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_I32_16X16X16_IU8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaI3216x16x16Iu8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaI3216x16x16Iu8Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_i32_16x16x16_iu8_e64_dpp"
+          : "v_wmma_i32_16x16x16_iu8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_I32_16X16X16_IU8 does not support DPP";
   return std::make_unique<VWmmaI3216x16x16Iu8Vop3p>(opcode);
 }
 } // namespace detail
@@ -1472,13 +1843,23 @@ VWmmaI3216x16x16Iu4Vop3p::VWmmaI3216x16x16Iu4Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_I32_16X16X16_IU4 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaI3216x16x16Iu4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaI3216x16x16Iu4Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_i32_16x16x16_iu4_e64_dpp"
+          : "v_wmma_i32_16x16x16_iu4",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_I32_16X16X16_IU4 does not support DPP";
   return std::make_unique<VWmmaI3216x16x16Iu4Vop3p>(opcode);
 }
 } // namespace detail
@@ -1500,13 +1881,23 @@ VWmmaF3216x16x16Fp8Fp8Vop3p::VWmmaF3216x16x16Fp8Fp8Vop3p(const MachineInst *inst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X16_FP8_FP8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16Fp8Fp8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x16Fp8Fp8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x16_fp8_fp8_e64_dpp"
+          : "v_wmma_f32_16x16x16_fp8_fp8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X16_FP8_FP8 does not support DPP";
   return std::make_unique<VWmmaF3216x16x16Fp8Fp8Vop3p>(opcode);
 }
 } // namespace detail
@@ -1528,13 +1919,23 @@ VWmmaF3216x16x16Fp8Bf8Vop3p::VWmmaF3216x16x16Fp8Bf8Vop3p(const MachineInst *inst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X16_FP8_BF8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16Fp8Bf8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x16Fp8Bf8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x16_fp8_bf8_e64_dpp"
+          : "v_wmma_f32_16x16x16_fp8_bf8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X16_FP8_BF8 does not support DPP";
   return std::make_unique<VWmmaF3216x16x16Fp8Bf8Vop3p>(opcode);
 }
 } // namespace detail
@@ -1556,13 +1957,23 @@ VWmmaF3216x16x16Bf8Fp8Vop3p::VWmmaF3216x16x16Bf8Fp8Vop3p(const MachineInst *inst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X16_BF8_FP8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16Bf8Fp8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x16Bf8Fp8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x16_bf8_fp8_e64_dpp"
+          : "v_wmma_f32_16x16x16_bf8_fp8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X16_BF8_FP8 does not support DPP";
   return std::make_unique<VWmmaF3216x16x16Bf8Fp8Vop3p>(opcode);
 }
 } // namespace detail
@@ -1584,13 +1995,23 @@ VWmmaF3216x16x16Bf8Bf8Vop3p::VWmmaF3216x16x16Bf8Bf8Vop3p(const MachineInst *inst
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_F32_16X16X16_BF8_BF8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaF3216x16x16Bf8Bf8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaF3216x16x16Bf8Bf8Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_f32_16x16x16_bf8_bf8_e64_dpp"
+          : "v_wmma_f32_16x16x16_bf8_bf8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_F32_16X16X16_BF8_BF8 does not support DPP";
   return std::make_unique<VWmmaF3216x16x16Bf8Bf8Vop3p>(opcode);
 }
 } // namespace detail
@@ -1612,13 +2033,23 @@ VWmmaI3216x16x32Iu4Vop3p::VWmmaI3216x16x32Iu4Vop3p(const MachineInst *inst)
   src_operands_[2] = &src2;
   num_src_ = 3;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_WMMA_I32_16X16X32_IU4 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVWmmaI3216x16x32Iu4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVWmmaI3216x16x32Iu4Vop3p(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_wmma_i32_16x16x32_iu4_e64_dpp"
+          : "v_wmma_i32_16x16x32_iu4",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_WMMA_I32_16X16X32_IU4 does not support DPP";
   return std::make_unique<VWmmaI3216x16x32Iu4Vop3p>(opcode);
 }
 } // namespace detail
@@ -1640,13 +2071,23 @@ VSwmmacF3216x16x32F16Vop3p::VSwmmacF3216x16x32F16Vop3p(const MachineInst *inst)
   src_operands_[3] = &src2;
   num_src_ = 4;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_F32_16X16X32_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x32F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacF3216x16x32F16Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_f32_16x16x32_f16_e64_dpp"
+          : "v_swmmac_f32_16x16x32_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_F32_16X16X32_F16 does not support DPP";
   return std::make_unique<VSwmmacF3216x16x32F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1668,13 +2109,23 @@ VSwmmacF3216x16x32Bf16Vop3p::VSwmmacF3216x16x32Bf16Vop3p(const MachineInst *inst
   src_operands_[3] = &src2;
   num_src_ = 4;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_F32_16X16X32_BF16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x32Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacF3216x16x32Bf16Vop3p(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_f32_16x16x32_bf16_e64_dpp"
+          : "v_swmmac_f32_16x16x32_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_F32_16X16X32_BF16 does not support DPP";
   return std::make_unique<VSwmmacF3216x16x32Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1696,13 +2147,23 @@ VSwmmacF1616x16x32F16Vop3p::VSwmmacF1616x16x32F16Vop3p(const MachineInst *inst)
   src_operands_[3] = &src2;
   num_src_ = 4;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_F16_16X16X32_F16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacF1616x16x32F16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacF1616x16x32F16Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_f16_16x16x32_f16_e64_dpp"
+          : "v_swmmac_f16_16x16x32_f16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_F16_16X16X32_F16 does not support DPP";
   return std::make_unique<VSwmmacF1616x16x32F16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1724,13 +2185,23 @@ VSwmmacBf1616x16x32Bf16Vop3p::VSwmmacBf1616x16x32Bf16Vop3p(const MachineInst *in
   src_operands_[3] = &src2;
   num_src_ = 4;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_BF16_16X16X32_BF16 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacBf1616x16x32Bf16Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacBf1616x16x32Bf16Vop3p(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_bf16_16x16x32_bf16_e64_dpp"
+          : "v_swmmac_bf16_16x16x32_bf16",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_BF16_16X16X32_BF16 does not support DPP";
   return std::make_unique<VSwmmacBf1616x16x32Bf16Vop3p>(opcode);
 }
 } // namespace detail
@@ -1752,13 +2223,23 @@ VSwmmacI3216x16x32Iu8Vop3p::VSwmmacI3216x16x32Iu8Vop3p(const MachineInst *inst)
   src_operands_[3] = &src2;
   num_src_ = 4;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_I32_16X16X32_IU8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacI3216x16x32Iu8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacI3216x16x32Iu8Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_i32_16x16x32_iu8_e64_dpp"
+          : "v_swmmac_i32_16x16x32_iu8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_I32_16X16X32_IU8 does not support DPP";
   return std::make_unique<VSwmmacI3216x16x32Iu8Vop3p>(opcode);
 }
 } // namespace detail
@@ -1780,13 +2261,23 @@ VSwmmacI3216x16x32Iu4Vop3p::VSwmmacI3216x16x32Iu4Vop3p(const MachineInst *inst)
   src_operands_[3] = &src2;
   num_src_ = 4;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_I32_16X16X32_IU4 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacI3216x16x32Iu4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacI3216x16x32Iu4Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_i32_16x16x32_iu4_e64_dpp"
+          : "v_swmmac_i32_16x16x32_iu4",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_I32_16X16X32_IU4 does not support DPP";
   return std::make_unique<VSwmmacI3216x16x32Iu4Vop3p>(opcode);
 }
 } // namespace detail
@@ -1808,13 +2299,23 @@ VSwmmacI3216x16x64Iu4Vop3p::VSwmmacI3216x16x64Iu4Vop3p(const MachineInst *inst)
   src_operands_[3] = &src2;
   num_src_ = 4;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_I32_16X16X64_IU4 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacI3216x16x64Iu4Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacI3216x16x64Iu4Vop3p(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_i32_16x16x64_iu4_e64_dpp"
+          : "v_swmmac_i32_16x16x64_iu4",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_I32_16X16X64_IU4 does not support DPP";
   return std::make_unique<VSwmmacI3216x16x64Iu4Vop3p>(opcode);
 }
 } // namespace detail
@@ -1836,13 +2337,23 @@ VSwmmacF3216x16x32Fp8Fp8Vop3p::VSwmmacF3216x16x32Fp8Fp8Vop3p(const MachineInst *
   src_operands_[3] = &src2;
   num_src_ = 4;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_F32_16X16X32_FP8_FP8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x32Fp8Fp8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacF3216x16x32Fp8Fp8Vop3p(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_f32_16x16x32_fp8_fp8_e64_dpp"
+          : "v_swmmac_f32_16x16x32_fp8_fp8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_F32_16X16X32_FP8_FP8 does not support DPP";
   return std::make_unique<VSwmmacF3216x16x32Fp8Fp8Vop3p>(opcode);
 }
 } // namespace detail
@@ -1864,13 +2375,23 @@ VSwmmacF3216x16x32Fp8Bf8Vop3p::VSwmmacF3216x16x32Fp8Bf8Vop3p(const MachineInst *
   src_operands_[3] = &src2;
   num_src_ = 4;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_F32_16X16X32_FP8_BF8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x32Fp8Bf8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacF3216x16x32Fp8Bf8Vop3p(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_f32_16x16x32_fp8_bf8_e64_dpp"
+          : "v_swmmac_f32_16x16x32_fp8_bf8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_F32_16X16X32_FP8_BF8 does not support DPP";
   return std::make_unique<VSwmmacF3216x16x32Fp8Bf8Vop3p>(opcode);
 }
 } // namespace detail
@@ -1892,13 +2413,23 @@ VSwmmacF3216x16x32Bf8Fp8Vop3p::VSwmmacF3216x16x32Bf8Fp8Vop3p(const MachineInst *
   src_operands_[3] = &src2;
   num_src_ = 4;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_F32_16X16X32_BF8_FP8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x32Bf8Fp8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacF3216x16x32Bf8Fp8Vop3p(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_f32_16x16x32_bf8_fp8_e64_dpp"
+          : "v_swmmac_f32_16x16x32_bf8_fp8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_F32_16X16X32_BF8_FP8 does not support DPP";
   return std::make_unique<VSwmmacF3216x16x32Bf8Fp8Vop3p>(opcode);
 }
 } // namespace detail
@@ -1920,13 +2451,23 @@ VSwmmacF3216x16x32Bf8Bf8Vop3p::VSwmmacF3216x16x32Bf8Bf8Vop3p(const MachineInst *
   src_operands_[3] = &src2;
   num_src_ = 4;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_SWMMAC_F32_16X16X32_BF8_BF8 does not support DPP", "");
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVSwmmacF3216x16x32Bf8Bf8Vop3p(const MachineInst *opcode) {
+DecodeResult decodeVSwmmacF3216x16x32Bf8Bf8Vop3p(const MachineInst *opcode,
+                                                 const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vop3p::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0)
+          ? "v_swmmac_f32_16x16x32_bf8_bf8_e64_dpp"
+          : "v_swmmac_f32_16x16x32_bf8_bf8",
+      reinterpret_cast<const Vop3p::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop3p::OpEncoding *>(inst)->src0))
+      [[unlikely]]
+    return emit_error.emit() << "V_SWMMAC_F32_16X16X32_BF8_BF8 does not support DPP";
   return std::make_unique<VSwmmacF3216x16x32Bf8Bf8Vop3p>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vopc.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -55,7 +54,15 @@ VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f16_dpp"
+          : "v_cmp_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -102,7 +109,15 @@ VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f16_dpp"
+          : "v_cmp_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -149,7 +164,15 @@ VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f16_dpp"
+          : "v_cmp_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -196,7 +219,15 @@ VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f16_dpp"
+          : "v_cmp_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -243,7 +274,15 @@ VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f16_dpp"
+          : "v_cmp_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -290,7 +329,15 @@ VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f16_dpp"
+          : "v_cmp_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -337,7 +384,15 @@ VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f16_dpp"
+          : "v_cmp_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -384,7 +439,15 @@ VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f16_dpp"
+          : "v_cmp_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -431,7 +494,15 @@ VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f16_dpp"
+          : "v_cmp_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -478,7 +549,15 @@ VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f16_dpp"
+          : "v_cmp_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -525,7 +604,15 @@ VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f16_dpp"
+          : "v_cmp_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -572,7 +659,15 @@ VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f16_dpp"
+          : "v_cmp_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -619,7 +714,15 @@ VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f16_dpp"
+          : "v_cmp_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -666,7 +769,15 @@ VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f16_dpp"
+          : "v_cmp_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -710,7 +821,15 @@ VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f32_dpp"
+          : "v_cmp_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -754,7 +873,15 @@ VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f32_dpp"
+          : "v_cmp_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -798,7 +925,15 @@ VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f32_dpp"
+          : "v_cmp_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -842,7 +977,15 @@ VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f32_dpp"
+          : "v_cmp_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -886,7 +1029,15 @@ VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f32_dpp"
+          : "v_cmp_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -930,7 +1081,15 @@ VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f32_dpp"
+          : "v_cmp_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -974,7 +1133,15 @@ VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f32_dpp"
+          : "v_cmp_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1018,7 +1185,15 @@ VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f32_dpp"
+          : "v_cmp_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1062,7 +1237,15 @@ VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f32_dpp"
+          : "v_cmp_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1106,7 +1289,15 @@ VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f32_dpp"
+          : "v_cmp_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1150,7 +1341,15 @@ VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f32_dpp"
+          : "v_cmp_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1194,7 +1393,15 @@ VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f32_dpp"
+          : "v_cmp_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1238,7 +1445,15 @@ VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f32_dpp"
+          : "v_cmp_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1282,7 +1497,15 @@ VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f32_dpp"
+          : "v_cmp_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -1306,14 +1529,22 @@ VCmpLtF64Vopc::VCmpLtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_f64_dpp"
+          : "v_cmp_lt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_F64 does not support DPP";
   return std::make_unique<VCmpLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1337,14 +1568,22 @@ VCmpEqF64Vopc::VCmpEqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_f64_dpp"
+          : "v_cmp_eq_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_F64 does not support DPP";
   return std::make_unique<VCmpEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1368,14 +1607,22 @@ VCmpLeF64Vopc::VCmpLeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_f64_dpp"
+          : "v_cmp_le_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_F64 does not support DPP";
   return std::make_unique<VCmpLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1399,14 +1646,22 @@ VCmpGtF64Vopc::VCmpGtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_f64_dpp"
+          : "v_cmp_gt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_F64 does not support DPP";
   return std::make_unique<VCmpGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1430,14 +1685,22 @@ VCmpLgF64Vopc::VCmpLgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LG_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lg_f64_dpp"
+          : "v_cmp_lg_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LG_F64 does not support DPP";
   return std::make_unique<VCmpLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1461,14 +1724,22 @@ VCmpGeF64Vopc::VCmpGeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_f64_dpp"
+          : "v_cmp_ge_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_F64 does not support DPP";
   return std::make_unique<VCmpGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1492,14 +1763,22 @@ VCmpOF64Vopc::VCmpOF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_O_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_o_f64_dpp"
+          : "v_cmp_o_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_O_F64 does not support DPP";
   return std::make_unique<VCmpOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1523,14 +1802,22 @@ VCmpUF64Vopc::VCmpUF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_U_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_u_f64_dpp"
+          : "v_cmp_u_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_U_F64 does not support DPP";
   return std::make_unique<VCmpUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1554,14 +1841,22 @@ VCmpNgeF64Vopc::VCmpNgeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGE_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nge_f64_dpp"
+          : "v_cmp_nge_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGE_F64 does not support DPP";
   return std::make_unique<VCmpNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1585,14 +1880,22 @@ VCmpNlgF64Vopc::VCmpNlgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLG_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNlgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlg_f64_dpp"
+          : "v_cmp_nlg_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLG_F64 does not support DPP";
   return std::make_unique<VCmpNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1616,14 +1919,22 @@ VCmpNgtF64Vopc::VCmpNgtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NGT_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNgtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ngt_f64_dpp"
+          : "v_cmp_ngt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NGT_F64 does not support DPP";
   return std::make_unique<VCmpNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1647,14 +1958,22 @@ VCmpNleF64Vopc::VCmpNleF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLE_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNleF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nle_f64_dpp"
+          : "v_cmp_nle_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLE_F64 does not support DPP";
   return std::make_unique<VCmpNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1678,14 +1997,22 @@ VCmpNeqF64Vopc::VCmpNeqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NEQ_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_neq_f64_dpp"
+          : "v_cmp_neq_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NEQ_F64 does not support DPP";
   return std::make_unique<VCmpNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1709,14 +2036,22 @@ VCmpNltF64Vopc::VCmpNltF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NLT_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNltF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_nlt_f64_dpp"
+          : "v_cmp_nlt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NLT_F64 does not support DPP";
   return std::make_unique<VCmpNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -1763,7 +2098,15 @@ VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i16_dpp"
+          : "v_cmp_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -1810,7 +2153,15 @@ VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i16_dpp"
+          : "v_cmp_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -1857,7 +2208,15 @@ VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i16_dpp"
+          : "v_cmp_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -1904,7 +2263,15 @@ VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i16_dpp"
+          : "v_cmp_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -1951,7 +2318,15 @@ VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i16_dpp"
+          : "v_cmp_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -1998,7 +2373,15 @@ VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i16_dpp"
+          : "v_cmp_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -2045,7 +2428,15 @@ VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u16_dpp"
+          : "v_cmp_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2092,7 +2483,15 @@ VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u16_dpp"
+          : "v_cmp_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2139,7 +2538,15 @@ VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u16_dpp"
+          : "v_cmp_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2186,7 +2593,15 @@ VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u16_dpp"
+          : "v_cmp_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2233,7 +2648,15 @@ VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u16_dpp"
+          : "v_cmp_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2280,7 +2703,15 @@ VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u16_dpp"
+          : "v_cmp_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -2324,7 +2755,15 @@ VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i32_dpp"
+          : "v_cmp_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2368,7 +2807,15 @@ VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i32_dpp"
+          : "v_cmp_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2412,7 +2859,15 @@ VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i32_dpp"
+          : "v_cmp_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2456,7 +2911,15 @@ VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i32_dpp"
+          : "v_cmp_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2500,7 +2963,15 @@ VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i32_dpp"
+          : "v_cmp_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2544,7 +3015,15 @@ VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i32_dpp"
+          : "v_cmp_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -2588,7 +3067,15 @@ VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u32_dpp"
+          : "v_cmp_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -2632,7 +3119,15 @@ VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u32_dpp"
+          : "v_cmp_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -2676,7 +3171,15 @@ VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u32_dpp"
+          : "v_cmp_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -2720,7 +3223,15 @@ VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u32_dpp"
+          : "v_cmp_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -2764,7 +3275,15 @@ VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u32_dpp"
+          : "v_cmp_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -2808,7 +3327,15 @@ VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u32_dpp"
+          : "v_cmp_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -2832,14 +3359,22 @@ VCmpLtI64Vopc::VCmpLtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_i64_dpp"
+          : "v_cmp_lt_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_I64 does not support DPP";
   return std::make_unique<VCmpLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -2863,14 +3398,22 @@ VCmpEqI64Vopc::VCmpEqI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_i64_dpp"
+          : "v_cmp_eq_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_I64 does not support DPP";
   return std::make_unique<VCmpEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -2894,14 +3437,22 @@ VCmpLeI64Vopc::VCmpLeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_i64_dpp"
+          : "v_cmp_le_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_I64 does not support DPP";
   return std::make_unique<VCmpLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -2925,14 +3476,22 @@ VCmpGtI64Vopc::VCmpGtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_i64_dpp"
+          : "v_cmp_gt_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_I64 does not support DPP";
   return std::make_unique<VCmpGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -2956,14 +3515,22 @@ VCmpNeI64Vopc::VCmpNeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_i64_dpp"
+          : "v_cmp_ne_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_I64 does not support DPP";
   return std::make_unique<VCmpNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -2987,14 +3554,22 @@ VCmpGeI64Vopc::VCmpGeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_I64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_i64_dpp"
+          : "v_cmp_ge_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_I64 does not support DPP";
   return std::make_unique<VCmpGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -3018,14 +3593,22 @@ VCmpLtU64Vopc::VCmpLtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LT_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_lt_u64_dpp"
+          : "v_cmp_lt_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LT_U64 does not support DPP";
   return std::make_unique<VCmpLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3049,14 +3632,22 @@ VCmpEqU64Vopc::VCmpEqU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_EQ_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_eq_u64_dpp"
+          : "v_cmp_eq_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_EQ_U64 does not support DPP";
   return std::make_unique<VCmpEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3080,14 +3671,22 @@ VCmpLeU64Vopc::VCmpLeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_LE_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_le_u64_dpp"
+          : "v_cmp_le_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_LE_U64 does not support DPP";
   return std::make_unique<VCmpLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3111,14 +3710,22 @@ VCmpGtU64Vopc::VCmpGtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GT_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_gt_u64_dpp"
+          : "v_cmp_gt_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GT_U64 does not support DPP";
   return std::make_unique<VCmpGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3142,14 +3749,22 @@ VCmpNeU64Vopc::VCmpNeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_NE_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ne_u64_dpp"
+          : "v_cmp_ne_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_NE_U64 does not support DPP";
   return std::make_unique<VCmpNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3173,14 +3788,22 @@ VCmpGeU64Vopc::VCmpGeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_GE_U64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_ge_u64_dpp"
+          : "v_cmp_ge_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_GE_U64 does not support DPP";
   return std::make_unique<VCmpGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -3227,7 +3850,16 @@ VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF16Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f16_dpp"
+          : "v_cmp_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3271,7 +3903,16 @@ VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF32Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f32_dpp"
+          : "v_cmp_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -3295,14 +3936,23 @@ VCmpClassF64Vopc::VCmpClassF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMP_CLASS_F64 does not support DPP", "");
   vcc.apply_fieldless_caps(false, false, false);
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpClassF64Vopc(const MachineInst *opcode,
+                                    const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmp_class_f64_dpp"
+          : "v_cmp_class_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMP_CLASS_F64 does not support DPP";
   return std::make_unique<VCmpClassF64Vopc>(opcode);
 }
 } // namespace detail
@@ -3353,7 +4003,15 @@ VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f16_dpp"
+          : "v_cmpx_lt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3404,7 +4062,15 @@ VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f16_dpp"
+          : "v_cmpx_eq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3455,7 +4121,15 @@ VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f16_dpp"
+          : "v_cmpx_le_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3506,7 +4180,15 @@ VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f16_dpp"
+          : "v_cmpx_gt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3557,7 +4239,15 @@ VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f16_dpp"
+          : "v_cmpx_lg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3608,7 +4298,15 @@ VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f16_dpp"
+          : "v_cmpx_ge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3659,7 +4357,15 @@ VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f16_dpp"
+          : "v_cmpx_o_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3710,7 +4416,15 @@ VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f16_dpp"
+          : "v_cmpx_u_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3761,7 +4475,16 @@ VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f16_dpp"
+          : "v_cmpx_nge_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3812,7 +4535,16 @@ VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f16_dpp"
+          : "v_cmpx_nlg_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3863,7 +4595,16 @@ VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f16_dpp"
+          : "v_cmpx_ngt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3914,7 +4655,16 @@ VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f16_dpp"
+          : "v_cmpx_nle_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF16Vopc>(opcode);
 }
 } // namespace detail
@@ -3965,7 +4715,16 @@ VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f16_dpp"
+          : "v_cmpx_neq_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4016,7 +4775,16 @@ VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF16Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f16_dpp"
+          : "v_cmpx_nlt_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF16Vopc>(opcode);
 }
 } // namespace detail
@@ -4064,7 +4832,15 @@ VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f32_dpp"
+          : "v_cmpx_lt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4112,7 +4888,15 @@ VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f32_dpp"
+          : "v_cmpx_eq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4160,7 +4944,15 @@ VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f32_dpp"
+          : "v_cmpx_le_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4208,7 +5000,15 @@ VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f32_dpp"
+          : "v_cmpx_gt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4256,7 +5056,15 @@ VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f32_dpp"
+          : "v_cmpx_lg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4304,7 +5112,15 @@ VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f32_dpp"
+          : "v_cmpx_ge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4352,7 +5168,15 @@ VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f32_dpp"
+          : "v_cmpx_o_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxOF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4400,7 +5224,15 @@ VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f32_dpp"
+          : "v_cmpx_u_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxUF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4448,7 +5280,16 @@ VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f32_dpp"
+          : "v_cmpx_nge_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgeF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4496,7 +5337,16 @@ VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f32_dpp"
+          : "v_cmpx_nlg_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNlgF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4544,7 +5394,16 @@ VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f32_dpp"
+          : "v_cmpx_ngt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNgtF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4592,7 +5451,16 @@ VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f32_dpp"
+          : "v_cmpx_nle_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNleF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4640,7 +5508,16 @@ VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f32_dpp"
+          : "v_cmpx_neq_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeqF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4688,7 +5565,16 @@ VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF32Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f32_dpp"
+          : "v_cmpx_nlt_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNltF32Vopc>(opcode);
 }
 } // namespace detail
@@ -4714,16 +5600,24 @@ VCmpxLtF64Vopc::VCmpxLtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_f64_dpp"
+          : "v_cmpx_lt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_F64 does not support DPP";
   return std::make_unique<VCmpxLtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4749,16 +5643,24 @@ VCmpxEqF64Vopc::VCmpxEqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_f64_dpp"
+          : "v_cmpx_eq_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_F64 does not support DPP";
   return std::make_unique<VCmpxEqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4784,16 +5686,24 @@ VCmpxLeF64Vopc::VCmpxLeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_f64_dpp"
+          : "v_cmpx_le_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_F64 does not support DPP";
   return std::make_unique<VCmpxLeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4819,16 +5729,24 @@ VCmpxGtF64Vopc::VCmpxGtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_f64_dpp"
+          : "v_cmpx_gt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_F64 does not support DPP";
   return std::make_unique<VCmpxGtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4854,16 +5772,24 @@ VCmpxLgF64Vopc::VCmpxLgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LG_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLgF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lg_f64_dpp"
+          : "v_cmpx_lg_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LG_F64 does not support DPP";
   return std::make_unique<VCmpxLgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4889,16 +5815,24 @@ VCmpxGeF64Vopc::VCmpxGeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_f64_dpp"
+          : "v_cmpx_ge_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_F64 does not support DPP";
   return std::make_unique<VCmpxGeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4924,16 +5858,24 @@ VCmpxOF64Vopc::VCmpxOF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_O_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxOF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxOF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_o_f64_dpp"
+          : "v_cmpx_o_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_O_F64 does not support DPP";
   return std::make_unique<VCmpxOF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4959,16 +5901,24 @@ VCmpxUF64Vopc::VCmpxUF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_U_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxUF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxUF64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_u_f64_dpp"
+          : "v_cmpx_u_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_U_F64 does not support DPP";
   return std::make_unique<VCmpxUF64Vopc>(opcode);
 }
 } // namespace detail
@@ -4994,16 +5944,25 @@ VCmpxNgeF64Vopc::VCmpxNgeF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGE_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgeF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgeF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nge_f64_dpp"
+          : "v_cmpx_nge_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGE_F64 does not support DPP";
   return std::make_unique<VCmpxNgeF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5029,16 +5988,25 @@ VCmpxNlgF64Vopc::VCmpxNlgF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLG_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNlgF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNlgF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlg_f64_dpp"
+          : "v_cmpx_nlg_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLG_F64 does not support DPP";
   return std::make_unique<VCmpxNlgF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5064,16 +6032,25 @@ VCmpxNgtF64Vopc::VCmpxNgtF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NGT_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNgtF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNgtF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ngt_f64_dpp"
+          : "v_cmpx_ngt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NGT_F64 does not support DPP";
   return std::make_unique<VCmpxNgtF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5099,16 +6076,25 @@ VCmpxNleF64Vopc::VCmpxNleF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLE_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNleF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNleF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nle_f64_dpp"
+          : "v_cmpx_nle_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLE_F64 does not support DPP";
   return std::make_unique<VCmpxNleF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5134,16 +6120,25 @@ VCmpxNeqF64Vopc::VCmpxNeqF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NEQ_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeqF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeqF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_neq_f64_dpp"
+          : "v_cmpx_neq_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NEQ_F64 does not support DPP";
   return std::make_unique<VCmpxNeqF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5169,16 +6164,25 @@ VCmpxNltF64Vopc::VCmpxNltF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NLT_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNltF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNltF64Vopc(const MachineInst *opcode,
+                                   const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_nlt_f64_dpp"
+          : "v_cmpx_nlt_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NLT_F64 does not support DPP";
   return std::make_unique<VCmpxNltF64Vopc>(opcode);
 }
 } // namespace detail
@@ -5229,7 +6233,15 @@ VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i16_dpp"
+          : "v_cmpx_lt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5280,7 +6292,15 @@ VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i16_dpp"
+          : "v_cmpx_eq_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5331,7 +6351,15 @@ VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i16_dpp"
+          : "v_cmpx_le_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5382,7 +6410,15 @@ VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i16_dpp"
+          : "v_cmpx_gt_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5433,7 +6469,15 @@ VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i16_dpp"
+          : "v_cmpx_ne_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5484,7 +6528,15 @@ VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i16_dpp"
+          : "v_cmpx_ge_i16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI16Vopc>(opcode);
 }
 } // namespace detail
@@ -5535,7 +6587,15 @@ VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u16_dpp"
+          : "v_cmpx_lt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5586,7 +6646,15 @@ VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u16_dpp"
+          : "v_cmpx_eq_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5637,7 +6705,15 @@ VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u16_dpp"
+          : "v_cmpx_le_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5688,7 +6764,15 @@ VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u16_dpp"
+          : "v_cmpx_gt_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5739,7 +6823,15 @@ VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u16_dpp"
+          : "v_cmpx_ne_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5790,7 +6882,15 @@ VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU16Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u16_dpp"
+          : "v_cmpx_ge_u16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU16Vopc>(opcode);
 }
 } // namespace detail
@@ -5838,7 +6938,15 @@ VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i32_dpp"
+          : "v_cmpx_lt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -5886,7 +6994,15 @@ VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i32_dpp"
+          : "v_cmpx_eq_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqI32Vopc>(opcode);
 }
 } // namespace detail
@@ -5934,7 +7050,15 @@ VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i32_dpp"
+          : "v_cmpx_le_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -5982,7 +7106,15 @@ VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i32_dpp"
+          : "v_cmpx_gt_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6030,7 +7162,15 @@ VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i32_dpp"
+          : "v_cmpx_ne_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6078,7 +7218,15 @@ VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i32_dpp"
+          : "v_cmpx_ge_i32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeI32Vopc>(opcode);
 }
 } // namespace detail
@@ -6126,7 +7274,15 @@ VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u32_dpp"
+          : "v_cmpx_lt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6174,7 +7330,15 @@ VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u32_dpp"
+          : "v_cmpx_eq_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxEqU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6222,7 +7386,15 @@ VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u32_dpp"
+          : "v_cmpx_le_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxLeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6270,7 +7442,15 @@ VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u32_dpp"
+          : "v_cmpx_gt_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGtU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6318,7 +7498,15 @@ VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u32_dpp"
+          : "v_cmpx_ne_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxNeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6366,7 +7554,15 @@ VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU32Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u32_dpp"
+          : "v_cmpx_ge_u32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxGeU32Vopc>(opcode);
 }
 } // namespace detail
@@ -6392,16 +7588,24 @@ VCmpxLtI64Vopc::VCmpxLtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_i64_dpp"
+          : "v_cmpx_lt_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_I64 does not support DPP";
   return std::make_unique<VCmpxLtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -6427,16 +7631,24 @@ VCmpxEqI64Vopc::VCmpxEqI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_i64_dpp"
+          : "v_cmpx_eq_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_I64 does not support DPP";
   return std::make_unique<VCmpxEqI64Vopc>(opcode);
 }
 } // namespace detail
@@ -6462,16 +7674,24 @@ VCmpxLeI64Vopc::VCmpxLeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_i64_dpp"
+          : "v_cmpx_le_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_I64 does not support DPP";
   return std::make_unique<VCmpxLeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -6497,16 +7717,24 @@ VCmpxGtI64Vopc::VCmpxGtI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_i64_dpp"
+          : "v_cmpx_gt_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_I64 does not support DPP";
   return std::make_unique<VCmpxGtI64Vopc>(opcode);
 }
 } // namespace detail
@@ -6532,16 +7760,24 @@ VCmpxNeI64Vopc::VCmpxNeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_i64_dpp"
+          : "v_cmpx_ne_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_I64 does not support DPP";
   return std::make_unique<VCmpxNeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -6567,16 +7803,24 @@ VCmpxGeI64Vopc::VCmpxGeI64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::SignExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_I64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeI64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeI64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_i64_dpp"
+          : "v_cmpx_ge_i64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_I64 does not support DPP";
   return std::make_unique<VCmpxGeI64Vopc>(opcode);
 }
 } // namespace detail
@@ -6602,16 +7846,24 @@ VCmpxLtU64Vopc::VCmpxLtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LT_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_lt_u64_dpp"
+          : "v_cmpx_lt_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LT_U64 does not support DPP";
   return std::make_unique<VCmpxLtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -6637,16 +7889,24 @@ VCmpxEqU64Vopc::VCmpxEqU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_EQ_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxEqU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxEqU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_eq_u64_dpp"
+          : "v_cmpx_eq_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_EQ_U64 does not support DPP";
   return std::make_unique<VCmpxEqU64Vopc>(opcode);
 }
 } // namespace detail
@@ -6672,16 +7932,24 @@ VCmpxLeU64Vopc::VCmpxLeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_LE_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxLeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxLeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_le_u64_dpp"
+          : "v_cmpx_le_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_LE_U64 does not support DPP";
   return std::make_unique<VCmpxLeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -6707,16 +7975,24 @@ VCmpxGtU64Vopc::VCmpxGtU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GT_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGtU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGtU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_gt_u64_dpp"
+          : "v_cmpx_gt_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GT_U64 does not support DPP";
   return std::make_unique<VCmpxGtU64Vopc>(opcode);
 }
 } // namespace detail
@@ -6742,16 +8018,24 @@ VCmpxNeU64Vopc::VCmpxNeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_NE_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxNeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxNeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ne_u64_dpp"
+          : "v_cmpx_ne_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_NE_U64 does not support DPP";
   return std::make_unique<VCmpxNeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -6777,16 +8061,24 @@ VCmpxGeU64Vopc::VCmpxGeU64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::ZeroExtend);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_GE_U64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxGeU64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxGeU64Vopc(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_ge_u64_dpp"
+          : "v_cmpx_ge_u64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_GE_U64 does not support DPP";
   return std::make_unique<VCmpxGeU64Vopc>(opcode);
 }
 } // namespace detail
@@ -6837,7 +8129,16 @@ VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF16Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF16Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f16_dpp"
+          : "v_cmpx_class_f16_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF16Vopc>(opcode);
 }
 } // namespace detail
@@ -6885,7 +8186,16 @@ VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF32Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF32Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f32_dpp"
+          : "v_cmpx_class_f32_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<VCmpxClassF32Vopc>(opcode);
 }
 } // namespace detail
@@ -6911,16 +8221,25 @@ VCmpxClassF64Vopc::VCmpxClassF64Vopc(const MachineInst *inst)
         64,
         static_cast<uint32_t>(reinterpret_cast<const VopcInstLiteralMachineInst *>(inst)->simm32),
         Operand::Literal32Widening::F64HighBits);
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
-      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0))
-    throw util::InvalidInst("V_CMPX_CLASS_F64 does not support DPP", "");
   exec.apply_fieldless_caps(false, false, false);
   sdst_exec.apply_fieldless_caps(false, false, false);
   flags_ |= WRITES_EXEC;
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeVCmpxClassF64Vopc(const MachineInst *opcode) {
+DecodeResult decodeVCmpxClassF64Vopc(const MachineInst *opcode,
+                                     const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
+  Result validation = Vopc::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)
+          ? "v_cmpx_class_f64_dpp"
+          : "v_cmpx_class_f64_e32",
+      reinterpret_cast<const Vopc::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
+  if (reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0 == amdgpu::SRC_DPP ||
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vopc::OpEncoding *>(inst)->src0)) [[unlikely]]
+    return emit_error.emit() << "V_CMPX_CLASS_F64 does not support DPP";
   return std::make_unique<VCmpxClassF64Vopc>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vopd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vopd.cpp
@@ -95,6 +95,24 @@ const char *Vopd::op_name(uint16_t op) {
   }
 }
 
+Result Vopd::validate_encoding(const MachineInst *inst, const util::DiagnosticEmitter &emit_error) {
+  const auto *words = reinterpret_cast<const uint32_t *>(inst);
+  const uint32_t word0 = words[0];
+  const uint32_t word1 = words[1];
+
+  const uint16_t opx = static_cast<uint16_t>((word0 >> 22) & 0xF);
+  const uint16_t opy = static_cast<uint16_t>((word0 >> 17) & 0x1F);
+  if (!is_valid_opcode(opx, kVopdXOpcodeMask)) [[unlikely]]
+    return emit_error.emit() << "invalid VOPD X opcode";
+  if (!is_valid_opcode(opy, kVopdYOpcodeMask)) [[unlikely]]
+    return emit_error.emit() << "invalid VOPD Y opcode";
+  const uint16_t srcx0 = static_cast<uint16_t>(word0 & 0x1FF);
+  const uint16_t srcy0 = static_cast<uint16_t>(word1 & 0x1FF);
+  if (srcx0 == 254 || srcy0 == 254) [[unlikely]]
+    return emit_error.emit() << "VOPD does not support 64-bit literals";
+  return Result::success();
+}
+
 Vopd::Vopd(const MachineInst *inst)
     : IsaInstruction<Isa>("vopd", selected_exec_fn(InstructionExecutionId::Vopd)),
       dstx_(32, OperandType::OPR_VGPR, 0), dsty_(32, OperandType::OPR_VGPR, 0),
@@ -110,16 +128,10 @@ Vopd::Vopd(const MachineInst *inst)
   encoding_id_ = 0x32;
   opx_ = static_cast<uint16_t>((word0_ >> 22) & 0xF);
   opy_ = static_cast<uint16_t>((word0_ >> 17) & 0x1F);
-  if (!is_valid_opcode(opx_, kVopdXOpcodeMask))
-    throw util::InvalidInst("invalid VOPD X opcode", "");
-  if (!is_valid_opcode(opy_, kVopdYOpcodeMask))
-    throw util::InvalidInst("invalid VOPD Y opcode", "");
   uint16_t srcx0 = static_cast<uint16_t>(word0_ & 0x1FF);
   uint16_t vsrcx1 = static_cast<uint16_t>((word0_ >> 9) & 0xFF);
   uint16_t srcy0 = static_cast<uint16_t>(word1_ & 0x1FF);
   uint16_t vsrcy1 = static_cast<uint16_t>((word1_ >> 9) & 0xFF);
-  if (srcx0 == 254 || srcy0 == 254)
-    throw util::InvalidInst("VOPD does not support 64-bit literals", "");
   uint16_t vdstx = static_cast<uint16_t>((word1_ >> 24) & 0xFF);
   uint16_t vdsty_hi = static_cast<uint16_t>((word1_ >> 17) & 0x7F);
   uint16_t vdsty = static_cast<uint16_t>((vdsty_hi << 1) | ((~vdstx) & 1u));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vopd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vopd.h
@@ -9,6 +9,7 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/encodings.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/operand.h"
+#include "rocjitsu/isa/decode_result.h"
 #include <cstdint>
 #include <string>
 
@@ -18,6 +19,8 @@ namespace rdna4 {
 class Vopd : public IsaInstruction<Isa> {
 public:
   explicit Vopd(const MachineInst *inst);
+  static Result validate_encoding(const MachineInst *inst,
+                                  const util::DiagnosticEmitter &emit_error);
   void execute_impl(amdgpu::Wavefront &wf);
 
 private:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vsample.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vsample.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vsample.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -27,7 +26,12 @@ ImageMsaaLoadVsample::ImageMsaaLoadVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageMsaaLoadVsample(const MachineInst *opcode) {
+DecodeResult decodeImageMsaaLoadVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_msaa_load", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageMsaaLoadVsample>(opcode);
 }
 } // namespace detail
@@ -49,7 +53,12 @@ ImageSampleVsample::ImageSampleVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleVsample(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleVsample>(opcode);
 }
 } // namespace detail
@@ -71,7 +80,12 @@ ImageSampleDVsample::ImageSampleDVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDVsample(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_d", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDVsample>(opcode);
 }
 } // namespace detail
@@ -93,7 +107,12 @@ ImageSampleLVsample::ImageSampleLVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLVsample(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_l", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLVsample>(opcode);
 }
 } // namespace detail
@@ -115,7 +134,12 @@ ImageSampleBVsample::ImageSampleBVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBVsample(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_b", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBVsample>(opcode);
 }
 } // namespace detail
@@ -137,7 +161,12 @@ ImageSampleLzVsample::ImageSampleLzVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLzVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLzVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_lz", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLzVsample>(opcode);
 }
 } // namespace detail
@@ -159,7 +188,12 @@ ImageSampleCVsample::ImageSampleCVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCVsample(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCVsample>(opcode);
 }
 } // namespace detail
@@ -181,7 +215,12 @@ ImageSampleCDVsample::ImageSampleCDVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c_d", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDVsample>(opcode);
 }
 } // namespace detail
@@ -203,7 +242,12 @@ ImageSampleCLVsample::ImageSampleCLVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c_l", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLVsample>(opcode);
 }
 } // namespace detail
@@ -225,7 +269,12 @@ ImageSampleCBVsample::ImageSampleCBVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c_b", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBVsample>(opcode);
 }
 } // namespace detail
@@ -247,7 +296,12 @@ ImageSampleCLzVsample::ImageSampleCLzVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLzVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLzVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c_lz", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLzVsample>(opcode);
 }
 } // namespace detail
@@ -269,7 +323,12 @@ ImageSampleOVsample::ImageSampleOVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleOVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleOVsample(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleOVsample>(opcode);
 }
 } // namespace detail
@@ -291,7 +350,12 @@ ImageSampleDOVsample::ImageSampleDOVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDOVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDOVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_d_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDOVsample>(opcode);
 }
 } // namespace detail
@@ -313,7 +377,12 @@ ImageSampleLOVsample::ImageSampleLOVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLOVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLOVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_l_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLOVsample>(opcode);
 }
 } // namespace detail
@@ -335,7 +404,12 @@ ImageSampleBOVsample::ImageSampleBOVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBOVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBOVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_b_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBOVsample>(opcode);
 }
 } // namespace detail
@@ -357,7 +431,12 @@ ImageSampleLzOVsample::ImageSampleLzOVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleLzOVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleLzOVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_lz_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleLzOVsample>(opcode);
 }
 } // namespace detail
@@ -379,7 +458,12 @@ ImageSampleCOVsample::ImageSampleCOVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCOVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCOVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCOVsample>(opcode);
 }
 } // namespace detail
@@ -401,7 +485,12 @@ ImageSampleCDOVsample::ImageSampleCDOVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDOVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDOVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c_d_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDOVsample>(opcode);
 }
 } // namespace detail
@@ -423,7 +512,12 @@ ImageSampleCLOVsample::ImageSampleCLOVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLOVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLOVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c_l_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLOVsample>(opcode);
 }
 } // namespace detail
@@ -445,7 +539,12 @@ ImageSampleCBOVsample::ImageSampleCBOVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBOVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBOVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c_b_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBOVsample>(opcode);
 }
 } // namespace detail
@@ -467,7 +566,12 @@ ImageSampleCLzOVsample::ImageSampleCLzOVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCLzOVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCLzOVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c_lz_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCLzOVsample>(opcode);
 }
 } // namespace detail
@@ -489,7 +593,12 @@ ImageGather4Vsample::ImageGather4Vsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4Vsample(const MachineInst *opcode) {
+DecodeResult decodeImageGather4Vsample(const MachineInst *opcode,
+                                       const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_gather4", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4Vsample>(opcode);
 }
 } // namespace detail
@@ -511,7 +620,12 @@ ImageGather4LVsample::ImageGather4LVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LVsample(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_gather4_l", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LVsample>(opcode);
 }
 } // namespace detail
@@ -533,7 +647,12 @@ ImageGather4BVsample::ImageGather4BVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4BVsample(const MachineInst *opcode) {
+DecodeResult decodeImageGather4BVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_gather4_b", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4BVsample>(opcode);
 }
 } // namespace detail
@@ -555,7 +674,12 @@ ImageGather4LzVsample::ImageGather4LzVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LzVsample(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LzVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_gather4_lz", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LzVsample>(opcode);
 }
 } // namespace detail
@@ -577,7 +701,12 @@ ImageGather4CVsample::ImageGather4CVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CVsample(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_gather4_c", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CVsample>(opcode);
 }
 } // namespace detail
@@ -599,7 +728,12 @@ ImageGather4CLzVsample::ImageGather4CLzVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLzVsample(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLzVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_gather4_c_lz", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLzVsample>(opcode);
 }
 } // namespace detail
@@ -621,7 +755,12 @@ ImageGather4OVsample::ImageGather4OVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4OVsample(const MachineInst *opcode) {
+DecodeResult decodeImageGather4OVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_gather4_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4OVsample>(opcode);
 }
 } // namespace detail
@@ -643,7 +782,12 @@ ImageGather4LzOVsample::ImageGather4LzOVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4LzOVsample(const MachineInst *opcode) {
+DecodeResult decodeImageGather4LzOVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_gather4_lz_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4LzOVsample>(opcode);
 }
 } // namespace detail
@@ -665,7 +809,12 @@ ImageGather4CLzOVsample::ImageGather4CLzOVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLzOVsample(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLzOVsample(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_gather4_c_lz_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLzOVsample>(opcode);
 }
 } // namespace detail
@@ -687,7 +836,12 @@ ImageGetLodVsample::ImageGetLodVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGetLodVsample(const MachineInst *opcode) {
+DecodeResult decodeImageGetLodVsample(const MachineInst *opcode,
+                                      const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_get_lod", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGetLodVsample>(opcode);
 }
 } // namespace detail
@@ -709,7 +863,12 @@ ImageSampleDG16Vsample::ImageSampleDG16Vsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDG16Vsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDG16Vsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_d_g16", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDG16Vsample>(opcode);
 }
 } // namespace detail
@@ -731,7 +890,12 @@ ImageSampleCDG16Vsample::ImageSampleCDG16Vsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDG16Vsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDG16Vsample(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c_d_g16", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDG16Vsample>(opcode);
 }
 } // namespace detail
@@ -753,7 +917,12 @@ ImageSampleDOG16Vsample::ImageSampleDOG16Vsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDOG16Vsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDOG16Vsample(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_d_o_g16", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDOG16Vsample>(opcode);
 }
 } // namespace detail
@@ -775,7 +944,12 @@ ImageSampleCDOG16Vsample::ImageSampleCDOG16Vsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDOG16Vsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDOG16Vsample(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c_d_o_g16", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDOG16Vsample>(opcode);
 }
 } // namespace detail
@@ -797,7 +971,12 @@ ImageSampleClVsample::ImageSampleClVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleClVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleClVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_cl", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleClVsample>(opcode);
 }
 } // namespace detail
@@ -819,7 +998,12 @@ ImageSampleDClVsample::ImageSampleDClVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_d_cl", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClVsample>(opcode);
 }
 } // namespace detail
@@ -841,7 +1025,12 @@ ImageSampleBClVsample::ImageSampleBClVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBClVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBClVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_b_cl", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBClVsample>(opcode);
 }
 } // namespace detail
@@ -863,7 +1052,12 @@ ImageSampleCClVsample::ImageSampleCClVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCClVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCClVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c_cl", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCClVsample>(opcode);
 }
 } // namespace detail
@@ -885,7 +1079,12 @@ ImageSampleCDClVsample::ImageSampleCDClVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c_d_cl", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClVsample>(opcode);
 }
 } // namespace detail
@@ -907,7 +1106,12 @@ ImageSampleCBClVsample::ImageSampleCBClVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBClVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBClVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c_b_cl", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBClVsample>(opcode);
 }
 } // namespace detail
@@ -929,7 +1133,12 @@ ImageSampleClOVsample::ImageSampleClOVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleClOVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleClOVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_cl_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleClOVsample>(opcode);
 }
 } // namespace detail
@@ -951,7 +1160,12 @@ ImageSampleDClOVsample::ImageSampleDClOVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClOVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClOVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_d_cl_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClOVsample>(opcode);
 }
 } // namespace detail
@@ -973,7 +1187,12 @@ ImageSampleBClOVsample::ImageSampleBClOVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleBClOVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleBClOVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_b_cl_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleBClOVsample>(opcode);
 }
 } // namespace detail
@@ -995,7 +1214,12 @@ ImageSampleCClOVsample::ImageSampleCClOVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCClOVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCClOVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c_cl_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCClOVsample>(opcode);
 }
 } // namespace detail
@@ -1017,7 +1241,12 @@ ImageSampleCDClOVsample::ImageSampleCDClOVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClOVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClOVsample(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c_d_cl_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClOVsample>(opcode);
 }
 } // namespace detail
@@ -1039,7 +1268,12 @@ ImageSampleCBClOVsample::ImageSampleCBClOVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCBClOVsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCBClOVsample(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c_b_cl_o", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCBClOVsample>(opcode);
 }
 } // namespace detail
@@ -1061,7 +1295,12 @@ ImageSampleCDClG16Vsample::ImageSampleCDClG16Vsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClG16Vsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClG16Vsample(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_c_d_cl_g16", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClG16Vsample>(opcode);
 }
 } // namespace detail
@@ -1083,7 +1322,12 @@ ImageSampleDClOG16Vsample::ImageSampleDClOG16Vsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClOG16Vsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClOG16Vsample(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_d_cl_o_g16", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClOG16Vsample>(opcode);
 }
 } // namespace detail
@@ -1105,7 +1349,13 @@ ImageSampleCDClOG16Vsample::ImageSampleCDClOG16Vsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleCDClOG16Vsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleCDClOG16Vsample(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation =
+      Vsample::validate_encoding("image_sample_c_d_cl_o_g16",
+                                 reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleCDClOG16Vsample>(opcode);
 }
 } // namespace detail
@@ -1127,7 +1377,12 @@ ImageSampleDClG16Vsample::ImageSampleDClG16Vsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageSampleDClG16Vsample(const MachineInst *opcode) {
+DecodeResult decodeImageSampleDClG16Vsample(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_sample_d_cl_g16", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageSampleDClG16Vsample>(opcode);
 }
 } // namespace detail
@@ -1149,7 +1404,12 @@ ImageGather4ClVsample::ImageGather4ClVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4ClVsample(const MachineInst *opcode) {
+DecodeResult decodeImageGather4ClVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_gather4_cl", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4ClVsample>(opcode);
 }
 } // namespace detail
@@ -1171,7 +1431,12 @@ ImageGather4BClVsample::ImageGather4BClVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4BClVsample(const MachineInst *opcode) {
+DecodeResult decodeImageGather4BClVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_gather4_b_cl", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4BClVsample>(opcode);
 }
 } // namespace detail
@@ -1193,7 +1458,12 @@ ImageGather4CClVsample::ImageGather4CClVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CClVsample(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CClVsample(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_gather4_c_cl", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CClVsample>(opcode);
 }
 } // namespace detail
@@ -1215,7 +1485,12 @@ ImageGather4CLVsample::ImageGather4CLVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CLVsample(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CLVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_gather4_c_l", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CLVsample>(opcode);
 }
 } // namespace detail
@@ -1237,7 +1512,12 @@ ImageGather4CBVsample::ImageGather4CBVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CBVsample(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CBVsample(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_gather4_c_b", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CBVsample>(opcode);
 }
 } // namespace detail
@@ -1259,7 +1539,12 @@ ImageGather4CBClVsample::ImageGather4CBClVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4CBClVsample(const MachineInst *opcode) {
+DecodeResult decodeImageGather4CBClVsample(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_gather4_c_b_cl", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4CBClVsample>(opcode);
 }
 } // namespace detail
@@ -1281,7 +1566,12 @@ ImageGather4hVsample::ImageGather4hVsample(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeImageGather4hVsample(const MachineInst *opcode) {
+DecodeResult decodeImageGather4hVsample(const MachineInst *opcode,
+                                        const DecodeErrorEmitter &emit_error) {
+  Result validation = Vsample::validate_encoding(
+      "image_gather4h", reinterpret_cast<const Vsample::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ImageGather4hVsample>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vscratch.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vscratch.cpp
@@ -7,7 +7,6 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vscratch.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
-#include "util/except.h"
 #include <memory>
 
 namespace rocjitsu {
@@ -31,7 +30,12 @@ ScratchLoadU8Vscratch::ScratchLoadU8Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadU8Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadU8Vscratch(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_u8", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadU8Vscratch>(opcode);
 }
 } // namespace detail
@@ -54,7 +58,12 @@ ScratchLoadI8Vscratch::ScratchLoadI8Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadI8Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadI8Vscratch(const MachineInst *opcode,
+                                         const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_i8", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadI8Vscratch>(opcode);
 }
 } // namespace detail
@@ -77,7 +86,12 @@ ScratchLoadU16Vscratch::ScratchLoadU16Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadU16Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadU16Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_u16", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadU16Vscratch>(opcode);
 }
 } // namespace detail
@@ -100,7 +114,12 @@ ScratchLoadI16Vscratch::ScratchLoadI16Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadI16Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadI16Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_i16", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadI16Vscratch>(opcode);
 }
 } // namespace detail
@@ -123,7 +142,12 @@ ScratchLoadB32Vscratch::ScratchLoadB32Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadB32Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadB32Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_b32", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadB32Vscratch>(opcode);
 }
 } // namespace detail
@@ -146,7 +170,12 @@ ScratchLoadB64Vscratch::ScratchLoadB64Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadB64Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadB64Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_b64", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadB64Vscratch>(opcode);
 }
 } // namespace detail
@@ -169,7 +198,12 @@ ScratchLoadB96Vscratch::ScratchLoadB96Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadB96Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadB96Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_b96", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadB96Vscratch>(opcode);
 }
 } // namespace detail
@@ -192,7 +226,12 @@ ScratchLoadB128Vscratch::ScratchLoadB128Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadB128Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadB128Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_b128", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadB128Vscratch>(opcode);
 }
 } // namespace detail
@@ -215,7 +254,12 @@ ScratchStoreB8Vscratch::ScratchStoreB8Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchStoreB8Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchStoreB8Vscratch(const MachineInst *opcode,
+                                          const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_store_b8", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchStoreB8Vscratch>(opcode);
 }
 } // namespace detail
@@ -238,7 +282,12 @@ ScratchStoreB16Vscratch::ScratchStoreB16Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchStoreB16Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchStoreB16Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_store_b16", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchStoreB16Vscratch>(opcode);
 }
 } // namespace detail
@@ -261,7 +310,12 @@ ScratchStoreB32Vscratch::ScratchStoreB32Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchStoreB32Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchStoreB32Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_store_b32", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchStoreB32Vscratch>(opcode);
 }
 } // namespace detail
@@ -284,7 +338,12 @@ ScratchStoreB64Vscratch::ScratchStoreB64Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchStoreB64Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchStoreB64Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_store_b64", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchStoreB64Vscratch>(opcode);
 }
 } // namespace detail
@@ -307,7 +366,12 @@ ScratchStoreB96Vscratch::ScratchStoreB96Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchStoreB96Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchStoreB96Vscratch(const MachineInst *opcode,
+                                           const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_store_b96", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchStoreB96Vscratch>(opcode);
 }
 } // namespace detail
@@ -330,7 +394,12 @@ ScratchStoreB128Vscratch::ScratchStoreB128Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchStoreB128Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchStoreB128Vscratch(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_store_b128", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchStoreB128Vscratch>(opcode);
 }
 } // namespace detail
@@ -353,7 +422,12 @@ ScratchLoadD16U8Vscratch::ScratchLoadD16U8Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadD16U8Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadD16U8Vscratch(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_d16_u8", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadD16U8Vscratch>(opcode);
 }
 } // namespace detail
@@ -382,7 +456,12 @@ ScratchLoadD16I8Vscratch::ScratchLoadD16I8Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadD16I8Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadD16I8Vscratch(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_d16_i8", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadD16I8Vscratch>(opcode);
 }
 } // namespace detail
@@ -411,7 +490,12 @@ ScratchLoadD16B16Vscratch::ScratchLoadD16B16Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadD16B16Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadD16B16Vscratch(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_d16_b16", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadD16B16Vscratch>(opcode);
 }
 } // namespace detail
@@ -440,7 +524,12 @@ ScratchLoadD16HiU8Vscratch::ScratchLoadD16HiU8Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadD16HiU8Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadD16HiU8Vscratch(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_d16_hi_u8", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadD16HiU8Vscratch>(opcode);
 }
 } // namespace detail
@@ -469,7 +558,12 @@ ScratchLoadD16HiI8Vscratch::ScratchLoadD16HiI8Vscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadD16HiI8Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadD16HiI8Vscratch(const MachineInst *opcode,
+                                              const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_d16_hi_i8", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadD16HiI8Vscratch>(opcode);
 }
 } // namespace detail
@@ -498,7 +592,13 @@ ScratchLoadD16HiB16Vscratch::ScratchLoadD16HiB16Vscratch(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadD16HiB16Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadD16HiB16Vscratch(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_d16_hi_b16", reinterpret_cast<const Vscratch::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadD16HiB16Vscratch>(opcode);
 }
 } // namespace detail
@@ -527,7 +627,13 @@ ScratchStoreD16HiB8Vscratch::ScratchStoreD16HiB8Vscratch(const MachineInst *inst
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchStoreD16HiB8Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchStoreD16HiB8Vscratch(const MachineInst *opcode,
+                                               const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_store_d16_hi_b8", reinterpret_cast<const Vscratch::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchStoreD16HiB8Vscratch>(opcode);
 }
 } // namespace detail
@@ -550,7 +656,13 @@ ScratchStoreD16HiB16Vscratch::ScratchStoreD16HiB16Vscratch(const MachineInst *in
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchStoreD16HiB16Vscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchStoreD16HiB16Vscratch(const MachineInst *opcode,
+                                                const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_store_d16_hi_b16", reinterpret_cast<const Vscratch::OpEncoding *>(opcode),
+      emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchStoreD16HiB16Vscratch>(opcode);
 }
 } // namespace detail
@@ -575,7 +687,12 @@ ScratchLoadBlockVscratch::ScratchLoadBlockVscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchLoadBlockVscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchLoadBlockVscratch(const MachineInst *opcode,
+                                            const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_load_block", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchLoadBlockVscratch>(opcode);
 }
 } // namespace detail
@@ -600,7 +717,12 @@ ScratchStoreBlockVscratch::ScratchStoreBlockVscratch(const MachineInst *inst)
 }
 
 namespace detail {
-std::unique_ptr<Instruction> decodeScratchStoreBlockVscratch(const MachineInst *opcode) {
+DecodeResult decodeScratchStoreBlockVscratch(const MachineInst *opcode,
+                                             const DecodeErrorEmitter &emit_error) {
+  Result validation = Vscratch::validate_encoding(
+      "scratch_store_block", reinterpret_cast<const Vscratch::OpEncoding *>(opcode), emit_error);
+  if (validation.failed()) [[unlikely]]
+    return Result::failure();
   return std::make_unique<ScratchStoreBlockVscratch>(opcode);
 }
 } // namespace detail

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/risc_v/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/risc_v/decoder.h
@@ -4,6 +4,7 @@
 #ifndef ROCJITSU_ISA_RISC_V_DECODER_H_
 #define ROCJITSU_ISA_RISC_V_DECODER_H_
 
+#include "rocjitsu/isa/decode_result.h"
 #include "rocjitsu/isa/instruction.h"
 
 #include <cstddef>
@@ -19,8 +20,13 @@ class Decoder {
 public:
   static constexpr std::size_t kMaxInstructionWords = 1;
   static std::unique_ptr<Instruction> decode(uint32_t instr);
-  static std::unique_ptr<Instruction> decode(const uint32_t *instr) {
-    return instr == nullptr ? nullptr : decode(*instr);
+  static DecodeResult decode(const uint32_t *instr, const DecodeErrorEmitter &emit_error) {
+    if (instr == nullptr)
+      return emit_error.emit() << "Null instruction encoding";
+    auto decoded = decode(*instr);
+    if (!decoded)
+      return emit_error.emit() << "Invalid instruction opcode";
+    return decoded;
   }
 
 private:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decode_result.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decode_result.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "rocjitsu/result.h"
+#include "util/diagnostic.h"
+
+#include <memory>
+
+namespace rocjitsu {
+
+class Instruction;
+
+using DecodeResult = FailureOr<std::unique_ptr<Instruction>>;
+using DecodeErrorEmitter = util::DiagnosticEmitter;
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.cpp
@@ -27,21 +27,11 @@ Decoder::~Decoder() {
 
 void Decoder::disable_pool() { Instruction::invalidate_allocator_pool(&pool_); }
 
-void Decoder::validate_instruction_operands(const Instruction &inst) {
-  for (int index = 0; index < inst.num_src_operands(); ++index) {
-    if (const Operand *operand = inst.src_operand(index))
-      operand->validate_encoding();
-  }
-  for (int index = 0; index < inst.num_dst_operands(); ++index) {
-    if (const Operand *operand = inst.dst_operand(index))
-      operand->validate_encoding();
-  }
-}
-
-Instruction *Decoder::decode(const rj_code_binary_inst_t *inst, uint64_t src_loc) {
-  Instruction *decoded = decode(inst);
-  if (decoded != nullptr)
-    decoded->src_loc_ = src_loc;
+DecodeResult Decoder::decode(const rj_code_binary_inst_t *inst, uint64_t src_loc,
+                             const DecodeErrorEmitter &emit_error) {
+  DecodeResult decoded = decode(inst, emit_error);
+  if (decoded.succeeded())
+    decoded.value()->src_loc_ = src_loc;
   return decoded;
 }
 
@@ -49,6 +39,21 @@ void Decoder::activate_pool(AllocFn alloc, DeallocFn dealloc, void *pool) {
   Instruction::alloc_fn_ = alloc;
   Instruction::dealloc_fn_ = dealloc;
   Instruction::alloc_pool_ = pool;
+}
+
+Result Decoder::validate_instruction_operands(const Instruction &inst,
+                                              const DecodeErrorEmitter &emit_error) {
+  for (int index = 0; index < inst.num_src_operands(); ++index) {
+    if (const Operand *operand = inst.src_operand(index))
+      if (operand->validate_encoding(emit_error).failed()) [[unlikely]]
+        return Result::failure();
+  }
+  for (int index = 0; index < inst.num_dst_operands(); ++index) {
+    if (const Operand *operand = inst.dst_operand(index))
+      if (operand->validate_encoding(emit_error).failed()) [[unlikely]]
+        return Result::failure();
+  }
+  return Result::success();
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.h
@@ -9,6 +9,7 @@
 
 #include "rocjitsu/base/api.h"
 #include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/decode_result.h"
 #include "rocjitsu/isa/execution_backend.h"
 #include "util/arena_alloc.h"
 
@@ -38,8 +39,15 @@ public:
 
   /// @brief Decode a binary instruction.
   /// @param[in] inst Pointer to the binary instruction encoding.
-  /// @returns Decoded Instruction pointer (pool or heap allocated).
-  virtual Instruction *decode(const rj_code_binary_inst_t *inst) = 0;
+  /// @param[in] emit_error Diagnostic destination for rejected encodings.
+  /// @returns A decoded instruction (pool or heap allocated), or failure.
+  virtual DecodeResult decode(const rj_code_binary_inst_t *inst,
+                              const DecodeErrorEmitter &emit_error) = 0;
+
+  /// @brief Decode silently, for expected speculative rejection.
+  DecodeResult decode(const rj_code_binary_inst_t *inst) {
+    return decode(inst, DecodeErrorEmitter{});
+  }
 
   /// @brief Maximum encoded instruction width and decode lookahead, in 32-bit words.
   /// @returns A nonzero bound covering both every raw-pointer read and the size of every
@@ -54,8 +62,10 @@ public:
   /// its location in a larger text stream.
   /// @param[in] inst Pointer to the binary instruction encoding.
   /// @param[in] src_loc Source byte offset in the decoded text stream.
-  /// @returns Decoded Instruction pointer (pool or heap allocated).
-  Instruction *decode(const rj_code_binary_inst_t *inst, uint64_t src_loc);
+  /// @param[in] emit_error Diagnostic destination for rejected encodings.
+  /// @returns A decoded instruction (pool or heap allocated), or failure.
+  DecodeResult decode(const rj_code_binary_inst_t *inst, uint64_t src_loc,
+                      const DecodeErrorEmitter &emit_error = {});
 
   /// @brief Create a decoder for the given architecture.
   static std::unique_ptr<Decoder> create(rj_code_arch_t arch);
@@ -86,7 +96,8 @@ protected:
   using DeallocFn = void (*)(void *, void *);
 
   static void activate_pool(AllocFn alloc, DeallocFn dealloc, void *pool);
-  static void validate_instruction_operands(const Instruction &inst);
+  static Result validate_instruction_operands(const Instruction &inst,
+                                              const DecodeErrorEmitter &emit_error);
 
   Pool pool_;
 };
@@ -99,12 +110,15 @@ public:
   explicit IsaDecoder(const IsaExecutionBackend *execution_backend = nullptr)
       : execution_backend_(execution_backend) {}
 
-  Instruction *decode(const rj_code_binary_inst_t *inst) override {
+  DecodeResult decode(const rj_code_binary_inst_t *inst,
+                      const DecodeErrorEmitter &emit_error) override {
     ScopedIsaExecutionBackend scope(execution_backend_);
-    auto result = Isa::Decoder::decode(inst);
-    if (result)
-      validate_instruction_operands(*result);
-    return result.release();
+    DecodeResult result = Isa::Decoder::decode(inst, emit_error);
+    if (result.failed()) [[unlikely]]
+      return Result::failure();
+    if (validate_instruction_operands(*result.value(), emit_error).failed()) [[unlikely]]
+      return Result::failure();
+    return result;
   }
 
   std::size_t max_instruction_words() const override { return Isa::Decoder::kMaxInstructionWords; }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/instruction.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/instruction.h
@@ -8,6 +8,7 @@
 #define ROCJITSU_ISA_INSTRUCTION_H_
 
 #include "rocjitsu/isa/operand.h"
+#include "rocjitsu/result.h"
 #include "util/intrusive_list.h"
 
 #include <array>
@@ -418,6 +419,12 @@ public:
   /// @param[in] mnemonic Human-readable mnemonic string.
   IsaInstruction(std::string_view mnemonic, ExecuteFn exec_fn, uint64_t src_loc = 0)
       : Instruction(mnemonic, exec_fn, src_loc) {}
+
+  /// @brief Accept encodings for formats without additional validation.
+  template <typename... Args>
+  static constexpr Result validate_encoding([[maybe_unused]] Args &&...args) noexcept {
+    return Result::success();
+  }
 
   /// @brief Helper to create an execute dispatch trampoline for a concrete type.
   ///

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.cpp
@@ -3,30 +3,30 @@
 
 #include "rocjitsu/isa/operand.h"
 #include "simdojo/components/vector_reg.h"
-#include "util/except.h"
 
 #include <memory>
 #include <stdexcept>
 
 namespace rocjitsu {
 
-void Operand::validate_encoding() const {
+Result Operand::emit_encoding_error(const util::DiagnosticEmitter &emit_error) const {
   switch (encoding_error_) {
-  case EncodingError::None:
-    return;
   case EncodingError::InvalidSelector:
-    throw util::InvalidInst("invalid operand selector", "");
+    return emit_error.emit() << "invalid operand selector";
   case EncodingError::InvalidScalarRegisterSelector:
-    throw util::InvalidInst("invalid scalar register selector", "");
+    return emit_error.emit() << "invalid scalar register selector";
   case EncodingError::InvalidLaneSelector:
-    throw util::InvalidInst("invalid lane selector", "");
+    return emit_error.emit() << "invalid lane selector";
   case EncodingError::InvalidExecSelector:
-    throw util::InvalidInst("invalid EXEC selector", "");
+    return emit_error.emit() << "invalid EXEC selector";
   case EncodingError::InvalidVgprSourceSelector:
-    throw util::InvalidInst("invalid VGPR source selector", "");
+    return emit_error.emit() << "invalid VGPR source selector";
   case EncodingError::InvalidScalarSourceSelector:
-    throw util::InvalidInst("invalid scalar source selector", "");
+    return emit_error.emit() << "invalid scalar source selector";
+  case EncodingError::None:
+    break;
   }
+  return emit_error.emit() << "unknown operand encoding failure";
 }
 
 std::optional<RegisterRef> Operand::to_register_ref() const { return std::nullopt; }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.h
@@ -9,6 +9,8 @@
 
 #include "rocjitsu/isa/arch/amdgpu/shared/vgpr_msb.h"
 #include "rocjitsu/isa/register_set.h"
+#include "rocjitsu/result.h"
+#include "util/diagnostic.h"
 
 #include <cassert>
 #include <cstdint>
@@ -88,7 +90,11 @@ public:
 
   /// Validate encoding constraints deferred until the complete instruction is
   /// decoded. Literal sentinels may replace their provisional operands first.
-  void validate_encoding() const;
+  Result validate_encoding(const util::DiagnosticEmitter &emit_error = {}) const {
+    if (encoding_error_ == EncodingError::None) [[likely]]
+      return Result::success();
+    return emit_encoding_error(emit_error);
+  }
 
   /// @brief Human-readable name for this operand (e.g. "v0", "s4", or a literal).
   virtual std::string name() const { return std::to_string(encoding_value_); }
@@ -195,6 +201,8 @@ public:
   }
 
 private:
+  Result emit_encoding_error(const util::DiagnosticEmitter &emit_error) const;
+
   // Value access is intentionally private. Instruction implementations use
   // RegisterAccess; Operand remains the ISA-specific resolver/backend.
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/rj_decode.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/rj_decode.cpp
@@ -90,11 +90,11 @@ rj_status_t rj_code_decoder_decode(rj_code_decoder_t *decoder,
 
   try {
     Instruction::ScopedHeapAllocation heap_allocation;
-    std::unique_ptr<Instruction> decoded(decoder->decoder->decode(binary_inst));
-    if (!decoded)
+    DecodeResult decoded = decoder->decoder->decode(binary_inst);
+    if (decoded.failed())
       return ROCJITSU_STATUS_ERROR;
 
-    *inst = reinterpret_cast<rj_code_inst_t *>(decoded.release());
+    *inst = reinterpret_cast<rj_code_inst_t *>(decoded.value().release());
     return ROCJITSU_STATUS_SUCCESS;
   } catch (const std::bad_alloc &) {
     return ROCJITSU_STATUS_OUT_OF_RESOURCES;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -604,23 +604,16 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
 
   active->trace_inst_count_++;
 
-  Instruction *inst = nullptr;
-  try {
-    inst = decoder_->decode(words);
-  } catch (const util::InvalidInst &e) {
-    util::Logger::vm("CU ", this->name(), ": wf", active->wf_id(), " HALT(InvalidInst) pc=0x",
+  util::StringDiagnostic decode_error;
+  DecodeResult decoded = decoder_->decode(words, decode_error.emitter());
+  if (decoded.failed()) {
+    util::Logger::vm("CU ", this->name(), ": wf", active->wf_id(), " HALT(decode rejection) pc=0x",
                      std::hex, active->pc, " words=[0x", words[0], ",0x", words[1], ",0x", words[2],
-                     ",0x", words[3], "]", std::dec, " what=", e.what());
+                     ",0x", words[3], "]", std::dec, " what=", decode_error.message());
     active->halt();
     return;
   }
-  if (!inst) {
-    util::Logger::vm("CU ", this->name(), ": wf", active->wf_id(), " HALT(null decode) pc=0x",
-                     std::hex, active->pc, " words=[0x", words[0], ",0x", words[1], ",0x", words[2],
-                     ",0x", words[3], "]", std::dec);
-    active->halt();
-    return;
-  }
+  Instruction *inst = decoded.value().release();
 
   int inst_size_signed = inst->size();
   assert(inst_size_signed > 0 && "instruction size must be positive");

--- a/emulation/rocjitsu/lib/util/include/util/result.h
+++ b/emulation/rocjitsu/lib/util/include/util/result.h
@@ -167,4 +167,6 @@ private:
   FailureOrStorage<T> storage_;
 };
 
+template <typename T> FailureOr(T) -> FailureOr<T>;
+
 } // namespace util

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include "decode_test_util.h"
 #include "rocjitsu/analysis/def_use_chain.h"
 #include "rocjitsu/analysis/exec_state.h"
 #include "rocjitsu/analysis/indirect_branch_discovery.h"
@@ -203,7 +204,7 @@ class TestDecoder : public Decoder {
 public:
   std::size_t max_instruction_words() const override { return 1; }
 
-  Instruction *decode(const rj_code_binary_inst_t *inst) override {
+  DecodeResult decode(const rj_code_binary_inst_t *inst, const DecodeErrorEmitter &) override {
     auto op = static_cast<TestOpcode>(*inst);
     switch (op) {
     case TestOpcode::Nop:
@@ -298,7 +299,7 @@ build_test_blocks(std::vector<TestOpcode> ops, std::span<const uint64_t> extra_l
 
   TestCodeObject co(std::move(words));
   TestDecoder decoder;
-  return BasicBlock::build(co, decoder, ROCJITSU_CODE_ARCH_CDNA3, extra_leaders);
+  return build_valid_blocks(co, decoder, ROCJITSU_CODE_ARCH_CDNA3, extra_leaders);
 }
 
 bool has_predecessor(const BasicBlock &block, const BasicBlock *pred) {
@@ -489,7 +490,7 @@ TEST(RegisterSetAnalysis, Cdna4WritelaneDestinationIsUseAndDef) {
   constexpr std::array<uint32_t, 2> kWritelaneV141S4Lane2 = {0xd28a008du, 0x00010404u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
 
-  std::unique_ptr<Instruction> inst(decoder->decode(kWritelaneV141S4Lane2.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, kWritelaneV141S4Lane2.data()));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_writelane_b32");
 
@@ -535,7 +536,7 @@ TEST(CfgAnalysis, Gfx1250ZeroPaddingTerminatesFallthrough) {
     TestCodeObject co(test_case.words);
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
     ASSERT_NE(decoder, nullptr);
-    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+    auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
     ASSERT_EQ(blocks.size(), 1u);
     EXPECT_EQ(blocks[0]->has_implicit_terminator(), test_case.has_implicit_terminator);
@@ -552,7 +553,7 @@ TEST(CfgAnalysis, Gfx1250ConditionalBranchKeepsTakenEdgeWhenPaddingTerminatesFal
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   ASSERT_EQ(blocks.size(), 2u);
   EXPECT_TRUE(blocks[0]->has_implicit_terminator());
@@ -573,7 +574,7 @@ TEST(CfgAnalysis, DirectCallToImplicitNonreturningTargetDropsFallthrough) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   auto *caller = block_starting_at(blocks, 0);
   auto *continuation = block_starting_at(blocks, 4);
@@ -606,7 +607,7 @@ TEST(CfgAnalysis, DirectCallToPaddingTerminatedBlockWithUnresolvedTakenTargetKee
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   auto *caller = block_starting_at(blocks, 0);
   auto *continuation = block_starting_at(blocks, 4);
@@ -672,7 +673,7 @@ TEST(CfgAnalysis, StandaloneInstructionHasNoDecodedNeighbors) {
   constexpr uint32_t kNop = 0xbf800000u;
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> instruction(decoder->decode(&kNop));
+  std::unique_ptr<Instruction> instruction(decode_valid(*decoder, &kNop));
 
   ASSERT_NE(instruction, nullptr);
   EXPECT_EQ(instruction->previous_instruction(), nullptr);
@@ -758,7 +759,7 @@ TEST(CfgAnalysis, IndirectRecoveryPrefilterAdmitsSetPcConsumer) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
   constexpr std::array<uint64_t, 1> extra_leaders{16};
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
 
   auto *builder = block_starting_at(blocks, 0);
   auto *consumer = block_starting_at(blocks, 16);
@@ -797,7 +798,7 @@ TEST(CfgAnalysis, PcBuilderWithoutConsumerProducesNoRecoveredEdge) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   ASSERT_EQ(blocks.size(), 1u);
   EXPECT_TRUE(blocks[0]->static_indirect_call_fixups().empty());
@@ -831,7 +832,7 @@ TEST(CfgAnalysis, RecoversMultipleSgprPairsFromOneBlockEntry) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *first_consumer = block_starting_at(blocks, 36);
   auto *second_consumer = block_starting_at(blocks, 40);
@@ -854,7 +855,7 @@ TEST(CfgAnalysis, OutOfRangeIndirectConsumersRemainUnresolved) {
     TestCodeObject co(std::vector<uint32_t>{consumer});
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
     ASSERT_NE(decoder, nullptr);
-    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+    auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
     ASSERT_EQ(blocks.size(), 1u);
     EXPECT_TRUE(blocks[0]->static_indirect_call_fixups().empty());
@@ -885,7 +886,7 @@ TEST(CfgAnalysis, IgnoresUnconsumedPairWhileRecoveringPendingConsumer) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
   constexpr std::array<uint64_t, 1> extra_leaders{20};
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
 
   auto *consumer = block_starting_at(blocks, 20);
   ASSERT_NE(consumer, nullptr);
@@ -922,7 +923,7 @@ TEST(CfgAnalysis, IncompleteFactConsumerIsFlaggedIncomplete) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *consumer = block_starting_at(blocks, 28);
   ASSERT_NE(consumer, nullptr);
@@ -955,7 +956,7 @@ TEST(CfgAnalysis, IncompleteSwappcTargetSetKeepsContinuation) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *consumer = block_starting_at(blocks, 28);
   auto *continuation = block_starting_at(blocks, 32);
@@ -995,7 +996,7 @@ TEST(CfgAnalysis, IncompleteRecoveredSetpcInCalleeKeepsOuterContinuation) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *caller = block_starting_at(blocks, 0);
   auto *continuation = block_starting_at(blocks, 4);
@@ -1035,7 +1036,7 @@ TEST(CfgAnalysis, ReportsResolvedPcAddressBuilderForEveryProducer) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *builder_block = block_starting_at(blocks, 0);
   ASSERT_NE(builder_block, nullptr);
@@ -1076,7 +1077,7 @@ TEST(CfgAnalysis, PcAddressBuilderWithGapInstructionIsReportedNonContiguous) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *builder_block = block_starting_at(blocks, 0);
   ASSERT_NE(builder_block, nullptr);
@@ -1106,7 +1107,7 @@ TEST(CfgAnalysis, UnfollowedPcAddressBuilderIsReportedUnresolved) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *builder_block = block_starting_at(blocks, 0);
   ASSERT_NE(builder_block, nullptr);
@@ -1144,7 +1145,7 @@ TEST(CfgAnalysis, DominatedPcBuilderRemainsCompleteAcrossCallLoopBackedge) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *consumer = block_starting_at(blocks, 20);
   ASSERT_NE(consumer, nullptr);
@@ -1183,7 +1184,7 @@ TEST(CfgAnalysis, SeedsTextEntryWithLoopBackedgeForCrossBlockPcBuilder) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *consumer = block_starting_at(blocks, 24);
   ASSERT_NE(consumer, nullptr);
@@ -1218,7 +1219,7 @@ TEST(CfgAnalysis, MultipleUnorderedExplicitEntriesMakeIncomingPcBuilderIncomplet
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
   constexpr std::array<uint64_t, 3> extra_leaders{28, 24, 28};
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
 
   for (uint64_t consumer_offset : {uint64_t{24}, uint64_t{28}}) {
     auto *consumer = block_starting_at(blocks, consumer_offset);
@@ -1253,7 +1254,7 @@ TEST(CfgAnalysis, RocrAbortTrapStopsTemporaryPcBuilderCfg) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
   constexpr std::array<uint64_t, 1> extra_leaders{20};
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
 
   auto *consumer = block_starting_at(blocks, 20);
   ASSERT_NE(consumer, nullptr);
@@ -1296,8 +1297,8 @@ TEST(CfgAnalysis, UnreachablePostRocrAbortBlockDoesNotPoisonPcBuilder) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, {},
-                                  ExternalEntryPolicy::ExplicitOnly);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, {},
+                                   ExternalEntryPolicy::ExplicitOnly);
 
   auto *consumer = block_starting_at(blocks, 32);
   ASSERT_NE(consumer, nullptr);
@@ -1332,7 +1333,7 @@ TEST(CfgAnalysis, DefaultEntryPolicyRecoversPredecessorlessFunction) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *consumer = block_starting_at(blocks, 24);
   ASSERT_NE(consumer, nullptr);
@@ -1357,7 +1358,7 @@ TEST(CfgAnalysis, DirectCallEdgeUsesTerminatorOffset) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *caller = block_starting_at(blocks, 0);
   auto *continuation = block_starting_at(blocks, 8);
@@ -1390,7 +1391,7 @@ TEST(BinaryTranslatorInternal, ScopeRootsRejectRelocationTableCallee) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *caller = block_starting_at(blocks, 0);
   auto *callee = block_starting_at(blocks, 8);
@@ -1430,7 +1431,7 @@ TEST(CfgAnalysis, DirectCallToNonreturningTargetDropsFallthrough) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *caller = block_starting_at(blocks, 0);
   auto *continuation = block_starting_at(blocks, 4);
@@ -1459,7 +1460,7 @@ TEST(CfgAnalysis, DirectCallWithCopiedReturnPairKeepsFallthrough) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *caller = block_starting_at(blocks, 0);
   auto *continuation = block_starting_at(blocks, 4);
@@ -1487,7 +1488,7 @@ TEST(CfgAnalysis, DirectCallWithUnrecoveredTailExitKeepsFallthrough) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *caller = block_starting_at(blocks, 0);
   auto *continuation = block_starting_at(blocks, 4);
@@ -1517,7 +1518,7 @@ TEST(CfgAnalysis, DirectCallCrossingScopeBoundaryKeepsFallthrough) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
   constexpr std::array<uint64_t, 1> extra_leaders{16};
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
 
   auto *caller = block_starting_at(blocks, 0);
   auto *continuation = block_starting_at(blocks, 4);
@@ -1549,7 +1550,7 @@ TEST(CfgAnalysis, NestedReturningCallMayReturnThroughOuterPair) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *outer = block_starting_at(blocks, 0);
   auto *outer_continuation = block_starting_at(blocks, 4);
@@ -1577,7 +1578,7 @@ TEST(CfgAnalysis, NestedNonreturningCallsDropBothFallthroughs) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *outer = block_starting_at(blocks, 0);
   auto *outer_continuation = block_starting_at(blocks, 4);
@@ -1612,7 +1613,7 @@ TEST(CfgAnalysis, CyclicCallGraphKeepsConservativeFallthrough) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *caller = block_starting_at(blocks, 0);
   auto *continuation = block_starting_at(blocks, 4);
@@ -1635,7 +1636,7 @@ TEST(CfgAnalysis, CallToInfiniteLoopDropsFallthrough) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *caller = block_starting_at(blocks, 0);
   auto *continuation = block_starting_at(blocks, 4);
@@ -1660,7 +1661,7 @@ TEST(CfgAnalysis, ZeroDeltaCallToNonreturningTargetKeepsSingleEdge) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *caller = block_starting_at(blocks, 0);
   auto *target = block_starting_at(blocks, 4);
@@ -1699,7 +1700,7 @@ TEST(CfgAnalysis, DirectCallKillsCarriedPcBuilderFacts) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *continuation = block_starting_at(blocks, 20);
   auto *stale_target = block_starting_at(blocks, 32);
@@ -1746,7 +1747,7 @@ TEST(CfgAnalysis, EitherHalfKillPredecessorPreventsRecoveredConsumer) {
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
     ASSERT_NE(decoder, nullptr);
     constexpr std::array<uint64_t, 1> extra_leaders{40};
-    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
+    auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
 
     auto *consumer = block_starting_at(blocks, 32);
     auto *target = block_starting_at(blocks, 40);
@@ -1790,7 +1791,7 @@ TEST(CfgAnalysis, RecoversSignedDeltaTemplateConsumers) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *sub_consumer = block_starting_at(blocks, 32);
   auto *add_consumer = block_starting_at(blocks, 44);
@@ -1837,7 +1838,7 @@ TEST(CfgAnalysis, KeepsDistinctBuildersReachingSameTarget) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *consumer = block_starting_at(blocks, 32);
   ASSERT_NE(consumer, nullptr);
@@ -1871,7 +1872,7 @@ TEST(CfgAnalysis, RecoveredSwappcToNonreturningTargetDropsFallthrough) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *consumer = block_starting_at(blocks, 16);
   auto *continuation = block_starting_at(blocks, 20);
@@ -1912,7 +1913,7 @@ TEST(CfgAnalysis, MixedSwappcTargetsKeepSharedContinuation) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 
   auto *consumer = block_starting_at(blocks, 32);
   auto *continuation = block_starting_at(blocks, 36);
@@ -1988,7 +1989,7 @@ TEST(CfgAnalysis, Gfx1250RecoversSignedDeltaTemplateWithPrefetch) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   auto *sub_consumer = block_starting_at(blocks, 44);
   auto *add_consumer = block_starting_at(blocks, 68);
@@ -2064,7 +2065,7 @@ TEST(CfgAnalysis, Gfx1250RecoversSignedDeltaTemplateWithXcntWaitAndPrefetch) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   auto *sub_consumer = block_starting_at(blocks, 44);
   auto *add_consumer = block_starting_at(blocks, 68);
@@ -2145,7 +2146,7 @@ TEST(CfgAnalysis, Gfx1250SignedDeltaRejectsMoveClobberingTemporary) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   // Clobbering the temporary on the subtract half breaks that half of the paired
   // signed-delta template. Because the two halves cross-validate to the same static
@@ -2186,7 +2187,7 @@ TEST(CfgAnalysis, IndirectRecoveryPrefilterAdmitsGfx1250LaneStashSwapPc) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   auto *consumer = block_starting_at(blocks, 48);
   auto *target = block_starting_at(blocks, 56);
@@ -2229,7 +2230,7 @@ TEST(CfgAnalysis, Gfx1250WideVgprWriteInvalidatesStashedLane) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   size_t total_fixups = 0;
   for (const auto &block : blocks)
@@ -2273,7 +2274,7 @@ TEST(CfgAnalysis, Gfx1250ExplicitVgprWriteInvalidatesOnlyItsDestinationBank) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   auto *consumer = block_starting_at(blocks, 68);
   ASSERT_NE(consumer, nullptr);
@@ -2308,7 +2309,7 @@ TEST(CfgAnalysis, Gfx1250CarriesLaneStashAcrossProvenBlockBoundary) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   auto *consumer = block_starting_at(blocks, 52);
   ASSERT_NE(consumer, nullptr);
@@ -2355,8 +2356,8 @@ TEST(CfgAnalysis, Gfx1250UnreachablePostRocrAbortBlockDoesNotPoisonLaneStash) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250, {},
-                                  ExternalEntryPolicy::ExplicitOnly);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250, {},
+                                   ExternalEntryPolicy::ExplicitOnly);
 
   auto *consumer = block_starting_at(blocks, 64);
   ASSERT_NE(consumer, nullptr);
@@ -2399,8 +2400,8 @@ TEST(CfgAnalysis, Gfx1250ExplicitOnlyRecoversLaneStashInRecoveredCallee) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250, {},
-                                  ExternalEntryPolicy::ExplicitOnly);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250, {},
+                                   ExternalEntryPolicy::ExplicitOnly);
 
   auto *outer_consumer = block_starting_at(blocks, 16);
   auto *inner_consumer = block_starting_at(blocks, 80);
@@ -2444,7 +2445,7 @@ TEST(CfgAnalysis, Gfx1250DirectCallKillsCarriedLaneStash) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   size_t total_fixups = 0;
   for (const auto &block : blocks)
@@ -2482,7 +2483,7 @@ TEST(CfgAnalysis, Gfx1250ExactCalleeSummaryPreservesUnwrittenCallerSavedLaneStas
     TestCodeObject co(std::move(words));
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
     ASSERT_NE(decoder, nullptr);
-    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+    auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
     const IndirectCallFixup *continuation_fixup = nullptr;
     for (const auto &block : blocks) {
@@ -2525,7 +2526,7 @@ TEST(CfgAnalysis, Gfx1250RelativeVgprDestinationDisablesExactCalleeSummary) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   for (const auto &block : blocks) {
     EXPECT_TRUE(std::ranges::none_of(
@@ -2570,7 +2571,7 @@ TEST(CfgAnalysis, Gfx1250GprIndexedVgprDestinationDisablesExactCalleeSummary) {
     TestCodeObject co(std::move(words));
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
     ASSERT_NE(decoder, nullptr);
-    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+    auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
     for (const auto &block : blocks) {
       EXPECT_TRUE(std::ranges::none_of(
@@ -2612,7 +2613,7 @@ TEST(CfgAnalysis, Gfx1250RelativeSgprDestinationDisablesExactCalleeSummary) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   for (const auto &block : blocks) {
     EXPECT_TRUE(std::ranges::none_of(
@@ -2653,7 +2654,7 @@ TEST(CfgAnalysis, Gfx1250CalleeSavedLaneStashSurvivesDirectCall) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   const IndirectCallFixup *continuation_fixup = nullptr;
   for (const auto &block : blocks) {
@@ -2709,7 +2710,7 @@ TEST(CfgAnalysis, Gfx1250ExactCalleeSummaryPreservesBankedLaneStash) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   const IndirectCallFixup *continuation_fixup = nullptr;
   for (const auto &block : blocks) {
@@ -2753,7 +2754,7 @@ TEST(CfgAnalysis, Gfx1250CalleeModeChangeInvalidatesContinuationBankSelection) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   for (const auto &block : blocks) {
     EXPECT_TRUE(std::ranges::none_of(
@@ -2811,7 +2812,7 @@ TEST(CfgAnalysis, Gfx1250IndirectCallKillsCarriedLaneStash) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   size_t total_fixups = 0;
   const IndirectCallFixup *call_fixup = nullptr;
@@ -2876,7 +2877,7 @@ TEST(CfgAnalysis, Gfx1250CalleeSavedLaneStashSurvivesIndirectCall) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   const IndirectCallFixup *continuation_fixup = nullptr;
   for (const auto &block : blocks) {
@@ -2923,7 +2924,7 @@ TEST(CfgAnalysis, Gfx1250SeedsTextEntryWithLoopBackedgeForLaneStash) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   auto *consumer = block_starting_at(blocks, 56);
   ASSERT_NE(consumer, nullptr);
@@ -2964,7 +2965,7 @@ TEST(CfgAnalysis, Gfx1250ExplicitKernelEntryClearsIncomingLaneStash) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   constexpr std::array<uint64_t, 1> extra_leaders{40};
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250, extra_leaders);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250, extra_leaders);
 
   size_t total_fixups = 0;
   for (const auto &block : blocks)
@@ -3001,7 +3002,7 @@ TEST(CfgAnalysis, Gfx1250A0UsesLowByteOfVgprMsb) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   auto *consumer = block_starting_at(blocks, 56);
   ASSERT_NE(consumer, nullptr);
@@ -3041,7 +3042,7 @@ TEST(CfgAnalysis, Gfx1250ImmediateModeWriteKeepsLaneStashBankKnown) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   auto *consumer = block_starting_at(blocks, 60);
   ASSERT_NE(consumer, nullptr);
@@ -3073,7 +3074,7 @@ TEST(CfgAnalysis, Gfx1250LaneRestoreReachesConsumerAcrossBranch) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   auto *consumer = block_starting_at(blocks, 52);
   ASSERT_NE(consumer, nullptr);
@@ -3104,7 +3105,7 @@ TEST(CfgAnalysis, Gfx1250PcPairCopyReachesConsumer) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   const IndirectCallFixup *copied_call = nullptr;
   for (const auto &block : blocks) {
@@ -3140,7 +3141,7 @@ TEST(CfgAnalysis, Gfx1250DirectCallOverwritesPcBuilderInReturnPair) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   for (const auto &block : blocks) {
     EXPECT_TRUE(std::ranges::none_of(
@@ -3170,7 +3171,7 @@ TEST(CfgAnalysis, Gfx1250SwapPcOverwritesPcBuilderInReturnPair) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   const IndirectCallFixup *first_call = nullptr;
   for (const auto &block : blocks) {
@@ -3232,7 +3233,7 @@ TEST(CfgAnalysis, Gfx1250CalleeSummaryRejectsRepurposedReturnPair) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   for (const auto &block : blocks) {
     EXPECT_TRUE(std::ranges::none_of(
@@ -3272,7 +3273,7 @@ TEST(CfgAnalysis, Gfx1250ExactCalleeSummaryPreservesUnwrittenRestoredSgprs) {
     TestCodeObject co(std::move(words));
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
     ASSERT_NE(decoder, nullptr);
-    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+    auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
     const IndirectCallFixup *fixup = nullptr;
     for (const auto &block : blocks) {
@@ -3344,7 +3345,7 @@ TEST(CfgAnalysis, Gfx1250CalleeSummaryVariantLimitFallsBackConservatively) {
     TestCodeObject co(std::move(words));
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
     EXPECT_NE(decoder, nullptr);
-    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+    auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
     return std::ranges::any_of(blocks, [&](const auto &block) {
       return std::ranges::any_of(block->static_indirect_call_fixups(),
@@ -3389,7 +3390,7 @@ TEST(CfgAnalysis, Gfx1250ExactCalleeSummaryDropsWrittenRestoredSgprs) {
     TestCodeObject co(std::move(words));
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
     ASSERT_NE(decoder, nullptr);
-    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+    auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
     const IndirectCallFixup *fixup = nullptr;
     for (const auto &block : blocks) {
@@ -3439,7 +3440,7 @@ TEST(CfgAnalysis, Gfx1250UnsupportedCalleeSummaryFallsBackToCallPreservedSgprs) 
     TestCodeObject co(std::move(words));
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
     ASSERT_NE(decoder, nullptr);
-    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+    auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
     const IndirectCallFixup *fixup = nullptr;
     for (const auto &block : blocks) {
@@ -3498,7 +3499,7 @@ TEST(CfgAnalysis, Gfx1250RestashedLaneTargetRemainsRecoverable) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   auto *consumer = block_starting_at(blocks, 80);
   ASSERT_NE(consumer, nullptr);
@@ -3537,7 +3538,7 @@ TEST(CfgAnalysis, Gfx1250CalleeSavedPcBuilderCanBeStashedAfterCall) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   const IndirectCallFixup *second_call = nullptr;
   for (const auto &block : blocks) {
@@ -3585,7 +3586,7 @@ TEST(CfgAnalysis, Gfx1250DoesNotRecoverLaneStashWithDifferingRoleBanks) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   size_t total_fixups = 0;
   for (const auto &block : blocks)
@@ -3626,7 +3627,7 @@ TEST(CfgAnalysis, Gfx1250InheritsBankAlongProvenCfgEdge) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
   auto *consumer = block_starting_at(blocks, 56);
   ASSERT_NE(consumer, nullptr);
@@ -3689,7 +3690,7 @@ TEST(CfgAnalysis, Gfx1250DoesNotReuseStashFromSkippedFallthroughPredecessor) {
       byte_offset += sizeof(uint32_t);
       continue;
     }
-    std::unique_ptr<Instruction> inst(decoder->decode(&inst_data[pc], byte_offset));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, &inst_data[pc], byte_offset));
     ASSERT_NE(inst, nullptr);
     const uint32_t inst_words = static_cast<uint32_t>(inst->size()) / sizeof(uint32_t);
     byte_offset += inst->size();
@@ -3734,7 +3735,7 @@ void run_indirect_discovery_for_test(std::vector<uint32_t> words,
       byte_offset += sizeof(uint32_t);
       continue;
     }
-    std::unique_ptr<Instruction> inst(decoder->decode(&inst_data[pc], byte_offset));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, &inst_data[pc], byte_offset));
     ASSERT_NE(inst, nullptr);
     const uint32_t inst_words = static_cast<uint32_t>(inst->size()) / sizeof(uint32_t);
     byte_offset += inst->size();
@@ -3899,7 +3900,7 @@ TEST(LivenessAnalysis, Gfx1250VgprMsbResolvesPhysicalRegisterBank) {
   TestCodeObject co({set_vgpr_msb[0], move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -3936,7 +3937,7 @@ TEST(LivenessAnalysis, Gfx1250ImplicitVgprUseResolvesDestinationBank) {
   TestCodeObject co({set_dst_bank_two[0], move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -3968,7 +3969,7 @@ TEST(LivenessAnalysis, Gfx1250D16LoadImplicitUseResolvesDestinationBank) {
   TestCodeObject co({set_dst_bank_two[0], load[0], load[1], load[2], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -4001,7 +4002,7 @@ TEST(LivenessAnalysis, Gfx1250ImplicitVgprUseResolvesDespiteExplicitBank0Alias) 
   TestCodeObject co({set_dst_bank_two[0], move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -4034,7 +4035,7 @@ TEST(LivenessAnalysis, Gfx1250SwapImplicitReadsResolvePerRole) {
   TestCodeObject co({set_banks[0], swap[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -4087,7 +4088,7 @@ TEST(LivenessAnalysis, Gfx1250DppPreserveReadResolvesToDstBank) {
   TestCodeObject co({set_banks[0], kDppMovWord0, kDppWord1Partial, end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -4121,7 +4122,7 @@ TEST(LivenessAnalysis, Gfx1250ImplicitVgprUseUnknownBankReadsEveryCandidate) {
   TestCodeObject co({setreg[0], move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -4155,7 +4156,7 @@ TEST(LivenessAnalysis, Gfx1250UnknownBankDefMakesEveryCandidateGloballyUsed) {
   TestCodeObject co({setreg[0], move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -4194,7 +4195,7 @@ TEST(LivenessAnalysis, Gfx1250RelativeVgprAccessDisablesGlobalUnusedQuery) {
   TestCodeObject co({move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -4217,7 +4218,7 @@ TEST(LivenessAnalysis, Gfx1250SwaprelDisablesGlobalUnusedQuery) {
   TestCodeObject co({swap[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -4245,7 +4246,7 @@ TEST(LivenessAnalysis, Gfx1250GprIndexModeWriteDisablesGlobalUnusedQuery) {
   TestCodeObject co({setreg[0], move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -4276,7 +4277,7 @@ TEST(LivenessAnalysis, Gfx1250ImmediateGprIndexModeWriteUsesLiteralValue) {
     TestCodeObject co({setreg[0], literal, move[0], end[0]});
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
     ASSERT_NE(decoder, nullptr);
-    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+    auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
     ASSERT_EQ(blocks.size(), 1u);
     auto scope = block_scope(blocks);
 
@@ -4309,7 +4310,7 @@ TEST(LivenessAnalysis, Cdna4DynamicGprIndexModeWriteDisablesGlobalUnusedQuery) {
   TestCodeObject co({setreg[0], move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -4339,7 +4340,7 @@ TEST(LivenessAnalysis, Cdna4ImmediateGprIndexModeWriteUsesLiteralValue) {
     TestCodeObject co({setreg[0], literal, move[0], end[0]});
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
     ASSERT_NE(decoder, nullptr);
-    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+    auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
     ASSERT_EQ(blocks.size(), 1u);
     auto scope = block_scope(blocks);
 
@@ -4371,7 +4372,7 @@ TEST(LivenessAnalysis, Gfx1250DynamicModeWriteConservativelyUsesEveryBank) {
   TestCodeObject co({setreg[0], move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -4406,7 +4407,7 @@ TEST(LivenessAnalysis, Gfx1250FullLiteralModeWriteRecoversKnownBank) {
   TestCodeObject co({dynamic_setreg[0], literal_setreg[0], 2u, move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -4446,7 +4447,7 @@ TEST(LivenessAnalysis, Gfx1250TruncatedLiteralModeWriteMarksBanksAmbiguous) {
   TestCodeObject co({set_bank_two[0], literal_setreg[0], 0xe4u, move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -4480,7 +4481,7 @@ TEST(LivenessAnalysis, Gfx1250PartialLiteralModeWritePreservesUntouchedBankBit) 
   TestCodeObject co({set_bank_one[0], literal_setreg[0], 1u, move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -4511,7 +4512,7 @@ TEST(LivenessAnalysis, Gfx1250ImmediateModeWritePreservesBanksOutsideRequestedSl
   TestCodeObject co({set_bank_one[0], literal_setreg[0], 0u, move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -4540,7 +4541,7 @@ TEST(LivenessAnalysis, Gfx1250LiteralModeWriteTracksEveryRole) {
   TestCodeObject co({literal_setreg[0], kModeFields, move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -4570,7 +4571,7 @@ TEST(LivenessAnalysis, Gfx1250ImmediateNonModeWriteDoesNotChangeBanks) {
   TestCodeObject co({literal_setreg[0], 0x000ff000u, move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = block_scope(blocks);
 
@@ -4602,7 +4603,7 @@ TEST(LivenessAnalysis, Gfx1250VgprMsbCfgJoinRequiresPredecessorsToAgree) {
       {branch_to_else[0], set_bank_two[0], branch_to_join[0], set_bank_zero[0], move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   auto scope = block_scope(blocks);
   BasicBlock *join = block_starting_at(blocks, 16);
   ASSERT_NE(join, nullptr);
@@ -4632,7 +4633,7 @@ TEST(LivenessAnalysis, Gfx1250VgprMsbCfgJoinPreservesAgreeingBank) {
       {branch_to_else[0], set_bank_two[0], branch_to_join[0], set_bank_two[0], move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   auto scope = block_scope(blocks);
   BasicBlock *join = block_starting_at(blocks, 16);
   ASSERT_NE(join, nullptr);
@@ -4673,7 +4674,7 @@ TEST(LivenessAnalysis, Gfx1250VgprMsbJoinExcludesUnreachablePredecessor) {
   TestCodeObject co({branch_over[0], set_bank_zero[0], set_bank_two[0], move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
   auto scope = block_scope(blocks);
 
   LivenessAnalysisOptions options;
@@ -4708,7 +4709,7 @@ std::vector<const Instruction *> insts_of(BasicBlock &block) {
 std::vector<std::unique_ptr<BasicBlock>> build_cdna4_blocks(std::vector<uint32_t> words) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
-  return BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  return build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
 }
 
 // Full end-to-end on real decoded instructions: `s_mov_b64 exec, -1` makes EXEC
@@ -5430,12 +5431,12 @@ constexpr uint32_t kVop1MovWord0Sdwa = (0x3Fu << 25) | (5u << 17) | (1u << 9) | 
 
 std::unique_ptr<Instruction> decode_cdna4(const std::array<uint32_t, 2> &words) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
-  return std::unique_ptr<Instruction>(decoder ? decoder->decode(words.data()) : nullptr);
+  return std::unique_ptr<Instruction>(decoder ? decode_valid(*decoder, words.data()) : nullptr);
 }
 
 std::unique_ptr<Instruction> decode_gfx1250(const std::array<uint32_t, 2> &words) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
-  return std::unique_ptr<Instruction>(decoder ? decoder->decode(words.data()) : nullptr);
+  return std::unique_ptr<Instruction>(decoder ? decode_valid(*decoder, words.data()) : nullptr);
 }
 
 TEST(GeneratedInstDefUse, Gfx1250Vop3CompareDefinesOneSgpr) {
@@ -5657,7 +5658,7 @@ std::unique_ptr<Instruction> decode_rdna4(std::initializer_list<uint32_t> words)
   std::array<uint32_t, 4> buf{};
   std::copy(words.begin(), words.end(), buf.begin());
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
-  return std::unique_ptr<Instruction>(decoder ? decoder->decode(buf.data()) : nullptr);
+  return std::unique_ptr<Instruction>(decoder ? decode_valid(*decoder, buf.data()) : nullptr);
 }
 
 TEST(GeneratedInstDefUse, Vop3DppPartialRowMaskReadsVgprDestination) {
@@ -5788,7 +5789,7 @@ TEST(GeneratedInstDefUse, WritelaneReadsDestinationGfx1250) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   std::array<uint32_t, 4> words{0xD7610005U, 0x00000404U, 0U, 0U};
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_writelane_b32");
 
@@ -5882,7 +5883,7 @@ std::unique_ptr<Instruction> decode_cdna3(std::initializer_list<uint32_t> words)
   std::array<uint32_t, 4> buf{};
   std::copy(words.begin(), words.end(), buf.begin());
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
-  return std::unique_ptr<Instruction>(decoder ? decoder->decode(buf.data()) : nullptr);
+  return std::unique_ptr<Instruction>(decoder ? decode_valid(*decoder, buf.data()) : nullptr);
 }
 
 TEST(GeneratedInstDefUse, D16TbufferLoadReadsDestination) {

--- a/emulation/rocjitsu/tests/buffer_operand_test.cpp
+++ b/emulation/rocjitsu/tests/buffer_operand_test.cpp
@@ -4,6 +4,7 @@
 /// @file buffer_operand_test.cpp
 /// @brief Regression tests for semantic legacy buffer operands.
 
+#include "decode_test_util.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
@@ -46,7 +47,7 @@ TEST_P(BufferOperandTest, AddressModeAndResourceUsePhysicalRegisters) {
     // VADDR=63, VDATA=68, raw SRSRC=1 (descriptor s[4:7]), SOFFSET=128 (zero).
     const uint32_t words[] = {tc.encoding | (tc.address_mode_in_hi_word ? 0u : mode.fields << 12),
                               0x8001443fu | (tc.address_mode_in_hi_word ? mode.fields << 22 : 0u)};
-    std::unique_ptr<Instruction> inst(decoder->decode(words));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
     ASSERT_NE(inst, nullptr) << tc.label;
     ASSERT_EQ(inst->mnemonic(), tc.mnemonic) << tc.label;
     ASSERT_GE(inst->num_src_operands(), 2) << tc.label;
@@ -83,7 +84,7 @@ TEST_P(BufferOperandTest, AddressModeAndResourceUsePhysicalRegisters) {
     // address components enabled to cover the acc fold together with VADDR
     // width and SRSRC scaling.
     const uint32_t words[] = {tc.encoding | (3u << 12), 0x8081443fu};
-    std::unique_ptr<Instruction> inst(decoder->decode(words));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
     ASSERT_NE(inst, nullptr) << tc.label;
 
     const auto vaddr = inst->src_operand(0)->to_register_ref();

--- a/emulation/rocjitsu/tests/cdna3_predicate_mask_test.cpp
+++ b/emulation/rocjitsu/tests/cdna3_predicate_mask_test.cpp
@@ -4,6 +4,7 @@
 /// @file cdna3_predicate_mask_test.cpp
 /// @brief CDNA3 predicate-mask semantics from hip-fpsan algebraic kernels.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -81,7 +82,7 @@ struct Fixture {
   }
 
   void execute(const std::array<uint32_t, 2> &words) {
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     cu->execute_instruction(inst.get(), *wf);
   }

--- a/emulation/rocjitsu/tests/cdna5_architecture_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_architecture_test.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "cdna5_sim_test_common.h"
+#include "decode_test_util.h"
 
 namespace {
 
@@ -135,7 +136,7 @@ TEST(Gfx1250CodeObjectTest, MachineFlagMapsToTarget) {
   ASSERT_NE(decoder, nullptr);
   const auto *text = co.text_sections()[0];
   auto *words = reinterpret_cast<const uint32_t *>(text->data());
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "s_endpgm");
 }
@@ -149,7 +150,7 @@ TEST(Gfx1250DecodeTest, SMovB64Literal64ConsumesThreeDwords) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "s_mov_b64");
   EXPECT_EQ(inst->size(), sizeof(words));
@@ -166,7 +167,7 @@ TEST(Gfx1250DecodeTest, ScalarSourceRejectsReservedSelector) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(words)), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, words));
 }
 
 TEST(Gfx1250DecodeTest, Vop3LiteralConsumesThreeDwords) {
@@ -178,7 +179,7 @@ TEST(Gfx1250DecodeTest, Vop3LiteralConsumesThreeDwords) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_and_or_b32");
   EXPECT_EQ(inst->size(), sizeof(words));
@@ -192,7 +193,7 @@ TEST(Gfx1250DecodeTest, Vop3RejectsLiteral64Selector) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(words)), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, words));
 }
 
 TEST(Gfx1250DecodeTest, Vop1RejectsUnsupportedLiteral32WithoutExtensionWord) {
@@ -200,7 +201,7 @@ TEST(Gfx1250DecodeTest, Vop1RejectsUnsupportedLiteral32WithoutExtensionWord) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(words.data())), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, words.data()));
 }
 
 TEST(Gfx1250DecodeTest, Vop2RejectsUnsupportedLiteral32WithoutExtensionWord) {
@@ -208,7 +209,7 @@ TEST(Gfx1250DecodeTest, Vop2RejectsUnsupportedLiteral32WithoutExtensionWord) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(words.data())), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, words.data()));
 }
 
 TEST(Gfx1250DecodeTest, Vop2RejectsUnsupportedLiteral64WithoutExtensionWords) {
@@ -216,7 +217,7 @@ TEST(Gfx1250DecodeTest, Vop2RejectsUnsupportedLiteral64WithoutExtensionWords) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(words.data())), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, words.data()));
 }
 
 TEST(Gfx1250DecodeTest, SaluRejectsMixedLiteralWidths) {
@@ -228,7 +229,7 @@ TEST(Gfx1250DecodeTest, SaluRejectsMixedLiteralWidths) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(words)), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, words));
 }
 
 TEST(Gfx1250DecodeTest, SendmsgRtnSelectorsAreNotLiterals) {
@@ -238,7 +239,7 @@ TEST(Gfx1250DecodeTest, SendmsgRtnSelectorsAreNotLiterals) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "s_sendmsg_rtn_b32");
   EXPECT_EQ(inst->size(), sizeof(words));
@@ -253,7 +254,7 @@ TEST(Gfx1250DecodeTest, VopdRejectsLiteral64Selector) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(words)), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, words));
 }
 
 TEST(Gfx1250DecodeTest, Vop3RejectsDppWithLiteral) {
@@ -265,7 +266,7 @@ TEST(Gfx1250DecodeTest, Vop3RejectsDppWithLiteral) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(words)), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, words));
 }
 
 TEST(Gfx1250DecodeTest, Vop3RejectsInvalidScalarDestination) {
@@ -277,7 +278,7 @@ TEST(Gfx1250DecodeTest, Vop3RejectsInvalidScalarDestination) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(words)), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, words));
 }
 
 TEST(Gfx1250DecodeTest, Vop3RejectsInvalidVgprSource) {
@@ -288,7 +289,7 @@ TEST(Gfx1250DecodeTest, Vop3RejectsInvalidVgprSource) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(words)), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, words));
 }
 
 TEST(Gfx1250DecodeTest, Vop3ReadlaneValidatesLaneSelector) {
@@ -303,10 +304,10 @@ TEST(Gfx1250DecodeTest, Vop3ReadlaneValidatesLaneSelector) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> valid(decoder->decode(valid_words));
+  std::unique_ptr<Instruction> valid(decode_valid(*decoder, valid_words));
   ASSERT_NE(valid, nullptr);
   EXPECT_EQ(valid->disassemble(), "v_readlane_b32 s0, v215, 1");
-  EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(invalid_words)), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, invalid_words));
 }
 
 TEST(Gfx1250DecodeTest, Vop3CmpxValidatesExecDestination) {
@@ -321,10 +322,10 @@ TEST(Gfx1250DecodeTest, Vop3CmpxValidatesExecDestination) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> valid(decoder->decode(valid_words));
+  std::unique_ptr<Instruction> valid(decode_valid(*decoder, valid_words));
   ASSERT_NE(valid, nullptr);
   EXPECT_EQ(valid->disassemble(), "v_cmpx_ne_u32 exec, v0, v1");
-  EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(invalid_words)), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, invalid_words));
 }
 
 TEST(Gfx1250DecodeTest, Vop3SdstLiteralConsumesThreeDwords) {
@@ -336,7 +337,7 @@ TEST(Gfx1250DecodeTest, Vop3SdstLiteralConsumesThreeDwords) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_subrev_co_u32");
   EXPECT_EQ(inst->size(), sizeof(words));
@@ -351,12 +352,12 @@ TEST(Gfx1250DecodeTest, VFmamkF64ImpliedLiteralConsumesThreeDwords) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> fmamk(decoder->decode(words));
+  std::unique_ptr<Instruction> fmamk(decode_valid(*decoder, words));
   ASSERT_NE(fmamk, nullptr);
   EXPECT_EQ(fmamk->mnemonic(), "v_fmamk_f64_e32");
   EXPECT_EQ(fmamk->size(), 3 * sizeof(uint32_t));
 
-  std::unique_ptr<Instruction> next(decoder->decode(words + 3));
+  std::unique_ptr<Instruction> next(decode_valid(*decoder, words + 3));
   ASSERT_NE(next, nullptr);
   EXPECT_EQ(next->mnemonic(), "v_cvt_u32_f64_e32");
 }
@@ -368,7 +369,7 @@ TEST(Gfx1250DecodeTest, SWaitXcntHasWaitcntMetadata) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "s_wait_xcnt");
   EXPECT_TRUE(inst->is_waitcnt());
@@ -384,7 +385,7 @@ TEST(Gfx1250DecodeTest, BufferOffenUsesSingleVaddrRegister) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "buffer_load_b128");
   ASSERT_EQ(inst->num_dst_operands(), 1);
@@ -425,7 +426,7 @@ TEST(Gfx1250DecodeTest, BufferWithoutIdxenOffenDoesNotExposeVaddrRegister) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "buffer_load_b128");
   ASSERT_EQ(inst->num_dst_operands(), 1);
@@ -454,7 +455,7 @@ TEST(Gfx1250DecodeTest, WmmaF8f6f4UsesMatrixFormatOperandWidths) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->disassemble(), "v_wmma_f32_16x16x128_f8f6f4 v[16:23], v[0:7], v[8:15], v[16:23] "
                                  "matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4");
@@ -470,7 +471,7 @@ TEST(Gfx1250DecodeTest, WmmaScaleF8f6f4ConsumesVop3px2Pair) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_wmma_scale_f32_16x16x128_f8f6f4");
   EXPECT_EQ(inst->size(), sizeof(words));
@@ -491,7 +492,7 @@ TEST(Gfx1250DecodeTest, WmmaScalePairRejectsInvalidEmbeddedSourceSelectors) {
 
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
     ASSERT_NE(decoder, nullptr);
-    EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(words)), util::InvalidInst);
+    EXPECT_TRUE(decode_fails(*decoder, words));
   }
 }
 
@@ -505,7 +506,7 @@ TEST(Gfx1250DecodeTest, WmmaScale16F8f6f4ConsumesVop3px2Pair) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_wmma_scale16_f32_16x16x128_f8f6f4");
   EXPECT_EQ(inst->size(), sizeof(words));
@@ -524,7 +525,7 @@ TEST(Gfx1250DecodeTest, WmmaScaleF4_32x16x128ConsumesVop3px2Pair) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_wmma_scale_f32_32x16x128_f4");
   EXPECT_EQ(inst->size(), sizeof(words));
@@ -542,7 +543,7 @@ TEST(Gfx1250DecodeTest, WmmaScalePrefixRejectsNonWmmaSuffix) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  EXPECT_THROW(static_cast<void>(decoder->decode(words)), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, words));
 }
 
 TEST(Gfx1250ExecutionTest, WmmaRegularScaleInlineZeroMatchesNeutralScalarSources) {
@@ -577,8 +578,8 @@ TEST(Gfx1250ExecutionTest, WmmaRegularScaleInlineZeroMatchesNeutralScalarSources
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> scalar_inst(decoder->decode(scalar_words.data()));
-  std::unique_ptr<Instruction> inline_inst(decoder->decode(inline_words.data()));
+  std::unique_ptr<Instruction> scalar_inst(decode_valid(*decoder, scalar_words.data()));
+  std::unique_ptr<Instruction> inline_inst(decode_valid(*decoder, inline_words.data()));
   ASSERT_NE(scalar_inst, nullptr);
   ASSERT_NE(inline_inst, nullptr);
   cu->execute_instruction(scalar_inst.get(), *wf);
@@ -602,7 +603,7 @@ TEST(Gfx1250DecodeTest, SwmmacPrintsIndexKeyAndReuseModifiers) {
       0xCC65081Au,
       0x1C8E0112u,
   };
-  std::unique_ptr<Instruction> index_key_inst(decoder->decode(index_key_words));
+  std::unique_ptr<Instruction> index_key_inst(decode_valid(*decoder, index_key_words));
   ASSERT_NE(index_key_inst, nullptr);
   EXPECT_EQ(index_key_inst->disassemble(),
             "v_swmmac_f32_16x16x64_f16 v[26:33], v[18:25], v[0:15], v35 index_key:1");
@@ -611,7 +612,7 @@ TEST(Gfx1250DecodeTest, SwmmacPrintsIndexKeyAndReuseModifiers) {
       0xCC65201Au,
       0x1C8E0112u,
   };
-  std::unique_ptr<Instruction> matrix_a_reuse_inst(decoder->decode(matrix_a_reuse_words));
+  std::unique_ptr<Instruction> matrix_a_reuse_inst(decode_valid(*decoder, matrix_a_reuse_words));
   ASSERT_NE(matrix_a_reuse_inst, nullptr);
   EXPECT_EQ(matrix_a_reuse_inst->disassemble(),
             "v_swmmac_f32_16x16x64_f16 v[26:33], v[18:25], v[0:15], v35 matrix_a_reuse");
@@ -620,7 +621,7 @@ TEST(Gfx1250DecodeTest, SwmmacPrintsIndexKeyAndReuseModifiers) {
       0xCC65401Au,
       0x1C8E0112u,
   };
-  std::unique_ptr<Instruction> matrix_b_reuse_inst(decoder->decode(matrix_b_reuse_words));
+  std::unique_ptr<Instruction> matrix_b_reuse_inst(decode_valid(*decoder, matrix_b_reuse_words));
   ASSERT_NE(matrix_b_reuse_inst, nullptr);
   EXPECT_EQ(matrix_b_reuse_inst->disassemble(),
             "v_swmmac_f32_16x16x64_f16 v[26:33], v[18:25], v[0:15], v35 matrix_b_reuse");
@@ -634,7 +635,7 @@ TEST(Gfx1250DecodeTest, VopdXyConsumesTwoDwords) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_dual_cndmask_b32 :: v_dual_mov_b32");
   EXPECT_EQ(inst->size(), sizeof(words));
@@ -651,7 +652,7 @@ TEST(Gfx1250DecodeTest, Vopd3ConsumesThreeDwords) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_dual_lshlrev_b32 :: v_dual_lshrrev_b32");
   EXPECT_EQ(inst->size(), sizeof(words));
@@ -668,7 +669,7 @@ TEST(Gfx1250DecodeTest, Vopd3RejectsSrcX0Literal32Selector) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(words)), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, words));
 }
 
 TEST(Gfx1250DecodeTest, Vopd3RejectsSrcY0Literal32Selector) {
@@ -680,7 +681,7 @@ TEST(Gfx1250DecodeTest, Vopd3RejectsSrcY0Literal32Selector) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(words)), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, words));
 }
 
 TEST(Gfx1250DecodeTest, VopdLiteralConsumesThreeDwords) {
@@ -692,7 +693,7 @@ TEST(Gfx1250DecodeTest, VopdLiteralConsumesThreeDwords) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_dual_mul_f32 :: v_dual_mov_b32");
   EXPECT_EQ(inst->size(), sizeof(words));
@@ -708,7 +709,7 @@ TEST(Gfx1250DecodeTest, VopdSourceOperandsFollowPrintedSlots) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_dual_lshlrev_b32 :: v_dual_mov_b32");
   EXPECT_EQ(inst->num_src_operands(), 3);
@@ -729,7 +730,7 @@ TEST(Gfx1250DecodeTest, VopdRejectsInvalidOpcodes) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   for (const auto &encoding : words)
-    EXPECT_THROW(static_cast<void>(decoder->decode(encoding.data())), util::InvalidInst);
+    EXPECT_TRUE(decode_fails(*decoder, encoding.data()));
 }
 
 TEST(Gfx1250DecodeTest, PublicDecoderReportsInvalidVopdEncoding) {
@@ -759,7 +760,7 @@ TEST(Gfx1250DecodeTest, Vopd3RejectsOverlappingDestinations) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   for (const auto &encoding : words)
-    EXPECT_THROW(static_cast<void>(decoder->decode(encoding.data())), util::InvalidInst);
+    EXPECT_TRUE(decode_fails(*decoder, encoding.data()));
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/cdna5_execution_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_execution_test.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "cdna5_sim_test_common.h"
+#include "decode_test_util.h"
 
 namespace {
 
@@ -46,7 +47,7 @@ TEST(Gfx1250ExecutionTest, ScalarMovesTreatS102AndS103AsOrdinarySgprs) {
       0,
       0,
   };
-  std::unique_ptr<Instruction> move64(decoder->decode(kMove64.data()));
+  std::unique_ptr<Instruction> move64(decode_valid(*decoder, kMove64.data()));
   ASSERT_NE(move64, nullptr);
   EXPECT_EQ(move64->mnemonic(), "s_mov_b64");
   EXPECT_EQ(move64->size(), 4);
@@ -66,7 +67,7 @@ TEST(Gfx1250ExecutionTest, ScalarMovesTreatS102AndS103AsOrdinarySgprs) {
       0,
   };
   for (const auto *words : {kWriteS102.data(), kWriteS103.data()}) {
-    std::unique_ptr<Instruction> move32(decoder->decode(words));
+    std::unique_ptr<Instruction> move32(decode_valid(*decoder, words));
     ASSERT_NE(move32, nullptr);
     EXPECT_EQ(move32->mnemonic(), "s_mov_b32");
     EXPECT_EQ(move32->size(), 4);
@@ -86,7 +87,7 @@ TEST(Gfx1250ExecutionTest, ScalarMovesTreatS102AndS103AsOrdinarySgprs) {
       0,
   };
   for (const auto *words : {kReadS102.data(), kReadS103.data()}) {
-    std::unique_ptr<Instruction> move32(decoder->decode(words));
+    std::unique_ptr<Instruction> move32(decode_valid(*decoder, words));
     ASSERT_NE(move32, nullptr);
     EXPECT_EQ(move32->mnemonic(), "s_mov_b32");
     EXPECT_EQ(move32->size(), 4);
@@ -100,7 +101,7 @@ TEST(Gfx1250ExecutionTest, ScalarMovesTreatS102AndS103AsOrdinarySgprs) {
       0,
       0,
   };
-  std::unique_ptr<Instruction> read64(decoder->decode(kReadS102S103.data()));
+  std::unique_ptr<Instruction> read64(decode_valid(*decoder, kReadS102S103.data()));
   ASSERT_NE(read64, nullptr);
   EXPECT_EQ(read64->mnemonic(), "s_mov_b64");
   EXPECT_EQ(read64->size(), 4);
@@ -130,7 +131,7 @@ TEST(Gfx1250ExecutionTest, Wave32VectorComparePreservesVccHiScratch) {
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
     ASSERT_NE(decoder, nullptr);
     constexpr auto kCompare = cdna5::build_vopc(cdna5::kVCmpGtI32Vopc, {.src0 = 28, .vsrc1 = 18});
-    std::unique_ptr<Instruction> decoded(decoder->decode(kCompare.data()));
+    std::unique_ptr<Instruction> decoded(decode_valid(*decoder, kCompare.data()));
     ASSERT_NE(decoded, nullptr);
     EXPECT_EQ(decoded->mnemonic(), "v_cmp_gt_i32_e32");
     decoded->execute(*decoded, wf);
@@ -312,7 +313,7 @@ TEST(Gfx1250ExecutionTest, IreeF16ReductionTailKeepsLane31Sum) {
   }};
 
   for (const auto &inst_words : words) {
-    std::unique_ptr<Instruction> inst(decoder->decode(inst_words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, inst_words.data()));
     ASSERT_NE(inst, nullptr);
     cu->execute_instruction(inst.get(), *wf);
   }
@@ -416,7 +417,8 @@ TEST(Gfx1250LiteralOperandTest, SplitBackendPreservesSignedAndEncodingSemantics)
     const auto signed_mad_base = cdna5::build_vop3(
         cdna5::kVMadNcI64I32Vop3, {.vdst = 4, .src0 = 129, .src1 = 129, .src2 = 255});
     const std::array signed_mad_words{signed_mad_base[0], signed_mad_base[1], literal};
-    std::unique_ptr<Instruction> signed_mad_decoded(decoder->decode(signed_mad_words.data()));
+    std::unique_ptr<Instruction> signed_mad_decoded(
+        decode_valid(*decoder, signed_mad_words.data()));
     ASSERT_NE(signed_mad_decoded, nullptr);
     EXPECT_EQ(signed_mad_decoded->mnemonic(), "v_mad_nc_i64_i32");
     EXPECT_EQ(signed_mad_decoded->size(), 12);
@@ -435,7 +437,8 @@ TEST(Gfx1250LiteralOperandTest, SplitBackendPreservesSignedAndEncodingSemantics)
     const auto unsigned_mad_base = cdna5::build_vop3(
         cdna5::kVMadNcU64U32Vop3, {.vdst = 6, .src0 = 129, .src1 = 129, .src2 = 255});
     const std::array unsigned_mad_words{unsigned_mad_base[0], unsigned_mad_base[1], literal};
-    std::unique_ptr<Instruction> unsigned_mad_decoded(decoder->decode(unsigned_mad_words.data()));
+    std::unique_ptr<Instruction> unsigned_mad_decoded(
+        decode_valid(*decoder, unsigned_mad_words.data()));
     ASSERT_NE(unsigned_mad_decoded, nullptr);
     auto *unsigned_mad = dynamic_cast<cdna5::VMadNcU64U32Vop3 *>(unsigned_mad_decoded.get());
     ASSERT_NE(unsigned_mad, nullptr);
@@ -451,7 +454,7 @@ TEST(Gfx1250LiteralOperandTest, SplitBackendPreservesSignedAndEncodingSemantics)
     const auto scalar_base =
         cdna5::build_sop2(cdna5::kSAshrI64Sop2, {.ssrc0 = 255, .ssrc1 = 128, .sdst = 0});
     const std::array scalar_words{scalar_base[0], literal};
-    std::unique_ptr<Instruction> scalar_decoded(decoder->decode(scalar_words.data()));
+    std::unique_ptr<Instruction> scalar_decoded(decode_valid(*decoder, scalar_words.data()));
     ASSERT_NE(scalar_decoded, nullptr);
     EXPECT_EQ(scalar_decoded->mnemonic(), "s_ashr_i64");
     EXPECT_EQ(scalar_decoded->size(), 8);
@@ -468,7 +471,7 @@ TEST(Gfx1250LiteralOperandTest, SplitBackendPreservesSignedAndEncodingSemantics)
     const auto b64_base =
         cdna5::build_sop2(cdna5::kSAndB64Sop2, {.ssrc0 = 255, .ssrc1 = 193, .sdst = 2});
     const std::array b64_words{b64_base[0], literal};
-    std::unique_ptr<Instruction> b64_decoded(decoder->decode(b64_words.data()));
+    std::unique_ptr<Instruction> b64_decoded(decode_valid(*decoder, b64_words.data()));
     ASSERT_NE(b64_decoded, nullptr);
     auto *b64 = dynamic_cast<cdna5::SAndB64Sop2 *>(b64_decoded.get());
     ASSERT_NE(b64, nullptr);
@@ -505,7 +508,7 @@ TEST(Gfx1250LiteralOperandTest, NegativeI64CompareCoversScalarAndAvailableSimdPa
     const auto compare_base =
         cdna5::build_vop3(cdna5::kVCmpLtI64Vop3, {.vdst = 0, .src0 = 255, .src1 = 256});
     const std::array compare_words{compare_base[0], compare_base[1], 0xffffffffu};
-    std::unique_ptr<Instruction> compare(decoder->decode(compare_words.data()));
+    std::unique_ptr<Instruction> compare(decode_valid(*decoder, compare_words.data()));
     ASSERT_NE(compare, nullptr);
     EXPECT_EQ(compare->mnemonic(), "v_cmp_lt_i64");
     EXPECT_EQ(compare->size(), 12);
@@ -556,7 +559,7 @@ TEST(Gfx1250LiteralOperandTest, ScalarMaskOperandsRejectLiteralMarkers) {
       SCOPED_TRACE(test_case.name);
       SCOPED_TRACE(marker);
       const std::array words{test_case.encoding[0], test_case.encoding[1], 0xffffffffu, 0u};
-      EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(words.data())), util::InvalidInst);
+      EXPECT_TRUE(decode_fails(*decoder, words.data()));
     }
   }
 }
@@ -576,7 +579,7 @@ TEST(Gfx1250LiteralOperandTest, PkF32LiteralReplicatesAndUsesAvailableSimdPath) 
 
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
     ASSERT_NE(decoder, nullptr);
-    std::unique_ptr<Instruction> add(decoder->decode(add_words.data()));
+    std::unique_ptr<Instruction> add(decode_valid(*decoder, add_words.data()));
     ASSERT_NE(add, nullptr);
     auto *typed_add = dynamic_cast<cdna5::VPkAddF32Vop3p *>(add.get());
     ASSERT_NE(typed_add, nullptr);
@@ -665,7 +668,7 @@ TEST(Gfx1250LiteralOperandTest, PkF32MixedLiteralVgprSourcesUseAvailableSimdPath
     const std::array words{base[0], base[1], kLiteral};
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
     ASSERT_NE(decoder, nullptr);
-    std::unique_ptr<Instruction> instruction(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> instruction(decode_valid(*decoder, words.data()));
     ASSERT_NE(instruction, nullptr);
 
     const Operand *literal_operand = instruction->src_operand(test_case.literal_source);
@@ -723,7 +726,7 @@ TEST(Gfx1250LiteralOperandTest, PkF32MixedLiteralSourceSpecificSelectorFallsBack
   const std::array words{base[0], base[1], kLiteral};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> instruction(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> instruction(decode_valid(*decoder, words.data()));
   ASSERT_NE(instruction, nullptr);
   auto *typed = dynamic_cast<cdna5::VPkAddF32Vop3p *>(instruction.get());
   ASSERT_NE(typed, nullptr);
@@ -771,7 +774,7 @@ TEST(Gfx1250ExecutionTest, PkF32AddMulSimdMatchesScalarWithPartialExec) {
           {.vdst = 4, .neg_hi = 2, .src0 = 256, .src1 = 258, .opsel_hi = 3, .neg = 1});
       auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
       ASSERT_NE(decoder, nullptr);
-      std::unique_ptr<Instruction> instruction(decoder->decode(words.data()));
+      std::unique_ptr<Instruction> instruction(decode_valid(*decoder, words.data()));
       ASSERT_NE(instruction, nullptr);
 
       Gfx1250Sim sim;
@@ -880,7 +883,7 @@ TEST(Gfx1250ExecutionTest, PkF32EveryNondefaultSelectorGateFallsBackToScalar) {
         words[0] |= uint32_t{1} << 14;
       auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
       ASSERT_NE(decoder, nullptr);
-      std::unique_ptr<Instruction> instruction(decoder->decode(words.data()));
+      std::unique_ptr<Instruction> instruction(decode_valid(*decoder, words.data()));
       ASSERT_NE(instruction, nullptr);
 
       Gfx1250Sim sim;
@@ -951,7 +954,7 @@ TEST(Gfx1250ExecutionTest, PkFmaF32SimdMatchesScalarWithPartialExec) {
     words[0] |= uint32_t{1} << 14; // pad_14 is the src2 high-half selector.
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
     ASSERT_NE(decoder, nullptr);
-    std::unique_ptr<Instruction> instruction(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> instruction(decode_valid(*decoder, words.data()));
     ASSERT_NE(instruction, nullptr);
     auto *typed = dynamic_cast<cdna5::VPkFmaF32Vop3p *>(instruction.get());
     ASSERT_NE(typed, nullptr);
@@ -1018,7 +1021,7 @@ TEST(Gfx1250DecodeTest, Vop3pRejectsLiteral64SelectorInEverySourcePosition) {
            cdna5::Vop3pBuilderFields{.src2 = 254},
        }) {
     const auto words = cdna5::build_vop3p(cdna5::kVPkFmaF32Vop3p, fields);
-    EXPECT_THROW(static_cast<void>(decoder->decode(words.data())), util::InvalidInst);
+    EXPECT_TRUE(decode_fails(*decoder, words.data()));
   }
 }
 
@@ -1028,7 +1031,7 @@ TEST(Gfx1250DecodeTest, BinaryVop3pIgnoresLiteral64SelectorInUnusedSrc2) {
 
   for (const uint32_t opcode : {cdna5::kVPkAddF32Vop3p, cdna5::kVPkMulF32Vop3p}) {
     const auto words = cdna5::build_vop3p(opcode, {.src0 = 128, .src1 = 129, .src2 = 254});
-    std::unique_ptr<Instruction> instruction(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> instruction(decode_valid(*decoder, words.data()));
     ASSERT_NE(instruction, nullptr);
     EXPECT_EQ(instruction->size(), 8);
     EXPECT_EQ(instruction->num_src_operands(), 2);
@@ -1074,7 +1077,7 @@ TEST(Gfx1250ExecutionTest, Wave32ScalarVccHiWritePreservesUpperHalf) {
   ASSERT_NE(decoder, nullptr);
 
   const uint32_t words[] = {0x8c6b7e6bu, 0}; // s_or_b32 vcc_hi, vcc_hi, exec_lo
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "s_or_b32");
   cu->execute_instruction(inst.get(), *wf);

--- a/emulation/rocjitsu/tests/cdna5_instruction_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_instruction_test.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "cdna5_sim_test_common.h"
+#include "decode_test_util.h"
 
 namespace {
 
@@ -83,8 +84,8 @@ TEST(Gfx1250SimulationTest, SAddPcI64WrapsAtUnsignedBoundaries) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> increment(decoder->decode(add_one.data()));
-  std::unique_ptr<Instruction> decrement(decoder->decode(add_minus_one.data()));
+  std::unique_ptr<Instruction> increment(decode_valid(*decoder, add_one.data()));
+  std::unique_ptr<Instruction> decrement(decode_valid(*decoder, add_minus_one.data()));
   ASSERT_NE(increment, nullptr);
   ASSERT_NE(decrement, nullptr);
 
@@ -285,7 +286,7 @@ TEST(Gfx1250SimulationTest, NamedBarrierSignalIsfirstPreservesSccWithoutAllocati
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   const std::array<uint32_t, 1> signal_words = {0xBE804F7Du};
-  std::unique_ptr<Instruction> signal(decoder->decode(signal_words.data()));
+  std::unique_ptr<Instruction> signal(decode_valid(*decoder, signal_words.data()));
   ASSERT_NE(signal, nullptr);
 
   wf->set_m0((2u << 16) | 1u);
@@ -309,10 +310,10 @@ void expect_barrier_init_reads_implicit_m0(uint32_t init_encoding, uint32_t init
   const std::array<uint32_t, 1> join_words = {0xBE805281u};   // s_barrier_join 1
   const std::array<uint32_t, 1> signal_words = {0xBE804F81u}; // s_barrier_signal_isfirst 1
   const std::array<uint32_t, 1> state_words = {0xBE845081u};  // s_get_barrier_state s4, 1
-  std::unique_ptr<Instruction> init(decoder->decode(init_words.data()));
-  std::unique_ptr<Instruction> join(decoder->decode(join_words.data()));
-  std::unique_ptr<Instruction> signal(decoder->decode(signal_words.data()));
-  std::unique_ptr<Instruction> state(decoder->decode(state_words.data()));
+  std::unique_ptr<Instruction> init(decode_valid(*decoder, init_words.data()));
+  std::unique_ptr<Instruction> join(decode_valid(*decoder, join_words.data()));
+  std::unique_ptr<Instruction> signal(decode_valid(*decoder, signal_words.data()));
+  std::unique_ptr<Instruction> state(decode_valid(*decoder, state_words.data()));
   ASSERT_NE(init, nullptr);
   ASSERT_NE(join, nullptr);
   ASSERT_NE(signal, nullptr);
@@ -360,10 +361,10 @@ TEST(Gfx1250SimulationTest, NamedBarrierSynchronizesJoinedWavesAcrossPhases) {
   const std::array<uint32_t, 1> signal_words = {0xBE804F7Du};
   const std::array<uint32_t, 1> wait_words = {0xBF940001u};
   const std::array<uint32_t, 1> state_words = {0xBE84507Du};
-  std::unique_ptr<Instruction> join(decoder->decode(join_words.data()));
-  std::unique_ptr<Instruction> signal(decoder->decode(signal_words.data()));
-  std::unique_ptr<Instruction> wait(decoder->decode(wait_words.data()));
-  std::unique_ptr<Instruction> state(decoder->decode(state_words.data()));
+  std::unique_ptr<Instruction> join(decode_valid(*decoder, join_words.data()));
+  std::unique_ptr<Instruction> signal(decode_valid(*decoder, signal_words.data()));
+  std::unique_ptr<Instruction> wait(decode_valid(*decoder, wait_words.data()));
+  std::unique_ptr<Instruction> state(decode_valid(*decoder, state_words.data()));
   ASSERT_NE(join, nullptr);
   ASSERT_NE(signal, nullptr);
   ASSERT_NE(wait, nullptr);
@@ -496,7 +497,7 @@ TEST(Gfx1250SimulationTest, WorkgroupSignalIsfirstAcceptsNegativeInlineBarrierId
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   const std::array<uint32_t, 1> signal_words = {0xBE804FC1u}; // s_barrier_signal_isfirst -1
-  std::unique_ptr<Instruction> signal(decoder->decode(signal_words.data()));
+  std::unique_ptr<Instruction> signal(decode_valid(*decoder, signal_words.data()));
   ASSERT_NE(signal, nullptr);
 
   cu->execute_instruction(signal.get(), *wf0);
@@ -1429,7 +1430,7 @@ TEST(Gfx1250SimulationTest, VopdFmamkUsesSrc2HighBank) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_dual_fmamk_f32 :: v_dual_mov_b32");
   cu->execute_instruction(inst.get(), *wf);
@@ -1574,7 +1575,7 @@ TEST(Gfx1250SimulationTest, DsAddtidLoadAndStoreUseM0ByteBaseAddresses) {
   const uint32_t expected1 = expected0 + sizeof(uint32_t);
 
   const uint32_t store_words[] = {0xDAC01234u, 0x00000500u};
-  std::unique_ptr<Instruction> store(decoder->decode(store_words));
+  std::unique_ptr<Instruction> store(decode_valid(*decoder, store_words));
   ASSERT_NE(store, nullptr);
   ASSERT_EQ(std::string_view(store->mnemonic()), "ds_store_addtid_b32");
   cu.execute_instruction(store.get(), *wf);
@@ -1594,7 +1595,7 @@ TEST(Gfx1250SimulationTest, DsAddtidLoadAndStoreUseM0ByteBaseAddresses) {
   EXPECT_EQ(cu.lds().read32(expected1), kLane1Data);
 
   const uint32_t load_words[] = {0xDAC41234u, 0x08000000u};
-  std::unique_ptr<Instruction> load(decoder->decode(load_words));
+  std::unique_ptr<Instruction> load(decode_valid(*decoder, load_words));
   ASSERT_NE(load, nullptr);
   ASSERT_EQ(std::string_view(load->mnemonic()), "ds_load_addtid_b32");
   cu.execute_instruction(load.get(), *wf);
@@ -1608,7 +1609,7 @@ TEST(Gfx1250SimulationTest, DsAddtidLoadAndStoreUseM0ByteBaseAddresses) {
   EXPECT_EQ(cu.read_vgpr(load_dst_base, 1), kLane1Data);
 
   wf->set_m0(0);
-  std::unique_ptr<Instruction> default_m0_store(decoder->decode(store_words));
+  std::unique_ptr<Instruction> default_m0_store(decode_valid(*decoder, store_words));
   ASSERT_NE(default_m0_store, nullptr);
   cu.execute_instruction(default_m0_store.get(), *wf);
   auto *default_m0_state = default_m0_store->data_as<amdgpu::VectorMemState>();
@@ -1731,7 +1732,7 @@ TEST(Gfx1250ExecutionTest, Vopd3CndmaskAppliesB32NegModifiers) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(cndmask.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, cndmask.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_dual_cndmask_b32 :: v_dual_cndmask_b32");
 

--- a/emulation/rocjitsu/tests/cdna5_sim_test_common.h
+++ b/emulation/rocjitsu/tests/cdna5_sim_test_common.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "aql_queue.h"
+#include "decode_test_util.h"
 #include "halt_snapshot_plugin.h"
 
 #include "embedded_schema.h"
@@ -328,7 +329,7 @@ inline std::unique_ptr<Instruction> decode_gfx1250(const std::array<uint32_t, 3>
     return nullptr;
   }
 
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   if (!inst) {
     ADD_FAILURE() << "decode() returned nullptr for gfx1250 instruction";
     return nullptr;

--- a/emulation/rocjitsu/tests/cdna5_tensor_dma_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_tensor_dma_test.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "cdna5_sim_test_common.h"
+#include "decode_test_util.h"
 
 namespace {
 
@@ -1125,7 +1126,7 @@ TEST(Gfx1250ExecutionTest, SBarrierWaitIsNoOpForSingleWaveWorkgroup) {
   ASSERT_NE(decoder, nullptr);
 
   const std::array<uint32_t, 2> wait_words = {0xBF94FFFFu, 0u};
-  std::unique_ptr<Instruction> wait_inst(decoder->decode(wait_words.data()));
+  std::unique_ptr<Instruction> wait_inst(decode_valid(*decoder, wait_words.data()));
   ASSERT_NE(wait_inst, nullptr);
   ASSERT_EQ(std::string_view(wait_inst->mnemonic()), "s_barrier_wait");
 
@@ -1152,7 +1153,7 @@ TEST(Gfx1250ExecutionTest, SBarrierWaitReleasesOnlyAfterSignalQuorum) {
   ASSERT_NE(decoder, nullptr);
 
   const std::array<uint32_t, 2> wait_words = {0xBF94FFFFu, 0u};
-  std::unique_ptr<Instruction> wait_inst(decoder->decode(wait_words.data()));
+  std::unique_ptr<Instruction> wait_inst(decode_valid(*decoder, wait_words.data()));
   ASSERT_NE(wait_inst, nullptr);
   ASSERT_EQ(std::string_view(wait_inst->mnemonic()), "s_barrier_wait");
 

--- a/emulation/rocjitsu/tests/check_model_only_symbols.cmake
+++ b/emulation/rocjitsu/tests/check_model_only_symbols.cmake
@@ -53,7 +53,7 @@ if(REQUIRED_MODEL_ARCHES)
     endforeach()
 else()
     set(_required_symbol
-        "rocjitsu::cdna5::Decoder::decode(unsigned int const*)"
+        "rocjitsu::cdna5::Decoder::decode(unsigned int const*, util::DiagnosticEmitter const&)"
     )
     string(FIND "${_symbols}" "${_required_symbol}" _match)
     if(_match EQUAL -1)

--- a/emulation/rocjitsu/tests/check_narrow_registry_symbols.cmake
+++ b/emulation/rocjitsu/tests/check_narrow_registry_symbols.cmake
@@ -17,7 +17,7 @@ endif()
 
 set(_required_symbols
     "rj_test_narrow_target_count"
-    "rocjitsu::cdna5::Decoder::decode(unsigned int const*)"
+    "rocjitsu::cdna5::Decoder::decode(unsigned int const*, util::DiagnosticEmitter const&)"
 )
 foreach(_required IN LISTS _required_symbols)
     string(FIND "${_symbols}" "${_required}" _match)

--- a/emulation/rocjitsu/tests/code/relocation_function_table_test.cpp
+++ b/emulation/rocjitsu/tests/code/relocation_function_table_test.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include "decode_test_util.h"
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/basic_block.h"
@@ -538,7 +539,7 @@ TEST(RelocationFunctionTable, ResolvesDynamicDispatchThroughGotAndTableLoads) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   std::array<uint64_t, 1> leaders{40};
-  const auto blocks = BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders);
+  const auto blocks = build_valid_blocks(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders);
   const auto dispatches = analyze_relocation_pairs(blocks, tables, 0x1000).dispatches;
   ASSERT_EQ(dispatches.size(), 1u);
   EXPECT_EQ(dispatches[0].table_index, 0u);
@@ -563,7 +564,7 @@ TEST(RelocationFunctionTable, ResolvesRcclDirectIndexedTableDispatch) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   std::array<uint64_t, 1> leaders{32};
-  const auto blocks = BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders);
+  const auto blocks = build_valid_blocks(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders);
   const auto analysis = analyze_relocation_pairs(blocks, tables, 0x1000);
   const auto &dispatches = analysis.dispatches;
   ASSERT_EQ(dispatches.size(), 1u);
@@ -602,7 +603,7 @@ TEST(RelocationFunctionTable, RejectsChainedAddressAddDispatch) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   std::array<uint64_t, 1> leaders{44};
-  const auto blocks = BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders);
+  const auto blocks = build_valid_blocks(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders);
   const auto dispatches = analyze_relocation_pairs(blocks, tables, 0x1000).dispatches;
   // The base is built with two literal adds; only one add offset can be relocated,
   // so the dispatch must fail closed rather than resolve to a value whose first
@@ -631,7 +632,7 @@ TEST(RelocationFunctionTable, ResolvesBackwardTableAddress) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   std::array<uint64_t, 1> leaders{32};
-  const auto blocks = BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders);
+  const auto blocks = build_valid_blocks(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders);
   const auto dispatches = analyze_relocation_pairs(blocks, tables, kAssumedTextVaddr).dispatches;
   ASSERT_EQ(dispatches.size(), 1u);
   EXPECT_EQ(dispatches[0].table_index, 0u);

--- a/emulation/rocjitsu/tests/dbi/hsa_dbi_nop_asm_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/hsa_dbi_nop_asm_test.cpp
@@ -75,7 +75,9 @@ protected:
     // TODO: instrument multiple instructions
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA2);
     ASSERT_NE(decoder, nullptr);
-    auto blocks = BasicBlock::build(*co, *decoder, ROCJITSU_CODE_ARCH_CDNA2);
+    auto block_result = BasicBlock::build(*co, *decoder, ROCJITSU_CODE_ARCH_CDNA2);
+    ASSERT_TRUE(block_result.succeeded());
+    auto blocks = std::move(block_result).value();
 
     ASSERT_FALSE(co->text_sections().empty());
     const auto *text = co->text_sections().front();
@@ -178,7 +180,9 @@ TEST_F(HsaDbiNopAsmStatic, PatchedElfActuallyContainsInstrumentation) {
   for (uint64_t anchor_idx = 0; anchor_idx < anchor_count_; ++anchor_idx) {
     rj_code_binary_inst_t anchor_word = 0;
     std::memcpy(&anchor_word, text->data() + anchor_offsets_[anchor_idx], sizeof(anchor_word));
-    std::unique_ptr<Instruction> decoded(decoder->decode(&anchor_word));
+    auto decode_result = decoder->decode(&anchor_word);
+    ASSERT_TRUE(decode_result.succeeded());
+    std::unique_ptr<Instruction> decoded = std::move(decode_result).value();
     ASSERT_NE(decoded, nullptr);
     EXPECT_NE(decoded->mnemonic().find("s_branch"), std::string_view::npos)
         << "Anchor at offset " << anchor_offsets_[anchor_idx]

--- a/emulation/rocjitsu/tests/dbi/hsa_dbi_nop_probe_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/hsa_dbi_nop_probe_test.cpp
@@ -70,9 +70,10 @@ bool decodes_mnemonic_within(Decoder &decoder, std::span<const uint8_t> text, ui
     rj_code_binary_inst_t word_buf[2] = {0, 0};
     const size_t avail = std::min<size_t>(sizeof(word_buf), text.size() - cur);
     std::memcpy(word_buf, text.data() + cur, avail);
-    std::unique_ptr<Instruction> inst(decoder.decode(word_buf));
-    if (!inst)
+    auto decoded = decoder.decode(word_buf);
+    if (decoded.failed())
       return false;
+    std::unique_ptr<Instruction> inst = std::move(decoded).value();
     if (inst->mnemonic() == mnemonic)
       return true;
     cur += static_cast<uint64_t>(inst->size());
@@ -127,7 +128,9 @@ protected:
     // test stays stable across compiler revisions.
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA2);
     ASSERT_NE(decoder, nullptr);
-    auto blocks = BasicBlock::build(*co, *decoder, ROCJITSU_CODE_ARCH_CDNA2);
+    auto block_result = BasicBlock::build(*co, *decoder, ROCJITSU_CODE_ARCH_CDNA2);
+    ASSERT_TRUE(block_result.succeeded());
+    auto blocks = std::move(block_result).value();
     ASSERT_FALSE(co->text_sections().empty());
     const auto *text = co->text_sections().front();
     const std::span<const uint8_t> text_bytes(reinterpret_cast<const uint8_t *>(text->data()),
@@ -236,7 +239,9 @@ TEST_F(HsaDbiNopProbeStatic, PatchedElfContainsProbeCallInstrumentation) {
   ASSERT_GT(text->size(), anchor_offset_ + sizeof(uint32_t));
   rj_code_binary_inst_t anchor_word = 0;
   std::memcpy(&anchor_word, text->data() + anchor_offset_, sizeof(anchor_word));
-  std::unique_ptr<Instruction> anchor_inst(decoder->decode(&anchor_word));
+  auto decoded = decoder->decode(&anchor_word);
+  ASSERT_TRUE(decoded.succeeded());
+  std::unique_ptr<Instruction> anchor_inst = std::move(decoded).value();
   ASSERT_NE(anchor_inst, nullptr);
   EXPECT_NE(anchor_inst->mnemonic().find("s_branch"), std::string_view::npos)
       << "Anchor at offset " << anchor_offset_ << " should decode as s_branch; got "

--- a/emulation/rocjitsu/tests/dbi/probe_fixture_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/probe_fixture_test.cpp
@@ -63,7 +63,9 @@ TEST(ProbeFixture, NopProbeResolvesAndReturns) {
   std::string last_mnemonic;
   size_t w = 0;
   while (w < num_words) {
-    std::unique_ptr<Instruction> inst(decoder->decode(&body[w]));
+    auto decoded = decoder->decode(&body[w]);
+    ASSERT_TRUE(decoded.succeeded());
+    std::unique_ptr<Instruction> inst = std::move(decoded).value();
     ASSERT_NE(inst, nullptr);
     const int size = inst->size();
     ASSERT_TRUE(size == 4 || size == 8) << "unexpected instruction size in probe body";

--- a/emulation/rocjitsu/tests/dbt/device_kernels_translate_tests.cpp
+++ b/emulation/rocjitsu/tests/dbt/device_kernels_translate_tests.cpp
@@ -9,6 +9,7 @@
 #endif
 
 #include "../test_paths.h"
+#include "decode_test_util.h"
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/builders/instruction_builder.h"
@@ -188,24 +189,17 @@ TEST(BinaryTranslatorE2E, TranslateVectorAddCdna4ToCdna3) {
     const size_t words = sec->size() / sizeof(uint32_t);
     size_t pc = 0;
     while (pc < words) {
-      try {
-        std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(&data[pc]));
-        if (!inst) {
-          ++decode_failures;
-          ++pc;
-          continue;
-        }
-        const std::string_view mnemonic(inst->mnemonic());
-        if (mnemonic.starts_with("v_add_"))
-          has_vector_add = true;
-        pc += inst->size() / 4;
-        ++inst_count;
-      } catch (const std::exception &e) {
-        std::cerr << "  decode fail at 0x" << std::hex << pc * 4 << " word=0x" << data[pc] << ": "
-                  << e.what() << "\n";
+      std::unique_ptr<rocjitsu::Instruction> inst(decode_valid(*decoder, &data[pc]));
+      if (!inst) {
         ++decode_failures;
         ++pc;
+        continue;
       }
+      const std::string_view mnemonic(inst->mnemonic());
+      if (mnemonic.starts_with("v_add_"))
+        has_vector_add = true;
+      pc += inst->size() / 4;
+      ++inst_count;
     }
   }
   EXPECT_GT(inst_count, 0) << "Translated text section should contain instructions";
@@ -614,7 +608,7 @@ TEST(BinaryTranslatorE2E,
   ASSERT_LT(original_info->entry_text_offset, text->size());
 
   std::unique_ptr<rocjitsu::Instruction> original_entry(
-      decoder->decode(&words[original_info->entry_text_offset / sizeof(uint32_t)]));
+      decode_valid(*decoder, &words[original_info->entry_text_offset / sizeof(uint32_t)]));
   ASSERT_NE(original_entry, nullptr);
   EXPECT_NE(std::string_view(original_entry->mnemonic()), "s_branch")
       << "Original kernel entry should not be replaced by a prologue branch stub";
@@ -626,7 +620,7 @@ TEST(BinaryTranslatorE2E,
 
   const auto *redirected_words = reinterpret_cast<const uint32_t *>(text->data());
   std::unique_ptr<rocjitsu::Instruction> redirected_entry(
-      decoder->decode(&redirected_words[redirected_section_offset / sizeof(uint32_t)]));
+      decode_valid(*decoder, &redirected_words[redirected_section_offset / sizeof(uint32_t)]));
   ASSERT_NE(redirected_entry, nullptr);
   EXPECT_EQ(std::string_view(redirected_entry->mnemonic()), "s_mov_b32")
       << "Redirected kernel entry should begin with the descriptor ABI prologue";
@@ -726,7 +720,7 @@ TEST(BinaryTranslatorE2E, OutputDecodesAsValidRdna4) {
     size_t pc = 0;
     while (pc < words) {
       try {
-        std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(&data[pc]));
+        std::unique_ptr<rocjitsu::Instruction> inst(decode_valid(*decoder, &data[pc]));
         if (!inst) {
           ++decode_failures;
           ++pc;
@@ -768,7 +762,7 @@ TEST(BinaryTranslatorE2E, NoGfx9WaitcntInOutput) {
     size_t pc = 0;
     while (pc < words) {
       try {
-        std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(&data[pc]));
+        std::unique_ptr<rocjitsu::Instruction> inst(decode_valid(*decoder, &data[pc]));
         if (!inst) {
           ++pc;
           continue;
@@ -852,7 +846,7 @@ TEST(BinaryTranslatorE2E, DumpTranslation) {
     printf("\n--- %s (%zu bytes, %zu words) ---\n", label, size, words);
     while (pc < words) {
       try {
-        std::unique_ptr<rocjitsu::Instruction> inst(dec->decode(&data[pc]));
+        std::unique_ptr<rocjitsu::Instruction> inst(decode_valid(*dec, &data[pc]));
         if (!inst) {
           printf("  0x%04zx: ???\n", pc * 4);
           ++pc;

--- a/emulation/rocjitsu/tests/dbt/multikernel_indirect_branch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/multikernel_indirect_branch_test.cpp
@@ -8,6 +8,7 @@
 #error "multikernel_indirect_branch_test.cpp requires HAS_DEVICE_KERNELS"
 #endif
 
+#include "decode_test_util.h"
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/basic_block.h"
@@ -47,7 +48,7 @@ size_t count_text_mnemonic(const rocjitsu::AmdGpuCodeObject &co, rj_code_arch_t 
     size_t word_offset = 0;
     while (word_offset < word_count) {
       std::unique_ptr<rocjitsu::Instruction> inst(
-          decoder->decode(words + word_offset, word_offset * sizeof(rj_code_binary_inst_t)));
+          decode_valid(*decoder, words + word_offset, word_offset * sizeof(rj_code_binary_inst_t)));
       if (!inst) {
         ++word_offset;
         continue;
@@ -177,7 +178,7 @@ cfg_block_counts_by_kernel(const rocjitsu::AmdGpuCodeObject &co,
     return counts;
 
   auto blocks =
-      rocjitsu::BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, kernel_entry_leaders);
+      rocjitsu::build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, kernel_entry_leaders);
 
   for (const char *name : kernel_names) {
     const auto *kernel = kernel_translation_by_name(source_kernels, co, name);
@@ -283,7 +284,7 @@ TEST(BinaryTranslatorE2E, BuildsCfgForRealMultiKernelIndirectBranches) {
   auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
   auto blocks =
-      rocjitsu::BasicBlock::build(*co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, kernel_entries);
+      rocjitsu::build_valid_blocks(*co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, kernel_entries);
   ASSERT_FALSE(blocks.empty());
 
   size_t recovered_swappc_blocks = 0;
@@ -367,7 +368,7 @@ TEST(BinaryTranslatorE2E, CountsRealMultiKernelIndirectBranchCfgBlocksPerKernel)
   auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
   auto blocks =
-      rocjitsu::BasicBlock::build(*co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, kernel_entry_leaders);
+      rocjitsu::build_valid_blocks(*co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, kernel_entry_leaders);
   ASSERT_FALSE(blocks.empty());
 
   struct ExpectedKernelCfg {

--- a/emulation/rocjitsu/tests/dbt/relocation_function_table_hip_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/relocation_function_table_hip_test.cpp
@@ -8,6 +8,7 @@
 #error "relocation_function_table_hip_test.cpp requires a gfx1250-capable device compiler"
 #endif
 
+#include "decode_test_util.h"
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/basic_block.h"
@@ -98,7 +99,7 @@ TEST(RelocationFunctionTableHip, TranslatesEightWayDeviceDispatch) {
   auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   const auto blocks =
-      rocjitsu::BasicBlock::build(*source, *decoder, ROCJITSU_CODE_ARCH_GFX1250, source_targets);
+      rocjitsu::build_valid_blocks(*source, *decoder, ROCJITSU_CODE_ARCH_GFX1250, source_targets);
   const auto dispatches =
       rocjitsu::analyze_relocation_pairs(blocks, source_tables, source->text_sections()[0]->vaddr())
           .dispatches;

--- a/emulation/rocjitsu/tests/dbt/semantic_scratch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/semantic_scratch_test.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include "decode_test_util.h"
 #include "rocjitsu/analysis/exec_state.h"
 #include "rocjitsu/analysis/liveness.h"
 #include "rocjitsu/code/basic_block.h"
@@ -65,7 +66,7 @@ std::vector<std::unique_ptr<BasicBlock>> build_scratch_test_blocks() {
   constexpr std::array words = {move[0], end[0]};
   ScratchTestCodeObject code(words);
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
-  return BasicBlock::build(code, *decoder, ROCJITSU_CODE_ARCH_CDNA3);
+  return build_valid_blocks(code, *decoder, ROCJITSU_CODE_ARCH_CDNA3);
 }
 
 std::vector<BasicBlock *>
@@ -221,7 +222,7 @@ TEST(SemanticScratchAllocator, GprIndexModeWriteBypassesKernelUnusedTier) {
   ScratchTestCodeObject code(words);
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(code, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(code, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_EQ(blocks.size(), 1u);
   auto scope = scratch_test_scope(blocks);
 

--- a/emulation/rocjitsu/tests/dbt/support/translate_test_support.cpp
+++ b/emulation/rocjitsu/tests/dbt/support/translate_test_support.cpp
@@ -5,6 +5,7 @@
 /// @brief Shared fixture implementations for CPU-only DBT translation tests.
 
 #include "translate_test_support.h"
+#include "decode_test_util.h"
 
 #include "elf_test_support.h"
 #include "rocjitsu/code/amdgpu_code_object.h"
@@ -321,7 +322,7 @@ std::unique_ptr<Instruction> decode_one(uint32_t word, rj_code_arch_t arch) {
   auto decoder = Decoder::create(arch);
   if (!decoder)
     return nullptr;
-  return std::unique_ptr<Instruction>(decoder->decode(&word));
+  return std::unique_ptr<Instruction>(decode_valid(*decoder, &word));
 }
 
 bool has_error_containing(const TranslatedCodeObject &result, DiagnosticKind kind,

--- a/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
@@ -4,6 +4,7 @@
 /// @file translate_gfx1250_test.cpp
 /// @brief CPU-only tests for gfx1250 revision translation.
 
+#include "decode_test_util.h"
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/builders/instruction_builder.h"
@@ -1215,7 +1216,7 @@ void expect_cdna3_text_matches(const rocjitsu::Section &text,
   std::vector<std::unique_ptr<rocjitsu::Instruction>> actual;
   for (size_t pc = 0; pc < word_count;) {
     SCOPED_TRACE(pc);
-    auto inst = std::unique_ptr<rocjitsu::Instruction>(decoder->decode(&words[pc]));
+    auto inst = std::unique_ptr<rocjitsu::Instruction>(decode_valid(*decoder, &words[pc]));
     ASSERT_NE(inst, nullptr);
     ASSERT_GT(inst->size(), 0u);
     ASSERT_EQ(inst->size() % sizeof(uint32_t), 0u);
@@ -1843,7 +1844,7 @@ decode_text_instructions(const rocjitsu::Section &text, rj_code_arch_t arch) {
   size_t word_offset = 0;
   while (word_offset < word_count) {
     std::unique_ptr<rocjitsu::Instruction> inst(
-        decoder->decode(words + word_offset, word_offset * sizeof(rj_code_binary_inst_t)));
+        decode_valid(*decoder, words + word_offset, word_offset * sizeof(rj_code_binary_inst_t)));
     if (!inst)
       break;
     word_offset += static_cast<size_t>(inst->size()) / sizeof(rj_code_binary_inst_t);
@@ -7657,7 +7658,7 @@ run_gfx1250_e5m3_replacement(uint16_t opcode, uint8_t opsel, Gfx1250E5m3Operand 
       opcode == cdna5::kVCvtPkFp8F32Vop3 ? "v_cvt_pk_fp8_f32" : "v_cvt_sr_fp8_f32";
   bool borrowed_a_carrier = false;
   for (size_t index = 0; index < word_count;) {
-    std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(text + index));
+    std::unique_ptr<rocjitsu::Instruction> inst(decode_valid(*decoder, text + index));
     if (inst == nullptr) {
       ADD_FAILURE() << "undecodable replacement word at " << index;
       return std::nullopt;
@@ -8748,7 +8749,9 @@ TEST(SemanticTranslator, Gfx1250ResidualChecksRecognizeEveryActionableSourceRule
                                           rocjitsu::ProcessorRevision::Gfx1250A0);
   for (size_t sample_index = 0; sample_index < samples.size(); ++sample_index) {
     SCOPED_TRACE(sample_index);
-    std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(samples[sample_index].data(), 0));
+    rocjitsu::DecodeResult decoded = decoder->decode(samples[sample_index].data(), 0);
+    ASSERT_TRUE(decoded.succeeded());
+    std::unique_ptr<rocjitsu::Instruction> inst = std::move(decoded).value();
     ASSERT_NE(inst, nullptr);
     EXPECT_EQ(inst->encoding_id(), residual_rules[sample_index]->src_encoding_id);
     EXPECT_EQ(inst->opcode(), residual_rules[sample_index]->src_opcode);
@@ -9351,7 +9354,7 @@ TEST(BinaryTranslatorE2E, Gfx1250F16K128WmmaLoweringMatchesUnloweredExecution) {
 
   std::vector<uint32_t> body_words;
   for (size_t offset = 0; offset < text_word_count;) {
-    std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(text_words + offset));
+    std::unique_ptr<rocjitsu::Instruction> inst(decode_valid(*decoder, text_words + offset));
     ASSERT_NE(inst, nullptr) << "translated word " << offset << " failed to decode";
     const std::string_view mnemonic(inst->mnemonic());
     if (mnemonic == "s_endpgm")
@@ -9449,7 +9452,7 @@ TEST(BinaryTranslatorE2E, Gfx1250F16K128WmmaLoweringMatchesUnloweredExecution) {
 
   auto run_source = [&] {
     const std::array<uint32_t, 2> words = {matrix[0], matrix[1]};
-    std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<rocjitsu::Instruction> inst(decode_valid(*decoder, words.data()));
     EXPECT_NE(inst, nullptr);
     EXPECT_EQ(std::string_view(inst->mnemonic()), "v_wmma_f16_16x16x128_fp8_fp8");
     cu->execute_instruction(inst.get(), *wf);
@@ -9457,7 +9460,8 @@ TEST(BinaryTranslatorE2E, Gfx1250F16K128WmmaLoweringMatchesUnloweredExecution) {
 
   auto run_lowered = [&] {
     for (size_t offset = 0; offset < body_words.size();) {
-      std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(body_words.data() + offset));
+      std::unique_ptr<rocjitsu::Instruction> inst(
+          decode_valid(*decoder, body_words.data() + offset));
       ASSERT_NE(inst, nullptr);
       cu->execute_instruction(inst.get(), *wf);
       offset += static_cast<size_t>(inst->size()) / sizeof(uint32_t);
@@ -12891,7 +12895,7 @@ TEST(BinaryTranslatorE2E, Gfx1250Standalone32x16Fp4SplitMatchesUnsplitExecution)
   // Collect the translated body, stopping at the terminator.
   std::vector<uint32_t> body_words;
   for (size_t offset = 0; offset < text_word_count;) {
-    std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(text_words + offset));
+    std::unique_ptr<rocjitsu::Instruction> inst(decode_valid(*decoder, text_words + offset));
     ASSERT_NE(inst, nullptr) << "translated word " << offset << " failed to decode";
     if (std::string_view(inst->mnemonic()) == "s_endpgm")
       break;
@@ -12979,7 +12983,7 @@ TEST(BinaryTranslatorE2E, Gfx1250Standalone32x16Fp4SplitMatchesUnsplitExecution)
   zero_destination();
   {
     const std::array<uint32_t, 2> words = {matrix[0], matrix[1]};
-    std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<rocjitsu::Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), "v_wmma_f32_32x16x128_f4");
     cu->execute_instruction(inst.get(), *wf);
@@ -13001,7 +13005,7 @@ TEST(BinaryTranslatorE2E, Gfx1250Standalone32x16Fp4SplitMatchesUnsplitExecution)
   zero_destination();
   size_t executed = 0;
   for (size_t offset = 0; offset < body_words.size();) {
-    std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(body_words.data() + offset));
+    std::unique_ptr<rocjitsu::Instruction> inst(decode_valid(*decoder, body_words.data() + offset));
     ASSERT_NE(inst, nullptr);
     cu->execute_instruction(inst.get(), *wf);
     offset += static_cast<size_t>(inst->size()) / sizeof(uint32_t);
@@ -14325,7 +14329,7 @@ TEST(BinaryTranslatorE2E, Gfx1250StagesFlatScratchBaseInDestinationWhenSgprsAreL
   ASSERT_NE(decoder, nullptr);
   bool found_rewritten_add = false;
   for (size_t offset = 0; offset < out_words;) {
-    std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(out + offset));
+    std::unique_ptr<rocjitsu::Instruction> inst(decode_valid(*decoder, out + offset));
     ASSERT_NE(inst, nullptr) << "translated word " << offset << " failed to decode";
     if (std::string_view(inst->mnemonic()) == "v_add_nc_u64") {
       ASSERT_NE(inst->raw_encoding(), nullptr);
@@ -14394,7 +14398,7 @@ TEST(BinaryTranslatorE2E, Gfx1250DestinationStagingExecutesInMatchingNonzeroBank
   auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   for (size_t offset = 0; offset < translated_count;) {
-    std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(translated_words + offset));
+    std::unique_ptr<rocjitsu::Instruction> inst(decode_valid(*decoder, translated_words + offset));
     ASSERT_NE(inst, nullptr) << "translated word " << offset << " failed to decode";
     if (std::string_view(inst->mnemonic()) == "s_endpgm")
       break;

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -1030,15 +1030,20 @@ public:
 
 class RewriteDischargeBoundTestDecoder final : public Decoder {
 public:
-  RewriteDischargeBoundTestDecoder(size_t max_instruction_words, size_t decoded_words)
-      : max_instruction_words_(max_instruction_words), decoded_words_(decoded_words) {}
+  RewriteDischargeBoundTestDecoder(size_t max_instruction_words, size_t decoded_words,
+                                   bool reject = false)
+      : max_instruction_words_(max_instruction_words), decoded_words_(decoded_words),
+        reject_(reject) {}
 
   std::size_t max_instruction_words() const override { return max_instruction_words_; }
 
-  Instruction *decode(const rj_code_binary_inst_t *words) override {
+  DecodeResult decode(const rj_code_binary_inst_t *words,
+                      const DecodeErrorEmitter &emit_error) override {
     ++decode_calls;
     observed_words.assign(words, words + max_instruction_words_);
-    return new RewriteDischargeBoundTestInstruction(decoded_words_);
+    if (reject_)
+      return emit_error.emit() << "test decoder rejected encoding";
+    return std::make_unique<RewriteDischargeBoundTestInstruction>(decoded_words_);
   }
 
   size_t decode_calls = 0;
@@ -1047,6 +1052,7 @@ public:
 private:
   size_t max_instruction_words_;
   size_t decoded_words_;
+  bool reject_;
 };
 
 TEST(BinaryTranslatorInternal, RewriteDischargeDecodeRejectsWidthBeyondDecoderMaximum) {
@@ -1079,6 +1085,22 @@ TEST(BinaryTranslatorInternal, RewriteDischargeDecodeRejectsZeroBoundWithoutDeco
             internal::RewriteDischargeDecodeStatus::InvalidLookaheadBound);
   EXPECT_EQ(instruction, nullptr);
   EXPECT_EQ(decoder.decode_calls, 0u);
+}
+
+TEST(BinaryTranslatorInternal, RewriteDischargeDecodeReportsRejectedEncoding) {
+  RewriteDischargeBoundTestDecoder decoder(/*max_instruction_words=*/1, /*decoded_words=*/1,
+                                           /*reject=*/true);
+  internal::RewriteDischargeInstructionDecoder bounded_decoder(decoder);
+  constexpr std::array<uint32_t, 1> words = {0x11111111u};
+  const auto bytes =
+      std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(words.data()), sizeof(words));
+  std::unique_ptr<Instruction> instruction;
+  util::StringDiagnostic decode_error;
+
+  EXPECT_EQ(bounded_decoder.decode(bytes, /*source_offset=*/8, instruction, decode_error.emitter()),
+            internal::RewriteDischargeDecodeStatus::InvalidEncoding);
+  EXPECT_EQ(instruction, nullptr);
+  EXPECT_EQ(decode_error.message(), "test decoder rejected encoding");
 }
 
 TEST(BinaryTranslatorInternal, RewriteDischargeDecodeClearsUnusedWordsAcrossCalls) {

--- a/emulation/rocjitsu/tests/decode_execute_benchmark.cpp
+++ b/emulation/rocjitsu/tests/decode_execute_benchmark.cpp
@@ -11,6 +11,7 @@
 /// This benchmark is NOT a pass/fail gate — it reports numbers for tracking
 /// performance regressions across changesets.
 
+#include "decode_test_util.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
@@ -95,7 +96,7 @@ std::vector<CorpusEntry> build_corpus(const TestEncEntry *encodings, size_t num_
 
     // Try decode — skip if the synthesized encoding doesn't decode.
     try {
-      auto *inst = decoder.decode(te.words.data());
+      auto *inst = decode_valid(decoder, te.words.data());
       if (inst) {
         corpus.push_back({te.mnemonic, te.words, cat});
         delete inst;
@@ -177,7 +178,7 @@ void run_benchmark(rj_code_arch_t arch, std::string_view arch_name, const TestEn
   auto decode_start = Clock::now();
   for (int iter = 0; iter < ITERATIONS; ++iter) {
     for (const auto &entry : corpus) {
-      auto *inst = decoder->decode(entry.words.data());
+      auto *inst = decode_valid(*decoder, entry.words.data());
       delete inst;
     }
   }
@@ -194,7 +195,7 @@ void run_benchmark(rj_code_arch_t arch, std::string_view arch_name, const TestEn
   auto full_start = Clock::now();
   for (int iter = 0; iter < ITERATIONS; ++iter) {
     for (const auto *entry : executable) {
-      auto *inst = decoder->decode(entry->words.data());
+      auto *inst = decode_valid(*decoder, entry->words.data());
       if (inst) {
         try {
           cu->execute_instruction(inst, *wf);

--- a/emulation/rocjitsu/tests/decode_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/decode_smoke_test.cpp
@@ -22,6 +22,7 @@
 ///   0xBFB00000 = s_endpgm (op = 48) — RDNA3/3.5/4
 ///                                     (GFX11/12: op=1 is s_setkill; s_endpgm moved to op=48)
 
+#include "decode_test_util.h"
 #include "rocjitsu/analysis/def_use_chain.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/builders.h"
@@ -54,7 +55,6 @@
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
 #include "rocjitsu/vm/amdgpu/register_access.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
-#include "util/except.h"
 
 #include <gtest/gtest.h>
 
@@ -65,6 +65,7 @@
 #include <format>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -115,13 +116,62 @@ struct DecodeCase {
 
 class DecoderSmokeTest : public ::testing::TestWithParam<DecodeCase> {};
 
+TEST(DecoderDiagnosticTest, ValidEncodingEmitsNothingAndKeepsLocation) {
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  std::vector<std::string> messages;
+  auto collect = [&](std::string_view message) { messages.emplace_back(message); };
+
+  DecodeResult decoded = decoder->decode(&S_NOP, 24, DecodeErrorEmitter(collect));
+
+  ASSERT_TRUE(decoded.succeeded());
+  EXPECT_EQ(decoded.value()->src_loc(), 24u);
+  EXPECT_TRUE(messages.empty());
+}
+
+TEST(DecoderDiagnosticTest, InvalidOpcodeEmitsExactlyOneDiagnostic) {
+  constexpr uint32_t invalid_opcode = 0xffffffffu;
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  std::vector<std::string> messages;
+  auto collect = [&](std::string_view message) { messages.emplace_back(message); };
+
+  DecodeResult decoded = decoder->decode(&invalid_opcode, DecodeErrorEmitter(collect));
+
+  EXPECT_TRUE(decoded.failed());
+  ASSERT_EQ(messages.size(), 1u);
+  EXPECT_EQ(messages.front(), "Invalid instruction opcode: FFFFFFFF");
+}
+
+TEST(DecoderDiagnosticTest, InvalidOperandEmitsExactlyOneDiagnostic) {
+  constexpr auto words = cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 209, .vdst = 0});
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  std::vector<std::string> messages;
+  auto collect = [&](std::string_view message) { messages.emplace_back(message); };
+
+  DecodeResult decoded = decoder->decode(words.data(), DecodeErrorEmitter(collect));
+
+  EXPECT_TRUE(decoded.failed());
+  ASSERT_EQ(messages.size(), 1u);
+  EXPECT_EQ(messages.front(), "invalid operand selector");
+}
+
+TEST(DecoderDiagnosticTest, NoOpEmitterStillRejectsInvalidOpcode) {
+  constexpr uint32_t invalid_opcode = 0xffffffffu;
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+
+  EXPECT_TRUE(decoder->decode(&invalid_opcode).failed());
+}
+
 TEST_P(DecoderSmokeTest, DecodesCorrectly) {
   const DecodeCase &tc = GetParam();
 
   auto decoder = Decoder::create(tc.arch);
   ASSERT_NE(decoder, nullptr) << "Decoder::create() returned nullptr for arch=" << tc.arch_name;
 
-  std::unique_ptr<Instruction> inst(decoder->decode(&tc.word));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, &tc.word));
   ASSERT_NE(inst, nullptr) << "decode() returned nullptr for arch=" << tc.arch_name << " word=0x"
                            << std::hex << tc.word;
 
@@ -137,7 +187,7 @@ TEST(Gfx1250DecodeTest, DisassemblesDpp8Selectors) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->size(), 8);
   EXPECT_EQ(inst->mnemonic(), "v_fract_f32_dpp");
@@ -200,14 +250,14 @@ TEST(ScalarRegisterSelectorDecodeTest, Rdna1AndRdna2RejectReservedHole) {
     for (const auto &[words, expected_selector] :
          {std::pair{&lower, 123}, std::pair{&upper, 125}}) {
       std::unique_ptr<Instruction> inst;
-      ASSERT_NO_THROW(inst.reset(decoder->decode(words->data())));
+      inst.reset(decode_valid(*decoder, words->data()));
       ASSERT_NE(inst, nullptr);
       ASSERT_EQ(inst->num_dst_operands(), 1);
       ASSERT_NE(inst->dst_operand(0), nullptr);
       EXPECT_EQ(inst->dst_operand(0)->encoding_value(), expected_selector);
     }
 
-    EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(hole.data())), util::InvalidInst);
+    EXPECT_TRUE(decode_fails(*decoder, hole.data()));
   };
 
   validate(ROCJITSU_CODE_ARCH_RDNA1, "rdna1", rdna1_lower, rdna1_hole, rdna1_upper);
@@ -223,36 +273,35 @@ TEST(OperandSelectorDecodeTest, Cdna1SdstRejectsReservedHole) {
   ASSERT_NE(decoder, nullptr);
   for (const auto &[word, expected_selector] : {std::pair{lower, 124}, std::pair{upper, 126}}) {
     std::unique_ptr<Instruction> inst;
-    ASSERT_NO_THROW(inst.reset(decoder->decode(&word)));
+    inst.reset(decode_valid(*decoder, &word));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(inst->num_dst_operands(), 1);
     ASSERT_NE(inst->dst_operand(0), nullptr);
     EXPECT_EQ(inst->dst_operand(0)->encoding_value(), expected_selector);
   }
 
-  EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(&hole)), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, &hole));
 }
 
 TEST(OperandSelectorDecodeTest, Cdna1RestrictedScalarSourceRejectsLiteralSelector) {
   cdna1::Operand valid(32, cdna1::OperandType::OPR_SSRC_NOLIT, 253);
-  EXPECT_NO_THROW(valid.validate_encoding());
+  EXPECT_TRUE(valid.validate_encoding().succeeded());
 
   cdna1::Operand invalid(32, cdna1::OperandType::OPR_SSRC_NOLIT, 255);
-  EXPECT_THROW(invalid.validate_encoding(), util::InvalidInst);
+  EXPECT_TRUE(invalid.validate_encoding().failed());
 }
 
 TEST(OperandSelectorDecodeTest, DirectSourceAndSmemOffsetRejectReservedSelectors) {
   constexpr auto vop1 = cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 209, .vdst = 0});
   auto gfx1250_decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(gfx1250_decoder, nullptr);
-  EXPECT_THROW(std::unique_ptr<Instruction>(gfx1250_decoder->decode(vop1.data())),
-               util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*gfx1250_decoder, vop1.data()));
 
   constexpr auto smem =
       cdna1::build_smem(cdna1::kSLoadDwordSmem, {.soffset_en = 1, .soffset = 125});
   auto cdna1_decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA1);
   ASSERT_NE(cdna1_decoder, nullptr);
-  EXPECT_THROW(std::unique_ptr<Instruction>(cdna1_decoder->decode(smem.data())), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*cdna1_decoder, smem.data()));
 }
 
 TEST(OperandSelectorDecodeTest, RestrictedVectorAndLaneOperandsRejectLiteralMarkers) {
@@ -265,7 +314,7 @@ TEST(OperandSelectorDecodeTest, RestrictedVectorAndLaneOperandsRejectLiteralMark
       words[i] = encoding[i];
     words[encoding.size()] = 7;
     words[encoding.size() + 1] = 0;
-    EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(words.data())), util::InvalidInst);
+    EXPECT_TRUE(decode_fails(*decoder, words.data()));
   };
 
   for (const uint16_t marker : {uint16_t{254}, uint16_t{255}}) {
@@ -290,7 +339,7 @@ TEST(OperandSelectorDecodeTest, Gfx1250WmmaSrc2ValidatesVgprOrInlineSelector) {
     SCOPED_TRACE(selector);
     const auto words = words_for(selector);
     std::unique_ptr<Instruction> inst;
-    ASSERT_NO_THROW(inst.reset(decoder->decode(words.data())));
+    inst.reset(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(inst->num_src_operands(), 3);
     ASSERT_NE(inst->src_operand(2), nullptr);
@@ -302,7 +351,7 @@ TEST(OperandSelectorDecodeTest, Gfx1250WmmaSrc2ValidatesVgprOrInlineSelector) {
        {uint16_t{209}, uint16_t{239}, uint16_t{249}, uint16_t{253}, uint16_t{255}}) {
     SCOPED_TRACE(selector);
     const auto words = words_for(selector);
-    EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(words.data())), util::InvalidInst);
+    EXPECT_TRUE(decode_fails(*decoder, words.data()));
   }
 
   for (const uint16_t selector : {uint16_t{0}, uint16_t{8}, uint16_t{129}, uint16_t{256}}) {
@@ -312,7 +361,7 @@ TEST(OperandSelectorDecodeTest, Gfx1250WmmaSrc2ValidatesVgprOrInlineSelector) {
                            {.vdst = 0, .src0 = 256, .src1 = 256, .src2 = selector});
     const std::array<uint32_t, 4> words{encoding[0], encoding[1], 0, 0};
     std::unique_ptr<Instruction> inst;
-    ASSERT_NO_THROW(inst.reset(decoder->decode(words.data())));
+    inst.reset(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_NE(inst->src_operand(2), nullptr);
     EXPECT_EQ(inst->src_operand(2)->encoding_value(), selector);
@@ -330,7 +379,7 @@ TEST(OperandSelectorDecodeTest, Gfx1250AndRdna4ValidateBarrierIdSelectors) {
       SCOPED_TRACE(static_cast<int>(selector));
       const auto words = build(selector);
       std::unique_ptr<Instruction> inst;
-      ASSERT_NO_THROW(inst.reset(decoder->decode(words.data())));
+      inst.reset(decode_valid(*decoder, words.data()));
       ASSERT_NE(inst, nullptr);
       ASSERT_EQ(inst->num_src_operands(), 1);
       ASSERT_NE(inst->src_operand(0), nullptr);
@@ -340,14 +389,14 @@ TEST(OperandSelectorDecodeTest, Gfx1250AndRdna4ValidateBarrierIdSelectors) {
     for (const uint8_t selector : std::array<uint8_t, 4>{0, 126, 160, 192}) {
       SCOPED_TRACE(static_cast<int>(selector));
       const auto words = build(selector);
-      EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(words.data())), util::InvalidInst);
+      EXPECT_TRUE(decode_fails(*decoder, words.data()));
     }
 
     for (const uint8_t marker : {uint8_t{254}, uint8_t{255}}) {
       SCOPED_TRACE(static_cast<int>(marker));
       const auto base = build(marker);
       const std::array<uint32_t, 3> words = {base[0], 7, 0};
-      EXPECT_THROW(std::unique_ptr<Instruction>(decoder->decode(words.data())), util::InvalidInst);
+      EXPECT_TRUE(decode_fails(*decoder, words.data()));
     }
   };
 
@@ -392,7 +441,7 @@ TEST(RawEncodingTest, PreservesScalarLiteralWordsAcrossAmdgpuIsas) {
     auto decoder = Decoder::create(tc.arch);
     ASSERT_NE(decoder, nullptr) << tc.arch_name;
     std::unique_ptr<Instruction> inst;
-    ASSERT_NO_THROW(inst.reset(decoder->decode(words))) << tc.arch_name;
+    inst.reset(decode_valid(*decoder, words));
     ASSERT_NE(inst, nullptr) << tc.arch_name;
     ASSERT_EQ(inst->size(), sizeof(words)) << tc.arch_name;
     ASSERT_NE(inst->raw_encoding(), nullptr) << tc.arch_name;
@@ -406,7 +455,7 @@ TEST(SendmsgReturnDecodeTest, Rdna3Selector255DoesNotConsumeLiteral) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA3);
   ASSERT_NE(decoder, nullptr);
 
-  std::unique_ptr<Instruction> inst(decoder->decode(&word));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, &word));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "s_sendmsg_rtn_b32");
   EXPECT_EQ(inst->size(), sizeof(word));
@@ -422,7 +471,7 @@ TEST(FieldlessOperandDecodeTest, SaveexecExposesInertExecAndSccOperands) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
 
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_and_saveexec_b64");
   ASSERT_EQ(inst->num_dst_operands(), 3);
@@ -570,7 +619,7 @@ TEST(Rdna4WaitcntDecodeSmokeTest, FormatsCompatWaitcntWithGfx11Layout) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
   ASSERT_NE(decoder, nullptr);
 
-  std::unique_ptr<Instruction> inst(decoder->decode(&s_waitcnt_vmcnt1));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, &s_waitcnt_vmcnt1));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "s_waitcnt");
   EXPECT_EQ(inst->disassemble(), "s_waitcnt vmcnt(1) expcnt(0) lgkmcnt(0)");
@@ -598,7 +647,7 @@ TEST(CdnaF16DeclaredLiteralDecodeTest, MasksExtensionToDeclaredOperandWidth) {
     };
     auto decoder = Decoder::create(tc.arch);
     ASSERT_NE(decoder, nullptr);
-    std::unique_ptr<Instruction> inst(decoder->decode(words));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(inst->mnemonic(), tc.mnemonic);
 
@@ -751,7 +800,7 @@ TEST(Rdna3DecodeTest, GlobalFlatAllOnesSaddrIsNull) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "global_load_b64");
   // vaddr + the fieldless OPR_GPUMEM memory operand (saddr is null, so it
@@ -806,7 +855,7 @@ TEST_P(RdnaVopdDecodeSmokeTest, DecodesDualSlotForms) {
   auto decoder = Decoder::create(tc.arch);
   ASSERT_NE(decoder, nullptr) << tc.arch_name;
 
-  std::unique_ptr<Instruction> inst(decoder->decode(tc.words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, tc.words.data()));
   ASSERT_NE(inst, nullptr) << tc.arch_name << " " << tc.case_name;
   EXPECT_EQ(inst->mnemonic(), tc.expected_mnemonic);
   EXPECT_EQ(inst->size(), tc.expected_size_bytes);
@@ -887,8 +936,7 @@ TEST_P(InvalidVopdSlotDecodeTest, RejectsOpcodeOutsideProfileSlot) {
   auto decoder = Decoder::create(tc.arch);
   ASSERT_NE(decoder, nullptr) << tc.arch_name;
 
-  EXPECT_THROW(static_cast<void>(decoder->decode(tc.words.data())), util::InvalidInst)
-      << tc.arch_name << " " << tc.case_name;
+  EXPECT_TRUE(decode_fails(*decoder, tc.words.data())) << tc.arch_name << " " << tc.case_name;
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -929,7 +977,7 @@ TEST_P(RdnaInvalidVopdDecodeSmokeTest, DoesNotClaimVopd3Encoding) {
   auto decoder = Decoder::create(tc.arch);
   ASSERT_NE(decoder, nullptr) << tc.arch_name;
 
-  EXPECT_THROW(static_cast<void>(decoder->decode(tc.words.data())), util::InvalidInst)
+  EXPECT_TRUE(decode_fails(*decoder, tc.words.data()))
       << tc.arch_name << " should reserve the 0xCF VOPD3 prefix";
 }
 
@@ -993,7 +1041,7 @@ TEST_P(RdnaVopdExecutionSmokeTest, PreservesFpRoundingAndDx9ZeroSemantics) {
 
   auto decoder = Decoder::create(tc.arch);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
 
   const uint32_t vb = wf->vgpr_alloc().base;
@@ -1049,7 +1097,7 @@ TEST_P(RdnaVopdExecutionSmokeTest, DualCndmaskConsumesVccLo) {
 
   auto decoder = Decoder::create(tc.arch);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(kWords.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, kWords.data()));
   ASSERT_NE(inst, nullptr);
 
   const uint32_t vb = wf->vgpr_alloc().base;
@@ -1127,7 +1175,7 @@ TEST_P(RdnaVopdExecutionSmokeTest, DualCndmaskAfterScalarVccMerge) {
   auto decoder = Decoder::create(tc.arch);
   ASSERT_NE(decoder, nullptr);
   const auto execute = [&](const std::array<uint32_t, 3> &inst_words) {
-    std::unique_ptr<Instruction> inst(decoder->decode(inst_words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, inst_words.data()));
     ASSERT_NE(inst, nullptr);
     cu->execute_instruction(inst.get(), *wf);
   };
@@ -1333,7 +1381,7 @@ TEST_P(MubufLdsModifierTest, LdsModifierInDisassembly) {
   auto decoder = Decoder::create(tc.arch);
   ASSERT_NE(decoder, nullptr);
 
-  std::unique_ptr<Instruction> inst(decoder->decode(tc.words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, tc.words));
   ASSERT_NE(inst, nullptr) << "decode() returned nullptr for " << tc.arch_name;
   EXPECT_EQ(inst->mnemonic(), "buffer_load_dword");
 
@@ -1372,7 +1420,7 @@ TEST(Cdna3DecodeTest, DsRead2st64AccDestinationUsesAccumulatorRegisterClass) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "ds_read2st64_b32");
   EXPECT_EQ(inst->disassemble(), "ds_read2st64_b32 acc[62:63], v243");
@@ -1391,7 +1439,7 @@ TEST(Cdna3DecodeTest, MfmaAccCdUsesAccumulatorRegisterClassForCAndD) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_mfma_f32_32x32x8_bf16");
   EXPECT_EQ(inst->disassemble(),
@@ -1421,7 +1469,7 @@ TEST(Cdna3DecodeTest, MfmaAccBitsSelectIndependentMultiplicandBanks) {
   ASSERT_NE(decoder, nullptr);
   for (const auto &tc : cases) {
     const uint32_t words[] = {0xD3E08088u, tc.high_word};
-    std::unique_ptr<Instruction> inst(decoder->decode(words));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(inst->mnemonic(), "v_mfma_f32_32x32x8_bf16");
 
@@ -1439,7 +1487,7 @@ TEST(Cdna3DecodeTest, MfmaAccCdPreservesInlineConstantSrc2) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_mfma_f32_32x32x8_bf16");
   EXPECT_EQ(inst->disassemble(), "v_mfma_f32_32x32x8_bf16 acc[136:151], acc[84:85], acc[82:83], 0");
@@ -1461,14 +1509,14 @@ TEST(Cdna2DecodeTest, MemoryAccBitSelectsAccumulatorDestination) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA2);
   ASSERT_NE(decoder, nullptr);
   for (const auto &tc : cases) {
-    std::unique_ptr<Instruction> vgpr_inst(decoder->decode(tc.vgpr_words.data()));
+    std::unique_ptr<Instruction> vgpr_inst(decode_valid(*decoder, tc.vgpr_words.data()));
     ASSERT_NE(vgpr_inst, nullptr) << tc.mnemonic;
     ASSERT_EQ(vgpr_inst->mnemonic(), tc.mnemonic);
     const auto vgpr_dst = vgpr_inst->dst_operand(0)->to_register_ref();
     ASSERT_TRUE(vgpr_dst.has_value()) << vgpr_inst->disassemble();
     EXPECT_EQ(*vgpr_dst, (RegisterRef{RegClass::VGPR, 5, tc.width})) << vgpr_inst->disassemble();
 
-    std::unique_ptr<Instruction> accvgpr_inst(decoder->decode(tc.accvgpr_words.data()));
+    std::unique_ptr<Instruction> accvgpr_inst(decode_valid(*decoder, tc.accvgpr_words.data()));
     ASSERT_NE(accvgpr_inst, nullptr) << tc.mnemonic;
     ASSERT_EQ(accvgpr_inst->mnemonic(), tc.mnemonic);
     const auto accvgpr_dst = accvgpr_inst->dst_operand(0)->to_register_ref();
@@ -1487,7 +1535,7 @@ TEST(Gfx1250DecodeTest, FmamkF64ConsumesThreeDwords) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_fmamk_f64_e32");
   EXPECT_EQ(inst->size(), sizeof(words));
@@ -1505,7 +1553,7 @@ TEST(Gfx1250DecodeTest, FmaakF64ConsumesThreeDwords) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_fmaak_f64_e32");
   EXPECT_EQ(inst->size(), sizeof(words));
@@ -1521,7 +1569,7 @@ TEST(Gfx1250DecodeTest, Vop3True16DestinationUsesFullEightBitVgprIndex) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_and_b16");
   EXPECT_EQ(inst->size(), sizeof(words));
@@ -1545,7 +1593,7 @@ TEST(Gfx1250DecodeTest, FlatVaddrWidthFollowsSaddrMode) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
 
-  std::unique_ptr<Instruction> saddr_inst(decoder->decode(saddr_words));
+  std::unique_ptr<Instruction> saddr_inst(decode_valid(*decoder, saddr_words));
   ASSERT_NE(saddr_inst, nullptr);
   EXPECT_EQ(saddr_inst->mnemonic(), "flat_load_b64");
   EXPECT_EQ(saddr_inst->disassemble(), "flat_load_b64 v[2:3], v1, s[6:7]");
@@ -1566,7 +1614,7 @@ TEST(Gfx1250DecodeTest, FlatVaddrWidthFollowsSaddrMode) {
   EXPECT_FALSE(saddr_def_use.uses.contains({RegClass::VGPR, 1, 2}));
   EXPECT_TRUE(saddr_def_use.uses.contains({RegClass::SGPR, 6, 2}));
 
-  std::unique_ptr<Instruction> vector_only_inst(decoder->decode(vector_only_words));
+  std::unique_ptr<Instruction> vector_only_inst(decode_valid(*decoder, vector_only_words));
   ASSERT_NE(vector_only_inst, nullptr);
   EXPECT_EQ(vector_only_inst->mnemonic(), "flat_load_b64");
   EXPECT_EQ(vector_only_inst->num_src_operands(), 2); // vaddr + gpumem
@@ -1593,7 +1641,7 @@ TEST(Gfx1250DecodeTest, GlobalVaddrWidthFollowsSaddrMode) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
 
-  std::unique_ptr<Instruction> saddr_inst(decoder->decode(saddr_words));
+  std::unique_ptr<Instruction> saddr_inst(decode_valid(*decoder, saddr_words));
   ASSERT_NE(saddr_inst, nullptr);
   EXPECT_EQ(saddr_inst->mnemonic(), "global_load_b64");
   EXPECT_EQ(saddr_inst->disassemble(), "global_load_b64 v[2:3], v10, s[6:7]");
@@ -1614,7 +1662,7 @@ TEST(Gfx1250DecodeTest, GlobalVaddrWidthFollowsSaddrMode) {
   EXPECT_FALSE(saddr_def_use.uses.contains({RegClass::VGPR, 10, 2}));
   EXPECT_TRUE(saddr_def_use.uses.contains({RegClass::SGPR, 6, 2}));
 
-  std::unique_ptr<Instruction> vector_only_inst(decoder->decode(vector_only_words));
+  std::unique_ptr<Instruction> vector_only_inst(decode_valid(*decoder, vector_only_words));
   ASSERT_NE(vector_only_inst, nullptr);
   EXPECT_EQ(vector_only_inst->mnemonic(), "global_load_b64");
   EXPECT_EQ(vector_only_inst->num_src_operands(), 2); // vaddr + gpumem
@@ -1634,7 +1682,7 @@ TEST(Gfx1250DecodeTest, GlobalStoreUsesScalarOffsetVaddrWidth) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "global_store_b64");
   EXPECT_EQ(inst->disassemble(), "global_store_b64 v10, v[2:3], s[6:7]");
@@ -1651,7 +1699,7 @@ TEST(Gfx1250DecodeTest, Vop3CompareWritesSingleScalarMaskRegister) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_cmp_gt_u32");
   EXPECT_EQ(inst->size(), sizeof(words));
@@ -1673,7 +1721,7 @@ TEST(Cdna4DecodeTest, MfmaF8f6f4DecodesStandaloneVop3pSuffix) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_mfma_f32_16x16x128_f8f6f4");
   EXPECT_EQ(inst->size(), sizeof(words));
@@ -1701,7 +1749,7 @@ TEST(Cdna4DecodeTest, MfmaF8f6f4SourceWidthsFollowFormatSelectors) {
         0xD3AD0024u | (format << 8),
         0x00024100u | (format << 29),
     };
-    std::unique_ptr<Instruction> inst(decoder->decode(words));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(inst->mnemonic(), "v_mfma_f32_16x16x128_f8f6f4");
 
@@ -1725,7 +1773,7 @@ TEST(Cdna4DecodeTest, MfmaScaleF8f6f4ConsumesVop3px2Prefix) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_mfma_f32_16x16x128_f8f6f4");
   EXPECT_EQ(inst->size(), sizeof(words));
@@ -1744,7 +1792,7 @@ TEST(AccVgprSrcCanonicalizationTest, MalformedRawSrcBelow256StaysInUnifiedRange)
     ASSERT_NE(decoder, nullptr);
     for (uint32_t raw : {0u, 5u, 128u, 255u}) {
       const uint32_t words[] = {0xD3D84003u, 0x18000000u | raw};
-      std::unique_ptr<Instruction> inst(decoder->decode(words));
+      std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
       ASSERT_NE(inst, nullptr);
       EXPECT_EQ(inst->mnemonic(), "v_accvgpr_read");
       ASSERT_EQ(inst->num_src_operands(), 1);
@@ -1765,7 +1813,7 @@ TEST(AccVgprSrcCanonicalizationTest, LegalRawSrcResolvesToUnifiedAccIndex) {
     ASSERT_NE(decoder, nullptr);
     for (uint32_t n : {0u, 1u, 63u}) {
       const uint32_t words[] = {0xD3D84003u, 0x18000000u | (256u + n)};
-      std::unique_ptr<Instruction> inst(decoder->decode(words));
+      std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
       ASSERT_NE(inst, nullptr);
       EXPECT_EQ(inst->mnemonic(), "v_accvgpr_read");
       ASSERT_EQ(inst->num_src_operands(), 1);
@@ -1786,7 +1834,7 @@ TEST(Cdna4DecodeTest, RejectsVop3px2PrefixWithoutMfmaSuffix) {
       0xD3AC0000u,
       0x00000000u,
   };
-  EXPECT_THROW(static_cast<void>(decoder->decode(unrelated_opcode)), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, unrelated_opcode));
 
   const uint32_t wrong_encoding[] = {
       0xD3AC0000u,
@@ -1794,7 +1842,7 @@ TEST(Cdna4DecodeTest, RejectsVop3px2PrefixWithoutMfmaSuffix) {
       0xD32D0000u,
       0x00000000u,
   };
-  EXPECT_THROW(static_cast<void>(decoder->decode(wrong_encoding)), util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, wrong_encoding));
 }
 
 TEST(Cdna4DecodeTest, MfmaScaleF8f6f4AcceptsSecondVop3px2Suffix) {
@@ -1807,7 +1855,7 @@ TEST(Cdna4DecodeTest, MfmaScaleF8f6f4AcceptsSecondVop3px2Suffix) {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_mfma_f32_32x32x64_f8f6f4");
   EXPECT_EQ(inst->size(), sizeof(words));

--- a/emulation/rocjitsu/tests/decode_test_util.h
+++ b/emulation/rocjitsu/tests/decode_test_util.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_TESTS_DECODE_TEST_UTIL_H_
+#define ROCJITSU_TESTS_DECODE_TEST_UTIL_H_
+
+#include "rocjitsu/code/basic_block.h"
+#include "rocjitsu/isa/decoder.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+namespace rocjitsu {
+
+/// Decode an instruction encoding expected to be valid by the surrounding test.
+///
+/// Returning nullptr preserves the existing assertion style at valid-decode
+/// call sites while rejection-specific tests inspect DecodeResult directly.
+inline Instruction *decode_valid(Decoder &decoder, const rj_code_binary_inst_t *inst) {
+  DecodeResult result = decoder.decode(inst);
+  if (result.failed())
+    return nullptr;
+  return result.value().release();
+}
+
+inline Instruction *decode_valid(Decoder &decoder, const rj_code_binary_inst_t *inst,
+                                 uint64_t src_loc) {
+  DecodeResult result = decoder.decode(inst, src_loc);
+  if (result.failed())
+    return nullptr;
+  return result.value().release();
+}
+
+inline bool decode_fails(Decoder &decoder, const rj_code_binary_inst_t *inst) {
+  return decoder.decode(inst).failed();
+}
+
+/// Unwrap a block build expected to succeed by the surrounding test.
+inline std::vector<std::unique_ptr<BasicBlock>>
+build_valid_blocks(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
+                   std::span<const uint64_t> extra_leaders = {},
+                   ExternalEntryPolicy entry_policy = ExternalEntryPolicy::InferPredecessorless,
+                   std::span<const uint64_t> extra_split_points = {}) {
+  util::StringDiagnostic decode_error;
+  auto result = BasicBlock::build(co, decoder, arch, decode_error.emitter(), extra_leaders,
+                                  entry_policy, extra_split_points);
+  if (result.failed()) {
+    ADD_FAILURE() << "failed to build expected-valid blocks: " << decode_error.message();
+    return {};
+  }
+  return std::move(result).value();
+}
+
+} // namespace rocjitsu
+
+#endif // ROCJITSU_TESTS_DECODE_TEST_UTIL_H_

--- a/emulation/rocjitsu/tests/decoder_c_api_test.cpp
+++ b/emulation/rocjitsu/tests/decoder_c_api_test.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include "decode_test_util.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
@@ -132,7 +133,7 @@ TEST(DecoderCApiTest, HeapAllocationScopeForgetsDestroyedPool) {
 
   auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<rocjitsu::Instruction> instruction(decoder->decode(&kCdnaSEndpgm));
+  std::unique_ptr<rocjitsu::Instruction> instruction(decode_valid(*decoder, &kCdnaSEndpgm));
   ASSERT_NE(instruction, nullptr);
   EXPECT_EQ(instruction->mnemonic(), "s_endpgm");
 }

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -10,6 +10,7 @@
 /// Machine-level preservation below RegisterAccess must not add callbacks.
 
 #include "aql_queue.h"
+#include "decode_test_util.h"
 
 #include "embedded_schema.h"
 #include "rocjitsu/code/amdgpu_elf.h"
@@ -1063,7 +1064,7 @@ TEST(ExecutionPluginTest, ValuSimdReadObservationUsesActiveExecMask) {
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
     uint32_t words[4] = {vop2_encode(/*opcode=*/52, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256), 0u, 0u,
                          0u};
-    Instruction *inst = decoder->decode(words);
+    Instruction *inst = decode_valid(*decoder, words);
     ASSERT_NE(inst, nullptr);
     cu->execute_instruction(inst, *wf);
     delete inst;
@@ -1095,7 +1096,7 @@ TEST(ExecutionPluginTest, ValuSimdWriteObservationUsesActiveExecMask) {
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
     uint32_t words[4] = {vop2_encode(/*opcode=*/52, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256), 0u, 0u,
                          0u};
-    Instruction *inst = decoder->decode(words);
+    Instruction *inst = decode_valid(*decoder, words);
     ASSERT_NE(inst, nullptr);
     cu->execute_instruction(inst, *wf);
     delete inst;
@@ -1142,7 +1143,7 @@ TEST(ExecutionPluginTest, DppObservationReportsExactSourceAndDestinationLanes) {
         vop1_encode(/*opcode=*/1, kDst, amdgpu::SRC_DPP),
         vop1_dpp_word(kSrc, /*dpp_ctrl=*/0, /*row_mask=*/0x1, /*bank_mask=*/0x5),
     };
-    Instruction *inst = decoder->decode(words);
+    Instruction *inst = decode_valid(*decoder, words);
     ASSERT_NE(inst, nullptr);
     plugin->events.clear();
     cu->execute_instruction(inst, *wf);
@@ -1191,7 +1192,7 @@ TEST(ExecutionPluginTest, DppOutOfBoundsObservationHonorsBoundCtrl) {
         vop1_dpp_word(kSrc, amdgpu::dpp::ROW_SHR1, /*row_mask=*/0xF,
                       /*bank_mask=*/0xF, bound_ctrl),
     };
-    std::unique_ptr<Instruction> inst(decoder->decode(words));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
     ASSERT_NE(inst, nullptr);
     plugin->events.clear();
     cu->execute_instruction(inst.get(), *wf);
@@ -1238,7 +1239,7 @@ TEST(ExecutionPluginTest, DppSourceDestinationAliasStagesBeforeWriting) {
       vop1_dpp_word(kReg, /*quad_perm:[1,0,3,2]=*/0xB1, /*row_mask=*/0x1,
                     /*bank_mask=*/0x1, /*bound_ctrl=*/true),
   };
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   plugin->events.clear();
   cu->execute_instruction(inst.get(), *wf);
@@ -1283,7 +1284,7 @@ TEST(ExecutionPluginTest, Dpp8FetchInactiveControlsSourceObservation) {
         vop1_encode(/*v_mov_b32 opcode=*/1, kDst, src_marker),
         kSrc | (lane_sel << 8u),
     };
-    std::unique_ptr<Instruction> inst(decoder->decode(words));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
     ASSERT_NE(inst, nullptr);
     plugin->events.clear();
     f.cu->execute_instruction(inst.get(), *wf);
@@ -1342,7 +1343,7 @@ TEST(ExecutionPluginTest, True16InstructionsReportSelectedSourceAndDestinationHa
     f.cu->write_vgpr(vb + 1, 0, 0xAAAA5555u);
     f.cu->write_vgpr(vb + 129, 0, 0xDEADBEEFu);
 
-    std::unique_ptr<Instruction> inst(decoder->decode(&test_case.word));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, &test_case.word));
     ASSERT_NE(inst, nullptr);
     plugin->events.clear();
     f.cu->execute_instruction(inst.get(), *wf);
@@ -1387,7 +1388,7 @@ TEST(ExecutionPluginTest, Gfx1250Simd64BitWriteReportsBothDestinationRegisters) 
         vop1_encode(/*v_mov_b64 opcode=*/29, kDst, /*generic VGPR source=*/256 + kSrc);
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
     ASSERT_NE(decoder, nullptr);
-    std::unique_ptr<Instruction> inst(decoder->decode(&word));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, &word));
     ASSERT_NE(inst, nullptr);
     plugin->events.clear();
     f.cu->execute_instruction(inst.get(), *wf);
@@ -1671,7 +1672,7 @@ TEST(ExecutionPluginTest, SdwaFloatingModifiersUseSemanticSourceWidth) {
 
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
     std::unique_ptr<Instruction> f32_inst(
-        decoder->decode(reinterpret_cast<const uint32_t *>(&add_f32)));
+        decode_valid(*decoder, reinterpret_cast<const uint32_t *>(&add_f32)));
     ASSERT_NE(f32_inst, nullptr);
     cu->write_vgpr(vb + kSrc0, 0, std::bit_cast<uint32_t>(-2.0f));
     cu->write_vgpr(vb + kSrc1, 0, std::bit_cast<uint32_t>(0.5f));
@@ -1690,7 +1691,7 @@ TEST(ExecutionPluginTest, SdwaFloatingModifiersUseSemanticSourceWidth) {
     cvt_bf16.dst_unused = amdgpu::sdwa::UNUSED_PAD;
 
     std::unique_ptr<Instruction> bf16_inst(
-        decoder->decode(reinterpret_cast<const uint32_t *>(&cvt_bf16)));
+        decode_valid(*decoder, reinterpret_cast<const uint32_t *>(&cvt_bf16)));
     ASSERT_NE(bf16_inst, nullptr);
     ASSERT_EQ(std::string_view(bf16_inst->mnemonic()), "v_cvt_f32_bf16_sdwa");
     cu->write_vgpr(vb + kSrc0, 0, 0xCAFE'C000u);
@@ -1712,7 +1713,7 @@ TEST(ExecutionPluginTest, SdwaFloatingModifiersUseSemanticSourceWidth) {
       add_f16.dst_unused = amdgpu::sdwa::UNUSED_PAD;
 
       std::unique_ptr<Instruction> f16_inst(
-          decoder->decode(reinterpret_cast<const uint32_t *>(&add_f16)));
+          decode_valid(*decoder, reinterpret_cast<const uint32_t *>(&add_f16)));
       ASSERT_NE(f16_inst, nullptr);
       const uint32_t shift = selection == amdgpu::sdwa::WORD_1 ? 16u : 0u;
       const uint32_t selected_word_mask = uint32_t{0xFFFF} << shift;
@@ -1755,7 +1756,8 @@ TEST(ExecutionPluginTest, SdwaVop2Src1SelectorReportsExactBytes) {
   raw.dst_unused = amdgpu::sdwa::UNUSED_PAD;
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
-  std::unique_ptr<Instruction> inst(decoder->decode(reinterpret_cast<const uint32_t *>(&raw)));
+  std::unique_ptr<Instruction> inst(
+      decode_valid(*decoder, reinterpret_cast<const uint32_t *>(&raw)));
   ASSERT_NE(inst, nullptr);
   plugin->events.clear();
   cu->execute_instruction(inst.get(), *wf);
@@ -1809,7 +1811,8 @@ TEST(ExecutionPluginTest, SdwaVop2ScalarSelectorsUseSgprs) {
     raw.dst_unused = amdgpu::sdwa::UNUSED_PAD;
 
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
-    std::unique_ptr<Instruction> inst(decoder->decode(reinterpret_cast<const uint32_t *>(&raw)));
+    std::unique_ptr<Instruction> inst(
+        decode_valid(*decoder, reinterpret_cast<const uint32_t *>(&raw)));
     ASSERT_NE(inst, nullptr);
     plugin->events.clear();
     cu->execute_instruction(inst.get(), *wf);
@@ -1891,7 +1894,7 @@ TEST(ExecutionPluginTest, SdwaObservationReportsExactSourceAndDestinationBytes) 
           vop1_encode(/*opcode=*/1, kDst, amdgpu::SRC_SDWA),
           vop1_sdwa_word(kSrc, test_case.dst_sel, test_case.dst_unused, test_case.src0_sel),
       };
-      Instruction *inst = decoder->decode(words);
+      Instruction *inst = decode_valid(*decoder, words);
       ASSERT_NE(inst, nullptr);
       plugin->events.clear();
       cu->execute_instruction(inst, *wf);
@@ -1947,7 +1950,7 @@ TEST(ExecutionPluginTest, SdwaClampIsAppliedInsideArchitecturalDestinationWrite)
       vop1_sdwa_word(kSrc, amdgpu::sdwa::DWORD, amdgpu::sdwa::UNUSED_PAD, amdgpu::sdwa::DWORD,
                      /*clamp=*/true),
   };
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   plugin->events.clear();
   cu->execute_instruction(inst.get(), *wf);
@@ -1984,7 +1987,7 @@ TEST(ExecutionPluginTest, SdwaClampHonorsDx10ClampMode) {
       vop1_sdwa_word(kSrc, amdgpu::sdwa::DWORD, amdgpu::sdwa::UNUSED_PAD, amdgpu::sdwa::DWORD,
                      /*clamp=*/true),
   };
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
 
   struct Case {
@@ -2028,7 +2031,7 @@ TEST(ExecutionPluginTest, SdwaPartialPreserveClampReportsFullDwordWrite) {
       vop1_sdwa_word(kSrc, amdgpu::sdwa::BYTE_1, amdgpu::sdwa::UNUSED_PRESERVE, amdgpu::sdwa::DWORD,
                      /*clamp=*/true),
   };
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   plugin->events.clear();
   cu->execute_instruction(inst.get(), *wf);
@@ -2145,7 +2148,7 @@ TEST(ExecutionPluginTest, F64SimdSourceReadObservationReportsBothHalves) {
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
     uint32_t words[4] = {vop2_encode(/*opcode=*/4, /*vdst=*/4, /*vsrc1=*/2, /*src0=*/256), 0u, 0u,
                          0u};
-    Instruction *inst = decoder->decode(words);
+    Instruction *inst = decode_valid(*decoder, words);
     ASSERT_NE(inst, nullptr);
     cu->execute_instruction(inst, *wf);
     delete inst;
@@ -2177,7 +2180,7 @@ TEST(ExecutionPluginTest, Vop3FmacSimdReadObservationReportsAccumulator) {
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_encode(/*opcode=*/315, /*vdst=*/4, /*src0=*/256, /*src1=*/257, words);
-    Instruction *inst = decoder->decode(words);
+    Instruction *inst = decode_valid(*decoder, words);
     ASSERT_NE(inst, nullptr);
     cu->execute_instruction(inst, *wf);
     delete inst;

--- a/emulation/rocjitsu/tests/fixtures/downstream_isa_fixture.h
+++ b/emulation/rocjitsu/tests/fixtures/downstream_isa_fixture.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "rocjitsu/isa/decode_result.h"
 #include "rocjitsu/isa/instruction.h"
 
 #include <cstddef>
@@ -28,7 +29,7 @@ public:
   public:
     // Source-integrated decoders publish their maximum encoded width and raw lookahead.
     static constexpr std::size_t kMaxInstructionWords = 1;
-    static std::unique_ptr<Instruction> decode(const rj_code_binary_inst_t *raw) {
+    static DecodeResult decode(const rj_code_binary_inst_t *raw, const DecodeErrorEmitter &) {
       return std::make_unique<DownstreamInstruction>(raw);
     }
   };

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -9,6 +9,7 @@
 /// rejected, and UnimplementedInst results must exactly match the explicit
 /// expectation for that ISA.
 
+#include "decode_test_util.h"
 #include "rocjitsu/base/rj_compiler.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna5/isa.h"
@@ -309,16 +310,7 @@ void run_execution_harness(rj_code_arch_t arch, std::string_view arch_name,
     }
 
     // Decode the instruction.
-    std::unique_ptr<Instruction> inst;
-    try {
-      inst.reset(decoder->decode(te.words.data()));
-    } catch (const util::InvalidInst &) {
-      decode_fail_list.emplace_back(te.mnemonic);
-      continue;
-    } catch (...) {
-      decode_fail_list.emplace_back(te.mnemonic);
-      continue;
-    }
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, te.words.data()));
     if (!inst) {
       decode_fail_list.emplace_back(te.mnemonic);
       continue;
@@ -446,7 +438,7 @@ TEST(Rdna4ExecMaskTest, Wave32ExecHiRemainsAvailableAsScalarScratch) {
 
   for (size_t i = 0; i < sequence.size(); ++i) {
     const uint32_t words[] = {sequence[i].first, 0};
-    std::unique_ptr<Instruction> inst(decoder->decode(words));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), sequence[i].second);
     cu->execute_instruction(inst.get(), *wf);
@@ -465,7 +457,7 @@ TEST(Rdna4ExecMaskTest, Wave32ExecHiRemainsAvailableAsScalarScratch) {
   wf->set_exec_raw(0xdeadbeef'ffffffffULL);
 
   const auto mov_b64 = encode_sop1(/*s_mov_b64=*/1, /*exec=*/126, /*s0=*/0);
-  std::unique_ptr<Instruction> inst(decoder->decode(mov_b64.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, mov_b64.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "s_mov_b64");
   cu->execute_instruction(inst.get(), *wf);
@@ -513,7 +505,7 @@ TEST(Gfx1250MemoryExecutionHarness, ExecutesRepresentativeValidAddressStores) {
 
   // global_store_b32 v0, v1, s[4:5]
   const uint32_t global_store_words[] = {0xEE068004u, 0x00800000u, 0x00000000u};
-  std::unique_ptr<Instruction> global_store(decoder->decode(global_store_words));
+  std::unique_ptr<Instruction> global_store(decode_valid(*decoder, global_store_words));
   ASSERT_NE(global_store, nullptr);
   ASSERT_EQ(std::string_view(global_store->mnemonic()), "global_store_b32");
   cu.execute_and_route(global_store.release(), *wf);
@@ -537,7 +529,7 @@ TEST(Gfx1250MemoryExecutionHarness, ExecutesRepresentativeValidAddressStores) {
 
   // buffer_store_b32 v0, v5, s[4:7], m0 offen
   const uint32_t buffer_store_words[] = {0xC406807Du, 0x40800800u, 0x00000005u};
-  std::unique_ptr<Instruction> buffer_store(decoder->decode(buffer_store_words));
+  std::unique_ptr<Instruction> buffer_store(decode_valid(*decoder, buffer_store_words));
   ASSERT_NE(buffer_store, nullptr);
   ASSERT_EQ(std::string_view(buffer_store->mnemonic()), "buffer_store_b32");
   cu.execute_and_route(buffer_store.release(), *wf);
@@ -575,7 +567,7 @@ TEST(Rdna4ScalarSccTest, AddSubCoI32UseSignedOverflow) {
   const uint32_t sb = wf->sgpr_alloc().base;
   auto run = [&](const std::array<uint32_t, 2> &words, std::string_view mnemonic, uint32_t lhs,
                  uint32_t rhs, uint32_t expected_result, bool expected_scc) {
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic);
 
@@ -634,7 +626,7 @@ void run_scalar_cvt_preserves_scc(rj_code_arch_t arch, std::string_view arch_nam
     const auto &tc = cases[i];
     const auto words = encode_sop1(tc.op, /*sdst=*/1, /*ssrc0=*/0);
     for (bool initial_scc : std::array<bool, 2>{false, true}) {
-      std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+      std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
       ASSERT_NE(inst, nullptr);
       ASSERT_EQ(std::string_view(inst->mnemonic()), tc.mnemonic) << arch_name;
 
@@ -742,7 +734,7 @@ TEST(Cdna4Vop3Test, CmpClassF16WritesWave64UpperMaskDword) {
 
     // CDNA4 v_cmp_class_f16 s0, v0, v1.
     const uint32_t words[] = {0xD0140000U, 0x00020300U};
-    std::unique_ptr<Instruction> inst(decoder->decode(words));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cmp_class_f16");
     cu->execute_instruction(inst.get(), *wf);
@@ -796,7 +788,7 @@ TEST(CdnaVop3True16Test, B16I16U16OpsUseOpSelAndCdnaDestinationPolicy) {
       const uint32_t vb = wf->vgpr_alloc().base;
 
       auto execute = [&](const std::array<uint32_t, 2> &words, std::string_view mnemonic) {
-        std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+        std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
         ASSERT_NE(inst, nullptr) << arch.name << " " << mnemonic;
         ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic) << arch.name;
         cu->execute_instruction(inst.get(), *wf);
@@ -879,7 +871,7 @@ TEST(Rdna3Dot2ExecutionTest, Vop2Dot2accF32F16AccumulatesDst) {
   cu->write_vgpr(vb + 2, 0, std::bit_cast<uint32_t>(5.0f));
 
   const auto words = encode_vop2(/*op=*/2, /*vdst=*/2, /*src0=*/256, /*vsrc1=*/1);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_dot2acc_f32_f16_e32");
   cu->execute_instruction(inst.get(), *wf);
@@ -920,7 +912,7 @@ TEST(Rdna4Dot2True16ExecutionTest, F16AppliesVop3ModifiersAndSelectedHalves) {
   const auto words = encode_vop3(/*op=*/0x266, /*vdst=*/3, /*src0=*/256, /*src1=*/257,
                                  /*src2=*/258, /*abs=*/0x1, /*opsel=*/0xCu, /*clamp=*/1,
                                  /*omod=*/3, /*neg=*/0x2);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_dot2_f16_f16");
   cu->execute_instruction(inst.get(), *wf);
@@ -960,7 +952,7 @@ TEST(Rdna4Dot2True16ExecutionTest, Bf16UsesSelectedAccumulatorAndDestinationHalf
 
   const auto words = encode_vop3(/*op=*/0x267, /*vdst=*/3, /*src0=*/256, /*src1=*/257,
                                  /*src2=*/258, /*abs=*/0, /*opsel=*/0x4u);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_dot2_bf16_bf16");
   cu->execute_instruction(inst.get(), *wf);
@@ -1012,7 +1004,7 @@ void run_cdna4_dot2_f32_bf16(bool force_scalar) {
                                                      .src1 = static_cast<uint16_t>(257),
                                                      .src2 = static_cast<uint16_t>(258),
                                                      .op_sel_hi = 3});
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_dot2_f32_bf16");
   cu->execute_instruction(inst.get(), *wf);
@@ -1073,7 +1065,7 @@ TEST(Cdna4Permlane16SwapExecutionTest, Wave64SwapsAllFourGroups) {
   const auto words = cdna4::build_vop1(
       cdna4::kVPermlane16SwapB32Vop1,
       {.src0 = static_cast<uint16_t>(256 + vsrc_reg), .vdst = static_cast<uint8_t>(vdst_reg)});
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_permlane16_swap_b32_e32");
   cu->execute_instruction(inst.get(), *wf);
@@ -1222,7 +1214,7 @@ TEST(Gfx1250WmmaTest, F16Fp8K64MatchesReferenceLayout) {
       0xCC6E0000U | 40u,
       (256u + 10u) | ((256u + 20u) << 9u) | ((256u + 30u) << 18u),
   };
-  std::unique_ptr<Instruction> inst(decoder->decode(wmma_words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, wmma_words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_wmma_f16_16x16x64_fp8_fp8");
   cu->execute_instruction(inst.get(), *wf);
@@ -1364,7 +1356,7 @@ TEST(Gfx1250Dpp8Test, Vop2AddF16UsesPermutedSourceLanes) {
       0x64000000u | amdgpu::SRC_DPP8_FI_0 | (kSrc1 << 9u) | (kDst << 17u),
       kSrc0 | (lane_sel << 8u),
   };
-  std::unique_ptr<Instruction> inst(decoder->decode(add_f16_dpp8_words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, add_f16_dpp8_words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_add_f16_dpp");
   EXPECT_EQ(inst->disassemble(), "v_add_f16_dpp v4.l, v2, v3.l dpp8:[7,0,3,2,5,4,1,6]");
@@ -1406,7 +1398,7 @@ TEST(Gfx1250ExecMaskTest, CmpxNeqAndScalarOrRestoreExec) {
 
   // s_mov_b32 s1, exec_lo
   const uint32_t save_exec_words[] = {0xBE81007EU, 0};
-  std::unique_ptr<Instruction> save_exec(decoder->decode(save_exec_words));
+  std::unique_ptr<Instruction> save_exec(decode_valid(*decoder, save_exec_words));
   ASSERT_NE(save_exec, nullptr);
   ASSERT_EQ(std::string_view(save_exec->mnemonic()), "s_mov_b32");
   cu->execute_instruction(save_exec.get(), *wf);
@@ -1420,7 +1412,7 @@ TEST(Gfx1250ExecMaskTest, CmpxNeqAndScalarOrRestoreExec) {
 
   // v_cmpx_neq_f32_e32 0, v4
   const uint32_t mask_zero_lane_words[] = {0x7D3A0880U, 0};
-  std::unique_ptr<Instruction> mask_zero_lane(decoder->decode(mask_zero_lane_words));
+  std::unique_ptr<Instruction> mask_zero_lane(decode_valid(*decoder, mask_zero_lane_words));
   ASSERT_NE(mask_zero_lane, nullptr);
   ASSERT_EQ(std::string_view(mask_zero_lane->mnemonic()), "v_cmpx_neq_f32_e32");
   cu->execute_instruction(mask_zero_lane.get(), *wf);
@@ -1428,7 +1420,7 @@ TEST(Gfx1250ExecMaskTest, CmpxNeqAndScalarOrRestoreExec) {
 
   // s_or_b32 exec_lo, exec_lo, s1
   const uint32_t restore_exec_words[] = {0x8C7E017EU, 0};
-  std::unique_ptr<Instruction> restore_exec(decoder->decode(restore_exec_words));
+  std::unique_ptr<Instruction> restore_exec(decode_valid(*decoder, restore_exec_words));
   ASSERT_NE(restore_exec, nullptr);
   ASSERT_EQ(std::string_view(restore_exec->mnemonic()), "s_or_b32");
   cu->execute_instruction(restore_exec.get(), *wf);
@@ -1468,7 +1460,7 @@ TEST(Gfx1250ExecMaskTest, Vop3CmpxGtI32KeepsInRangeLanesActive) {
 
   // v_cmpx_gt_i32_e64 s3, v2
   const uint32_t in_range_words[] = {0xD4C4007EU, 0x02020403U};
-  std::unique_ptr<Instruction> in_range(decoder->decode(in_range_words));
+  std::unique_ptr<Instruction> in_range(decode_valid(*decoder, in_range_words));
   ASSERT_NE(in_range, nullptr);
   ASSERT_EQ(std::string_view(in_range->mnemonic()), "v_cmpx_gt_i32");
   cu->execute_instruction(in_range.get(), *wf);
@@ -1512,7 +1504,7 @@ TEST(Gfx1250ExecMaskTest, Vop3CmpF32PreservesHighMaskSgprOnWave32) {
 
   // v_cmp_eq_f32_e64 s0, 0, v4
   const uint32_t compare_words[] = {0xD4120000U, 0x02020880U};
-  std::unique_ptr<Instruction> compare(decoder->decode(compare_words));
+  std::unique_ptr<Instruction> compare(decode_valid(*decoder, compare_words));
   ASSERT_NE(compare, nullptr);
   ASSERT_EQ(std::string_view(compare->mnemonic()), "v_cmp_eq_f32");
   cu->execute_instruction(compare.get(), *wf);
@@ -1554,7 +1546,7 @@ TEST(Gfx1250True16Vop3Test, SelectedHalfArithmeticPreservesDestinationHalf) {
   }
 
   auto execute = [&](const uint32_t(&words)[2], std::string_view mnemonic) {
-    std::unique_ptr<Instruction> inst(decoder->decode(words));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic);
     cu->execute_instruction(inst.get(), *wf);
@@ -1626,7 +1618,7 @@ TEST(Gfx1250True16Vop2Test, AddF16UsesSelectedHighVsrc1AndPreservesLowDestinatio
 
   // v_add_f16_e32 v2.h, v0.h, v1.h
   const uint32_t words[] = {0x65050380U, 0x00000000U};
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_add_f16_e32");
   EXPECT_NE(inst->disassemble().find("v2.h"), std::string::npos);
@@ -1668,7 +1660,7 @@ TEST(Gfx1250True16Vop2Test, FmacF16HighDestinationUsesSelectedAccumulatorHalf) {
 
   // v_fmac_f16_e32 v0.h, v1.h, v2.h
   const uint32_t words[] = {0x6D010581U, 0x00000000U};
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_fmac_f16_e32");
   EXPECT_NE(inst->disassemble().find("v0.h"), std::string::npos);
@@ -1709,7 +1701,7 @@ TEST(Gfx1250True16Vop3Test, MulLoU16UsesSelectedHighSourceHalf) {
 
   // v_mul_lo_u16 v2.l, 0x12b3, v0.h op_sel:[0,1,0]
   const uint32_t words[] = {0xD7051002U, 0x020200FFU, 0x000012B3U};
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_mul_lo_u16");
   cu->execute_instruction(inst.get(), *wf);
@@ -1750,7 +1742,7 @@ TEST(Gfx1250True16Vop3Test, CmpLtI16UsesSelectedHighSourceHalf) {
 
   // v_cmp_lt_i16 s0, -1, v0.h op_sel:[0,1,0]
   const uint32_t words[] = {0xD4311000U, 0x020200C1U};
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cmp_lt_i16");
   cu->execute_instruction(inst.get(), *wf);
@@ -1797,7 +1789,7 @@ TEST(Gfx1250True16Vop3Test, CmpClassF16UsesSelectedMaskHalf) {
 
     constexpr auto words = encode_vop3(/*op=*/125, /*vdst=*/0, /*src0=*/256, /*src1=*/256,
                                        /*src2=*/0, /*abs=*/0, /*opsel=*/0x2);
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cmp_class_f16");
     cu->execute_instruction(inst.get(), *wf);
@@ -1843,7 +1835,7 @@ TEST(Gfx1250True16Vop3Test, CmpxClassF16UsesSelectedMaskHalf) {
 
     constexpr auto words = encode_vop3(/*op=*/253, /*vdst=*/126, /*src0=*/256, /*src1=*/256,
                                        /*src2=*/0, /*abs=*/0, /*opsel=*/0x2);
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cmpx_class_f16");
     cu->execute_instruction(inst.get(), *wf);
@@ -1884,7 +1876,7 @@ TEST(Gfx1250True16Vop3Test, SpecialVop3OpsUseSelectedHalves) {
 
     const uint32_t vb = wf->vgpr_alloc().base;
     auto execute = [&](const std::array<uint32_t, 2> &words, std::string_view mnemonic) {
-      std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+      std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
       ASSERT_NE(inst, nullptr);
       ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic);
       cu->execute_instruction(inst.get(), *wf);
@@ -1968,7 +1960,7 @@ TEST(Gfx1250True16VopcTest, CmpLtI16ReadsPackedHighVsrc1) {
 
   // v_cmp_lt_i16_e32 vcc_lo, -1, v0.h
   const uint32_t words[] = {0x7C6300C1U};
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cmp_lt_i16_e32");
   cu->execute_instruction(inst.get(), *wf);
@@ -2014,7 +2006,7 @@ TEST(Rdna4True16Vop3Test, CmpGeF16UsesSelectedHighSourceHalf) {
 
     // v_cmp_ge_f16_e64 s0, |v0.h|, 0.5 op_sel:[1,0,0]
     const uint32_t words[] = {0xD4060900U, 0x0201E100U};
-    std::unique_ptr<Instruction> inst(decoder->decode(words));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cmp_ge_f16");
     cu->execute_instruction(inst.get(), *wf);
@@ -2062,7 +2054,7 @@ TEST(Rdna4True16Vop3Test, CmpClassF16UsesSelectedMaskHalf) {
 
     constexpr auto words = encode_vop3(/*op=*/125, /*vdst=*/0, /*src0=*/256, /*src1=*/256,
                                        /*src2=*/0, /*abs=*/0, /*opsel=*/0x2);
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cmp_class_f16");
     cu->execute_instruction(inst.get(), *wf);
@@ -2109,7 +2101,7 @@ TEST(Rdna4True16Vop3Test, CmpClassF16InlineConstantUsesF16Broadcast) {
 
     constexpr auto words = encode_vop3(/*op=*/125, /*vdst=*/0, /*src0=*/242, /*src1=*/4,
                                        /*src2=*/0, /*abs=*/0, /*opsel=*/0);
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cmp_class_f16");
     cu->execute_instruction(inst.get(), *wf);
@@ -2155,7 +2147,7 @@ TEST(Rdna4True16Vop3Test, CmpxClassF16UsesSelectedMaskHalf) {
 
     constexpr auto words = encode_vop3(/*op=*/253, /*vdst=*/126, /*src0=*/256, /*src1=*/256,
                                        /*src2=*/0, /*abs=*/0, /*opsel=*/0x2);
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cmpx_class_f16");
     cu->execute_instruction(inst.get(), *wf);
@@ -2224,13 +2216,13 @@ TEST(Rdna4True16Vop3Test, ClassF16HelperSequenceMovesMaskIntoSelectedHighHalf) {
     const uint32_t mov_words[] = {0x7F003901U, 0};
     const uint32_t cmp_words[] = {0xD47D1000U, 0x02020100U};
     const uint32_t select_words[] = {0xD5010000U, 0x00010280U};
-    std::unique_ptr<Instruction> mov(decoder->decode(mov_words));
+    std::unique_ptr<Instruction> mov(decode_valid(*decoder, mov_words));
     ASSERT_NE(mov, nullptr);
     ASSERT_EQ(std::string_view(mov->mnemonic()), "v_mov_b16_e32");
-    std::unique_ptr<Instruction> cmp(decoder->decode(cmp_words));
+    std::unique_ptr<Instruction> cmp(decode_valid(*decoder, cmp_words));
     ASSERT_NE(cmp, nullptr);
     ASSERT_EQ(std::string_view(cmp->mnemonic()), "v_cmp_class_f16");
-    std::unique_ptr<Instruction> select(decoder->decode(select_words));
+    std::unique_ptr<Instruction> select(decode_valid(*decoder, select_words));
     ASSERT_NE(select, nullptr);
     ASSERT_EQ(std::string_view(select->mnemonic()), "v_cndmask_b32");
 
@@ -2297,7 +2289,7 @@ TEST(Rdna4True16Vop3Test, RcpF16WritesSelectedHighDestinationHalf) {
 
     // v_rcp_f16_e64 v0.h, -v0.l op_sel:[0,1]
     const uint32_t words[] = {0xD5D44000U, 0x22010100U};
-    std::unique_ptr<Instruction> inst(decoder->decode(words));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), "v_rcp_f16");
     cu->execute_instruction(inst.get(), *wf);
@@ -2339,7 +2331,7 @@ TEST(Rdna4True16Vop3Test, CvtF32F16AppliesAbsToSelectedSourceHalf) {
 
     // v_cvt_f32_f16_e64 v4, |v2.l|
     const uint32_t words[] = {0xD58B0104U, 0x02010102U};
-    std::unique_ptr<Instruction> inst(decoder->decode(words));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cvt_f32_f16");
     cu->execute_instruction(inst.get(), *wf);
@@ -2389,7 +2381,7 @@ TEST(Rdna4True16Vop3Test, AddF16UsesSelectedHalvesAndPreservesDestinationHalf) {
     constexpr auto words = encode_vop3(/*op=*/0x132, /*vdst=*/2, /*src0=*/256,
                                        /*src1=*/257, /*src2=*/0, /*abs=*/0,
                                        /*opsel=*/0xB);
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), "v_add_f16");
     cu->execute_instruction(inst.get(), *wf);
@@ -2524,7 +2516,8 @@ TEST(Rdna4True16Vop3Test, UnaryDpp16ScalarAndSimdMatchMaskedLaneRouting) {
 
     static_assert(sizeof(raw) == 3 * sizeof(uint32_t));
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
-    std::unique_ptr<Instruction> inst(decoder->decode(reinterpret_cast<const uint32_t *>(&raw)));
+    std::unique_ptr<Instruction> inst(
+        decode_valid(*decoder, reinterpret_cast<const uint32_t *>(&raw)));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), "v_rcp_f16");
     cu->execute_instruction(inst.get(), *wf);
@@ -2612,7 +2605,8 @@ TEST(Rdna4True16Vop3Test, VopcDpp16ScalarAndSimdMatchMaskedLaneRouting) {
 
     static_assert(sizeof(raw) == 3 * sizeof(uint32_t));
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
-    std::unique_ptr<Instruction> inst(decoder->decode(reinterpret_cast<const uint32_t *>(&raw)));
+    std::unique_ptr<Instruction> inst(
+        decode_valid(*decoder, reinterpret_cast<const uint32_t *>(&raw)));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cmp_ge_f16");
     cu->execute_instruction(inst.get(), *wf);
@@ -2699,7 +2693,8 @@ TEST(Rdna4True16Vop3Test, UnaryDpp8ScalarAndSimdMatchPermutedLanes) {
 
     static_assert(sizeof(raw) == 3 * sizeof(uint32_t));
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
-    std::unique_ptr<Instruction> inst(decoder->decode(reinterpret_cast<const uint32_t *>(&raw)));
+    std::unique_ptr<Instruction> inst(
+        decode_valid(*decoder, reinterpret_cast<const uint32_t *>(&raw)));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), "v_rcp_f16_e64_dpp");
     EXPECT_EQ(inst->disassemble(), "v_rcp_f16_e64_dpp v2, v0 dpp8:[7,0,5,2,3,6,1,4] fi:1");
@@ -2761,7 +2756,7 @@ TEST(Rdna4True16Vop3Test, FmacF16UsesSelectedAccumulatorHalfAndPreservesDestinat
     constexpr auto words = encode_vop3(/*op=*/0x136, /*vdst=*/3, /*src0=*/256,
                                        /*src1=*/257, /*src2=*/0, /*abs=*/0,
                                        /*opsel=*/0xB);
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), "v_fmac_f16");
     cu->execute_instruction(inst.get(), *wf);
@@ -2813,7 +2808,7 @@ TEST(Rdna4True16Vop3Test, TernaryI16U16UsesSelectedHalvesAndPreservesDestination
                        std::string_view mnemonic, uint16_t expected_high) {
       cu->write_vgpr(vb + dst, 0, pack16(static_cast<uint16_t>(0xA000u | dst), 0xCAFEu));
       const auto words = encode_vop3(op, dst, src0, src1, src2, /*abs=*/0, /*opsel=*/0xF);
-      std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+      std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
       ASSERT_NE(inst, nullptr);
       ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic);
       cu->execute_instruction(inst.get(), *wf);
@@ -2864,7 +2859,7 @@ TEST(Rdna4True16Vop3Test, SpecialVop3OpsUseSelectedHalves) {
 
     const uint32_t vb = wf->vgpr_alloc().base;
     auto execute = [&](const std::array<uint32_t, 2> &words, std::string_view mnemonic) {
-      std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+      std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
       ASSERT_NE(inst, nullptr);
       ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic);
       cu->execute_instruction(inst.get(), *wf);
@@ -2957,7 +2952,7 @@ TEST(Rdna4Vop3CndmaskTest, B32AppliesNegModifierBeforeSelect) {
 
     // v_cndmask_b32 v2, -v0, v1, s[0:1]
     const uint32_t words[] = {0xD5010002U, 0x20020300U};
-    std::unique_ptr<Instruction> inst(decoder->decode(words));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cndmask_b32");
     cu->execute_instruction(inst.get(), *wf);
@@ -3003,7 +2998,7 @@ TEST(Rdna4Atan2F16Test, SignedHalfCompareFeedsQuadrantSelect) {
 
     // v_cmp_gt_i16_e32 vcc_lo, 0, v2.l
     const uint32_t i16_cmp_words[] = {0x7C680480U, 0};
-    std::unique_ptr<Instruction> i16_cmp(decoder->decode(i16_cmp_words));
+    std::unique_ptr<Instruction> i16_cmp(decode_valid(*decoder, i16_cmp_words));
     ASSERT_NE(i16_cmp, nullptr);
     ASSERT_EQ(std::string_view(i16_cmp->mnemonic()), "v_cmp_gt_i16_e32");
     cu->execute_instruction(i16_cmp.get(), *wf);
@@ -3011,7 +3006,7 @@ TEST(Rdna4Atan2F16Test, SignedHalfCompareFeedsQuadrantSelect) {
 
     // v_cndmask_b32_e64 v6, 0, 0x40490fdb, vcc_lo
     const uint32_t pi_select_words[] = {0xD5010006U, 0x01A9FE80U, 0x40490FDBU};
-    std::unique_ptr<Instruction> pi_select(decoder->decode(pi_select_words));
+    std::unique_ptr<Instruction> pi_select(decode_valid(*decoder, pi_select_words));
     ASSERT_NE(pi_select, nullptr);
     ASSERT_EQ(std::string_view(pi_select->mnemonic()), "v_cndmask_b32");
     cu->execute_instruction(pi_select.get(), *wf);
@@ -3020,7 +3015,7 @@ TEST(Rdna4Atan2F16Test, SignedHalfCompareFeedsQuadrantSelect) {
 
     // v_cmp_gt_f16_e32 vcc_lo, 0, v2.l
     const uint32_t f16_cmp_words[] = {0x7C080480U, 0};
-    std::unique_ptr<Instruction> f16_cmp(decoder->decode(f16_cmp_words));
+    std::unique_ptr<Instruction> f16_cmp(decode_valid(*decoder, f16_cmp_words));
     ASSERT_NE(f16_cmp, nullptr);
     ASSERT_EQ(std::string_view(f16_cmp->mnemonic()), "v_cmp_gt_f16_e32");
     cu->execute_instruction(f16_cmp.get(), *wf);
@@ -3062,7 +3057,7 @@ TEST(Rdna4Atan2F16Test, DualCndmaskReadsOldPairedSlotSource) {
 
   // v_dual_cndmask_b32 v4, v4, v5 :: v_dual_mov_b32 v5, 0x4016cbe4
   const uint32_t words[] = {0xCA500B04U, 0x040400FFU, 0x4016CBE4U};
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_dual_cndmask_b32 :: v_dual_mov_b32");
   cu->execute_instruction(inst.get(), *wf);
@@ -3125,7 +3120,7 @@ TEST(Rdna4Atan2F16Test, TailSequenceKeepsNegativeXQuadrant) {
   }};
 
   for (const auto &words : program) {
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     cu->execute_instruction(inst.get(), *wf);
   }
@@ -3169,7 +3164,7 @@ TEST(Rdna4Vop3pFmaMixTest, F32AppliesAbsModifiersFromNegHi) {
 
     // v_fma_mix_f32 v0, |v3|, s0, neg(0) op_sel_hi:[1,0,0]
     const uint32_t abs_src0_words[] = {0xCC200100U, 0x8A000103U};
-    std::unique_ptr<Instruction> abs_src0_inst(decoder->decode(abs_src0_words));
+    std::unique_ptr<Instruction> abs_src0_inst(decode_valid(*decoder, abs_src0_words));
     ASSERT_NE(abs_src0_inst, nullptr);
     ASSERT_EQ(std::string_view(abs_src0_inst->mnemonic()), "v_fma_mix_f32");
     cu->execute_instruction(abs_src0_inst.get(), *wf);
@@ -3182,7 +3177,7 @@ TEST(Rdna4Vop3pFmaMixTest, F32AppliesAbsModifiersFromNegHi) {
 
     // v_fma_mix_f32 v0, v4, s0, |v3| op_sel_hi:[0,0,1]
     const uint32_t abs_src2_words[] = {0xCC204400U, 0x040C0104U};
-    std::unique_ptr<Instruction> abs_src2_inst(decoder->decode(abs_src2_words));
+    std::unique_ptr<Instruction> abs_src2_inst(decode_valid(*decoder, abs_src2_words));
     ASSERT_NE(abs_src2_inst, nullptr);
     ASSERT_EQ(std::string_view(abs_src2_inst->mnemonic()), "v_fma_mix_f32");
     cu->execute_instruction(abs_src2_inst.get(), *wf);
@@ -3193,7 +3188,7 @@ TEST(Rdna4Vop3pFmaMixTest, F32AppliesAbsModifiersFromNegHi) {
 
     // v_fma_mix_f32 v0, v2, 1.0, v0 op_sel_hi:[1,1,0]
     const uint32_t inline_one_f32_words[] = {0xCC200000U, 0x1C01E502U};
-    std::unique_ptr<Instruction> inline_one_f32_inst(decoder->decode(inline_one_f32_words));
+    std::unique_ptr<Instruction> inline_one_f32_inst(decode_valid(*decoder, inline_one_f32_words));
     ASSERT_NE(inline_one_f32_inst, nullptr);
     ASSERT_EQ(std::string_view(inline_one_f32_inst->mnemonic()), "v_fma_mix_f32");
     cu->execute_instruction(inline_one_f32_inst.get(), *wf);
@@ -3204,7 +3199,7 @@ TEST(Rdna4Vop3pFmaMixTest, F32AppliesAbsModifiersFromNegHi) {
 
     // v_fma_mixlo_f16 v0, v2, 1.0, 0 op_sel_hi:[1,1,0]
     const uint32_t inline_one_f16_words[] = {0xCC210000U, 0x1A01E502U};
-    std::unique_ptr<Instruction> inline_one_f16_inst(decoder->decode(inline_one_f16_words));
+    std::unique_ptr<Instruction> inline_one_f16_inst(decode_valid(*decoder, inline_one_f16_words));
     ASSERT_NE(inline_one_f16_inst, nullptr);
     ASSERT_EQ(std::string_view(inline_one_f16_inst->mnemonic()), "v_fma_mixlo_f16");
     cu->execute_instruction(inline_one_f16_inst.get(), *wf);
@@ -3216,7 +3211,7 @@ TEST(Rdna4Vop3pFmaMixTest, F32AppliesAbsModifiersFromNegHi) {
 
     // v_fma_mix_f32 v0, |v2|, -1.0, s0 op_sel_hi:[1,1,0]
     const uint32_t atanh_den_words[] = {0xCC200100U, 0x1801E702U};
-    std::unique_ptr<Instruction> atanh_den_inst(decoder->decode(atanh_den_words));
+    std::unique_ptr<Instruction> atanh_den_inst(decode_valid(*decoder, atanh_den_words));
     ASSERT_NE(atanh_den_inst, nullptr);
     ASSERT_EQ(std::string_view(atanh_den_inst->mnemonic()), "v_fma_mix_f32");
     cu->execute_instruction(atanh_den_inst.get(), *wf);
@@ -3226,7 +3221,7 @@ TEST(Rdna4Vop3pFmaMixTest, F32AppliesAbsModifiersFromNegHi) {
 
     // v_fma_mix_f32 v3, |v2|, 1.0, s0 op_sel_hi:[1,1,0]
     const uint32_t atanh_num_words[] = {0xCC200103U, 0x1801E502U};
-    std::unique_ptr<Instruction> atanh_num_inst(decoder->decode(atanh_num_words));
+    std::unique_ptr<Instruction> atanh_num_inst(decode_valid(*decoder, atanh_num_words));
     ASSERT_NE(atanh_num_inst, nullptr);
     ASSERT_EQ(std::string_view(atanh_num_inst->mnemonic()), "v_fma_mix_f32");
     cu->execute_instruction(atanh_num_inst.get(), *wf);
@@ -3238,7 +3233,7 @@ TEST(Rdna4Vop3pFmaMixTest, F32AppliesAbsModifiersFromNegHi) {
 
     // v_fma_mixhi_f16 v0, v3, s0, 0
     const uint32_t atanh_scale_words[] = {0xCC220000U, 0x02000103U};
-    std::unique_ptr<Instruction> atanh_scale_inst(decoder->decode(atanh_scale_words));
+    std::unique_ptr<Instruction> atanh_scale_inst(decode_valid(*decoder, atanh_scale_words));
     ASSERT_NE(atanh_scale_inst, nullptr);
     ASSERT_EQ(std::string_view(atanh_scale_inst->mnemonic()), "v_fma_mixhi_f16");
     cu->execute_instruction(atanh_scale_inst.get(), *wf);
@@ -3281,7 +3276,7 @@ TEST(Rdna4True16Vop3Test, B16BitwiseLiteralPreservesInputSignBit) {
 
     // v_and_b16 v1.l, 0x8000, v3.l
     const uint32_t and_words[] = {0xD7620001U, 0x020206FFU, 0xFFFF8000U};
-    std::unique_ptr<Instruction> and_inst(decoder->decode(and_words));
+    std::unique_ptr<Instruction> and_inst(decode_valid(*decoder, and_words));
     ASSERT_NE(and_inst, nullptr);
     ASSERT_EQ(std::string_view(and_inst->mnemonic()), "v_and_b16");
     ASSERT_NE(and_inst->src_operand(0), nullptr);
@@ -3296,7 +3291,7 @@ TEST(Rdna4True16Vop3Test, B16BitwiseLiteralPreservesInputSignBit) {
 
     // v_and_b16 v1.l, 0x8000, v3.l op_sel:[1,0,0]
     const uint32_t and_high_words[] = {0xD7620801U, 0x020206FFU, 0x80000000U};
-    std::unique_ptr<Instruction> and_high_inst(decoder->decode(and_high_words));
+    std::unique_ptr<Instruction> and_high_inst(decode_valid(*decoder, and_high_words));
     ASSERT_NE(and_high_inst, nullptr);
     ASSERT_EQ(std::string_view(and_high_inst->mnemonic()), "v_and_b16");
     ASSERT_NE(and_high_inst->src_operand(0), nullptr);
@@ -3311,7 +3306,7 @@ TEST(Rdna4True16Vop3Test, B16BitwiseLiteralPreservesInputSignBit) {
 
     // v_and_b16 v1.l, v3.l, 0x8000 op_sel:[0,1,0]
     const uint32_t and_src1_high_words[] = {0xD7621001U, 0x0201FF03U, 0x80000000U};
-    std::unique_ptr<Instruction> and_src1_high_inst(decoder->decode(and_src1_high_words));
+    std::unique_ptr<Instruction> and_src1_high_inst(decode_valid(*decoder, and_src1_high_words));
     ASSERT_NE(and_src1_high_inst, nullptr);
     ASSERT_EQ(std::string_view(and_src1_high_inst->mnemonic()), "v_and_b16");
     ASSERT_NE(and_src1_high_inst->src_operand(1), nullptr);
@@ -3325,7 +3320,7 @@ TEST(Rdna4True16Vop3Test, B16BitwiseLiteralPreservesInputSignBit) {
 
     // v_xor_b16 v0.l, v1.l, v0.l
     const uint32_t xor_words[] = {0xD7640000U, 0x02020101U};
-    std::unique_ptr<Instruction> xor_inst(decoder->decode(xor_words));
+    std::unique_ptr<Instruction> xor_inst(decode_valid(*decoder, xor_words));
     ASSERT_NE(xor_inst, nullptr);
     ASSERT_EQ(std::string_view(xor_inst->mnemonic()), "v_xor_b16");
     cu->execute_instruction(xor_inst.get(), *wf);
@@ -3370,7 +3365,7 @@ TEST(Gfx1250True16Vop3Test, CndmaskB16UsesSelectedSourceHalfAndPreservesDestinat
 
   // v_cndmask_b16 v2.h, v0.l, v1.h, s[0:1] op_sel:[0,1,0,1]
   const uint32_t words[] = {0xD65D5002U, 0x00020300U};
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cndmask_b16");
   cu->execute_instruction(inst.get(), *wf);
@@ -3410,7 +3405,7 @@ TEST(Gfx1250True16Vop3Test, LshrrevB16UsesSelectedSourceHalfAndPreservesDestinat
 
   // v_lshrrev_b16 v16.h, 8, v17.l op_sel:[0,0,1]
   const uint32_t words[] = {0xD7394010U, 0x02022288U};
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_lshrrev_b16");
   cu->execute_instruction(inst.get(), *wf);
@@ -3453,7 +3448,7 @@ TEST(Gfx1250True16Vop3Test, Bitop3B16UsesSelectedSourceHalfAndPreservesDestinati
   }
 
   auto execute = [&](const uint32_t(&words)[2], std::string_view mnemonic) {
-    std::unique_ptr<Instruction> inst(decoder->decode(words));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic);
     cu->execute_instruction(inst.get(), *wf);
@@ -3512,7 +3507,7 @@ TEST(Gfx1250True16Vop1Test, MovB16HighDestinationPreservesLowHalf) {
 
   // v_mov_b16_e32 v2.h, v0.l
   const uint32_t words[] = {0x7F043900U, 0x00000000U};
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_mov_b16_e32");
   EXPECT_NE(inst->disassemble().find("v2.h"), std::string::npos);
@@ -3551,7 +3546,7 @@ TEST(Rdna3True16Vop1Test, MovB16HighDestinationPreservesLowHalf) {
 
   // v_mov_b16_e32 v2.h, v0.l
   const uint32_t words[] = {0x7F043900U, 0x00000000U};
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_mov_b16_e32");
   EXPECT_NE(inst->disassemble().find("v2.h"), std::string::npos);
@@ -3603,7 +3598,7 @@ TEST(Rdna3DppTest, VAddF32RowShrMatchesWaveReduceSequence) {
       cu->write_vgpr(vb + 3, lane, std::bit_cast<uint32_t>(input[lane]));
 
     for (const auto &words : dpp_adds) {
-      std::unique_ptr<Instruction> inst(decoder->decode(words));
+      std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
       ASSERT_NE(inst, nullptr);
       ASSERT_EQ(std::string_view(inst->mnemonic()), "v_add_f32_e32");
       cu->execute_instruction(inst.get(), *wf);
@@ -3613,14 +3608,14 @@ TEST(Rdna3DppTest, VAddF32RowShrMatchesWaveReduceSequence) {
     EXPECT_EQ(cu->read_vgpr(vb + 3, 31), std::bit_cast<uint32_t>(2.0f));
 
     const uint32_t swizzle_words[] = {0xD8D401E0U, 0x04000003U};
-    std::unique_ptr<Instruction> swizzle_inst(decoder->decode(swizzle_words));
+    std::unique_ptr<Instruction> swizzle_inst(decode_valid(*decoder, swizzle_words));
     ASSERT_NE(swizzle_inst, nullptr);
     ASSERT_EQ(std::string_view(swizzle_inst->mnemonic()), "ds_swizzle_b32");
     cu->execute_instruction(swizzle_inst.get(), *wf);
     EXPECT_EQ(cu->read_vgpr(vb + 4, 31), std::bit_cast<uint32_t>(-4.0f));
 
     const uint32_t final_add_words[] = {0xD5030003U, 0x02020903U};
-    std::unique_ptr<Instruction> final_add_inst(decoder->decode(final_add_words));
+    std::unique_ptr<Instruction> final_add_inst(decode_valid(*decoder, final_add_words));
     ASSERT_NE(final_add_inst, nullptr);
     ASSERT_EQ(std::string_view(final_add_inst->mnemonic()), "v_add_f32");
     cu->execute_instruction(final_add_inst.get(), *wf);
@@ -3663,7 +3658,7 @@ TEST(Rdna3ScalarOperandTest, NullSdstDoesNotClobberM0) {
 
   // v_add_co_ci_u32_e64 v5, null, 0, 0, s9
   const uint32_t words[] = {0xD5207C05U, 0x00250080U};
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_add_co_ci_u32");
   EXPECT_NE(inst->disassemble().find("null"), std::string::npos);
@@ -3705,7 +3700,7 @@ TEST(Gfx1250True16Vop1Test, CvtF16F32HighDestinationPreservesLowHalf) {
 
   // v_cvt_f16_f32_e32 v0.h, v2
   const uint32_t words[] = {0x7F001502U, 0x00000000U};
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cvt_f16_f32_e32");
   EXPECT_NE(inst->disassemble().find("v0.h"), std::string::npos);
@@ -3744,7 +3739,7 @@ TEST(Gfx1250CvtFp8Test, F16DecodeVop3UsesSelectedByte) {
 
   // v_cvt_f16_fp8 v1.l, v0 byte_sel:2
   const uint32_t fp8_words[] = {0xD5F70801U, 0x00000100U};
-  std::unique_ptr<Instruction> fp8_inst(decoder->decode(fp8_words));
+  std::unique_ptr<Instruction> fp8_inst(decode_valid(*decoder, fp8_words));
   ASSERT_NE(fp8_inst, nullptr);
   ASSERT_EQ(std::string_view(fp8_inst->mnemonic()), "v_cvt_f16_fp8");
   cu->execute_instruction(fp8_inst.get(), *wf);
@@ -3755,7 +3750,7 @@ TEST(Gfx1250CvtFp8Test, F16DecodeVop3UsesSelectedByte) {
 
   // v_cvt_f16_bf8 v1.l, v0 byte_sel:3
   const uint32_t bf8_words[] = {0xD5F81801U, 0x00000100U};
-  std::unique_ptr<Instruction> bf8_inst(decoder->decode(bf8_words));
+  std::unique_ptr<Instruction> bf8_inst(decode_valid(*decoder, bf8_words));
   ASSERT_NE(bf8_inst, nullptr);
   ASSERT_EQ(std::string_view(bf8_inst->mnemonic()), "v_cvt_f16_bf8");
   cu->execute_instruction(bf8_inst.get(), *wf);
@@ -3792,7 +3787,7 @@ TEST(Gfx1250CvtFp8Test, F16E5M3OverflowHonorsFp16OvflMode) {
   // v_cvt_f16_fp8 v1.l, v0 byte_sel:2 clamp. On gfx1250, clamp selects the
   // unsigned E5M3 FP8 decode; 0xFE is finite but overflows FP16.
   const uint32_t fp8_words[] = {0xD5F78801U, 0x00000100U};
-  std::unique_ptr<Instruction> fp8_inst(decoder->decode(fp8_words));
+  std::unique_ptr<Instruction> fp8_inst(decode_valid(*decoder, fp8_words));
   ASSERT_NE(fp8_inst, nullptr);
   ASSERT_EQ(std::string_view(fp8_inst->mnemonic()), "v_cvt_f16_fp8");
 
@@ -3808,7 +3803,7 @@ TEST(Gfx1250CvtFp8Test, F16E5M3OverflowHonorsFp16OvflMode) {
 
   // Same conversion with OPSEL[3]=1 writes the high destination half.
   const uint32_t fp8_high_words[] = {0xD5F7C801U, 0x00000100U};
-  std::unique_ptr<Instruction> fp8_high_inst(decoder->decode(fp8_high_words));
+  std::unique_ptr<Instruction> fp8_high_inst(decode_valid(*decoder, fp8_high_words));
   ASSERT_NE(fp8_high_inst, nullptr);
   ASSERT_EQ(std::string_view(fp8_high_inst->mnemonic()), "v_cvt_f16_fp8");
   cu->write_vgpr(vb + 1, 0, 0x5555BEEFu);
@@ -3845,7 +3840,7 @@ TEST(Gfx1250CvtFp8Test, F32DecodeVop3UsesSelectedByte) {
 
   // v_cvt_f32_fp8 v1, v0 byte_sel:2
   const uint32_t fp8_words[] = {0xD5EC0801U, 0x00000100U};
-  std::unique_ptr<Instruction> fp8_inst(decoder->decode(fp8_words));
+  std::unique_ptr<Instruction> fp8_inst(decode_valid(*decoder, fp8_words));
   ASSERT_NE(fp8_inst, nullptr);
   ASSERT_EQ(std::string_view(fp8_inst->mnemonic()), "v_cvt_f32_fp8");
   cu->execute_instruction(fp8_inst.get(), *wf);
@@ -3855,7 +3850,7 @@ TEST(Gfx1250CvtFp8Test, F32DecodeVop3UsesSelectedByte) {
 
   // v_cvt_f32_bf8 v1, v0 byte_sel:3
   const uint32_t bf8_words[] = {0xD5ED1801U, 0x00000100U};
-  std::unique_ptr<Instruction> bf8_inst(decoder->decode(bf8_words));
+  std::unique_ptr<Instruction> bf8_inst(decode_valid(*decoder, bf8_words));
   ASSERT_NE(bf8_inst, nullptr);
   ASSERT_EQ(std::string_view(bf8_inst->mnemonic()), "v_cvt_f32_bf8");
   cu->execute_instruction(bf8_inst.get(), *wf);
@@ -3893,7 +3888,7 @@ TEST(Gfx1250CvtFp8Test, E4M3OverflowHonorsFp16OvflMode) {
 
   // v_cvt_pk_fp8_f32 v2.l, v5, v6
   const auto words = encode_vop3(cdna5::kVCvtPkFp8F32Vop3, 2, vgpr_src(5), vgpr_src(6), 0);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cvt_pk_fp8_f32");
   cu->execute_instruction(inst.get(), *wf);
@@ -3936,7 +3931,7 @@ TEST(Gfx1250CvtFp8Test, Bf8OverflowHonorsFp16OvflMode) {
 
   // v_cvt_pk_bf8_f32 v2.l, v5, v6
   const auto words = encode_vop3(cdna5::kVCvtPkBf8F32Vop3, 2, vgpr_src(5), vgpr_src(6), 0);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cvt_pk_bf8_f32");
   cu->execute_instruction(inst.get(), *wf);
@@ -3970,7 +3965,7 @@ TEST(Gfx1250CvtF16Test, SrPackedF16ConsumesAdvancedSeedAndFp16OvflMode) {
 
   const auto words =
       encode_vop3(cdna5::kVCvtSrPkF16F32Vop3, 2, vgpr_src(5), vgpr_src(6), vgpr_src(7));
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cvt_sr_pk_f16_f32");
 
@@ -4034,7 +4029,7 @@ TEST(Rdna4CvtFp8Test, E4M3OverflowHonorsFp16OvflMode) {
 
   // v_cvt_pk_fp8_f32 v2.l, v5, v6
   const auto words = encode_vop3(rdna4::kVCvtPkFp8F32Vop3, 2, vgpr_src(5), vgpr_src(6), 0);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cvt_pk_fp8_f32");
   cu->execute_instruction(inst.get(), *wf);
@@ -4077,7 +4072,7 @@ TEST(Rdna4CvtFp8Test, Bf8OverflowHonorsFp16OvflMode) {
 
   // v_cvt_pk_bf8_f32 v2.l, v5, v6
   const auto packed_words = encode_vop3(rdna4::kVCvtPkBf8F32Vop3, 2, vgpr_src(5), vgpr_src(6), 0);
-  std::unique_ptr<Instruction> packed_inst(decoder->decode(packed_words.data()));
+  std::unique_ptr<Instruction> packed_inst(decode_valid(*decoder, packed_words.data()));
   ASSERT_NE(packed_inst, nullptr);
   ASSERT_EQ(std::string_view(packed_inst->mnemonic()), "v_cvt_pk_bf8_f32");
 
@@ -4095,7 +4090,7 @@ TEST(Rdna4CvtFp8Test, Bf8OverflowHonorsFp16OvflMode) {
 
   // v_cvt_sr_bf8_f32 v2, v5, v6 byte_sel:0
   const auto sr_words = encode_vop3(rdna4::kVCvtSrBf8F32Vop3, 2, vgpr_src(5), vgpr_src(6), 0);
-  std::unique_ptr<Instruction> sr_inst(decoder->decode(sr_words.data()));
+  std::unique_ptr<Instruction> sr_inst(decode_valid(*decoder, sr_words.data()));
   ASSERT_NE(sr_inst, nullptr);
   ASSERT_EQ(std::string_view(sr_inst->mnemonic()), "v_cvt_sr_bf8_f32");
 
@@ -4139,7 +4134,7 @@ TEST(Rdna4CvtF16Test, F32OverflowHonorsFp16OvflMode) {
 
   // v_cvt_f16_f32 v2.l, v5
   const auto words = encode_vop3(rdna4::kVCvtF16F32Vop3, 2, vgpr_src(5), 0, 0);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cvt_f16_f32");
   cu->execute_instruction(inst.get(), *wf);
@@ -4186,7 +4181,7 @@ TEST(Rdna4CvtF16Test, U16OverflowHonorsFp16OvflModeInScalarAndSimdPaths) {
 
     // v_cvt_f16_u16 v2.l, v5
     const auto words = encode_vop3(rdna4::kVCvtF16U16Vop3, 2, vgpr_src(5), 0, 0);
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cvt_f16_u16");
     cu->execute_instruction(inst.get(), *wf);
@@ -4234,7 +4229,7 @@ TEST(Rdna4Fp16ValuTest, AddOverflowHonorsFp16OvflModeInScalarAndSimdPaths) {
     cu->write_vgpr(vb + 2, 0, 0xA5A5BEEFu);
 
     const auto words = encode_vop3(rdna4::kVAddF16Vop3, 2, vgpr_src(0), vgpr_src(1), 0);
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), "v_add_f16");
     cu->execute_instruction(inst.get(), *wf);
@@ -4268,25 +4263,25 @@ TEST(Cdna4CvtSrTest, SingleResultF16Bf16ConsumesSeedAndFp16OvflMode) {
   ASSERT_NE(decoder, nullptr);
 
   const auto f16_words = encode_cdna_vop3(cdna4::kVCvtSrF16F32Vop3, 2, vgpr_src(5), vgpr_src(6), 0);
-  std::unique_ptr<Instruction> f16_inst(decoder->decode(f16_words.data()));
+  std::unique_ptr<Instruction> f16_inst(decode_valid(*decoder, f16_words.data()));
   ASSERT_NE(f16_inst, nullptr);
   ASSERT_EQ(std::string_view(f16_inst->mnemonic()), "v_cvt_sr_f16_f32");
 
   const auto f16_hi_words =
       encode_cdna_vop3(cdna4::kVCvtSrF16F32Vop3, 2, vgpr_src(5), vgpr_src(6), 0, 0x8);
-  std::unique_ptr<Instruction> f16_hi_inst(decoder->decode(f16_hi_words.data()));
+  std::unique_ptr<Instruction> f16_hi_inst(decode_valid(*decoder, f16_hi_words.data()));
   ASSERT_NE(f16_hi_inst, nullptr);
   ASSERT_EQ(std::string_view(f16_hi_inst->mnemonic()), "v_cvt_sr_f16_f32");
 
   const auto bf16_words =
       encode_cdna_vop3(cdna4::kVCvtSrBf16F32Vop3, 3, vgpr_src(5), vgpr_src(6), 0);
-  std::unique_ptr<Instruction> bf16_inst(decoder->decode(bf16_words.data()));
+  std::unique_ptr<Instruction> bf16_inst(decode_valid(*decoder, bf16_words.data()));
   ASSERT_NE(bf16_inst, nullptr);
   ASSERT_EQ(std::string_view(bf16_inst->mnemonic()), "v_cvt_sr_bf16_f32");
 
   const auto bf16_hi_words =
       encode_cdna_vop3(cdna4::kVCvtSrBf16F32Vop3, 3, vgpr_src(5), vgpr_src(6), 0, 0x8);
-  std::unique_ptr<Instruction> bf16_hi_inst(decoder->decode(bf16_hi_words.data()));
+  std::unique_ptr<Instruction> bf16_hi_inst(decode_valid(*decoder, bf16_hi_words.data()));
   ASSERT_NE(bf16_hi_inst, nullptr);
   ASSERT_EQ(std::string_view(bf16_hi_inst->mnemonic()), "v_cvt_sr_bf16_f32");
 
@@ -4401,7 +4396,7 @@ TEST(Cdna4CvtPkTest, F16Bf16F32OverflowHonorsFp16OvflMode) {
 
   // v_cvt_pk_f16_f32 v2, v5, v6
   const auto f16_words = encode_cdna_vop3(cdna4::kVCvtPkF16F32Vop3, 2, vgpr_src(5), vgpr_src(6), 0);
-  std::unique_ptr<Instruction> f16_inst(decoder->decode(f16_words.data()));
+  std::unique_ptr<Instruction> f16_inst(decode_valid(*decoder, f16_words.data()));
   ASSERT_NE(f16_inst, nullptr);
   ASSERT_EQ(std::string_view(f16_inst->mnemonic()), "v_cvt_pk_f16_f32");
 
@@ -4419,7 +4414,7 @@ TEST(Cdna4CvtPkTest, F16Bf16F32OverflowHonorsFp16OvflMode) {
   // v_cvt_pk_bf16_f32 v2, v5, v6
   const auto bf16_words =
       encode_cdna_vop3(cdna4::kVCvtPkBf16F32Vop3, 2, vgpr_src(5), vgpr_src(6), 0);
-  std::unique_ptr<Instruction> bf16_inst(decoder->decode(bf16_words.data()));
+  std::unique_ptr<Instruction> bf16_inst(decode_valid(*decoder, bf16_words.data()));
   ASSERT_NE(bf16_inst, nullptr);
   ASSERT_EQ(std::string_view(bf16_inst->mnemonic()), "v_cvt_pk_bf16_f32");
 
@@ -4482,13 +4477,13 @@ TEST(CdnaLegacyCvtF16Test, SetregImm32ModeControlsOverflowingF32ToF16) {
     cu->write_vgpr(vb + 5, 0, std::bit_cast<uint32_t>(70000.0f));
 
     const auto cvt_words = encode_cdna_vop3(arch_case.cvt_op, 2, vgpr_src(5), 0, 0);
-    std::unique_ptr<Instruction> cvt_inst(decoder->decode(cvt_words.data()));
+    std::unique_ptr<Instruction> cvt_inst(decode_valid(*decoder, cvt_words.data()));
     ASSERT_NE(cvt_inst, nullptr);
     ASSERT_EQ(std::string_view(cvt_inst->mnemonic()), "v_cvt_f16_f32");
 
     constexpr uint32_t kHwregFp16Ovfl = encode_hwreg(1, 23, 1);
     const auto setreg_words = encode_sopk(arch_case.setreg_imm_op, 0, kHwregFp16Ovfl, 1);
-    std::unique_ptr<Instruction> setreg_inst(decoder->decode(setreg_words.data()));
+    std::unique_ptr<Instruction> setreg_inst(decode_valid(*decoder, setreg_words.data()));
     ASSERT_NE(setreg_inst, nullptr);
     ASSERT_EQ(std::string_view(setreg_inst->mnemonic()), "s_setreg_imm32_b32");
 
@@ -4532,7 +4527,7 @@ TEST(Rdna4ScalarF16Test, AddDoesNotConsumeFp16OvflMode) {
   cu->write_sgpr(sb + 1, util::f32_to_f16(65504.0f));
 
   const auto words = encode_sop2(rdna4::kSAddF16Sop2, 2, 0, 1);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "s_add_f16");
 
@@ -4568,7 +4563,7 @@ TEST(Rdna4ScalarF16Test, CvtF16F32ConsumesFp16OvflMode) {
   cu->write_sgpr(sb + 0, std::bit_cast<uint32_t>(70000.0f));
 
   const auto words = encode_sop1(rdna4::kSCvtF16F32Sop1, 2, 0);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "s_cvt_f16_f32");
 
@@ -4612,13 +4607,13 @@ TEST(Cdna3CvtFp8Test, SetregImm32ModeChangeRecomputesFp16OvflRounding) {
 
   // v_cvt_pk_fp8_f32 v2.l, v5, v6. CDNA3 uses FNUZ FP8 encodings.
   const auto words = encode_cdna_vop3(cdna3::kVCvtPkFp8F32Vop3, 2, vgpr_src(5), vgpr_src(6), 0);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cvt_pk_fp8_f32");
 
   constexpr uint32_t kHwregFp16Ovfl = encode_hwreg(1, 23, 1);
   const auto setreg_words = encode_sopk(cdna3::kSSetregImm32B32Sopk, 0, kHwregFp16Ovfl, 1);
-  std::unique_ptr<Instruction> setreg_inst(decoder->decode(setreg_words.data()));
+  std::unique_ptr<Instruction> setreg_inst(decode_valid(*decoder, setreg_words.data()));
   ASSERT_NE(setreg_inst, nullptr);
   ASSERT_EQ(std::string_view(setreg_inst->mnemonic()), "s_setreg_imm32_b32");
 
@@ -4668,7 +4663,7 @@ TEST(Gfx1250CvtFp8Test, F16SourceFp8Bf8ConversionsIgnoreFp16OvflMode) {
   auto run_packed_case = [&](uint32_t op, std::string_view mnemonic, uint32_t src,
                              uint32_t expected) {
     const auto words = encode_vop3(op, 2, vgpr_src(5), 0, 0);
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic);
 
@@ -4687,7 +4682,7 @@ TEST(Gfx1250CvtFp8Test, F16SourceFp8Bf8ConversionsIgnoreFp16OvflMode) {
   auto run_sr_case = [&](uint32_t op, std::string_view mnemonic, uint32_t src, uint32_t seed,
                          uint32_t expected_byte) {
     const auto words = encode_vop3(op, 2, vgpr_src(5), vgpr_src(6), 0);
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic);
 
@@ -4742,7 +4737,7 @@ TEST(Cdna3CvtFp8Test, Bf8AndStochasticPathsHonorFp16OvflMode) {
 
   // v_cvt_pk_bf8_f32 v2.l, v5, v6
   const auto bf8_words = encode_cdna_vop3(cdna3::kVCvtPkBf8F32Vop3, 2, vgpr_src(5), vgpr_src(6), 0);
-  std::unique_ptr<Instruction> bf8_inst(decoder->decode(bf8_words.data()));
+  std::unique_ptr<Instruction> bf8_inst(decode_valid(*decoder, bf8_words.data()));
   ASSERT_NE(bf8_inst, nullptr);
   ASSERT_EQ(std::string_view(bf8_inst->mnemonic()), "v_cvt_pk_bf8_f32");
 
@@ -4762,7 +4757,7 @@ TEST(Cdna3CvtFp8Test, Bf8AndStochasticPathsHonorFp16OvflMode) {
   // v_cvt_sr_fp8_f32 v2, v5, v6 byte_sel:0
   const auto sr_fp8_words =
       encode_cdna_vop3(cdna3::kVCvtSrFp8F32Vop3, 2, vgpr_src(5), vgpr_src(6), 0);
-  std::unique_ptr<Instruction> sr_fp8_inst(decoder->decode(sr_fp8_words.data()));
+  std::unique_ptr<Instruction> sr_fp8_inst(decode_valid(*decoder, sr_fp8_words.data()));
   ASSERT_NE(sr_fp8_inst, nullptr);
   ASSERT_EQ(std::string_view(sr_fp8_inst->mnemonic()), "v_cvt_sr_fp8_f32");
 
@@ -4782,7 +4777,7 @@ TEST(Cdna3CvtFp8Test, Bf8AndStochasticPathsHonorFp16OvflMode) {
   // v_cvt_sr_bf8_f32 v2, v5, v6 byte_sel:0
   const auto sr_bf8_words =
       encode_cdna_vop3(cdna3::kVCvtSrBf8F32Vop3, 2, vgpr_src(5), vgpr_src(6), 0);
-  std::unique_ptr<Instruction> sr_bf8_inst(decoder->decode(sr_bf8_words.data()));
+  std::unique_ptr<Instruction> sr_bf8_inst(decode_valid(*decoder, sr_bf8_words.data()));
   ASSERT_NE(sr_bf8_inst, nullptr);
   ASSERT_EQ(std::string_view(sr_bf8_inst->mnemonic()), "v_cvt_sr_bf8_f32");
 
@@ -4830,7 +4825,7 @@ TEST(Cdna4CvtScaleTest, ScaledFp8Bf8OverflowHonorsFp16OvflMode) {
   // v_cvt_scalef32_pk_fp8_f32 v2.l, v5, v6, v7
   const auto scaled_fp8_words =
       encode_cdna_vop3(cdna4::kVCvtScalef32PkFp8F32Vop3, 2, vgpr_src(5), vgpr_src(6), vgpr_src(7));
-  std::unique_ptr<Instruction> scaled_fp8_inst(decoder->decode(scaled_fp8_words.data()));
+  std::unique_ptr<Instruction> scaled_fp8_inst(decode_valid(*decoder, scaled_fp8_words.data()));
   ASSERT_NE(scaled_fp8_inst, nullptr);
   ASSERT_EQ(std::string_view(scaled_fp8_inst->mnemonic()), "v_cvt_scalef32_pk_fp8_f32");
 
@@ -4851,7 +4846,7 @@ TEST(Cdna4CvtScaleTest, ScaledFp8Bf8OverflowHonorsFp16OvflMode) {
   // v_cvt_scalef32_pk_bf8_f32 v2.l, v5, v6, v7
   const auto scaled_bf8_words =
       encode_cdna_vop3(cdna4::kVCvtScalef32PkBf8F32Vop3, 2, vgpr_src(5), vgpr_src(6), vgpr_src(7));
-  std::unique_ptr<Instruction> scaled_bf8_inst(decoder->decode(scaled_bf8_words.data()));
+  std::unique_ptr<Instruction> scaled_bf8_inst(decode_valid(*decoder, scaled_bf8_words.data()));
   ASSERT_NE(scaled_bf8_inst, nullptr);
   ASSERT_EQ(std::string_view(scaled_bf8_inst->mnemonic()), "v_cvt_scalef32_pk_bf8_f32");
 
@@ -4867,12 +4862,12 @@ TEST(Cdna4CvtScaleTest, ScaledFp8Bf8OverflowHonorsFp16OvflMode) {
   auto run_scaled_f16_dst_case = [&](uint32_t op, std::string_view mnemonic, uint32_t packed_src,
                                      float scale) {
     const auto low_words = encode_cdna_vop3(op, 2, vgpr_src(5), vgpr_src(7), 0);
-    std::unique_ptr<Instruction> low_inst(decoder->decode(low_words.data()));
+    std::unique_ptr<Instruction> low_inst(decode_valid(*decoder, low_words.data()));
     ASSERT_NE(low_inst, nullptr);
     ASSERT_EQ(std::string_view(low_inst->mnemonic()), mnemonic);
 
     const auto high_words = encode_cdna_vop3(op, 2, vgpr_src(5), vgpr_src(7), 0, 0x8);
-    std::unique_ptr<Instruction> high_inst(decoder->decode(high_words.data()));
+    std::unique_ptr<Instruction> high_inst(decode_valid(*decoder, high_words.data()));
     ASSERT_NE(high_inst, nullptr);
     ASSERT_EQ(std::string_view(high_inst->mnemonic()), mnemonic);
 
@@ -4902,7 +4897,7 @@ TEST(Cdna4CvtScaleTest, ScaledFp8Bf8OverflowHonorsFp16OvflMode) {
   auto run_scaled_packed_case = [&](uint32_t op, std::string_view mnemonic, uint32_t packed_src,
                                     uint32_t expected_clear, uint32_t expected_set) {
     const auto words = encode_cdna_vop3(op, 2, vgpr_src(5), vgpr_src(7), 0);
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic);
 
@@ -4975,7 +4970,7 @@ TEST(Cdna4CvtScaleTest, WideFp6ToF16ConsumesFp16OvflMode) {
   // v_cvt_scalef32_pk32_f16_fp6 v[2:17], v[20:25], v30
   const auto words =
       encode_cdna_vop3(cdna4::kVCvtScalef32Pk32F16Fp6Vop3, 2, vgpr_src(20), vgpr_src(30), 0);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cvt_scalef32_pk32_f16_fp6");
 
@@ -5023,7 +5018,7 @@ TEST(Gfx1250CvtFp8Test, E5M3ClampSelectsUnsignedFp8Format) {
 
   // v_cvt_f32_fp8 v1, v0 byte_sel:2 clamp
   const uint32_t decode_words[] = {0xD5EC8801U, 0x00000100U};
-  std::unique_ptr<Instruction> decode_inst(decoder->decode(decode_words));
+  std::unique_ptr<Instruction> decode_inst(decode_valid(*decoder, decode_words));
   ASSERT_NE(decode_inst, nullptr);
   ASSERT_EQ(std::string_view(decode_inst->mnemonic()), "v_cvt_f32_fp8");
   cu->execute_instruction(decode_inst.get(), *wf);
@@ -5035,7 +5030,7 @@ TEST(Gfx1250CvtFp8Test, E5M3ClampSelectsUnsignedFp8Format) {
 
   // v_cvt_pk_fp8_f32 v2.l, s5, s6 clamp
   const uint32_t pack_lo_words[] = {0xD7698002U, 0x02000C05U};
-  std::unique_ptr<Instruction> pack_lo_inst(decoder->decode(pack_lo_words));
+  std::unique_ptr<Instruction> pack_lo_inst(decode_valid(*decoder, pack_lo_words));
   ASSERT_NE(pack_lo_inst, nullptr);
   ASSERT_EQ(std::string_view(pack_lo_inst->mnemonic()), "v_cvt_pk_fp8_f32");
   cu->execute_instruction(pack_lo_inst.get(), *wf);
@@ -5045,7 +5040,7 @@ TEST(Gfx1250CvtFp8Test, E5M3ClampSelectsUnsignedFp8Format) {
 
   // v_cvt_pk_fp8_f32 v2.h, s5, s6 op_sel:[0,0,1] clamp
   const uint32_t pack_hi_words[] = {0xD769C002U, 0x02000C05U};
-  std::unique_ptr<Instruction> pack_hi_inst(decoder->decode(pack_hi_words));
+  std::unique_ptr<Instruction> pack_hi_inst(decode_valid(*decoder, pack_hi_words));
   ASSERT_NE(pack_hi_inst, nullptr);
   ASSERT_EQ(std::string_view(pack_hi_inst->mnemonic()), "v_cvt_pk_fp8_f32");
   cu->execute_instruction(pack_hi_inst.get(), *wf);
@@ -5055,7 +5050,7 @@ TEST(Gfx1250CvtFp8Test, E5M3ClampSelectsUnsignedFp8Format) {
 
   // v_cvt_sr_fp8_f32 v2, s5, s6 byte_sel:2 clamp
   const uint32_t sr_words[] = {0xD76BC002U, 0x02000C05U};
-  std::unique_ptr<Instruction> sr_inst(decoder->decode(sr_words));
+  std::unique_ptr<Instruction> sr_inst(decode_valid(*decoder, sr_words));
   ASSERT_NE(sr_inst, nullptr);
   ASSERT_EQ(std::string_view(sr_inst->mnemonic()), "v_cvt_sr_fp8_f32");
   cu->execute_instruction(sr_inst.get(), *wf);
@@ -5067,7 +5062,7 @@ TEST(Gfx1250CvtFp8Test, E5M3ClampSelectsUnsignedFp8Format) {
 
   // v_cvt_sr_fp8_f16 v2, s5, s6 byte_sel:2 clamp
   const uint32_t sr_f16_words[] = {0xD774C002U, 0x02000C05U};
-  std::unique_ptr<Instruction> sr_f16_inst(decoder->decode(sr_f16_words));
+  std::unique_ptr<Instruction> sr_f16_inst(decode_valid(*decoder, sr_f16_words));
   ASSERT_NE(sr_f16_inst, nullptr);
   ASSERT_EQ(std::string_view(sr_f16_inst->mnemonic()), "v_cvt_sr_fp8_f16");
   cu->execute_instruction(sr_f16_inst.get(), *wf);
@@ -5107,7 +5102,7 @@ TEST(Gfx1250CvtScaleTest, UnpackUsesSelectedE8M0ScaleByte) {
 
   // v_cvt_scale_pk8_f32_fp8 v[2:9], v[0:1], v10 scale_sel:2
   const uint32_t pk8_words[] = {0xD6AA1002U, 0x02021500U};
-  std::unique_ptr<Instruction> pk8_inst(decoder->decode(pk8_words));
+  std::unique_ptr<Instruction> pk8_inst(decode_valid(*decoder, pk8_words));
   ASSERT_NE(pk8_inst, nullptr);
   ASSERT_EQ(std::string_view(pk8_inst->mnemonic()), "v_cvt_scale_pk8_f32_fp8");
   cu->execute_instruction(pk8_inst.get(), *wf);
@@ -5121,7 +5116,7 @@ TEST(Gfx1250CvtScaleTest, UnpackUsesSelectedE8M0ScaleByte) {
 
   // v_cvt_scale_pk16_f32_fp6 v[18:33], v[0:2], v10 scale_sel:1
   const uint32_t pk16_words[] = {0xD6C90812U, 0x02021500U};
-  std::unique_ptr<Instruction> pk16_inst(decoder->decode(pk16_words));
+  std::unique_ptr<Instruction> pk16_inst(decode_valid(*decoder, pk16_words));
   ASSERT_NE(pk16_inst, nullptr);
   ASSERT_EQ(std::string_view(pk16_inst->mnemonic()), "v_cvt_scale_pk16_f32_fp6");
   cu->execute_instruction(pk16_inst.get(), *wf);
@@ -5164,7 +5159,7 @@ TEST(Gfx1250DsSwizzleTest, VdsBroadcastReadsAddrSource) {
   // ds_swizzle_b32 v2, v1 offset:swizzle(BROADCAST,32,15)
   // gfx1250 encodes this as VDS, where the sole source VGPR is the addr field.
   const uint32_t swizzle_words[] = {0xD8D401E0U, 0x02000001U};
-  std::unique_ptr<Instruction> swizzle_inst(decoder->decode(swizzle_words));
+  std::unique_ptr<Instruction> swizzle_inst(decode_valid(*decoder, swizzle_words));
   ASSERT_NE(swizzle_inst, nullptr);
   ASSERT_EQ(std::string_view(swizzle_inst->mnemonic()), "ds_swizzle_b32");
   cu->execute_instruction(swizzle_inst.get(), *wf);
@@ -5177,7 +5172,7 @@ TEST(Gfx1250DsSwizzleTest, VdsBroadcastReadsAddrSource) {
 
   // ds_swizzle_b32 v2, v1 offset:0x80b1, QDMode quad permutation (1, 0, 3, 2)
   const uint32_t quad_perm_words[] = {0xD8D480B1U, 0x02000001U};
-  std::unique_ptr<Instruction> quad_perm_inst(decoder->decode(quad_perm_words));
+  std::unique_ptr<Instruction> quad_perm_inst(decode_valid(*decoder, quad_perm_words));
   ASSERT_NE(quad_perm_inst, nullptr);
   ASSERT_EQ(std::string_view(quad_perm_inst->mnemonic()), "ds_swizzle_b32");
   cu->execute_instruction(quad_perm_inst.get(), *wf);
@@ -5223,7 +5218,7 @@ TEST(Gfx1250AtomicReturnTest, GlobalAtomicAddF32ReturnsOldValue) {
 
   // global_atomic_add_f32 v0, v2, v1, s[4:5] th:TH_ATOMIC_RETURN scope:SCOPE_DEV
   const uint32_t words[] = {0xEE158004U, 0x00980000U, 0x00000002U};
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "global_atomic_add_f32");
   cu.execute_and_route(inst.release(), *wf);
@@ -5266,7 +5261,7 @@ TEST(Gfx1250AtomicReturnTest, GlobalAtomicAddF32AllowsDstSrcAlias) {
 
   // global_atomic_add_f32 v1, v2, v1, s[4:5] th:TH_ATOMIC_RETURN scope:SCOPE_DEV
   const uint32_t words[] = {0xEE158004U, 0x00980001U, 0x00000002U};
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "global_atomic_add_f32");
   cu.execute_and_route(inst.release(), *wf);
@@ -5310,7 +5305,7 @@ TEST(Gfx1250AtomicReturnTest, GlobalAtomicAddU64CopiesHighSourceDword) {
 
   // global_atomic_add_u64 v2, v[0:1], s[4:5] scope:SCOPE_DEV
   const uint32_t words[] = {0xEE10C004U, 0x00080000U, 0x00000002U};
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "global_atomic_add_u64");
   cu.execute_and_route(inst.release(), *wf);
@@ -5353,7 +5348,7 @@ TEST(Gfx1250AtomicReturnTest, GlobalAtomicCmpswapB32ReturnsOldValue) {
 
   // global_atomic_cmpswap_b32 v0, v2, v[4:5], s[4:5] th:TH_ATOMIC_RETURN scope:SCOPE_DEV
   const uint32_t words[] = {0xEE0D0004U, 0x02180000U, 0x00000002U};
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "global_atomic_cmpswap_b32");
   cu.execute_and_route(inst.release(), *wf);
@@ -5393,13 +5388,13 @@ TEST(HwregTest, GetregReadsModeAndStatusTargetIds) {
     const std::array<uint32_t, 2> unknown_words =
         encode_sopk(arch_case.getreg_op, 6, kHwregUnknown32);
 
-    std::unique_ptr<Instruction> mode_inst(decoder->decode(mode_words.data()));
+    std::unique_ptr<Instruction> mode_inst(decode_valid(*decoder, mode_words.data()));
     ASSERT_NE(mode_inst, nullptr);
     EXPECT_EQ(std::string_view(mode_inst->mnemonic()), "s_getreg_b32");
-    std::unique_ptr<Instruction> status_inst(decoder->decode(status_words.data()));
+    std::unique_ptr<Instruction> status_inst(decode_valid(*decoder, status_words.data()));
     ASSERT_NE(status_inst, nullptr);
     EXPECT_EQ(std::string_view(status_inst->mnemonic()), "s_getreg_b32");
-    std::unique_ptr<Instruction> unknown_inst(decoder->decode(unknown_words.data()));
+    std::unique_ptr<Instruction> unknown_inst(decode_valid(*decoder, unknown_words.data()));
     ASSERT_NE(unknown_inst, nullptr);
     EXPECT_EQ(std::string_view(unknown_inst->mnemonic()), "s_getreg_b32");
 
@@ -5836,10 +5831,10 @@ TEST(HwregTest, GetregExtractsPartialModeAndStatusFields) {
     const std::array<uint32_t, 2> status_words =
         encode_sopk(arch_case.getreg_op, 5, kHwregStatusNibble);
 
-    std::unique_ptr<Instruction> mode_inst(decoder->decode(mode_words.data()));
+    std::unique_ptr<Instruction> mode_inst(decode_valid(*decoder, mode_words.data()));
     ASSERT_NE(mode_inst, nullptr);
     EXPECT_EQ(std::string_view(mode_inst->mnemonic()), "s_getreg_b32");
-    std::unique_ptr<Instruction> status_inst(decoder->decode(status_words.data()));
+    std::unique_ptr<Instruction> status_inst(decode_valid(*decoder, status_words.data()));
     ASSERT_NE(status_inst, nullptr);
     EXPECT_EQ(std::string_view(status_inst->mnemonic()), "s_getreg_b32");
 
@@ -5887,7 +5882,7 @@ TEST(HwregTest, SetregImm32StatusIsReadOnly) {
     const std::array<uint32_t, 2> words =
         encode_sopk(arch_case.setreg_imm_op, 0, kHwregStatus32, kImm32Value);
 
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr) << "Failed to decode s_setreg_imm32_b32";
     EXPECT_EQ(std::string_view(inst->mnemonic()).substr(0, 16), "s_setreg_imm32_b");
 
@@ -5929,7 +5924,7 @@ TEST(HwregTest, SetregImm32WritesModeFp16Ovfl) {
     const std::array<uint32_t, 2> words =
         encode_sopk(arch_case.setreg_imm_op, 0, kHwregMode32, kImm32Value);
 
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr) << "Failed to decode s_setreg_imm32_b32";
 
     auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
@@ -5968,7 +5963,7 @@ TEST(HwregTest, SetregB32WritesModeFp16OvflFromSgpr) {
 
     constexpr uint32_t kHwregMode32 = encode_hwreg(1);
     const std::array<uint32_t, 2> words = encode_sopk(arch_case.setreg_op, 4, kHwregMode32);
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr) << "Failed to decode s_setreg_b32";
     EXPECT_EQ(std::string_view(inst->mnemonic()), "s_setreg_b32");
 
@@ -6014,7 +6009,7 @@ TEST(HwregTest, SetregImm32PartialBitfield) {
     constexpr uint32_t kImm32 = 0xFFFFFFFF;
     const std::array<uint32_t, 2> words = encode_sopk(arch_case.setreg_imm_op, 0, kHwreg, kImm32);
 
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
 
     auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
@@ -6069,7 +6064,7 @@ TEST(D16FormatExecution, PackedFormatD16LoadStoreThrowUnimplemented) {
   // reused across cases without any reset.
   for (const auto &c : cases) {
     SCOPED_TRACE(c.mnemonic);
-    std::unique_ptr<Instruction> inst(decoder->decode(c.words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, c.words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), c.mnemonic);
     EXPECT_TRUE(inst->is_memory_op()) << c.mnemonic;

--- a/emulation/rocjitsu/tests/isa_registry_composition_test.cpp
+++ b/emulation/rocjitsu/tests/isa_registry_composition_test.cpp
@@ -4,6 +4,7 @@
 /// @file isa_registry_composition_test.cpp
 /// @brief Multi-component static ISA registry composition tests.
 
+#include "decode_test_util.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/isa/target_registry.h"
@@ -32,7 +33,7 @@ TEST(IsaRegistryCompositionTest, ComponentsKeepIndependentStaticSubsets) {
   constexpr uint32_t kSNop = 0xBF800000u;
   std::unique_ptr<Decoder> full_decoder = Decoder::create(full, "gfx1250");
   ASSERT_NE(full_decoder, nullptr);
-  std::unique_ptr<Instruction> full_instruction(full_decoder->decode(&kSNop));
+  std::unique_ptr<Instruction> full_instruction(decode_valid(*full_decoder, &kSNop));
   ASSERT_NE(full_instruction, nullptr);
   EXPECT_NE(full_instruction->execute, nullptr);
 

--- a/emulation/rocjitsu/tests/isa_target_registry_test.cpp
+++ b/emulation/rocjitsu/tests/isa_target_registry_test.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include "decode_test_util.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna1/target_provider.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna2/target_provider.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna4/target_provider.h"
@@ -23,8 +24,11 @@ namespace {
 
 class FixtureDecoder final : public Decoder {
 public:
-  Instruction *decode(const rj_code_binary_inst_t *) override { return nullptr; }
   std::size_t max_instruction_words() const override { return 1; }
+
+  DecodeResult decode(const rj_code_binary_inst_t *, const DecodeErrorEmitter &) override {
+    return Result::failure();
+  }
 };
 
 std::unique_ptr<Decoder> create_fixture_decoder() { return std::make_unique<FixtureDecoder>(); }
@@ -354,9 +358,15 @@ TEST(IsaTargetRegistryTest, BuiltinRegistryUsesDescriptorOwnedPublicEnumBindings
   std::unique_ptr<Decoder> risc_v_decoder = Decoder::create(registry, ROCJITSU_CODE_ARCH_RV64I);
   ASSERT_NE(risc_v_decoder, nullptr);
   constexpr rj_code_binary_inst_t kAddiX1X0One = 0x00100093;
-  std::unique_ptr<Instruction> risc_v_instruction(risc_v_decoder->decode(&kAddiX1X0One));
+  std::unique_ptr<Instruction> risc_v_instruction(decode_valid(*risc_v_decoder, &kAddiX1X0One));
   ASSERT_NE(risc_v_instruction, nullptr);
   EXPECT_NE(risc_v_instruction->execute, nullptr);
+
+  constexpr rj_code_binary_inst_t kInvalidRiscV = 0xffffffffu;
+  std::vector<std::string> diagnostics;
+  auto collect = [&](std::string_view message) { diagnostics.emplace_back(message); };
+  EXPECT_TRUE(risc_v_decoder->decode(&kInvalidRiscV, DecodeErrorEmitter(collect)).failed());
+  EXPECT_EQ(diagnostics, std::vector<std::string>{"Invalid instruction opcode"});
 }
 
 TEST(IsaTargetRegistryTest, PublicCEntryPointAcceptsCanonicalTargetIds) {

--- a/emulation/rocjitsu/tests/matmul_test.cpp
+++ b/emulation/rocjitsu/tests/matmul_test.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "aql_queue.h"
+#include "decode_test_util.h"
 #include "test_paths.h"
 
 #include "embedded_schema.h"
@@ -74,7 +75,7 @@ std::vector<std::unique_ptr<Instruction>> decode_all(const CodeObject &co) {
     size_t words = sec->size() / sizeof(uint32_t);
     size_t pc = 0;
     while (pc < words) {
-      std::unique_ptr<Instruction> inst(decoder->decode(&data[pc]));
+      std::unique_ptr<Instruction> inst(decode_valid(*decoder, &data[pc]));
       EXPECT_NE(inst, nullptr);
       ++pc;
       if (inst && inst->size() == 8)

--- a/emulation/rocjitsu/tests/model_only_isa_test.cpp
+++ b/emulation/rocjitsu/tests/model_only_isa_test.cpp
@@ -4,6 +4,7 @@
 /// @file model_only_isa_test.cpp
 /// @brief Link and decode smoke test for the narrow model-only ISA boundary.
 
+#include "decode_test_util.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna5/isa.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
@@ -30,12 +31,12 @@ TEST(ModelOnlyIsaTest, DecodesWithoutExecutionCallback) {
   ASSERT_NE(decoder, nullptr);
   EXPECT_EQ(Decoder::create(registry, ROCJITSU_CODE_ARCH_RDNA4), nullptr);
 
-  std::unique_ptr<Instruction> inst(decoder->decode(&kSNop));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, &kSNop));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "s_nop");
   EXPECT_EQ(inst->execute, nullptr);
 
-  inst.reset(decoder->decode(&kVMovB32V0V1));
+  inst.reset(decode_valid(*decoder, &kVMovB32V0V1));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_mov_b32_e32");
   ASSERT_EQ(inst->num_src_operands(), 1);

--- a/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include "decode_test_util.h"
 #include "rocjitsu/code/patch/instrumentor.h"
 
 #include "rocjitsu/code/amdgpu_code_object.h"
@@ -892,7 +893,7 @@ TEST(InstrumentorPatch, PatchesEightByteAnchorEndToEnd) {
   auto decode_at = [&](uint64_t off) {
     std::array<rj_code_binary_inst_t, 2> w{};
     std::memcpy(w.data(), text->data() + off, w.size() * sizeof(rj_code_binary_inst_t));
-    return std::unique_ptr<Instruction>(decoder->decode(w.data()));
+    return std::unique_ptr<Instruction>(decode_valid(*decoder, w.data()));
   };
 
   // Patched anchor decodes as a forward s_branch.
@@ -1186,7 +1187,7 @@ protected:
   std::unique_ptr<Instruction> decode_word(const Section *section, size_t byte_offset) {
     rj_code_binary_inst_t word = 0;
     std::memcpy(&word, section->data() + byte_offset, sizeof(word));
-    return std::unique_ptr<Instruction>(decoder_->decode(&word));
+    return std::unique_ptr<Instruction>(decode_valid(*decoder_, &word));
   }
 
   // Byte size of the original .text before instrumentation. The trampoline cave

--- a/emulation/rocjitsu/tests/patch/probe_callable_test.cpp
+++ b/emulation/rocjitsu/tests/patch/probe_callable_test.cpp
@@ -165,6 +165,18 @@ TEST(ProbeCallableTest, BuildsNopProbe) {
   EXPECT_EQ(callable->output_text_offset, 0u); // assigned by a later layout step.
 }
 
+TEST(ProbeCallableTest, ReportsRejectedEncodingAndWordOffset) {
+  const std::vector<uint32_t> body{0xffffffffu, kSSetpcS30S31};
+  const auto image = make_elf(body);
+  AmdGpuCodeObject obj(image.data(), image.size());
+
+  std::string err;
+  EXPECT_FALSE(build_probe_callable(obj, whole_body_symbol(body), ROCJITSU_CODE_ARCH_CDNA2, &err)
+                   .has_value());
+  EXPECT_NE(err.find("word 0"), std::string::npos) << err;
+  EXPECT_NE(err.find("Invalid instruction opcode"), std::string::npos) << err;
+}
+
 TEST(ProbeCallableTest, RejectsBodyWithCall) {
   const std::vector<uint32_t> body{kSSwappcS30S31, kSSetpcS30S31};
   const auto image = make_elf(body);

--- a/emulation/rocjitsu/tests/patch/probe_clobber_test.cpp
+++ b/emulation/rocjitsu/tests/patch/probe_clobber_test.cpp
@@ -74,6 +74,14 @@ TEST(ProbeClobber, NopProbeSummaryIsEmpty) {
   EXPECT_FALSE(summary->uses_private_segment);
 }
 
+TEST(ProbeClobber, ReportsRejectedEncodingAndWordOffset) {
+  const auto callable = make_callable({0xffffffffu, kSSetpcS30S31});
+  std::string err;
+  EXPECT_FALSE(build_probe_clobber_summary(callable, &err).has_value());
+  EXPECT_NE(err.find("word 0"), std::string::npos) << err;
+  EXPECT_NE(err.find("Invalid instruction opcode"), std::string::npos) << err;
+}
+
 // The summary is decode-derived, not declared: a body that writes s5 reports s5
 // (and only s5) as an ordinary clobber.
 TEST(ProbeClobber, DerivesOrdinaryClobberFromBody) {

--- a/emulation/rocjitsu/tests/patch/spill_manager_test.cpp
+++ b/emulation/rocjitsu/tests/patch/spill_manager_test.cpp
@@ -3,6 +3,7 @@
 
 #include "rocjitsu/code/patch/spill_manager.h"
 
+#include "decode_test_util.h"
 #include "rocjitsu/analysis/exec_state.h"
 #include "rocjitsu/analysis/liveness.h"
 #include "rocjitsu/code/basic_block.h"
@@ -111,7 +112,7 @@ class IntegDecoder : public Decoder {
 public:
   std::size_t max_instruction_words() const override { return 1; }
 
-  Instruction *decode(const rj_code_binary_inst_t *inst) override {
+  DecodeResult decode(const rj_code_binary_inst_t *inst, const DecodeErrorEmitter &) override {
     auto op = static_cast<IntegOpcode>(*inst);
     switch (op) {
     case IntegOpcode::Def_Vgpr0_Sgpr4:
@@ -535,7 +536,7 @@ TEST(SpillManager, IntegrationFromLiveBefore) {
   };
   TestCodeObject co(std::move(words));
   IntegDecoder decoder;
-  auto blocks = BasicBlock::build(co, decoder, ROCJITSU_CODE_ARCH_CDNA3);
+  auto blocks = build_valid_blocks(co, decoder, ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_FALSE(blocks.empty());
 
   // Pick the probe-site instruction by mnemonic match.

--- a/emulation/rocjitsu/tests/pseudo_scalar_exec_test.cpp
+++ b/emulation/rocjitsu/tests/pseudo_scalar_exec_test.cpp
@@ -4,6 +4,7 @@
 /// @file pseudo_scalar_exec_test.cpp
 /// @brief Cross-architecture pseudo-scalar transcendental execution tests.
 
+#include "decode_test_util.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/opcodes.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/test_encodings.h"
@@ -701,7 +702,7 @@ TEST_P(PseudoScalarExecTest, ExecutesAtExecZeroWithDestinationOpselZeroAndUsesLo
       encode_vop3(profile, test_case.mnemonic, kDestinationSgpr, kSourceSgpr,
                   {.source_opsel = test_case.set_source_opsel});
   ASSERT_EQ(words[0] & kDestinationOpselBit, 0u) << "OPSEL[3] must select the low destination half";
-  std::unique_ptr<Instruction> instruction(fixture.decoder->decode(words.data()));
+  std::unique_ptr<Instruction> instruction(decode_valid(*fixture.decoder, words.data()));
   ASSERT_NE(instruction, nullptr) << profile.name << " " << test_case.mnemonic;
   ASSERT_EQ(std::string_view(instruction->mnemonic()), test_case.mnemonic) << profile.name;
   EXPECT_EQ(instruction->size(), 8u);
@@ -730,7 +731,7 @@ TEST_P(PseudoScalarExecTest, ExecutesWithVccAsSourceAndDestination) {
 
     const InstructionWords words = encode_vop3(profile, test_case.mnemonic, selector, selector,
                                                {.source_opsel = test_case.set_source_opsel});
-    std::unique_ptr<Instruction> instruction(fixture.decoder->decode(words.data()));
+    std::unique_ptr<Instruction> instruction(decode_valid(*fixture.decoder, words.data()));
     ASSERT_NE(instruction, nullptr);
 
     const uint64_t source = selector == kVccSelectors[0]
@@ -759,7 +760,7 @@ TEST(PseudoScalarDecodeTest, RejectsOutOfClassDestinations) {
         SCOPED_TRACE(selector);
         const InstructionWords words =
             encode_vop3(profile, test_case.mnemonic, selector, kSourceSgpr);
-        EXPECT_THROW((void)decoder->decode(words.data()), util::InvalidInst);
+        EXPECT_TRUE(decode_fails(*decoder, words.data()));
       }
     }
   }
@@ -774,10 +775,7 @@ TEST(PseudoScalarDecodeTest, RejectsDppAndDpp8Sources) {
     ASSERT_NE(decoder, nullptr) << profile.name;
     for (const uint32_t source : kUnsupportedSources) {
       const InstructionWords words = encode_vop3(profile, "v_s_sqrt_f32", kDestinationSgpr, source);
-      EXPECT_THROW(
-          { std::unique_ptr<Instruction> instruction(decoder->decode(words.data())); },
-          util::InvalidInst)
-          << profile.name << " source=" << source;
+      EXPECT_TRUE(decode_fails(*decoder, words.data())) << profile.name << " source=" << source;
     }
   }
 }
@@ -890,7 +888,7 @@ TEST_P(PseudoScalarSpecialExecTest, CoversLiteralModifierAndModeBehavior) {
 
   const InstructionWords words =
       encode_vop3(profile, test_case.mnemonic, kDestinationSgpr, kSourceSgpr, test_case.encoding);
-  std::unique_ptr<Instruction> instruction(fixture.decoder->decode(words.data()));
+  std::unique_ptr<Instruction> instruction(decode_valid(*fixture.decoder, words.data()));
   ASSERT_NE(instruction, nullptr) << profile.name << " " << test_case.mnemonic;
   ASSERT_EQ(std::string_view(instruction->mnemonic()), test_case.mnemonic) << profile.name;
   EXPECT_EQ(instruction->size(), test_case.encoding.use_literal ? 12u : 8u);
@@ -930,13 +928,13 @@ TEST(PseudoScalarModeIntegrationTest, SetregInstructionsUpdateModesConsumedByPse
 
     const BaseEncodingWords set_round_words =
         encode_sopk(profile.setreg_op, kModeSgpr, encode_hwreg(kModeHwreg));
-    std::unique_ptr<Instruction> set_round(fixture.decoder->decode(set_round_words.data()));
+    std::unique_ptr<Instruction> set_round(decode_valid(*fixture.decoder, set_round_words.data()));
     ASSERT_NE(set_round, nullptr);
     ASSERT_EQ(std::string_view(set_round->mnemonic()), "s_setreg_b32");
 
     const InstructionWords exp_words =
         encode_vop3(profile, "v_s_exp_f32", kDestinationSgpr, kSourceSgpr);
-    std::unique_ptr<Instruction> exp(fixture.decoder->decode(exp_words.data()));
+    std::unique_ptr<Instruction> exp(decode_valid(*fixture.decoder, exp_words.data()));
     ASSERT_NE(exp, nullptr);
 
     fixture.wavefront->set_mode_raw(0);
@@ -949,13 +947,14 @@ TEST(PseudoScalarModeIntegrationTest, SetregInstructionsUpdateModesConsumedByPse
 
     const BaseEncodingWords set_denorm_words =
         encode_sopk(profile.setreg_imm_op, 0, encode_hwreg(kModeHwreg, 6, 2), 1u);
-    std::unique_ptr<Instruction> set_denorm(fixture.decoder->decode(set_denorm_words.data()));
+    std::unique_ptr<Instruction> set_denorm(
+        decode_valid(*fixture.decoder, set_denorm_words.data()));
     ASSERT_NE(set_denorm, nullptr);
     ASSERT_EQ(std::string_view(set_denorm->mnemonic()), "s_setreg_imm32_b32");
 
     const InstructionWords log_words =
         encode_vop3(profile, "v_s_log_f16", kDestinationSgpr, kSourceSgpr, {.source_opsel = true});
-    std::unique_ptr<Instruction> log(fixture.decoder->decode(log_words.data()));
+    std::unique_ptr<Instruction> log(decode_valid(*fixture.decoder, log_words.data()));
     ASSERT_NE(log, nullptr);
 
     fixture.wavefront->set_mode_raw(0);

--- a/emulation/rocjitsu/tests/scalar_scc_test.cpp
+++ b/emulation/rocjitsu/tests/scalar_scc_test.cpp
@@ -4,6 +4,7 @@
 /// @file scalar_scc_test.cpp
 /// @brief Cross-architecture scalar SCC execution and preservation tests.
 
+#include "decode_test_util.h"
 #include "rocjitsu/analysis/def_use_chain.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/decoder.h"
@@ -211,7 +212,7 @@ public:
 
   std::unique_ptr<Instruction> decode(const EncodingWords &words,
                                       std::string_view expected_mnemonic) {
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     if (inst) {
       EXPECT_EQ(std::string_view(inst->mnemonic()), expected_mnemonic) << profile.name;
     }
@@ -278,7 +279,7 @@ void expect_wrexec_def_use(const ScalarSccProfile &profile, const WrexecPair &pa
   const uint8_t width = pair.is_b64 ? 2 : 1;
   for (const auto mnemonic : {pair.first, pair.second}) {
     const auto words = encode_sop1(profile, mnemonic, kDestSgpr, kSourceSgpr);
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr) << profile.name << " " << mnemonic;
     ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic) << profile.name;
 
@@ -684,7 +685,7 @@ TEST(ScalarSccTest, AddkAndMulkRegisterDestinationRead) {
     const std::array mnemonics{addk_mnemonic(profile), std::string_view{"s_mulk_i32"}};
     for (const auto mnemonic : mnemonics) {
       const auto words = encode_sopk(profile, mnemonic, /*sdst=*/4, /*simm16=*/1);
-      std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+      std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
       ASSERT_NE(inst, nullptr) << profile.name << " " << mnemonic;
       ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic) << profile.name;
 

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -4,6 +4,7 @@
 /// @file shared_infra_test.cpp
 /// @brief Phase B unit tests: addr_calc, MMA execution, wavefront context, CU factory.
 
+#include "decode_test_util.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna1/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna2/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna3/isa.h"
@@ -12,14 +13,17 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna5/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/cdna1/opcodes.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/vop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/vopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/cdna2/opcodes.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/vop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/vopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/cdna3/opcodes.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/vop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/vopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h"
@@ -35,10 +39,12 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/rdna1/opcodes.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/vop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/vopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/rdna2/opcodes.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/vop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/vopc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/execution_backend.h"
@@ -2309,6 +2315,7 @@ TEST(DppPermuteTest, WriteMaskHonorsBoundCtrlAndBroadcastValidity) {
 struct Cdna1DppTraits {
   static constexpr const char *name = "cdna1";
   static constexpr rj_code_arch_t arch = ROCJITSU_CODE_ARCH_CDNA1;
+  static constexpr uint16_t vopc_opcode = cdna1::kVCmpEqU32Vopc;
   static const IsaExecutionBackend &backend() { return cdna1::execution_backend(); }
   using MachineInst = cdna1::MachineInst;
   using Vop1VopDppMachineInst = cdna1::Vop1VopDppMachineInst;
@@ -2320,6 +2327,7 @@ struct Cdna1DppTraits {
 struct Cdna2DppTraits {
   static constexpr const char *name = "cdna2";
   static constexpr rj_code_arch_t arch = ROCJITSU_CODE_ARCH_CDNA2;
+  static constexpr uint16_t vopc_opcode = cdna2::kVCmpEqU32Vopc;
   static const IsaExecutionBackend &backend() { return cdna2::execution_backend(); }
   static constexpr uint32_t wf_size = 64;
   using MachineInst = cdna2::MachineInst;
@@ -2334,6 +2342,7 @@ struct Cdna2DppTraits {
 struct Cdna3DppTraits {
   static constexpr const char *name = "cdna3";
   static constexpr rj_code_arch_t arch = ROCJITSU_CODE_ARCH_CDNA3;
+  static constexpr uint16_t vopc_opcode = cdna3::kVCmpEqU32Vopc;
   static const IsaExecutionBackend &backend() { return cdna3::execution_backend(); }
   static constexpr uint32_t wf_size = 64;
   using MachineInst = cdna3::MachineInst;
@@ -2348,6 +2357,7 @@ struct Cdna3DppTraits {
 struct Cdna4DppTraits {
   static constexpr const char *name = "cdna4";
   static constexpr rj_code_arch_t arch = ROCJITSU_CODE_ARCH_CDNA4;
+  static constexpr uint16_t vopc_opcode = cdna4::kVCmpEqU32Vopc;
   static const IsaExecutionBackend &backend() { return cdna4::execution_backend(); }
   static constexpr uint32_t wf_size = 64;
   using MachineInst = cdna4::MachineInst;
@@ -2362,6 +2372,7 @@ struct Cdna4DppTraits {
 struct Rdna1DppTraits {
   static constexpr const char *name = "rdna1";
   static constexpr rj_code_arch_t arch = ROCJITSU_CODE_ARCH_RDNA1;
+  static constexpr uint16_t vopc_opcode = rdna1::kVCmpEqU32Vopc;
   static const IsaExecutionBackend &backend() { return rdna1::execution_backend(); }
   using MachineInst = rdna1::MachineInst;
   using VopcMachineInst = rdna1::VopcMachineInst;
@@ -2375,6 +2386,7 @@ struct Rdna1DppTraits {
 struct Rdna2DppTraits {
   static constexpr const char *name = "rdna2";
   static constexpr rj_code_arch_t arch = ROCJITSU_CODE_ARCH_RDNA2;
+  static constexpr uint16_t vopc_opcode = rdna2::kVCmpEqU32Vopc;
   static const IsaExecutionBackend &backend() { return rdna2::execution_backend(); }
   using MachineInst = rdna2::MachineInst;
   using VopcMachineInst = rdna2::VopcMachineInst;
@@ -3149,32 +3161,34 @@ template <typename Traits> void wave32_generated_vcmpx_preserves_exec_hi() {
   EXPECT_EQ(wf->exec_raw(), 0xA5A55A5A0F0F0F0FULL);
 }
 
-template <typename Traits> void unsupported_rdna_vopc_dpp_throws() {
+template <typename Traits> void unsupported_rdna_vopc_dpp_rejects() {
   SCOPED_TRACE(Traits::name);
 
-  auto expect_throws = [](uint32_t src0) {
+  auto decoder = Decoder::create(Traits::arch);
+  ASSERT_NE(decoder, nullptr);
+  auto expect_rejection = [&](uint32_t src0) {
     typename Traits::Vop1VopDpp16MachineInst raw{};
     raw.src0 = src0;
-
-    EXPECT_THROW(typename Traits::VCmpEqU32Vopc(
-                     reinterpret_cast<const typename Traits::MachineInst *>(&raw)),
-                 util::InvalidInst);
+    raw.op = Traits::vopc_opcode;
+    raw.encoding = 62;
+    EXPECT_TRUE(decode_fails(*decoder, reinterpret_cast<const uint32_t *>(&raw)));
   };
 
-  expect_throws(amdgpu::SRC_DPP);
-  expect_throws(amdgpu::SRC_DPP8_FI_0);
-  expect_throws(amdgpu::SRC_DPP8_FI_1);
+  expect_rejection(amdgpu::SRC_DPP);
+  expect_rejection(amdgpu::SRC_DPP8_FI_0);
+  expect_rejection(amdgpu::SRC_DPP8_FI_1);
 }
 
-template <typename Traits> void unsupported_cdna_vopc_dpp_throws() {
+template <typename Traits> void unsupported_cdna_vopc_dpp_rejects() {
   SCOPED_TRACE(Traits::name);
 
   typename Traits::Vop1VopDppMachineInst raw{};
   raw.src0 = amdgpu::SRC_DPP;
-
-  EXPECT_THROW(
-      typename Traits::VCmpEqU32Vopc(reinterpret_cast<const typename Traits::MachineInst *>(&raw)),
-      util::InvalidInst);
+  raw.op = Traits::vopc_opcode;
+  raw.encoding = 62;
+  auto decoder = Decoder::create(Traits::arch);
+  ASSERT_NE(decoder, nullptr);
+  EXPECT_TRUE(decode_fails(*decoder, reinterpret_cast<const uint32_t *>(&raw)));
 }
 
 void cdna4_vop1_sdwa_availability_is_instruction_specific() {
@@ -3186,9 +3200,13 @@ void cdna4_vop1_sdwa_availability_is_instruction_specific() {
   raw.dst_sel = amdgpu::sdwa::DWORD;
   raw.dst_unused = amdgpu::sdwa::UNUSED_PAD;
 
-  EXPECT_NO_THROW(cdna4::VMovB32Vop1(reinterpret_cast<const cdna4::MachineInst *>(&raw)));
-  EXPECT_THROW(cdna4::VCvtF64I32Vop1(reinterpret_cast<const cdna4::MachineInst *>(&raw)),
-               util::InvalidInst);
+  raw.encoding = cdna4::encoding::kVop1 >> 2;
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  raw.op = cdna4::kVMovB32Vop1;
+  EXPECT_FALSE(decode_fails(*decoder, reinterpret_cast<const uint32_t *>(&raw)));
+  raw.op = cdna4::kVCvtF64I32Vop1;
+  EXPECT_TRUE(decode_fails(*decoder, reinterpret_cast<const uint32_t *>(&raw)));
 }
 
 TEST(SdwaTest, Cdna4DisassemblesDestinationAndSourceAttributes) {
@@ -3207,7 +3225,7 @@ TEST(SdwaTest, Cdna4DisassemblesDestinationAndSourceAttributes) {
   const auto words = std::bit_cast<std::array<uint32_t, 2>>(raw);
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->disassemble(), "v_floor_f32_sdwa v0, v92 clamp div:2 dst_sel:BYTE_0 "
                                  "dst_unused:UNUSED_PAD src0_sel:BYTE_0");
@@ -3231,7 +3249,7 @@ TEST(SdwaTest, Cdna4DisassemblesCompareDestinationAndSourceModifiers) {
   const auto words = std::bit_cast<std::array<uint32_t, 2>>(raw);
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->disassemble(),
             "v_cmp_eq_f32_sdwa s[4:5], -|v0|, -v1 src0_sel:BYTE_0 src1_sel:DWORD");
@@ -3253,7 +3271,7 @@ TEST(SdwaTest, Cdna4DisassemblesImplicitCompareDestination) {
   const auto words = std::bit_cast<std::array<uint32_t, 2>>(raw);
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->disassemble(), "v_cmp_eq_f32_sdwa vcc, v0, v1 src0_sel:DWORD src1_sel:DWORD");
 }
@@ -3277,7 +3295,7 @@ TEST(SdwaTest, Cdna4DisassemblesBothVop2Sources) {
   const auto words = std::bit_cast<std::array<uint32_t, 2>>(raw);
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->disassemble(),
             "v_add_f32_sdwa v5, -|v2|, -v3 dst_sel:DWORD dst_unused:UNUSED_PAD "
@@ -3299,7 +3317,7 @@ TEST(DecodeSizeTest, Cdna4UsesOpcodeOperandCapabilitiesForLiteralSelectors) {
   set_gpr_idx.op = cdna4::kSSetGprIdxOnSopc;
   set_gpr_idx.encoding = cdna4::encoding::kSopc;
   const auto set_gpr_idx_words = std::bit_cast<std::array<uint32_t, 1>>(set_gpr_idx);
-  std::unique_ptr<Instruction> set_gpr_idx_inst(decoder->decode(set_gpr_idx_words.data()));
+  std::unique_ptr<Instruction> set_gpr_idx_inst(decode_valid(*decoder, set_gpr_idx_words.data()));
   ASSERT_NE(set_gpr_idx_inst, nullptr);
   EXPECT_EQ(set_gpr_idx_inst->size(), sizeof(uint32_t));
 
@@ -3309,7 +3327,7 @@ TEST(DecodeSizeTest, Cdna4UsesOpcodeOperandCapabilitiesForLiteralSelectors) {
   get_pc.sdst = 0;
   get_pc.encoding = cdna4::encoding::kSop1;
   const auto get_pc_words = std::bit_cast<std::array<uint32_t, 1>>(get_pc);
-  std::unique_ptr<Instruction> get_pc_inst(decoder->decode(get_pc_words.data()));
+  std::unique_ptr<Instruction> get_pc_inst(decode_valid(*decoder, get_pc_words.data()));
   ASSERT_NE(get_pc_inst, nullptr);
   EXPECT_EQ(get_pc_inst->size(), sizeof(uint32_t));
 
@@ -3319,16 +3337,14 @@ TEST(DecodeSizeTest, Cdna4UsesOpcodeOperandCapabilitiesForLiteralSelectors) {
   fork.op = cdna4::kSCbranchGForkSop2;
   fork.encoding = cdna4::encoding::kSop2 >> 7;
   const auto fork_words = std::bit_cast<std::array<uint32_t, 1>>(fork);
-  EXPECT_THROW(
-      { std::unique_ptr<Instruction> fork_inst(decoder->decode(fork_words.data())); },
-      util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, fork_words.data()));
 
   cdna4::Vop1MachineInst v_nop{};
   v_nop.src0 = 255;
   v_nop.op = cdna4::kVNopVop1;
   v_nop.encoding = cdna4::encoding::kVop1 >> 2;
   const auto v_nop_words = std::bit_cast<std::array<uint32_t, 1>>(v_nop);
-  std::unique_ptr<Instruction> v_nop_inst(decoder->decode(v_nop_words.data()));
+  std::unique_ptr<Instruction> v_nop_inst(decode_valid(*decoder, v_nop_words.data()));
   ASSERT_NE(v_nop_inst, nullptr);
   EXPECT_EQ(v_nop_inst->size(), sizeof(uint32_t));
 
@@ -3339,7 +3355,8 @@ TEST(DecodeSizeTest, Cdna4UsesOpcodeOperandCapabilitiesForLiteralSelectors) {
   scalar_literal.encoding = cdna4::encoding::kSop1;
   const std::array<uint32_t, 2> scalar_literal_words = {std::bit_cast<uint32_t>(scalar_literal),
                                                         0x12345678u};
-  std::unique_ptr<Instruction> scalar_literal_inst(decoder->decode(scalar_literal_words.data()));
+  std::unique_ptr<Instruction> scalar_literal_inst(
+      decode_valid(*decoder, scalar_literal_words.data()));
   ASSERT_NE(scalar_literal_inst, nullptr);
   EXPECT_EQ(scalar_literal_inst->size(), sizeof(scalar_literal_words));
 }
@@ -3361,8 +3378,7 @@ void cdna4_unsupported_sdwa_decode_halts_wave() {
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  EXPECT_THROW(
-      { std::unique_ptr<Instruction> inst(decoder->decode(words.data())); }, util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, words.data()));
 
   amdgpu::GpuMemory mem("cdna4_unsupported_sdwa_mem");
   amdgpu::L2Cache l2("cdna4_unsupported_sdwa_l2");
@@ -3393,10 +3409,11 @@ template <typename Raw> void rdna4_vop3_dpp_marker_is_instruction_specific(uint3
   raw.src1 = 5;
   raw.vdst = 8;
 
-  EXPECT_NO_THROW(rdna4::VAddF32Vop3(reinterpret_cast<const rdna4::MachineInst *>(&raw)));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  EXPECT_FALSE(decode_fails(*decoder, reinterpret_cast<const uint32_t *>(&raw)));
   raw.op = rdna4::kVAddF64Vop3;
-  EXPECT_THROW(rdna4::VAddF64Vop3(reinterpret_cast<const rdna4::MachineInst *>(&raw)),
-               util::InvalidInst);
+  EXPECT_TRUE(decode_fails(*decoder, reinterpret_cast<const uint32_t *>(&raw)));
 }
 
 template <typename Raw> void rdna4_vop3p_dpp_marker_is_unsupported(uint32_t marker) {
@@ -3407,8 +3424,9 @@ template <typename Raw> void rdna4_vop3p_dpp_marker_is_unsupported(uint32_t mark
   raw.vsrc0 = 4;
   raw.src1 = 5;
   raw.vdst = 8;
-  EXPECT_THROW(rdna4::VPkAddF16Vop3p(reinterpret_cast<const rdna4::MachineInst *>(&raw)),
-               util::InvalidInst);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  EXPECT_TRUE(decode_fails(*decoder, reinterpret_cast<const uint32_t *>(&raw)));
 }
 
 void rdna4_vop3_dpp_availability_is_instruction_specific() {
@@ -3433,11 +3451,11 @@ TEST(DppPermuteTest, CdnaGeneratedVop1DppWriteMaskHonorsBoundCtrl) {
   cdna_generated_vop1_dpp_write_mask_honors_bound_ctrl<Cdna4DppTraits>();
 }
 
-TEST(DppPermuteTest, CdnaVopcDppThrowsUnsupported) {
-  unsupported_cdna_vopc_dpp_throws<Cdna1DppTraits>();
-  unsupported_cdna_vopc_dpp_throws<Cdna2DppTraits>();
-  unsupported_cdna_vopc_dpp_throws<Cdna3DppTraits>();
-  unsupported_cdna_vopc_dpp_throws<Cdna4DppTraits>();
+TEST(DppPermuteTest, CdnaVopcDppRejectsUnsupported) {
+  unsupported_cdna_vopc_dpp_rejects<Cdna1DppTraits>();
+  unsupported_cdna_vopc_dpp_rejects<Cdna2DppTraits>();
+  unsupported_cdna_vopc_dpp_rejects<Cdna3DppTraits>();
+  unsupported_cdna_vopc_dpp_rejects<Cdna4DppTraits>();
 }
 
 TEST(DppPermuteTest, Cdna4Vop1SdwaAvailabilityIsInstructionSpecific) {
@@ -3554,12 +3572,12 @@ TEST(ExecMaskTest, RdnaGeneratedVcmpxWave32PreservesExecHi) {
   wave32_generated_vcmpx_preserves_exec_hi<Gfx1250DppTraits>();
 }
 
-TEST(DppPermuteTest, Rdna1VopcDppThrowsUnsupported) {
-  unsupported_rdna_vopc_dpp_throws<Rdna1DppTraits>();
+TEST(DppPermuteTest, Rdna1VopcDppRejectsUnsupported) {
+  unsupported_rdna_vopc_dpp_rejects<Rdna1DppTraits>();
 }
 
-TEST(DppPermuteTest, Rdna2VopcDppThrowsUnsupported) {
-  unsupported_rdna_vopc_dpp_throws<Rdna2DppTraits>();
+TEST(DppPermuteTest, Rdna2VopcDppRejectsUnsupported) {
+  unsupported_rdna_vopc_dpp_rejects<Rdna2DppTraits>();
 }
 
 // ---------------------------------------------------------------------------
@@ -3837,7 +3855,7 @@ TEST(RdnaScratchExecutionTest, Rdna3B128StoreFeedsB32LoadsWithVectorOffsets) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA3);
   ASSERT_NE(decoder, nullptr);
   auto execute_mem = [&](std::array<uint32_t, 2> words) {
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     cu->execute_and_route(inst.release(), *wf);
   };
@@ -4380,7 +4398,7 @@ void expect_vector_lane_reads_use_own_wave_vgprs(rj_code_arch_t arch) {
 
   for (uint32_t i = 0; i < wfs.size(); ++i) {
     const uint32_t sbase = wfs[i]->sgpr_alloc().base;
-    std::unique_ptr<Instruction> inst(decoder->decode(kReadfirstlaneS24V1.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, kReadfirstlaneS24V1.data()));
     ASSERT_NE(inst, nullptr);
     cu->write_sgpr(sbase + 24, 0);
     cu->execute_instruction(inst.get(), *wfs[i]);
@@ -4389,7 +4407,7 @@ void expect_vector_lane_reads_use_own_wave_vgprs(rj_code_arch_t arch) {
 
   for (uint32_t i = 0; i < wfs.size(); ++i) {
     const uint32_t sbase = wfs[i]->sgpr_alloc().base;
-    std::unique_ptr<Instruction> inst(decoder->decode(kReadlaneS4V141Lane2.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, kReadlaneS4V141Lane2.data()));
     ASSERT_NE(inst, nullptr);
     cu->write_sgpr(sbase + 2, 0);
     cu->write_sgpr(sbase + 4, 0);
@@ -4399,7 +4417,7 @@ void expect_vector_lane_reads_use_own_wave_vgprs(rj_code_arch_t arch) {
 
   for (uint32_t i = 0; i < wfs.size(); ++i) {
     const uint32_t sbase = wfs[i]->sgpr_alloc().base;
-    std::unique_ptr<Instruction> inst(decoder->decode(kReadlaneS4V4Lane31.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, kReadlaneS4V4Lane31.data()));
     ASSERT_NE(inst, nullptr);
     cu->write_sgpr(sbase + 4, 0);
     cu->write_sgpr(sbase + 31, 0);
@@ -4409,7 +4427,7 @@ void expect_vector_lane_reads_use_own_wave_vgprs(rj_code_arch_t arch) {
 
   for (uint32_t i = 0; i < wfs.size(); ++i) {
     const uint32_t sbase = wfs[i]->sgpr_alloc().base;
-    std::unique_ptr<Instruction> inst(decoder->decode(kReadlaneS4V141S2.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, kReadlaneS4V141S2.data()));
     ASSERT_NE(inst, nullptr);
     cu->write_sgpr(sbase + 2, 31);
     cu->write_sgpr(sbase + 4, 0);
@@ -4420,7 +4438,7 @@ void expect_vector_lane_reads_use_own_wave_vgprs(rj_code_arch_t arch) {
   for (uint32_t i = 0; i < wfs.size(); ++i) {
     const uint32_t sbase = wfs[i]->sgpr_alloc().base;
     const uint32_t vbase = wfs[i]->vgpr_alloc().base;
-    std::unique_ptr<Instruction> inst(decoder->decode(kWritelaneV141S4S2.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, kWritelaneV141S4S2.data()));
     ASSERT_NE(inst, nullptr);
     cu->write_sgpr(sbase + 2, 31);
     cu->write_sgpr(sbase + 4, 0x500u + i);

--- a/emulation/rocjitsu/tests/simd_correctness/vop1_cvt_f64_scalar_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop1_cvt_f64_scalar_correctness_test.cpp
@@ -15,6 +15,7 @@
 /// a visibly wrong result. No SIMD is involved (these ops are not on the SIMD
 /// fast path); this exercises the plain decode+execute scalar path.
 
+#include "decode_test_util.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
@@ -81,7 +82,7 @@ struct Fixture {
     write64(vb + 2, 0, 0xA5A5A5A5A5A5A5A5ull); // sentinel in dst pair
     uint32_t enc = vop1_encode(op, /*vdst=*/2, /*src0=*/256);
     uint32_t words[4] = {enc, 0u, 0u, 0u};
-    Instruction *inst = decoder->decode(words);
+    Instruction *inst = decode_valid(*decoder, words);
     EXPECT_NE(inst, nullptr);
     cu->execute_instruction(inst, *wf);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop1_cvt_f64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop1_cvt_f64_simd_correctness_test.cpp
@@ -22,6 +22,7 @@
 /// conversions are exact (NaN->0 and the saturating clamp are deterministic),
 /// compared with no carve-out.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -205,7 +206,7 @@ void check_case(const CvtCase &c, uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t enc = vop1_encode(c.opcode, /*vdst=*/2, /*src0=*/256);
     uint32_t words[4] = {enc, 0u, 0u, 0u};
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     auto out = fx.run(inst, c, exec);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop1_cvt_f8_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop1_cvt_f8_simd_correctness_test.cpp
@@ -13,6 +13,7 @@
 /// equal with EXPECT_EQ (util::set_force_scalar_for_testing flips the gate
 /// in-process). In-process inactive lanes must keep the DST sentinel.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -126,7 +127,7 @@ void check_words(const std::string &label, const uint32_t words[4], uint64_t exe
     Fixture fx;
     EXPECT_NE(fx.cu, nullptr);
     EXPECT_NE(fx.wf, nullptr);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << label << " decode failed";
     auto out = fx.run(inst, block, exec);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop1_f64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop1_f64_simd_correctness_test.cpp
@@ -19,6 +19,7 @@
 /// inputs, so both runs skip the same lanes. v_mov_b64 is a pure bit copy and is
 /// compared exactly (no NaN carve-out).
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -165,7 +166,7 @@ void check_case(const F64UnaryCase &c, uint64_t exec) {
     // src0 = v0:v1 (enc 256), vdst = v2:v3.
     uint32_t enc = vop1_encode(c.opcode, /*vdst=*/2, /*src0=*/256);
     uint32_t words[4] = {enc, 0u, 0u, 0u};
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     auto out = fx.run(inst, exec);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop1_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop1_simd_correctness_test.cpp
@@ -16,6 +16,7 @@
 /// raw random with explicit edge lanes injected (0, ±0, ±Inf, NaN, denormal,
 /// INT32 extremes) rather than sanitized to finite normals.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -221,7 +222,7 @@ void check_case(const Vop1Case &c, uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t enc = vop1_encode(c.opcode, /*vdst=*/2, /*src0=*/256);
     uint32_t words[4] = {enc, 0u, 0u, 0u};
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.label << ": decode failed";
     auto out = fx.run(inst, seed, exec);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_carry_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_carry_simd_correctness_test.cpp
@@ -17,6 +17,7 @@
 /// lanes — random-only inputs hide these corners. Inactive-lane carry-out VCC
 /// bits are zeroed under full and partial EXEC masks.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -166,7 +167,7 @@ void check_case(const CarryCase &c, uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t enc = vop2_encode(c.opcode, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
     uint32_t words[4] = {enc, 0u, 0u, 0u};
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.label << ": decode failed";
     auto out = fx.run(inst, SEED, exec, vcc_in);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_cndmask_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_cndmask_simd_correctness_test.cpp
@@ -12,6 +12,7 @@
 /// (util::set_force_scalar_for_testing flips the gate in-process).
 /// In-process inactive EXEC lanes must keep the dst sentinel.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -115,7 +116,7 @@ void check_case(uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t enc = vop2_encode(/*opcode=*/0, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
     uint32_t words[4] = {enc, 0u, 0u, 0u};
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << "v_cndmask_b32: decode failed";
     auto out = fx.run(inst, SEED, exec, vcc);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_fma_f16_rdna_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_fma_f16_rdna_simd_correctness_test.cpp
@@ -17,6 +17,7 @@
 /// through the packed vs scalar FMA (accepted), so lanes with a NaN input are
 /// excluded identically in both runs (the skip is input-derived).
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -163,7 +164,7 @@ void check_case(const FmaCase &c, uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t enc = vop2_encode(c.opcode, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
     uint32_t words[4] = {enc, kLiteral, 0u, 0u};
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.label << ": decode failed";
     fx.seed_inputs(SEED, exec, &nan_lane);
     fx.cu->execute_instruction(inst, *fx.wf);

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_fma_f64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_fma_f64_simd_correctness_test.cpp
@@ -18,6 +18,7 @@
 /// those lanes are excluded from the comparison — NaN-ness of the result is
 /// deterministic from the inputs, so both runs skip the same lanes.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -192,7 +193,7 @@ void check_fmac_literal_src0(bool force_scalar) {
 
   uint32_t enc = vop2_encode(/*opcode=*/4, /*vdst=*/4, /*vsrc1=*/2, /*src0=*/255);
   uint32_t words[4] = {enc, kLiteralHighWord, 0u, 0u};
-  Instruction *inst = fx.decoder->decode(words);
+  Instruction *inst = decode_valid(*fx.decoder, words);
   ASSERT_NE(inst, nullptr) << "v_fmac_f64 literal decode failed";
   fx.cu->execute_instruction(inst, *fx.wf);
   delete inst;
@@ -217,7 +218,7 @@ void check_fmac(uint64_t exec) {
     // v_fmac_f64 = VOP2 op 4. src0 = v0:v1 (enc 256), vsrc1 = v2:v3, vdst = v4:v5.
     uint32_t enc = vop2_encode(/*opcode=*/4, /*vdst=*/4, /*vsrc1=*/2, /*src0=*/256);
     uint32_t words[4] = {enc, 0u, 0u, 0u};
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << "v_fmac_f64 decode failed";
     auto out = fx.run(inst, exec);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_fma_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_fma_simd_correctness_test.cpp
@@ -22,6 +22,7 @@
 /// equal per active, non-skipped lane (util::set_force_scalar_for_testing flips
 /// the gate in-process).
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -188,7 +189,7 @@ void check_case(const FmaCase &c, uint64_t exec) {
     // f16 constant 0x3E00 = 1.5h (high bits ignored by the op).
     const uint32_t literal = c.is_f16 ? 0x00003E00u : 0x3FC00000u;
     uint32_t words[4] = {enc, c.has_literal ? literal : 0u, 0u, 0u};
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.label << ": decode failed";
     seeded = fx.seed_inputs(SEED, c.is_f16, exec, &nan_lane);
     fx.cu->execute_instruction(inst, *fx.wf);

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_minmax_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_minmax_simd_correctness_test.cpp
@@ -18,6 +18,7 @@
 /// ±0 and NaN in both operand orders on the low lanes — the corner cases the
 /// earlier (reverted) f16 min/max shipped without and silently diverged on.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -194,7 +195,7 @@ void check_case(const MinMaxCase &c, uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t enc = vop2_encode(c.opcode, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
     uint32_t words[4] = {enc, 0u, 0u, 0u};
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.label << ": decode failed";
     nan_lane = fx.seed_inputs(SEED, c.is_f16, exec);
     fx.cu->execute_instruction(inst, *fx.wf);

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_simd_correctness_test.cpp
@@ -11,6 +11,7 @@
 /// here). In-process the test also checks inactive-lane preservation under full
 /// and partial EXEC masks.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -188,7 +189,7 @@ void check_case(const Vop2Case &c, uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t enc = vop2_encode(c.opcode, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
     uint32_t words[4] = {enc, 0u, 0u, 0u};
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.label << ": decode failed";
     auto out = fx.run(inst, SEED, c.is_float, exec);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_b16_rdna_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_b16_rdna_simd_correctness_test.cpp
@@ -19,6 +19,7 @@
 /// — the high 16 bits of the destination VGPR are zeroed. The CU and decoder
 /// are built for RDNA3; encoding marker is 0x35<<26.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -174,7 +175,7 @@ void check_binary(const BinCase &c, uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     rdna3_vop3_encode(c.opcode, kDstVgpr, /*src0=*/256, /*src1=*/257, /*src2=*/0, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     auto out = fx.run(inst, rot, exec);
     delete inst;
@@ -210,7 +211,7 @@ void check_not_b16(uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     rdna3_vop3_encode(/*op=*/489, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/0, /*src2=*/0, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << "v_not_b16_vop3 decode failed";
     auto out = fx.run(inst, 0, exec);
     delete inst;
@@ -246,7 +247,7 @@ void check_cndmask_b16(uint64_t exec, uint64_t sel) {
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     rdna3_vop3_encode(/*op=*/605, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/257, /*src2=*/sb,
                       words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << "v_cndmask_b16_vop3 decode failed";
     auto out = fx.run(inst, rot, exec);
     delete inst;
@@ -335,7 +336,7 @@ void check_mov_b16(uint64_t exec, uint32_t omod, uint32_t clamp) {
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     rdna3_vop3_encode_mod(/*op=*/412, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/0, /*src2=*/0,
                           clamp, omod, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << "v_mov_b16_vop3 decode failed";
     auto out = fx.run(inst, 0, exec);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_binary_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_binary_simd_correctness_test.cpp
@@ -13,6 +13,7 @@
 /// with EXPECT_EQ (util::set_force_scalar_for_testing flips the gate in-process).
 /// In-process inactive lanes must stay preserved under full and partial EXEC.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -258,7 +259,7 @@ void check(const Case &c, uint32_t abs, uint32_t neg, uint32_t omod, uint32_t cl
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_encode(c.opcode, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/257, abs, neg, omod, clamp,
                 words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     auto out = fx.run(inst, c.kind, exec);
     delete inst;
@@ -346,7 +347,7 @@ void check_f16(const Case &c, uint32_t abs, uint32_t neg, uint32_t omod, uint32_
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_encode(c.opcode, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/257, abs, neg, omod, clamp,
                 words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     auto out = fx.run(inst, c.kind, exec);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_carry_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_carry_simd_correctness_test.cpp
@@ -19,6 +19,7 @@
 /// lanes must keep the sentinel. Inputs deliberately seed the 32-bit
 /// carry/borrow boundary on the low lanes.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -246,7 +247,7 @@ void check_case(const char *mem_label, const char *l2_label, const char *cu_labe
     uint32_t words[2] = {0u, 0u};
     vop3_sdstenc_encode(c.opcode, /*vdst=*/2, /*sdst=*/sb,
                         /*src0=*/256, /*src1=*/257, /*src2=*/src2_field, encoding_marker, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.label << ": decode failed";
     auto out = fx.run(inst, SEED, exec, vcc_in, SDST_SEED, sb, cin_word, cin_pair);
     delete inst;
@@ -325,7 +326,7 @@ void check_rdna4_wave64_carry_in_oracle() {
     uint32_t words[2] = {0u, 0u};
     vop3_sdstenc_encode(/*op=*/288, /*vdst=*/2, /*sdst=*/sb,
                         /*src0=*/256, /*src1=*/257, /*src2=*/cin_pair, kRdna3Encoding, words);
-    std::unique_ptr<Instruction> inst(fx.decoder->decode(words));
+    std::unique_ptr<Instruction> inst(decode_valid(*fx.decoder, words));
     ASSERT_NE(inst, nullptr);
 
     const uint32_t vbase = fx.wf->vgpr_alloc().base;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_cndmask_pack_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_cndmask_pack_simd_correctness_test.cpp
@@ -15,6 +15,7 @@
 ///   - v_pack_b32_f16_vop3: pack the OPSEL-selected 16-bit halves of src0/src1
 ///     into a b32 dst.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -181,7 +182,7 @@ void check_cndmask_one(uint64_t exec, uint64_t sel) {
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_tern_encode(/*op=*/256, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/257,
                      /*src2=*/sb, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << "v_cndmask_b32_vop3 decode failed";
     auto out = fx.run(inst, rot, exec);
     delete inst;
@@ -220,7 +221,7 @@ void check_pack_one(uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_bin_encode(/*op=*/672, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/257, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << "v_pack_b32_f16_vop3 decode failed";
     auto out = fx.run(inst, rot, exec);
     delete inst;
@@ -259,7 +260,7 @@ void check_pack_opsel_high_halves(uint64_t exec) {
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_bin_encode(/*op=*/672, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/257, words,
                     kOpSelSrc0Src1High);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << "v_pack_b32_f16_vop3 decode failed";
     auto out = fx.run(inst, kRot, exec);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_cvt_f64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_cvt_f64_simd_correctness_test.cpp
@@ -21,6 +21,7 @@
 /// both runs skip the same words. The int conversions are exact (NaN -> 0,
 /// saturating clamp), compared with no carve-out.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -180,7 +181,7 @@ void check_case(const CvtCase &c, uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_encode(c.opcode, /*vdst=*/2, /*src0=*/256, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     auto out = fx.run(inst, c, exec);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_cvt_pk_f32_rdna_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_cvt_pk_f32_rdna_correctness_test.cpp
@@ -26,6 +26,7 @@
 /// any future re-introduction of a mismatched SIMD functor is caught. The CU and
 /// decoder are built for RDNA3; VOP3 encoding marker is 0x35<<26.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -195,7 +196,7 @@ void check_op(uint32_t opcode, bool is_u16, uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     rdna3_vop3_encode(opcode, kDstVgpr, /*src0=*/256, /*src1=*/257, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << name << " decode failed";
     auto out = fx.run(inst, exec);
     delete inst;
@@ -254,7 +255,7 @@ TEST(Vop3CvtPkF32RdnaCorrectness, BugMarker_40000) {
     auto exec_op = [&](uint32_t opcode) -> uint32_t {
       uint32_t words[4] = {0u, 0u, 0u, 0u};
       rdna3_vop3_encode(opcode, kDstVgpr, 256, 257, words);
-      Instruction *inst = fx.decoder->decode(words);
+      Instruction *inst = decode_valid(*fx.decoder, words);
       EXPECT_NE(inst, nullptr);
       fx.cu->execute_instruction(inst, *fx.wf);
       uint32_t r = fx.cu->read_vgpr(vb + kDstVgpr, 0);
@@ -291,7 +292,7 @@ void check_cvt_pk_norm_i16(uint64_t exec) {
     fx.wf->set_exec(exec);
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     rdna3_vop3_encode(kOpCvtPkNormI16F32, kDstVgpr, /*src0=*/256, /*src1=*/257, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << name << " decode failed";
     fx.cu->execute_instruction(inst, *fx.wf);
     std::array<uint32_t, WF_SIZE> out{};
@@ -344,7 +345,7 @@ TEST(Vop3CvtPkF32RdnaCorrectness, NormI16_SignedMarker) {
 
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     rdna3_vop3_encode(kOpCvtPkNormI16F32, kDstVgpr, 256, 257, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     ASSERT_NE(inst, nullptr);
     fx.cu->execute_instruction(inst, *fx.wf);
     const uint32_t lane0 = fx.cu->read_vgpr(vb + kDstVgpr, 0);

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_div_helpers_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_div_helpers_simd_correctness_test.cpp
@@ -23,6 +23,7 @@
 /// FMA quiets a different NaN operand vs scalar std::fma — accepted
 /// divergence shared with the rest of the ternary fp suite).
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -208,7 +209,7 @@ void check_div_fixup_f32(uint64_t exec) {
       uint32_t words[4] = {0u, 0u, 0u, 0u};
       vop3_tern_encode(opcode, /*vdst=*/kDstVgpr32, /*src0=*/256, /*src1=*/257,
                        /*src2=*/258, words);
-      Instruction *inst = fx.decoder->decode(words);
+      Instruction *inst = decode_valid(*fx.decoder, words);
       EXPECT_NE(inst, nullptr) << name << " decode failed";
       auto out = fx.run32(inst, 0, r1, r2, exec, /*vcc=*/0);
       delete inst;
@@ -249,7 +250,7 @@ std::array<uint32_t, WF_SIZE> run_div_fixup_f16_opsel(bool force_scalar, uint32_
   uint32_t words[4] = {0u, 0u, 0u, 0u};
   vop3_tern_encode(opcode, /*vdst=*/kDstVgpr32, /*src0=*/256, /*src1=*/257, /*src2=*/258, words,
                    op_sel);
-  Instruction *inst = fx.decoder->decode(words);
+  Instruction *inst = decode_valid(*fx.decoder, words);
   EXPECT_NE(inst, nullptr) << "v_div_fixup_f16-family decode failed";
 
   const uint32_t vb = fx.wf->vgpr_alloc().base;
@@ -283,7 +284,7 @@ void check_div_fixup_f64(uint64_t exec) {
     // src2=v4:v5; vdst = kDstVgpr64:kDstVgpr64+1.
     vop3_tern_encode(/*op=*/479, /*vdst=*/kDstVgpr64, /*src0=*/256, /*src1=*/258,
                      /*src2=*/260, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << "v_div_fixup_f64_vop3 decode failed";
     auto out = fx.run64(inst, 0, r1, r2, exec, /*vcc=*/0);
     delete inst;
@@ -320,7 +321,7 @@ std::array<uint32_t, WF_SIZE> run_div_fixup_f32_nan_precedence(bool force_scalar
   EXPECT_NE(fx.wf, nullptr);
   uint32_t words[4] = {0u, 0u, 0u, 0u};
   vop3_tern_encode(opcode, /*vdst=*/kDstVgpr32, /*src0=*/256, /*src1=*/257, /*src2=*/258, words);
-  Instruction *inst = fx.decoder->decode(words);
+  Instruction *inst = decode_valid(*fx.decoder, words);
   EXPECT_NE(inst, nullptr) << "v_div_fixup_f32-family decode failed";
 
   constexpr uint32_t kP = 0x3F800000u;
@@ -352,7 +353,7 @@ std::array<uint64_t, WF_SIZE> run_div_fixup_f64_nan_precedence(bool force_scalar
   uint32_t words[4] = {0u, 0u, 0u, 0u};
   vop3_tern_encode(/*op=*/479, /*vdst=*/kDstVgpr64, /*src0=*/256, /*src1=*/258,
                    /*src2=*/260, words);
-  Instruction *inst = fx.decoder->decode(words);
+  Instruction *inst = decode_valid(*fx.decoder, words);
   EXPECT_NE(inst, nullptr) << "v_div_fixup_f64_vop3 decode failed";
 
   constexpr uint64_t kP = 0x3FF0000000000000ULL;
@@ -394,7 +395,7 @@ void check_div_fmas_f32(uint64_t exec) {
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_tern_encode(/*op=*/482, /*vdst=*/kDstVgpr32, /*src0=*/256, /*src1=*/257,
                      /*src2=*/258, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << "v_div_fmas_f32_vop3 decode failed";
     auto out = fx.run32(inst, 0, r1, 2 * r1, exec, vcc);
     delete inst;
@@ -438,7 +439,7 @@ void check_div_fmas_f64(uint64_t exec) {
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_tern_encode(/*op=*/483, /*vdst=*/kDstVgpr64, /*src0=*/256, /*src1=*/258,
                      /*src2=*/260, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << "v_div_fmas_f64_vop3 decode failed";
     auto out = fx.run64(inst, 0, r1, 2 * r1, exec, vcc);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_fmac_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_fmac_simd_correctness_test.cpp
@@ -19,6 +19,7 @@
 /// These ops are NOT benched: looping the same instruction creates a loop-
 /// carried RAW dep on the accumulator that serializes both modes to ~1x.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -225,7 +226,7 @@ void check_case(const Case &c, uint32_t abs, uint32_t neg, uint32_t omod, uint32
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_encode(c.opcode, /*vdst=*/kAccVgpr, /*src0=*/256, /*src1=*/256 + src1_v, abs, neg, omod,
                 clamp, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     auto out = fx.run(inst, c.kind, rot, exec);
     delete inst;
@@ -292,7 +293,7 @@ TEST(Vop3FmacSimdCorrectness, VMacF16LowDstZeroesHighHalf) {
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_encode(/*op=*/291, /*vdst=*/kAccVgpr, /*src0=*/256, /*src1=*/257, /*abs=*/0, /*neg=*/0,
                 /*omod=*/0, /*clamp=*/0, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << "v_mac_f16_vop3 decode failed";
     auto out = fx.run(inst, Kind::F16, /*rot=*/0, /*exec=*/~0ULL);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_fp16_transcendental_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_fp16_transcendental_simd_correctness_test.cpp
@@ -16,6 +16,7 @@
 /// comparison — NaN-ness is deterministic from the inputs, so both runs skip the
 /// same lanes. In-process inactive lanes must keep the sentinel.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -152,7 +153,7 @@ void check_case(const Case &c, uint32_t abs, uint32_t neg, uint32_t omod, uint32
     EXPECT_NE(fx.wf, nullptr);
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_encode(c.opcode, /*vdst=*/kDstVgpr, /*src0=*/256, abs, neg, omod, clamp, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     auto out = fx.run(inst, exec, lane_input);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_fp16_unary_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_fp16_unary_simd_correctness_test.cpp
@@ -16,6 +16,7 @@
 /// so both runs skip the same lanes. In-process inactive lanes must keep the
 /// sentinel.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -150,7 +151,7 @@ void check_case(const Case &c, uint32_t abs, uint32_t neg, uint32_t omod, uint32
     EXPECT_NE(fx.wf, nullptr);
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_encode(c.opcode, /*vdst=*/kDstVgpr, /*src0=*/256, abs, neg, omod, clamp, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     auto out = fx.run(inst, exec);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_fp64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_fp64_simd_correctness_test.cpp
@@ -16,6 +16,7 @@
 /// from the comparison so both runs skip the same lanes. In-process inactive
 /// lanes must stay preserved.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -165,7 +166,7 @@ void check_case(const Case &c, uint32_t abs, uint32_t neg, uint32_t omod, uint32
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_encode(c.opcode, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/258, abs, neg, omod, clamp,
                 words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     auto out = fx.run(inst, rot, exec);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_int_binary_extra_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_int_binary_extra_simd_correctness_test.cpp
@@ -13,6 +13,7 @@
 /// equal with EXPECT_EQ (util::set_force_scalar_for_testing flips the gate
 /// in-process). In-process inactive lanes must keep the sentinel.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -145,7 +146,7 @@ void check_case(const Case &c, uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_bin_encode(c.opcode, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/257, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     auto out = fx.run(inst, rot, exec);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_int_widening_ternary_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_int_widening_ternary_simd_correctness_test.cpp
@@ -15,6 +15,7 @@
 /// equal with EXPECT_EQ (util::set_force_scalar_for_testing flips the gate
 /// in-process). In-process inactive lanes must keep the sentinel.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -150,7 +151,7 @@ void check_case(const Case &c, uint64_t exec) {
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_encode(c.opcode, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/257,
                 /*src2=*/(c.ternary ? 258u : 0u), words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     auto out = fx.run(inst, rot, exec);
     delete inst;
@@ -199,7 +200,7 @@ void check_mad_u32_u16_opsel_high_halves(uint64_t exec) {
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_encode(/*op=*/497, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/257, /*src2=*/258, words,
                 kOpSelSrc0Src1High);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << "v_mad_u32_u16_vop3 decode failed";
     fx.cu->execute_instruction(inst, *fx.wf);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_ldexp_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_ldexp_simd_correctness_test.cpp
@@ -11,6 +11,7 @@
 /// identical inputs/EXEC -- and the result arrays are asserted equal with
 /// EXPECT_EQ (util::set_force_scalar_for_testing flips the gate in-process).
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -165,7 +166,7 @@ void check_case(const Case &c, uint32_t abs, uint32_t neg, uint32_t omod, uint32
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_encode(c.opcode, /*vdst=*/4, /*src0=*/256, /*src1=*/256 + src1_v, abs, neg, omod, clamp,
                 words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     auto out = fx.run(inst, c.f64, rot, exec);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_shift64_scalar_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_shift64_scalar_correctness_test.cpp
@@ -25,6 +25,7 @@
 /// low-word-only read or a high-word-dropping write is visible. No SIMD is
 /// involved; this exercises the plain decode+execute scalar path.
 
+#include "decode_test_util.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
@@ -105,7 +106,7 @@ struct Fixture {
     }
     wf->set_exec(~0ULL);
     uint32_t words[4] = {w.w0, w.w1, 0u, 0u};
-    Instruction *inst = decoder->decode(words);
+    Instruction *inst = decode_valid(*decoder, words);
     ASSERT_NE(inst, nullptr) << "decode failed for " << expect_mnemonic;
     EXPECT_EQ(inst->mnemonic(), expect_mnemonic) << "decoded wrong op";
     cu->execute_instruction(inst, *wf);

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_shift64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_shift64_simd_correctness_test.cpp
@@ -15,6 +15,7 @@
 /// The wide MAD cases also compare the explicit SGPR-pair carry/overflow mask.
 /// In-process inactive lanes must keep the sentinel.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -151,7 +152,7 @@ void check_revshift(const char *name, uint32_t op, uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t words[2] = {0u, 0u};
     vop3_encode(op, kDstVgpr, /*src0=*/256, /*src1=*/258, /*src2=*/0, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << name << " decode failed";
     uint32_t vb = fx.wf->vgpr_alloc().base;
     for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
@@ -187,7 +188,7 @@ void check_lshl_add(uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t words[2] = {0u, 0u};
     vop3_encode(/*op=*/520, kDstVgpr, /*src0=*/256, /*src1=*/258, /*src2=*/260, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << "v_lshl_add_u64 decode failed";
     uint32_t vb = fx.wf->vgpr_alloc().base;
     for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
@@ -269,7 +270,7 @@ void check_mad64(const char *name, uint32_t op, bool is_signed, uint64_t exec) {
     EXPECT_EQ(sb % 2u, 0u) << name << ": sgpr_alloc base not pair-aligned";
     uint32_t words[2] = {0u, 0u};
     vop3_sdstenc_encode(op, kDstVgpr, sb, /*src0=*/256, /*src1=*/258, /*src2=*/260, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << name << " decode failed";
     uint32_t vb = fx.wf->vgpr_alloc().base;
     for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_ternary_fp_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_ternary_fp_simd_correctness_test.cpp
@@ -19,6 +19,7 @@
 /// initialize src0+src1+vdst (the third FMA arg comes from vdst, no src2
 /// member), so they need a separate accumulate-form glue path.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -244,7 +245,7 @@ void check_case(const Case &c, uint32_t abs, uint32_t neg, uint32_t omod, uint32
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_encode(c.opcode, vdst, /*src0=*/256, /*src1=*/256 + src1_v, /*src2=*/256 + src2_v, abs,
                 neg, omod, clamp, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     auto out = fx.run(inst, c.kind, rot, exec);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_ternary_int_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_ternary_int_simd_correctness_test.cpp
@@ -12,6 +12,7 @@
 /// with EXPECT_EQ (util::set_force_scalar_for_testing flips the gate in-process).
 /// In-process inactive lanes must keep the sentinel.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -169,7 +170,7 @@ void check_case(const Case &c, uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_tern_encode(c.opcode, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/257, /*src2=*/258, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     auto out = fx.run(inst, rot, exec);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_unary_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_unary_simd_correctness_test.cpp
@@ -13,6 +13,7 @@
 /// (util::set_force_scalar_for_testing flips the gate in-process). In-process
 /// inactive lanes must stay preserved under full/partial EXEC.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -180,7 +181,7 @@ void check(const Case &c, uint32_t abs, uint32_t neg, uint32_t omod, uint32_t cl
     EXPECT_NE(fx.wf, nullptr);
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_encode(c.opcode, /*vdst=*/kDstVgpr, /*src0=*/256, abs, neg, omod, clamp, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     auto out = fx.run(inst, c.kind, exec);
     delete inst;
@@ -276,7 +277,7 @@ TEST(Vop3UnarySimdCorrectness, MovB32_PreservesBits) {
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_encode(/*op=v_mov_b32=*/321, /*vdst=*/kDstVgpr, /*src0=*/256, s.abs, s.neg, s.omod,
                 s.clamp, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     ASSERT_NE(inst, nullptr);
     uint32_t vb = fx.wf->vgpr_alloc().base;
     for (uint32_t lane = 0; lane < WF_SIZE; ++lane)

--- a/emulation/rocjitsu/tests/simd_correctness/vop3p_dot_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3p_dot_simd_correctness_test.cpp
@@ -25,6 +25,7 @@
 /// payload divergence, same carve-out as the pk_fma slices). Default packing
 /// (op_sel = 0, op_sel_hi = 3) only — non-default modes bail to scalar.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -135,7 +136,7 @@ void check_int_case(const IntCase &c, uint64_t exec, uint32_t clamp) {
     uint32_t words[2] = {0u, 0u};
     vop3p_encode_dot(c.opcode, kDstVgpr, /*src0=*/256, /*src1=*/257, /*src2=*/258, /*neg=*/0,
                      /*neg_hi=*/0, clamp, words);
-    Instruction *inst = decoder->decode(words);
+    Instruction *inst = decode_valid(*decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
 
     uint32_t vb = wf->vgpr_alloc().base;
@@ -245,7 +246,7 @@ void check_f16_case(uint64_t exec, uint32_t neg, uint32_t neg_hi, uint32_t clamp
     uint32_t words[2] = {0u, 0u};
     vop3p_encode_dot(/*op=*/35, kDstVgpr, /*src0=*/256, /*src1=*/257, /*src2=*/258, neg, neg_hi,
                      clamp, words);
-    Instruction *inst = decoder->decode(words);
+    Instruction *inst = decode_valid(*decoder, words);
     EXPECT_NE(inst, nullptr) << "v_dot2_f32_f16 decode failed";
 
     uint32_t vb = wf->vgpr_alloc().base;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3p_fma_mix_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3p_fma_mix_simd_correctness_test.cpp
@@ -33,6 +33,7 @@
 /// different payloads (accepted divergence, mirroring the existing VOP3
 /// ternary tests).
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -351,7 +352,7 @@ void check_combo(uint32_t opcode, const ModCombo &mc, uint64_t exec, uint32_t ds
       vop3p_encode_cdna4(opcode, kDstVgpr, /*neg_hi=*/mc.abs, mc.op_sel, mc.op_sel_hi_2, mc.clamp,
                          /*src0=*/256, /*src1=*/257, /*src2=*/258, mc.op_sel_hi, mc.neg, words);
     }
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << label << " decode failed";
     auto out = fx.run(inst, rot, widen0, widen1, widen2, exec, dst_seed);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3p_mov_b32_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3p_mov_b32_simd_correctness_test.cpp
@@ -12,6 +12,7 @@
 /// mixed SGPR-pair/VGPR-pair case covers the legal scalar source encoding.
 /// In-process inactive lanes must keep the sentinel.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -213,7 +214,7 @@ void check(uint64_t exec) {
     uint32_t words[2] = {0u, 0u};
     // src0 = VGPR 256 (pair v0:v1), src1 = VGPR 258 (pair v2:v3).
     vop3p_encode(/*op=*/51, kDstVgpr, /*src0=*/256, /*src1=*/258, op_sel, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << "v_pk_mov_b32_vop3p decode failed";
     auto out =
         force_scalar ? fx.run(inst, rot, exec) : fx.run_simd_probe(inst, arch, rot, exec, op_sel);
@@ -287,7 +288,7 @@ TEST(Vop3pMovB32SimdCorrectness, ProductionSimdDispatchGolden) {
     ASSERT_NE(fx.wf, nullptr);
     uint32_t words[2] = {0u, 0u};
     vop3p_encode(/*op=*/51, kDstVgpr, /*src0=*/256, /*src1=*/258, kOpSel, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     ASSERT_NE(inst, nullptr) << arch.name << " v_pk_mov_b32_vop3p decode failed";
     const auto out = fx.run(inst, kRot, kExec);
     delete inst;
@@ -324,7 +325,7 @@ TEST(Vop3pMovB32SimdCorrectness, MixedSgprPairAndVgprPairGolden) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t words[2] = {0u, 0u};
     vop3p_encode(/*op=*/51, kDstVgpr, test_case.src0, test_case.src1, test_case.op_sel, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << arch.name << " " << test_case.name
                              << " v_pk_mov_b32_vop3p decode failed";
     auto out = force_scalar

--- a/emulation/rocjitsu/tests/simd_correctness/vop3p_pk_binary_fp16_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3p_pk_binary_fp16_simd_correctness_test.cpp
@@ -18,6 +18,7 @@
 /// computed from the inputs, identical in both runs, so both skip the same
 /// lanes. In-process inactive lanes must keep the sentinel.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -181,7 +182,7 @@ void check_case(const Case &c, uint64_t exec, uint32_t neg, uint32_t neg_hi) {
                            neg, words);
     else
       vop3p_encode_binary(c.opcode, kDstVgpr, neg_hi, /*src0=*/256, /*src1=*/257, neg, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     auto out = fx.run(inst, rot, exec);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop3p_pk_binary_int_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3p_pk_binary_int_simd_correctness_test.cpp
@@ -21,6 +21,7 @@
 /// shift-saturation, and identical-pair cases on both halves
 /// independently.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -172,7 +173,7 @@ void check_case(const Case &c, uint64_t exec) {
                                    words);
     else
       vop3p_encode_default_binary(c.opcode, kDstVgpr, /*src0=*/256, /*src1=*/257, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     auto out = fx.run(inst, rot, exec);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vop_alias_rdna_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop_alias_rdna_simd_correctness_test.cpp
@@ -26,6 +26,7 @@
 ///     modifiers — verified inline in the regen for this slice) + 2 ints
 ///     missing from CDNA4 (v_minmax / v_maxmin u32/i32 are RDNA3+ only).
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -226,7 +227,7 @@ void check_case(const VopCase &c, uint64_t exec) {
       vop3_encode(c.opcode, kDstVgpr, SRC0_VGPR, SRC1_VGPR, SRC2_VGPR, words);
       break;
     }
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << ": decode failed";
     auto out = fx.run(inst, rot, exec, vcc_in);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_cmp_class_scalar_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_cmp_class_scalar_correctness_test.cpp
@@ -16,6 +16,7 @@
 /// either direction is caught. f64 patterns all have a nonzero high word, so a
 /// low-word-only read or f32-precision classify fails the +normal/-normal rows.
 
+#include "decode_test_util.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
@@ -83,7 +84,7 @@ struct Fixture {
     cu->write_vgpr(vb + 2, 0, mask);
     uint32_t enc = vopc_encode(op, /*src0=*/256, /*vsrc1=*/2);
     uint32_t words[4] = {enc, 0u, 0u, 0u};
-    Instruction *inst = decoder->decode(words);
+    Instruction *inst = decode_valid(*decoder, words);
     EXPECT_NE(inst, nullptr);
     cu->execute_instruction(inst, *wf);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_cmp_class_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_cmp_class_simd_correctness_test.cpp
@@ -18,6 +18,7 @@
 /// outcomes for every input incl. NaN payload), so the compare is bit-exact with
 /// no carve-out.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -221,7 +222,7 @@ void check_all(uint64_t exec) {
       uint32_t vsrc1 = (c.kind == Kind::F64) ? 2u : 1u; // f64 src0 spans v0:v1
       uint32_t enc = vopc_encode(c.opcode, /*src0=*/256, vsrc1);
       uint32_t words[4] = {enc, 0u, 0u, 0u};
-      Instruction *inst = fx.decoder->decode(words);
+      Instruction *inst = decode_valid(*fx.decoder, words);
       EXPECT_NE(inst, nullptr) << c.name << " decode failed";
       uint64_t vcc = fx.run(inst, c.kind, rot, exec, vcc_in);
       delete inst;
@@ -273,7 +274,7 @@ void check_all_vop3(uint64_t exec) {
           EXPECT_NE(fx.wf, nullptr);
           uint32_t words[4] = {0u, 0u, 0u, 0u};
           vop3_encode(c.opcode, /*vdst=*/kVccSdst, /*src0=*/256, src1, abs, neg, words);
-          Instruction *inst = fx.decoder->decode(words);
+          Instruction *inst = decode_valid(*fx.decoder, words);
           EXPECT_NE(inst, nullptr) << c.name << " decode failed";
           uint64_t vcc = fx.run(inst, c.kind, rot, exec, vcc_in);
           delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_simd_correctness_test.cpp
@@ -15,6 +15,7 @@
 /// split lo/hi VGPR-pair read path. Inputs seed NaN/±Inf/±0/denorm (floats) and
 /// signed/extreme boundaries (ints); float compares are bit-exact in both modes.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -180,7 +181,7 @@ void check_all(uint64_t exec) {
     uint32_t vsrc1 = is_64bit(c.kind) ? 2u : 1u;
     uint32_t enc = vopc_encode(c.opcode, /*src0=*/256, vsrc1);
     uint32_t words[4] = {enc, 0u, 0u, 0u};
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << "VOPC opcode " << c.opcode << " decode failed";
     uint64_t vcc = fx.run(inst, c.kind, exec, vcc_in);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_fp16_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_fp16_simd_correctness_test.cpp
@@ -14,6 +14,7 @@
 /// EXPECT_EQ (util::set_force_scalar_for_testing flips the gate in-process).
 /// In-process inactive SGPR-pair bits must be zeroed.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -149,7 +150,7 @@ void check_case(const Case &c, uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_cmp_encode(c.opcode, /*vdst=*/kVccSdst, /*src0=*/256, /*src1=*/257, abs, neg, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed (abs=" << abs << " neg=" << neg << ")";
     uint64_t vcc = fx.run(inst, rot, exec, vcc_in);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_fp32_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_fp32_simd_correctness_test.cpp
@@ -14,6 +14,7 @@
 /// equal with EXPECT_EQ (util::set_force_scalar_for_testing flips the gate
 /// in-process). In-process inactive SGPR-pair bits must be zeroed.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -157,7 +158,7 @@ void check_case(const Case &c, uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_cmp_encode(c.opcode, /*vdst=*/kVccSdst, /*src0=*/256, /*src1=*/257, abs, neg, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed (abs=" << abs << " neg=" << neg << ")";
     uint64_t vcc = fx.run(inst, rot, exec, vcc_in);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_fp64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_fp64_simd_correctness_test.cpp
@@ -14,6 +14,7 @@
 /// EXPECT_EQ (util::set_force_scalar_for_testing flips the gate in-process).
 /// In-process inactive SGPR-pair bits must be zeroed.
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -154,7 +155,7 @@ void check_case(const Case &c, uint64_t exec) {
     EXPECT_NE(fx.wf, nullptr);
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_cmp_encode(c.opcode, /*vdst=*/kVccSdst, /*src0=*/256, /*src1=*/258, abs, neg, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed (abs=" << abs << " neg=" << neg << ")";
     uint64_t vcc = fx.run(inst, rot, exec, vcc_in);
     delete inst;

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_int_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_int_simd_correctness_test.cpp
@@ -19,6 +19,7 @@
 /// over the test loop so eq/lt/gt/le/ge/ne all fire on real boundary cases (incl.
 /// signed-negative vs unsigned wrap).
 
+#include "decode_test_util.h"
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
@@ -232,7 +233,7 @@ void check_case(const Case &c, uint64_t exec) {
     const uint32_t src1_vgpr = (c.width == Width::B64) ? 2u : 2u; // v2:v3 / v2
     uint32_t words[4] = {0u, 0u, 0u, 0u};
     vop3_cmp_encode(c.opcode, /*vdst=*/kVccSdst, /*src0=*/256u, /*src1=*/256u + src1_vgpr, words);
-    Instruction *inst = fx.decoder->decode(words);
+    Instruction *inst = decode_valid(*fx.decoder, words);
     EXPECT_NE(inst, nullptr) << c.name << " decode failed";
     uint64_t vcc = fx.run(inst, c.width, rot, exec, vcc_in);
     delete inst;

--- a/emulation/rocjitsu/tests/smem_sbase_operand_test.cpp
+++ b/emulation/rocjitsu/tests/smem_sbase_operand_test.cpp
@@ -26,6 +26,7 @@
 ///   - s_store_dwordx2: store family, where sdata is also a source so SBASE is
 ///     not the first source operand.
 
+#include "decode_test_util.h"
 #include "rocjitsu/analysis/def_use_chain.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/decoder.h"
@@ -94,7 +95,7 @@ TEST_P(SmemSbaseOperandTest, SbaseResolvesToScaledSgpr) {
   auto decoder = Decoder::create(tc.arch);
   ASSERT_NE(decoder, nullptr) << "Decoder::create() failed for " << tc.label;
 
-  std::unique_ptr<Instruction> inst(decoder->decode(tc.word.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, tc.word.data()));
   ASSERT_NE(inst, nullptr) << "decode() returned nullptr for " << tc.label;
   ASSERT_EQ(inst->mnemonic(), tc.mnemonic) << "unexpected mnemonic for " << tc.label;
 

--- a/emulation/rocjitsu/tests/util_result_test.cpp
+++ b/emulation/rocjitsu/tests/util_result_test.cpp
@@ -135,6 +135,17 @@ TEST(FailureOrTest, RepresentsValueOrFailureWithoutThrowing) {
   static_assert(std::is_same_v<rocjitsu::FailureOr<int>, IntResult>);
 }
 
+TEST(FailureOrTest, DeducesValueType) {
+  constexpr auto int_result = util::FailureOr(42);
+  auto pointer_result = util::FailureOr(std::make_unique<int>(42));
+
+  static_assert(std::is_same_v<std::remove_cv_t<decltype(int_result)>, util::FailureOr<int>>);
+  static_assert(std::is_same_v<decltype(pointer_result), util::FailureOr<std::unique_ptr<int>>>);
+  static_assert(int_result.succeeded() && int_result.value() == 42);
+  ASSERT_TRUE(pointer_result.succeeded());
+  EXPECT_EQ(*pointer_result.value(), 42);
+}
+
 TEST(FailureOrTest, RejectsSuccessfulResult) {
   EXPECT_DEBUG_DEATH(
       { [[maybe_unused]] util::FailureOr<int> result(util::Result::success()); }, "");

--- a/emulation/rocjitsu/tests/v_add_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/v_add_simd_benchmark.cpp
@@ -9,6 +9,7 @@
 /// then unset (SIMD). Scalar-vs-SIMD bit-equivalence is verified separately by
 /// the *SimdCorrectness* suites (in-process double-run + EXPECT_EQ), not here.
 
+#include "decode_test_util.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/decoder.h"
@@ -189,7 +190,7 @@ void run_words(const char *label, uint32_t w0, uint32_t w1, bool sanitize_finite
   ASSERT_NE(fx.wf, nullptr);
 
   uint32_t words[4] = {w0, w1, 0u, 0u};
-  Instruction *inst = fx.decoder->decode(words);
+  Instruction *inst = decode_valid(*fx.decoder, words);
   ASSERT_NE(inst, nullptr) << label << ": decode failed";
 
   constexpr uint64_t SEED = 0xC0FFEE'1234'5678ULL;

--- a/emulation/rocjitsu/tests/vector_add_test.cpp
+++ b/emulation/rocjitsu/tests/vector_add_test.cpp
@@ -9,6 +9,7 @@
 /// CPU golden reference.
 
 #include "aql_queue.h"
+#include "decode_test_util.h"
 #include "test_paths.h"
 
 #include "embedded_schema.h"
@@ -216,7 +217,7 @@ TEST(VectorAddCodeObjectTest, LoadsAndDecodes) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   const auto *text = co->text_sections()[0];
   const auto *data = reinterpret_cast<const uint32_t *>(text->data());
-  std::unique_ptr<Instruction> inst(decoder->decode(data));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, data));
   EXPECT_NE(inst, nullptr) << "Failed to decode first instruction";
 }
 

--- a/emulation/rocjitsu/tools/CMakeLists.txt
+++ b/emulation/rocjitsu/tools/CMakeLists.txt
@@ -33,6 +33,13 @@ add_executable(rj_dbt_translate rj_dbt_translate_main.cpp)
 target_link_libraries(rj_dbt_translate PRIVATE rocjitsu_translate_cli)
 rj_configure_target(rj_dbt_translate TOOL)
 
+add_executable(rj_decode_benchmark rj_decode_benchmark.cpp)
+target_link_libraries(
+    rj_decode_benchmark
+    PRIVATE ${RJ_TOOL_OBJECT_LIBS} util flatbuffers Threads::Threads
+)
+rj_configure_target(rj_decode_benchmark TOOL)
+
 # Ahead-of-time population of the shared translation tier.
 #
 # Deliberately narrow: the fixed-profile translator, the store, and nothing else

--- a/emulation/rocjitsu/tools/dbt_translate.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate.cpp
@@ -95,17 +95,19 @@ void record_decode_failure(CodeSectionReport &section_report, size_t byte_offset
         continue;
       }
       try {
-        std::unique_ptr<Instruction> inst(decoder->decode(&words[pc]));
-        if (!inst) {
-          record_decode_failure(section_report, pc * sizeof(uint32_t), "decode returned null");
+        util::StringDiagnostic decode_error;
+        DecodeResult decoded = decoder->decode(&words[pc], decode_error.emitter());
+        if (decoded.failed()) {
+          record_decode_failure(section_report, pc * sizeof(uint32_t), decode_error.message());
           if (include_disassembly) {
             os << "  0x" << std::hex << std::setw(4) << std::setfill('0') << pc * 4
-               << ": <decode returned null>\n"
+               << ": <decode error: " << decode_error.message() << ">\n"
                << std::dec << std::setfill(' ');
           }
           ++pc;
           continue;
         }
+        std::unique_ptr<Instruction> inst = std::move(decoded).value();
 
         const uint32_t inst_words = inst->size() / sizeof(uint32_t);
         ++section_report.instruction_count;
@@ -317,14 +319,11 @@ collect_executable_sections(const AmdGpuCodeObject &object) {
     return "<source offset out of range>";
 
   const auto *words = reinterpret_cast<const uint32_t *>(text->data());
-  try {
-    std::unique_ptr<Instruction> inst(decoder->decode(&words[offset / sizeof(uint32_t)]));
-    if (!inst)
-      return "<decode returned null>";
-    return inst->disassemble();
-  } catch (const std::exception &e) {
-    return std::string("<decode error: ") + e.what() + ">";
-  }
+  util::StringDiagnostic decode_error;
+  DecodeResult decoded = decoder->decode(&words[offset / sizeof(uint32_t)], decode_error.emitter());
+  if (decoded.failed())
+    return std::string("<decode error: ") + decode_error.message() + ">";
+  return decoded.value()->disassemble();
 }
 
 [[nodiscard]] std::vector<std::string> disassemble_words(std::span<const uint32_t> words,
@@ -338,21 +337,18 @@ collect_executable_sections(const AmdGpuCodeObject &object) {
 
   size_t pc = 0;
   while (pc < words.size()) {
-    try {
-      std::unique_ptr<Instruction> inst(decoder->decode(&words[pc]));
-      if (!inst) {
-        lines.push_back("<decode returned null>");
-        ++pc;
-        continue;
-      }
-
-      lines.push_back(inst->disassemble());
-      const uint32_t inst_words = inst->size() / sizeof(uint32_t);
-      pc += inst_words == 0 ? 1 : inst_words;
-    } catch (const std::exception &e) {
-      lines.push_back(std::string("<decode error: ") + e.what() + ">");
+    util::StringDiagnostic decode_error;
+    DecodeResult decoded = decoder->decode(&words[pc], decode_error.emitter());
+    if (decoded.failed()) {
+      lines.push_back(std::string("<decode error: ") + decode_error.message() + ">");
       ++pc;
+      continue;
     }
+
+    const std::unique_ptr<Instruction> &inst = decoded.value();
+    lines.push_back(inst->disassemble());
+    const uint32_t inst_words = inst->size() / sizeof(uint32_t);
+    pc += inst_words == 0 ? 1 : inst_words;
   }
 
   return lines;

--- a/emulation/rocjitsu/tools/rj_decode_benchmark.cpp
+++ b/emulation/rocjitsu/tools/rj_decode_benchmark.cpp
@@ -1,0 +1,310 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file rj_decode_benchmark.cpp
+/// @brief Measure decoder throughput over the text of a real code object.
+
+#include "rocjitsu/code/amdgpu_code_object.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+
+#include <array>
+#include <charconv>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+using namespace rocjitsu;
+using Clock = std::chrono::steady_clock;
+
+constexpr std::size_t kLookaheadWords = 4;
+constexpr std::size_t kDefaultInvalidLimit = 65536;
+
+struct TextRange {
+  std::size_t begin;
+  std::size_t word_count;
+};
+
+struct DecodeCorpus {
+  std::vector<uint32_t> words;
+  std::vector<TextRange> ranges;
+  std::vector<std::size_t> valid_offsets;
+  std::vector<std::array<uint32_t, kLookaheadWords>> invalid_encodings;
+  std::size_t text_bytes = 0;
+  std::size_t scan_rejections = 0;
+};
+
+struct Options {
+  std::string input;
+  std::optional<rj_code_arch_t> arch;
+  std::size_t iterations = 1;
+  std::size_t invalid_limit = kDefaultInvalidLimit;
+};
+
+struct Measurement {
+  std::size_t attempts = 0;
+  std::size_t unexpected = 0;
+  uint64_t checksum = 0;
+  std::chrono::nanoseconds elapsed{};
+};
+
+void print_usage(std::ostream &os) {
+  os << "Usage: rj_decode_benchmark INPUT [--target TARGET] [--iterations N] "
+        "[--invalid-limit N]\n"
+        "Targets: gfx942, gfx950, gfx1200, gfx1201, gfx1250\n";
+}
+
+[[nodiscard]] std::optional<rj_code_arch_t> parse_target(std::string_view value) {
+  if (value == "gfx942")
+    return ROCJITSU_CODE_ARCH_CDNA3;
+  if (value == "gfx950")
+    return ROCJITSU_CODE_ARCH_CDNA4;
+  if (value == "gfx1200" || value == "gfx1201")
+    return ROCJITSU_CODE_ARCH_RDNA4;
+  if (value == "gfx1250")
+    return ROCJITSU_CODE_ARCH_GFX1250;
+  return std::nullopt;
+}
+
+[[nodiscard]] std::optional<rj_code_arch_t> arch_for_target(rj_code_target_id_t target) {
+  switch (target) {
+  case ROCJITSU_CODE_TARGET_GFX942:
+    return ROCJITSU_CODE_ARCH_CDNA3;
+  case ROCJITSU_CODE_TARGET_GFX950:
+    return ROCJITSU_CODE_ARCH_CDNA4;
+  case ROCJITSU_CODE_TARGET_GFX1200:
+  case ROCJITSU_CODE_TARGET_GFX1201:
+    return ROCJITSU_CODE_ARCH_RDNA4;
+  case ROCJITSU_CODE_TARGET_GFX1250:
+    return ROCJITSU_CODE_ARCH_GFX1250;
+  default:
+    return std::nullopt;
+  }
+}
+
+[[nodiscard]] bool parse_size(std::string_view text, std::size_t &value) {
+  auto [ptr, error] = std::from_chars(text.data(), text.data() + text.size(), value);
+  return error == std::errc{} && ptr == text.data() + text.size();
+}
+
+[[nodiscard]] std::optional<Options> parse_options(int argc, char **argv) {
+  Options options;
+  for (int index = 1; index < argc; ++index) {
+    const std::string_view arg(argv[index]);
+    if (arg == "--help") {
+      print_usage(std::cout);
+      return std::nullopt;
+    }
+    if (arg == "--target" && index + 1 < argc) {
+      options.arch = parse_target(argv[++index]);
+      if (!options.arch) {
+        std::cerr << "Unsupported target: " << argv[index] << '\n';
+        return std::nullopt;
+      }
+      continue;
+    }
+    if (arg == "--iterations" && index + 1 < argc) {
+      if (!parse_size(argv[++index], options.iterations) || options.iterations == 0) {
+        std::cerr << "Iterations must be a positive integer\n";
+        return std::nullopt;
+      }
+      continue;
+    }
+    if (arg == "--invalid-limit" && index + 1 < argc) {
+      if (!parse_size(argv[++index], options.invalid_limit)) {
+        std::cerr << "Invalid limit must be a non-negative integer\n";
+        return std::nullopt;
+      }
+      continue;
+    }
+    if (!arg.starts_with("--") && options.input.empty()) {
+      options.input = arg;
+      continue;
+    }
+    std::cerr << "Unexpected argument: " << arg << '\n';
+    return std::nullopt;
+  }
+  if (options.input.empty()) {
+    print_usage(std::cerr);
+    return std::nullopt;
+  }
+  return options;
+}
+
+void copy_encoding(std::span<const uint32_t> words, std::size_t offset,
+                   std::array<uint32_t, kLookaheadWords> &copy) {
+  copy.fill(0);
+  const std::size_t available = std::min(copy.size(), words.size() - offset);
+  std::copy_n(words.begin() + static_cast<std::ptrdiff_t>(offset), available, copy.begin());
+}
+
+[[nodiscard]] bool collect_corpus(const AmdGpuCodeObject &object, Decoder &decoder,
+                                  std::size_t invalid_limit, DecodeCorpus &corpus,
+                                  std::string &error) {
+  for (const Section *section : object.text_sections()) {
+    const std::size_t word_count = section->size() / sizeof(uint32_t);
+    const std::size_t begin = corpus.words.size();
+    corpus.words.resize(begin + word_count + kLookaheadWords, 0);
+    std::memcpy(corpus.words.data() + begin, section->data(), word_count * sizeof(uint32_t));
+    corpus.ranges.push_back({begin, word_count});
+    corpus.text_bytes += word_count * sizeof(uint32_t);
+  }
+
+  for (const TextRange range : corpus.ranges) {
+    std::size_t relative_offset = 0;
+    while (relative_offset < range.word_count) {
+      const std::size_t offset = range.begin + relative_offset;
+      DecodeResult decoded = decoder.decode(corpus.words.data() + offset);
+      if (decoded.failed()) {
+        ++corpus.scan_rejections;
+        if (corpus.invalid_encodings.size() < invalid_limit) {
+          std::array<uint32_t, kLookaheadWords> encoding;
+          copy_encoding(corpus.words, offset, encoding);
+          corpus.invalid_encodings.push_back(encoding);
+        }
+        ++relative_offset;
+        continue;
+      }
+
+      const std::size_t byte_size = decoded.value()->size();
+      if (byte_size == 0 || byte_size % sizeof(uint32_t) != 0) {
+        error = "decoder returned an invalid instruction size";
+        return false;
+      }
+      const std::size_t instruction_words = byte_size / sizeof(uint32_t);
+      if (instruction_words > range.word_count - relative_offset) {
+        error = "decoded instruction crosses a text-section boundary";
+        return false;
+      }
+      corpus.valid_offsets.push_back(offset);
+      relative_offset += instruction_words;
+    }
+  }
+
+  static constexpr std::array<uint32_t, 4> kMutationMasks = {0xffffffffu, 0xff800000u, 0x007fffffu,
+                                                             0x9e3779b9u};
+  for (std::size_t offset : corpus.valid_offsets) {
+    if (corpus.invalid_encodings.size() >= invalid_limit)
+      break;
+    std::array<uint32_t, kLookaheadWords> encoding;
+    copy_encoding(corpus.words, offset, encoding);
+    const uint32_t original = encoding[0];
+    for (uint32_t mask : kMutationMasks) {
+      encoding[0] = original ^ mask;
+      if (decoder.decode(encoding.data()).failed()) {
+        corpus.invalid_encodings.push_back(encoding);
+        break;
+      }
+    }
+  }
+  return true;
+}
+
+[[nodiscard]] Measurement measure_valid(const DecodeCorpus &corpus, Decoder &decoder,
+                                        std::size_t iterations) {
+  Measurement measurement;
+  measurement.attempts = corpus.valid_offsets.size() * iterations;
+  const auto start = Clock::now();
+  for (std::size_t iteration = 0; iteration < iterations; ++iteration) {
+    for (std::size_t offset : corpus.valid_offsets) {
+      DecodeResult decoded = decoder.decode(corpus.words.data() + offset);
+      if (decoded.failed()) {
+        ++measurement.unexpected;
+        continue;
+      }
+      measurement.checksum += decoded.value()->size();
+    }
+  }
+  measurement.elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now() - start);
+  return measurement;
+}
+
+[[nodiscard]] Measurement measure_invalid(const DecodeCorpus &corpus, Decoder &decoder,
+                                          std::size_t iterations) {
+  Measurement measurement;
+  measurement.attempts = corpus.invalid_encodings.size() * iterations;
+  const auto start = Clock::now();
+  for (std::size_t iteration = 0; iteration < iterations; ++iteration) {
+    for (const auto &encoding : corpus.invalid_encodings) {
+      DecodeResult decoded = decoder.decode(encoding.data());
+      if (decoded.succeeded()) {
+        ++measurement.unexpected;
+        measurement.checksum += decoded.value()->size();
+      }
+    }
+  }
+  measurement.elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now() - start);
+  return measurement;
+}
+
+void print_measurement(std::string_view name, const Measurement &measurement) {
+  const double elapsed_ns = static_cast<double>(measurement.elapsed.count());
+  const double ns_per_attempt = measurement.attempts == 0 ? 0.0 : elapsed_ns / measurement.attempts;
+  const double mips = elapsed_ns == 0.0 ? 0.0 : measurement.attempts / (elapsed_ns / 1e9) / 1e6;
+  std::cout << name << ": " << measurement.attempts << " attempts, " << std::fixed
+            << std::setprecision(2) << ns_per_attempt << " ns/attempt, " << mips << " MIPS, "
+            << measurement.unexpected << " unexpected, checksum " << measurement.checksum << '\n';
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  const std::optional<Options> options = parse_options(argc, argv);
+  if (!options)
+    return argc > 1 && std::string_view(argv[1]) == "--help" ? 0 : 1;
+
+  try {
+    AmdGpuCodeObject object(options->input);
+    if (!object.is_valid()) {
+      std::cerr << "Failed to parse input code object\n";
+      return 2;
+    }
+    const std::optional<rj_code_arch_t> arch =
+        options->arch ? options->arch : arch_for_target(object.target_id());
+    if (!arch) {
+      std::cerr << "Cannot infer decoder target; pass --target\n";
+      return 2;
+    }
+    std::unique_ptr<Decoder> decoder = Decoder::create(*arch);
+    if (!decoder) {
+      std::cerr << "No decoder is available for the selected target\n";
+      return 2;
+    }
+
+    DecodeCorpus corpus;
+    std::string error;
+    if (!collect_corpus(object, *decoder, options->invalid_limit, corpus, error)) {
+      std::cerr << error << '\n';
+      return 2;
+    }
+    if (corpus.valid_offsets.empty()) {
+      std::cerr << "No valid instruction encodings found in text sections\n";
+      return 2;
+    }
+
+    std::cout << "text: " << corpus.text_bytes << " bytes, " << corpus.valid_offsets.size()
+              << " valid instructions, " << corpus.scan_rejections << " rejected words, "
+              << corpus.invalid_encodings.size() << " invalid samples\n";
+    const Measurement valid = measure_valid(corpus, *decoder, options->iterations);
+    print_measurement("valid", valid);
+    if (!corpus.invalid_encodings.empty()) {
+      const Measurement invalid = measure_invalid(corpus, *decoder, options->iterations);
+      print_measurement("invalid", invalid);
+    }
+    return valid.unexpected == 0 ? 0 : 3;
+  } catch (const std::exception &error) {
+    std::cerr << "Benchmark failed: " << error.what() << '\n';
+    return 2;
+  }
+}


### PR DESCRIPTION
Instruction rejection is normal decoder control flow, so represent it explicitly instead of throwing. Generated decoders now return DecodeResult, diagnostics travel through the failure path, and decoder, operand, translation, patching, fuzz, test, and tool callers handle the result directly. The generator remains the source of truth and all architecture outputs are regenerated.

Build on the prerequisite Result and diagnostic utilities. Keep validation call sites uniform without emitting empty per-format methods: IsaInstruction supplies a static constexpr success fallback, while formats hide it only when they have real checks. Generated validation temporaries spell out Result, with no virtual dispatch.

Add a valid-dominated large-object decode benchmark. Against the exception-based baseline, the final niche-backed implementation is 4.1% faster on successful decodes and 34.0x faster when rejecting invalid encodings, based on medians from nine interleaved CPU-pinned runs with identical checksums and no unexpected accepts or rejects.